### PR TITLE
MM-67904 Fix inflated count in search results Messages tab

### DIFF
--- a/webapp/channels/src/components/search_results/search_results.test.tsx
+++ b/webapp/channels/src/components/search_results/search_results.test.tsx
@@ -181,7 +181,7 @@ describe('components/SearchResults', () => {
             const dateLine = DATE_LINE + new Date('2026-03-12').getTime();
 
             const {container} = renderSearchResults({
-                results: [dateLine, post] as any,
+                results: [dateLine, post],
                 searchType: 'files',
                 isSearchAtEnd: true,
             });
@@ -198,7 +198,7 @@ describe('components/SearchResults', () => {
             const dateLine2 = DATE_LINE + new Date('2026-03-13').getTime();
 
             const {container} = renderSearchResults({
-                results: [dateLine1, post1, dateLine2, post2] as any,
+                results: [dateLine1, post1, dateLine2, post2],
                 searchType: 'files',
                 isSearchAtEnd: true,
             });
@@ -212,7 +212,7 @@ describe('components/SearchResults', () => {
             const dateLine = DATE_LINE + new Date('2026-03-12').getTime();
 
             const {container} = renderSearchResults({
-                results: [dateLine, post] as any,
+                results: [dateLine, post],
                 searchType: 'files',
                 isSearchAtEnd: false,
                 searchPage: 1,

--- a/webapp/channels/src/components/search_results/search_results.test.tsx
+++ b/webapp/channels/src/components/search_results/search_results.test.tsx
@@ -4,6 +4,8 @@
 import {within} from '@testing-library/react';
 import React from 'react';
 
+import {DATE_LINE} from 'mattermost-redux/utils/post_list';
+
 import SearchResults, {arePropsEqual} from 'components/search_results/search_results';
 
 import {renderWithContext} from 'tests/react_testing_utils';
@@ -165,6 +167,59 @@ describe('components/SearchResults', () => {
             expect(jest.mocked(popoutRhsSearch)).toHaveBeenCalledWith(
                 expect.any(String), team.name, 'hello', 'search', 'messages', undefined, team.id,
             );
+        });
+    });
+
+    describe('messagesCounter', () => {
+        // Render with the Files tab selected so the body of the panel does not
+        // try to render the message Post items (whose connected components
+        // require Redux state that is out of scope for these tests). The
+        // messagesCounter is rendered on the Messages tab regardless of the
+        // active tab, so this still exercises the count calculation.
+        test('should not count date separators in the messages counter', () => {
+            const post = TestHelper.getPostMock({id: 'post1', message: 'unique message'});
+            const dateLine = DATE_LINE + new Date('2026-03-12').getTime();
+
+            const {container} = renderSearchResults({
+                results: [dateLine, post] as any,
+                searchType: 'files',
+                isSearchAtEnd: true,
+            });
+
+            const counter = container.querySelector('.messages-tab .counter');
+            expect(counter).not.toBeNull();
+            expect(counter?.textContent).toBe('1');
+        });
+
+        test('should count only posts when multiple date separators are present', () => {
+            const post1 = TestHelper.getPostMock({id: 'post1', message: 'unique message 1'});
+            const post2 = TestHelper.getPostMock({id: 'post2', message: 'unique message 2'});
+            const dateLine1 = DATE_LINE + new Date('2026-03-12').getTime();
+            const dateLine2 = DATE_LINE + new Date('2026-03-13').getTime();
+
+            const {container} = renderSearchResults({
+                results: [dateLine1, post1, dateLine2, post2] as any,
+                searchType: 'files',
+                isSearchAtEnd: true,
+            });
+
+            const counter = container.querySelector('.messages-tab .counter');
+            expect(counter?.textContent).toBe('2');
+        });
+
+        test('should append "+" to the messages counter when more results may be available', () => {
+            const post = TestHelper.getPostMock({id: 'post1', message: 'unique message'});
+            const dateLine = DATE_LINE + new Date('2026-03-12').getTime();
+
+            const {container} = renderSearchResults({
+                results: [dateLine, post] as any,
+                searchType: 'files',
+                isSearchAtEnd: false,
+                searchPage: 1,
+            });
+
+            const counter = container.querySelector('.messages-tab .counter');
+            expect(counter?.textContent).toBe('1+');
         });
     });
 

--- a/webapp/channels/src/components/search_results/search_results.tsx
+++ b/webapp/channels/src/components/search_results/search_results.tsx
@@ -150,6 +150,12 @@ const SearchResults: React.FC<Props> = (props: Props): JSX.Element => {
 
     const noResults = (!results || !Array.isArray(results) || results.length === 0);
     const noFileResults = (!fileResults || !Array.isArray(fileResults) || fileResults.length === 0);
+
+    // The `results` prop is a mix of posts and date-separator strings (added by
+    // makeAddDateSeparatorsForSearchResults). The messages counter must reflect
+    // only the actual posts, otherwise the count is inflated by one per date
+    // group (see MM-67904).
+    const messagesCount = Array.isArray(results) ? results.filter((item) => typeof item !== 'string' || !isDateLine(item)).length : 0;
     const isLoading = isSearchingTerm || isSearchingFlaggedPost || isSearchingPinnedPost || !isOpened;
     const isAtEnd = (searchType === DataSearchTypes.MESSAGES_SEARCH_TYPE && isSearchAtEnd) || (searchType === DataSearchTypes.FILES_SEARCH_TYPE && isSearchFilesAtEnd);
     const showLoadMore = !isAtEnd && !isChannelFiles && !isFlaggedPosts && !isPinnedPosts;
@@ -390,7 +396,7 @@ const SearchResults: React.FC<Props> = (props: Props): JSX.Element => {
                     selected={searchType}
                     selectedFilter={searchFilterType}
                     isFileAttachmentsEnabled={isFileAttachmentsEnabled(config)}
-                    messagesCounter={isSearchAtEnd || props.searchPage === 0 ? `${results.length}` : `${results.length}+`}
+                    messagesCounter={isSearchAtEnd || props.searchPage === 0 ? `${messagesCount}` : `${messagesCount}+`}
                     filesCounter={isSearchFilesAtEnd || props.searchPage === 0 ? `${fileResults.length}` : `${fileResults.length}+`}
                     onChange={setSearchType}
                     onFilter={setSearchFilterType}

--- a/webapp/channels/src/components/search_results/search_results.tsx
+++ b/webapp/channels/src/components/search_results/search_results.tsx
@@ -151,11 +151,12 @@ const SearchResults: React.FC<Props> = (props: Props): JSX.Element => {
     const noResults = (!results || !Array.isArray(results) || results.length === 0);
     const noFileResults = (!fileResults || !Array.isArray(fileResults) || fileResults.length === 0);
 
-    // The `results` prop is a mix of posts and date-separator strings (added by
-    // makeAddDateSeparatorsForSearchResults). The messages counter must reflect
-    // only the actual posts, otherwise the count is inflated by one per date
-    // group (see MM-67904).
-    const messagesCount = Array.isArray(results) ? results.filter((item) => typeof item !== 'string' || !isDateLine(item)).length : 0;
+    // The `results` prop is typed as `Array<Post | string>`. Strings are
+    // non-Post entries (date separators injected by
+    // makeAddDateSeparatorsForSearchResults), so the messages counter only
+    // counts the non-string entries. Otherwise the count is inflated by one
+    // per date group (see MM-67904).
+    const messagesCount = Array.isArray(results) ? results.filter((item) => typeof item !== 'string').length : 0;
     const isLoading = isSearchingTerm || isSearchingFlaggedPost || isSearchingPinnedPost || !isOpened;
     const isAtEnd = (searchType === DataSearchTypes.MESSAGES_SEARCH_TYPE && isSearchAtEnd) || (searchType === DataSearchTypes.FILES_SEARCH_TYPE && isSearchFilesAtEnd);
     const showLoadMore = !isAtEnd && !isChannelFiles && !isFlaggedPosts && !isPinnedPosts;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

The "Messages" counter in the search results RHS was rendering `results.length`, but `results` is the array produced by `makeAddDateSeparatorsForSearchResults` (`webapp/channels/src/packages/mattermost-redux/src/utils/post_list.ts`), which interleaves date-line strings between posts (one per date group). A search returning a single post therefore showed `2`, and `N` posts spread across `D` date groups showed `N + D`.

This PR filters date-line strings out of `results` before computing the counter so it reflects only the actual matching posts. File results are unaffected (no separators are injected there).

**QA steps**

1. Post a unique message in any channel (e.g. `zebraflux42xyz unique message`).
2. Search for the unique term using the channel search bar.
3. Confirm the badge on the **Messages** tab in the RHS shows `1` (previously showed `2`).
4. Optionally post additional unique-term messages on different days and confirm the badge equals the number of matching posts (not posts + date separators).

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-67904

#### Screenshots

![Search results Messages counter shows 1 after fix](https://cursor.com/artifacts/c/art-fb1daff9-9a4a-49e9-8ad2-8d7efbca77e5)

<a href="https://cursor.com/agents/bc-210b51e6-7ecf-4295-8862-e0cae5b564f7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsearch_count_fix_after.mp4"><img src="https://cursor.com/artifacts/c/art-cf9bc0e8-3c5e-49ec-8b1c-487f3536f6ad" alt="search_count_fix_after.mp4" /></a>

#### Release Note
```release-note
Fixed an issue where the search results "Messages" tab counter was inflated by one for each date group, causing a single matching post to be shown as "2".
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-210b51e6-7ecf-4295-8862-e0cae5b564f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-210b51e6-7ecf-4295-8862-e0cae5b564f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to the SearchResults component's messages counter logic and only alter how the counter is computed (filtering out string date-separators). New unit tests cover the adjusted behavior; no shared utilities, auth, persistence, or public APIs are modified.  
**QA Recommendation:** Minimal manual QA—verify message counts for single-day and multi-day search results and confirm the "+" behavior when more results may exist.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->