### PR TITLE
MM-68697 Preserve sender file ID in plugin-relayed shared channel attachments

### DIFF
--- a/server/channels/app/shared_channel.go
+++ b/server/channels/app/shared_channel.go
@@ -339,6 +339,7 @@ func (a *App) ReceiveSharedChannelAttachmentSyncMsg(rctx request.CTX, pluginID, 
 		Filename:  fi.Name,
 		FileSize:  fi.Size,
 		RemoteId:  rc.RemoteId,
+		ReqFileId: fi.Id,
 	}
 
 	us, appErr := a.CreateUploadSession(rctx, us)

--- a/server/channels/app/shared_channel_test.go
+++ b/server/channels/app/shared_channel_test.go
@@ -1360,7 +1360,11 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsg(t *testing.T) {
 		remoteUser, appErr := th.App.CreateUser(th.Context, remoteUser)
 		require.Nil(t, appErr)
 
+		// The sender-side file ID must be preserved on the receiving server so the
+		// post's FileIds (which reference the sender ID) resolve to the saved file.
+		senderFileID := model.NewId()
 		fi := &model.FileInfo{
+			Id:        senderFileID,
 			CreatorId: remoteUser.Id,
 			Name:      "hello.txt",
 			Size:      13,
@@ -1369,12 +1373,13 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsg(t *testing.T) {
 		saved, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("hello, world!")))
 		require.NoError(t, err)
 		require.NotNil(t, saved)
-		assert.NotEmpty(t, saved.Id)
+		assert.Equal(t, senderFileID, saved.Id, "saved FileInfo must keep the sender's file ID")
 		assert.Equal(t, rc.RemoteId, *saved.RemoteId)
 
 		// Verify the FileInfo was persisted with a server-constructed path
 		storedFI, appErr := th.App.GetFileInfo(th.Context, saved.Id)
 		require.Nil(t, appErr)
+		assert.Equal(t, senderFileID, storedFI.Id)
 		assert.Equal(t, "hello.txt", storedFI.Name)
 		assert.NotEmpty(t, storedFI.Path)
 		assert.Contains(t, storedFI.Path, "hello.txt")


### PR DESCRIPTION
#### Summary
This PR fixes a bug where Shared Channels plugin API for receiving file attachments orphaned the saved file. 

`ReceiveSharedChannelAttachmentSyncMsg` constructed an `UploadSession` without `ReqFileId`, so `UploadData` `server/channels/app/upload.go:306-307`) generated a fresh ID for the saved `FileInfo`. Meanwhile, the synced post arriving via `ReceiveSharedChannelSyncMsg` carried the sender's original file ID in `FileIds`, so the post pointed at an ID that did not exist on the receiver. The bytes and the `FileInfo` row were both persisted, the cursor advanced, and the plugin's `OnSharedChannelsAttachmentSyncMsg` returned nil, so the failure was silent.

The cluster-to-cluster path in `server/platform/services/sharedchannel/attachment.go:57` already sets `ReqFileId: fi.Id`. The plugin path was a regression relative to that path.

## Changes

- `server/channels/app/shared_channel.go`: add `ReqFileId: fi.Id` to the `UploadSession` constructed in `ReceiveSharedChannelAttachmentSyncMsg`. One-line fix mirroring the cluster-to-cluster path.                                                   

- `server/channels/app/shared_channel_test.go`: tighten the success subtest in `TestPluginAPIReceiveSharedChannelAttachmentSyncMsg` to set a sender-side `fi.Id` and assert the saved `FileInfo` keeps it. The prior assertion (`assert.NotEmpty(t, saved.Id)`) was satisfied by the buggy code as well, since a server-generated ID is also non-empty.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68697

```release-note
Fixed an issue where file attachments synced over a shared channel through a plugin (using the OnSharedChannelsAttachmentSyncMsg / ReceiveSharedChannelAttachmentSyncMsg plugin API pair) were stored on the receiving server but did not appear in the corresponding post, because the saved FileInfo was given a new ID instead of preserving the sender's file ID referenced by the post.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal regression risk - this is a highly isolated fix (+1 line) that adds a missing field to an UploadSession, mirroring an existing proven pattern from cluster-to-cluster attachment handling. The affected code path (plugin-relayed shared channel attachments) is well-defined and not used by core systems.

**QA Recommendation:** Standard testing sufficient. The enhanced test assertions combined with the isolated nature of the change make manual QA optional, though a quick smoke test of plugin-shared-channel attachment sync would be prudent if the feature is frequently used in deployments.

---

## Release Note

Fixed an issue where file attachments synced over a shared channel through a plugin (OnSharedChannelsAttachmentSyncMsg / ReceiveSharedChannelAttachmentSyncMsg) were stored on the receiving server under a new ID and thus did not appear in the corresponding post; attachments now preserve the sender's file ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->