### PR TITLE
Fix compact mode: consecutive bot reply header floating incorrectly in RHS

### DIFF
--- a/webapp/channels/src/sass/components/_post-right.scss
+++ b/webapp/channels/src/sass/components/_post-right.scss
@@ -139,8 +139,6 @@
 
                     &.same--user.post--bot {
                         .post__header {
-                            height: auto;
-                            margin-left: 0;
                             float: none;
                         }
                     }

--- a/webapp/channels/src/sass/components/_post-right.scss
+++ b/webapp/channels/src/sass/components/_post-right.scss
@@ -136,6 +136,14 @@
                             opacity: 0.73;
                         }
                     }
+
+                    &.same--user.post--bot {
+                        .post__header {
+                            height: auto;
+                            margin-left: 0;
+                            float: none;
+                        }
+                    }
                 }
             }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

In compact display mode, when a bot user sends consecutive replies in the RHS thread view, the `.post__header` floats incorrectly — the username/BOT-badge/timestamp renders inline with the message body instead of on its own line above it.

**Root cause**: A CSS specificity conflict. The global rule in `_post.scss` that sets `float: left` for compact bot replies carries specificity `(0,7,0)` (six chained class selectors + one descendant class). The ThreadViewer/post-right override in `_post-right.scss` that should reset `float: none` only carries specificity `(0,6,0)` because it does not include `.same--user` or `.post--bot` in its selector chain. The global rule wins, and `float: left` is applied even inside the RHS panel.

**Fix**: Add a `.same--user.post--bot` sub-selector inside the `.post-right__container` / `.ThreadViewer` compact-reply block in `_post-right.scss`. The resulting compiled selector has specificity `(0,8,0)`, which beats the global rule and correctly resets `float` to `none`.

**QA steps**:
1. Enable compact display mode (Settings → Display → Message Display → Compact).
2. Open a channel that has a thread with consecutive bot replies.
3. Open the thread in the RHS.
4. Verify that each consecutive bot reply shows its header (username / BOT badge / timestamp) on its own line above the message body.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-67419

#### Screenshots

**Before** — header floats inline with message body:

![Before fix: broken layout](https://cursor.com/artifacts/c/art-8351abc7-c384-4c41-a1d2-f1d441090cfe)

**After** — header correctly on its own line:

![After fix: correct layout](https://cursor.com/artifacts/c/art-33b3e396-30f3-4c94-b5e3-ba753d9cefc3)

#### Release Note

```release-note
Fixed an issue where consecutive bot replies in the RHS thread view displayed with the message header incorrectly floating inline with the message body when using compact display mode.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6626af81-884e-474d-bdfc-187b9925ef36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6626af81-884e-474d-bdfc-187b9925ef36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** This change is an isolated CSS specificity tweak in webapp/channels/src/sass/components/_post-right.scss that affects only compact-mode rendering of consecutive bot replies in the RHS; it does not modify logic, shared utilities, or critical flows. Risk of regressions is minimal but visual regressions around post header layout in compact mode should be checked.

**QA Recommendation:** Perform targeted manual QA using the provided steps (enable compact mode, open a thread with consecutive bot replies in RHS) and, if available, run visual regression tests for the thread/RHS component.

---

## Release Note

Fixed an issue where consecutive bot replies in the RHS thread view displayed with the message header incorrectly floating inline with the message body when using compact display mode.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->