### PR TITLE
fix(bookmarks): disable DnD with one item; don't open menu without overflow

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/channel/channel_bookmarks_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/channel/channel_bookmarks_spec.ts
@@ -340,6 +340,33 @@ describe('Channel Bookmarks', () => {
                 cy.visit(`/${testTeam.name}/channels/${publicChannel.name}`);
             });
         });
+
+        it('reorder is disabled when only one bookmark exists', () => {
+            // # Use a fresh channel with exactly one bookmark
+            cy.apiCreateChannel(testTeam.id, `single-${getRandomId(4)}`, 'single bookmark', 'O').then((result) => {
+                cy.visit(`/${testTeam.name}/channels/${result.channel.name}`);
+
+                const {displayName} = createLinkBookmark({displayName: 'Solo Bookmark', fromChannelMenu: true});
+
+                // # Press Space on the only bookmark
+                cy.findByTestId('channel-bookmarks-container').findByRole('link', {name: displayName}).focus().
+                    trigger('keydown', {key: ' ', code: 'Space', bubbles: true});
+
+                cy.wait(TIMEOUTS.HALF_SEC);
+
+                // * Reorder visual state did not engage (no 3px reorder outline)
+                cy.findByTestId('channel-bookmarks-container').
+                    find('[data-bookmark-id] > div').first().
+                    should('not.have.css', 'outline-width', '3px');
+
+                // * Bookmark count and identity unchanged
+                cy.findByTestId('channel-bookmarks-container').findAllByRole('link').
+                    should('have.length', 1).first().should('contain', displayName);
+
+                // # Return to original channel for subsequent tests
+                cy.visit(`/${testTeam.name}/channels/${publicChannel.name}`);
+            });
+        });
     });
 
     describe('manage bookmarks - permissions enforcement', () => {

--- a/webapp/channels/src/components/channel_bookmarks/bookmarks_bar_menu.test.tsx
+++ b/webapp/channels/src/components/channel_bookmarks/bookmarks_bar_menu.test.tsx
@@ -1,0 +1,100 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import type {ChannelBookmark} from '@mattermost/types/channel_bookmarks';
+
+import {renderWithContext} from 'tests/react_testing_utils';
+
+import BookmarksBarMenu from './bookmarks_bar_menu';
+
+const mockDropTargetForElements: jest.Mock = jest.fn(() => () => undefined);
+
+jest.mock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
+    dropTargetForElements: (arg: unknown) => mockDropTargetForElements(arg),
+}));
+
+function makeBookmark(id: string): ChannelBookmark {
+    return {
+        id,
+        channel_id: 'c1',
+        owner_id: 'u1',
+        type: 'link',
+        link_url: 'https://example.com',
+        display_name: `bm-${id}`,
+        sort_order: 0,
+        create_at: 0,
+        update_at: 0,
+        delete_at: 0,
+    } as ChannelBookmark;
+}
+
+const baseProps = {
+    channelId: 'c1',
+    bookmarks: {} as Record<string, ChannelBookmark>,
+    hasBookmarks: true,
+    limitReached: false,
+    canUploadFiles: true,
+    canReorder: true,
+    isDragging: false,
+    canAdd: true,
+};
+
+type DropTargetConfig = {
+    canDrop: (args: {source: {data: Record<string, unknown>}}) => boolean;
+    getData: () => Record<string, unknown>;
+};
+
+describe('BookmarksBarMenu — overflow drop target', () => {
+    beforeEach(() => {
+        mockDropTargetForElements.mockClear();
+    });
+
+    test('canDrop returns false when there is no overflow', () => {
+        renderWithContext(
+            <BookmarksBarMenu
+                {...baseProps}
+                overflowItems={[]}
+            />,
+        );
+
+        expect(mockDropTargetForElements).toHaveBeenCalledTimes(1);
+        const config = mockDropTargetForElements.mock.calls[0][0] as unknown as DropTargetConfig;
+        expect(config.getData()).toEqual({type: 'overflow-trigger'});
+        expect(config.canDrop({source: {data: {type: 'bookmark'}}})).toBe(false);
+    });
+
+    test('canDrop returns true for bookmark sources when overflow items exist', () => {
+        const overflowItems = ['a', 'b'];
+        const bookmarks = {a: makeBookmark('a'), b: makeBookmark('b')};
+
+        renderWithContext(
+            <BookmarksBarMenu
+                {...baseProps}
+                overflowItems={overflowItems}
+                bookmarks={bookmarks}
+            />,
+        );
+
+        expect(mockDropTargetForElements).toHaveBeenCalledTimes(1);
+        const config = mockDropTargetForElements.mock.calls[0][0] as unknown as DropTargetConfig;
+        expect(config.canDrop({source: {data: {type: 'bookmark'}}})).toBe(true);
+    });
+
+    test('canDrop returns false for non-bookmark sources even with overflow', () => {
+        const overflowItems = ['a'];
+        const bookmarks = {a: makeBookmark('a')};
+
+        renderWithContext(
+            <BookmarksBarMenu
+                {...baseProps}
+                overflowItems={overflowItems}
+                bookmarks={bookmarks}
+            />,
+        );
+
+        const config = mockDropTargetForElements.mock.calls[0][0] as unknown as DropTargetConfig;
+        expect(config.canDrop({source: {data: {type: 'something-else'}}})).toBe(false);
+    });
+});

--- a/webapp/channels/src/components/channel_bookmarks/bookmarks_bar_menu.tsx
+++ b/webapp/channels/src/components/channel_bookmarks/bookmarks_bar_menu.tsx
@@ -77,7 +77,10 @@ function BookmarksBarMenu({
         }
     }, []);
 
-    // Register as drop target for overflow auto-open trigger
+    // Drops are rejected via canDrop when there is no overflow so the trailing
+    // add-bookmark button never auto-opens the menu during a drag.
+    const hasOverflowRef = useRef(hasOverflow);
+    hasOverflowRef.current = hasOverflow;
     useEffect(() => {
         const el = triggerRef.current;
         if (!el) {
@@ -86,7 +89,7 @@ function BookmarksBarMenu({
         return dropTargetForElements({
             element: el,
             getData: () => ({type: 'overflow-trigger'}),
-            canDrop: ({source}) => source.data.type === 'bookmark',
+            canDrop: ({source}) => source.data.type === 'bookmark' && hasOverflowRef.current,
         });
     }, []);
 

--- a/webapp/channels/src/components/channel_bookmarks/channel_bookmarks.tsx
+++ b/webapp/channels/src/components/channel_bookmarks/channel_bookmarks.tsx
@@ -24,6 +24,7 @@ function ChannelBookmarks({channelId}: Props) {
     const canUploadFiles = useCanUploadFiles();
     const hasBookmarks = Boolean(order?.length);
     const limitReached = order.length >= MAX_BOOKMARKS_PER_CHANNEL;
+    const canDrag = canReorder && order.length > 1;
 
     // --- Overflow detection ---
     const {
@@ -54,7 +55,7 @@ function ChannelBookmarks({channelId}: Props) {
         onReorder: reorder,
         getName: useCallback((id: string) => bookmarks[id]?.display_name ?? '', [bookmarks]),
         onOverflowOpenChange: setForceOverflowOpen,
-        canReorder,
+        canReorder: canDrag,
     });
 
     // Pause overflow recalculation while dragging or keyboard reordering.
@@ -89,9 +90,9 @@ function ChannelBookmarks({channelId}: Props) {
                             key={id}
                             id={id}
                             bookmark={bookmark}
-                            disabled={!canReorder}
+                            disabled={!canDrag}
                             isDraggingGlobal={isDragging}
-                            keyboardReorderProps={!isHidden && canReorder ? getItemProps(id) : undefined}
+                            keyboardReorderProps={!isHidden && canDrag ? getItemProps(id) : undefined}
                             isKeyboardReordering={!isHidden && reorderState.isReordering && reorderState.itemId === id}
                             hidden={isHidden}
                             onMount={registerItemRef}
@@ -106,13 +107,13 @@ function ChannelBookmarks({channelId}: Props) {
                     hasBookmarks={hasBookmarks}
                     limitReached={limitReached}
                     canUploadFiles={canUploadFiles}
-                    canReorder={canReorder}
+                    canReorder={canDrag}
                     isDragging={isDragging}
                     canAdd={canAdd}
                     forceOpen={forceOverflowOpen}
                     onOpenChange={setForceOverflowOpen}
                     reorderState={reorderState}
-                    getItemProps={canReorder ? getItemProps : undefined}
+                    getItemProps={canDrag ? getItemProps : undefined}
                 />
             </BookmarksBarContent>
         </Container>

--- a/webapp/channels/src/components/channel_bookmarks/hooks/use_bookmark_drag_drop.test.ts
+++ b/webapp/channels/src/components/channel_bookmarks/hooks/use_bookmark_drag_drop.test.ts
@@ -1,0 +1,90 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {renderHookWithContext} from 'tests/react_testing_utils';
+
+import {useBookmarkDragDrop} from './use_bookmark_drag_drop';
+
+const mockDraggable: jest.Mock = jest.fn(() => () => undefined);
+const mockDropTargetForElements: jest.Mock = jest.fn(() => () => undefined);
+
+jest.mock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
+    draggable: (arg: unknown) => mockDraggable(arg),
+    dropTargetForElements: (arg: unknown) => mockDropTargetForElements(arg),
+}));
+
+jest.mock('@atlaskit/pragmatic-drag-and-drop/combine', () => ({
+    combine: (...cleanups: Array<() => void>) => () => cleanups.forEach((c) => c()),
+}));
+
+jest.mock('@atlaskit/pragmatic-drag-and-drop/element/set-custom-native-drag-preview', () => ({
+    setCustomNativeDragPreview: jest.fn(),
+}));
+
+jest.mock('@atlaskit/pragmatic-drag-and-drop/prevent-unhandled', () => ({
+    preventUnhandled: {start: jest.fn(), stop: jest.fn()},
+}));
+
+jest.mock('@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge', () => ({
+    attachClosestEdge: (data: unknown) => data,
+    extractClosestEdge: () => null,
+}));
+
+describe('useBookmarkDragDrop', () => {
+    beforeEach(() => {
+        mockDraggable.mockClear();
+        mockDropTargetForElements.mockClear();
+    });
+
+    test('does not register draggable or drop target when canReorder is false', () => {
+        const element = document.createElement('div');
+
+        renderHookWithContext(
+            () => useBookmarkDragDrop({
+                id: 'bm1',
+                container: 'bar',
+                allowedEdges: ['left', 'right'],
+                displayName: 'Example',
+                canReorder: false,
+                element,
+            }),
+        );
+
+        expect(mockDraggable).not.toHaveBeenCalled();
+        expect(mockDropTargetForElements).not.toHaveBeenCalled();
+    });
+
+    test('registers draggable and drop target when canReorder is true', () => {
+        const element = document.createElement('div');
+
+        renderHookWithContext(
+            () => useBookmarkDragDrop({
+                id: 'bm1',
+                container: 'bar',
+                allowedEdges: ['left', 'right'],
+                displayName: 'Example',
+                canReorder: true,
+                element,
+            }),
+        );
+
+        expect(mockDraggable).toHaveBeenCalledTimes(1);
+        expect(mockDropTargetForElements).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not register when element is null even if canReorder is true', () => {
+        renderHookWithContext(
+            () => useBookmarkDragDrop({
+                id: 'bm1',
+                container: 'bar',
+                allowedEdges: ['left', 'right'],
+                displayName: 'Example',
+                canReorder: true,
+                element: null,
+            }),
+        );
+
+        expect(mockDraggable).not.toHaveBeenCalled();
+        expect(mockDropTargetForElements).not.toHaveBeenCalled();
+    });
+});

--- a/webapp/channels/src/components/channel_bookmarks/hooks/use_bookmarks_dnd.test.ts
+++ b/webapp/channels/src/components/channel_bookmarks/hooks/use_bookmarks_dnd.test.ts
@@ -1,0 +1,113 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {act} from '@testing-library/react';
+
+import {renderHookWithContext} from 'tests/react_testing_utils';
+
+import {useBookmarksDnd} from './use_bookmarks_dnd';
+
+type MonitorConfig = {
+    canMonitor: (args: {source: {data: Record<string, unknown>}}) => boolean;
+    onDragStart: (args: {source: {data: Record<string, unknown>}}) => void;
+    onDrop: (args: {
+        source: {data: Record<string, unknown>};
+        location: {current: {dropTargets: Array<{data: Record<string, unknown>}>}};
+    }) => void;
+    onDropTargetChange: (args: {
+        location: {current: {dropTargets: Array<{data: Record<string, unknown>}>}};
+    }) => void;
+};
+
+const registeredMonitors: MonitorConfig[] = [];
+
+jest.mock('@atlaskit/pragmatic-drag-and-drop/element/adapter', () => ({
+    monitorForElements: (config: MonitorConfig) => {
+        registeredMonitors.push(config);
+        return () => {
+            const idx = registeredMonitors.indexOf(config);
+            if (idx !== -1) {
+                registeredMonitors.splice(idx, 1);
+            }
+        };
+    },
+}));
+
+jest.mock('@atlaskit/pragmatic-drag-and-drop-hitbox/closest-edge', () => ({
+    extractClosestEdge: () => null,
+}));
+
+function dropTargets(...targets: Array<Record<string, unknown>>) {
+    return {current: {dropTargets: targets.map((data) => ({data}))}};
+}
+
+describe('useBookmarksDnd — overflow open guard', () => {
+    beforeEach(() => {
+        registeredMonitors.length = 0;
+    });
+
+    test('onDropTargetChange forces overflow open when overflow exists', () => {
+        const onReorder = jest.fn().mockResolvedValue(undefined);
+
+        const {result} = renderHookWithContext(() => useBookmarksDnd({
+            order: ['a', 'b', 'c', 'd'],
+            visibleItems: ['a', 'b'],
+            onReorder,
+        }));
+
+        expect(registeredMonitors).toHaveLength(1);
+        const monitor = registeredMonitors[0];
+
+        act(() => {
+            monitor.onDropTargetChange({
+                location: dropTargets({type: 'overflow-trigger'}),
+            });
+        });
+
+        expect(result.current.forceOverflowOpen).toBe(true);
+    });
+
+    test('onDropTargetChange does NOT force overflow open when there is no overflow', () => {
+        const onReorder = jest.fn().mockResolvedValue(undefined);
+
+        const {result} = renderHookWithContext(() => useBookmarksDnd({
+            order: ['a', 'b', 'c'],
+            visibleItems: ['a', 'b', 'c'],
+            onReorder,
+        }));
+
+        const monitor = registeredMonitors[0];
+
+        act(() => {
+            monitor.onDropTargetChange({
+                location: dropTargets({type: 'overflow-trigger'}),
+            });
+        });
+
+        expect(result.current.forceOverflowOpen).toBeUndefined();
+    });
+
+    test('onDrop does NOT force overflow open when dropping on overflow-trigger without overflow', () => {
+        const onReorder = jest.fn().mockResolvedValue(undefined);
+
+        const {result} = renderHookWithContext(() => useBookmarksDnd({
+            order: ['a', 'b', 'c'],
+            visibleItems: ['a', 'b', 'c'],
+            onReorder,
+        }));
+
+        const monitor = registeredMonitors[0];
+
+        act(() => {
+            monitor.onDragStart({source: {data: {bookmarkId: 'a', type: 'bookmark'}}});
+        });
+        act(() => {
+            monitor.onDrop({
+                source: {data: {bookmarkId: 'a', type: 'bookmark'}},
+                location: dropTargets({type: 'overflow-trigger'}),
+            });
+        });
+
+        expect(result.current.forceOverflowOpen).toBe(false);
+    });
+});

--- a/webapp/channels/src/components/channel_bookmarks/hooks/use_bookmarks_dnd.test.ts
+++ b/webapp/channels/src/components/channel_bookmarks/hooks/use_bookmarks_dnd.test.ts
@@ -110,4 +110,28 @@ describe('useBookmarksDnd — overflow open guard', () => {
 
         expect(result.current.forceOverflowOpen).toBe(false);
     });
+
+    test('onDrop does NOT call onReorder when dropping on overflow-trigger without overflow', () => {
+        const onReorder = jest.fn().mockResolvedValue(undefined);
+
+        renderHookWithContext(() => useBookmarksDnd({
+            order: ['a', 'b', 'c'],
+            visibleItems: ['a', 'b', 'c'],
+            onReorder,
+        }));
+
+        const monitor = registeredMonitors[0];
+
+        act(() => {
+            monitor.onDragStart({source: {data: {bookmarkId: 'a', type: 'bookmark'}}});
+        });
+        act(() => {
+            monitor.onDrop({
+                source: {data: {bookmarkId: 'a', type: 'bookmark'}},
+                location: dropTargets({type: 'overflow-trigger'}),
+            });
+        });
+
+        expect(onReorder).not.toHaveBeenCalled();
+    });
 });

--- a/webapp/channels/src/components/channel_bookmarks/hooks/use_bookmarks_dnd.ts
+++ b/webapp/channels/src/components/channel_bookmarks/hooks/use_bookmarks_dnd.ts
@@ -76,9 +76,11 @@ export function useBookmarksDnd({
             onDrop: ({source, location}) => {
                 setActiveId(null);
 
-                // Keep overflow menu open if dropped into overflow; close if dropped into bar
                 const dropTarget = location.current.dropTargets[0];
-                const droppedInOverflow = dropTarget?.data.container === 'overflow' || dropTarget?.data.type === 'overflow-trigger';
+                const hasOverflow = orderRef.current.length > visibleItemsRef.current.length;
+                const droppedInOverflow =
+                    dropTarget?.data.container === 'overflow' ||
+                    (dropTarget?.data.type === 'overflow-trigger' && hasOverflow);
                 setForceOverflowOpen(droppedInOverflow);
 
                 const sourceId = source.data.bookmarkId as string;
@@ -121,9 +123,9 @@ export function useBookmarksDnd({
             },
 
             onDropTargetChange: ({location}) => {
-                // Detect when drag enters overflow-trigger zone
                 const target = location.current.dropTargets[0];
-                if (target?.data.type === 'overflow-trigger') {
+                const hasOverflow = orderRef.current.length > visibleItemsRef.current.length;
+                if (target?.data.type === 'overflow-trigger' && hasOverflow) {
                     setForceOverflowOpen(true);
                 }
             },

--- a/webapp/channels/src/components/channel_bookmarks/hooks/use_bookmarks_dnd.ts
+++ b/webapp/channels/src/components/channel_bookmarks/hooks/use_bookmarks_dnd.ts
@@ -100,6 +100,10 @@ export function useBookmarksDnd({
                 let newIndex: number;
 
                 if (target.data.type === 'overflow-trigger') {
+                    if (!hasOverflow) {
+                        return;
+                    }
+
                     // Dropped on the overflow trigger — place at the beginning of overflow
                     newIndex = visibleItemsRef.current.length;
                 } else if (target.data.type === 'bookmark') {


### PR DESCRIPTION
#### Summary
Two follow-up bug fixes from MM-56762 (Channel Bookmarks overflow menu):

1. **Single-item bar** — drag-and-drop reordering is now disabled when the bar has only one bookmark. Previously the chip entered drag state, the custom drag preview was rendered, and the global `isDragging` flag flipped on, even though there was nothing to swap with. Fix: derive `canDrag = canReorder && order.length > 1` in `channel_bookmarks.tsx` and feed that through to both the DnD draggable and the keyboard-reorder hook.
2. **No-overflow auto-open** — when the bar has no overflow items but the user has add-bookmark permission, the trailing `+` button shares the menu container with the overflow menu. Dragging another bookmark over `+` used to fire `onDropTargetChange` with `overflow-trigger`, forcing the menu open and showing only "Add a link" / "Attach a file" — confusing during a drag. Fix: gate the overflow-trigger drop target via `canDrop` using a ref to current overflow state in `bookmarks_bar_menu.tsx`, plus a defensive guard in `useBookmarksDnd` so `onDropTargetChange` / `onDrop` never force the menu open when overflow is empty.

QA steps:
- Single-bookmark bar: try to drag the chip — no drag preview, no movement. Try Space to start a keyboard reorder — the chip's reorder outline does not appear.
- No-overflow bar with add permission: drag a bookmark over the trailing `+` button — the menu does not open.
- Channels with overflow: existing reorder + drop-into-overflow flows unchanged.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68684

#### Screenshots
N/A — no visual changes; the fix removes accidental visual states (drag affordance, menu auto-open) in two edge cases.

#### Release Note
```release-note
Fixed channel bookmarks drag-and-drop edge cases: reordering is now disabled when a bar has only one bookmark, and the trailing add-bookmark button no longer auto-opens the menu when dragging over it without any items in overflow.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes modify drag-and-drop behavior across multiple related components (BookmarksBarMenu, channel_bookmarks, and DnD hooks) with conditional overflow handling logic. While the fixes are defensive (preventing unintended drag states), DnD behavior with multiple interacting pieces could introduce subtle edge case regressions despite comprehensive test coverage.

**QA Recommendation:** Manual QA testing recommended for drag-and-drop workflows with single bookmarks and edge cases around overflow menu triggering. Automated test coverage is comprehensive, but interactive DnD scenarios benefit from exploratory testing given the interconnected nature of the changes across multiple files.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->