### PR TITLE
Update user active endpoint

### DIFF
--- a/server/channels/api4/user.go
+++ b/server/channels/api4/user.go
@@ -1704,6 +1704,13 @@ func updateUserActive(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if user.IsBot {
+		if err := c.App.SessionHasPermissionToManageBot(c.AppContext, *c.AppContext.Session(), c.Params.UserId); err != nil {
+			c.Err = err
+			return
+		}
+	}
+
 	if active && user.IsGuest() && !*c.App.Config().GuestAccountsSettings.Enable {
 		c.Err = model.NewAppError("updateUserActive", "api.user.update_active.cannot_enable_guest_when_guest_feature_is_disabled.app_error", nil, "userId="+c.Params.UserId, http.StatusUnauthorized)
 		return

--- a/server/channels/api4/user.go
+++ b/server/channels/api4/user.go
@@ -1705,8 +1705,8 @@ func updateUserActive(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	if user.IsBot {
-		if err := c.App.SessionHasPermissionToManageBot(c.AppContext, *c.AppContext.Session(), c.Params.UserId); err != nil {
-			c.Err = err
+		if permErr := c.App.SessionHasPermissionToManageBot(c.AppContext, *c.AppContext.Session(), c.Params.UserId); permErr != nil {
+			c.Err = permErr
 			return
 		}
 	}

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -3138,6 +3138,83 @@ func TestUpdateUserActive(t *testing.T) {
 			CheckForbiddenStatus(t, resp)
 		})
 	})
+
+	t.Run("user manager without bot permissions cannot deactivate bot accounts", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.EnableBotAccountCreation = true
+		})
+
+		bot, botResp, err := th.SystemAdminClient.CreateBot(context.Background(), &model.Bot{
+			Username:    GenerateTestUsername(),
+			DisplayName: "Test Bot",
+			Description: "bot for permission test",
+		})
+		require.NoError(t, err)
+		CheckCreatedStatus(t, botResp)
+		defer func() {
+			appErr := th.App.PermanentDeleteBot(th.Context, bot.UserId)
+			assert.Nil(t, appErr)
+		}()
+
+		// Give BasicUser the User Manager permission to edit users, but no bot permissions.
+		th.AddPermissionToRole(t, model.PermissionSysconsoleWriteUserManagementUsers.Id, model.SystemUserRoleId)
+		defer th.RemovePermissionFromRole(t, model.PermissionSysconsoleWriteUserManagementUsers.Id, model.SystemUserRoleId)
+
+		th.LoginBasic(t)
+
+		// A User Manager without bot permissions must be blocked.
+		// SessionHasPermissionToManageBot returns 404 (not 403) when the caller
+		// has no bot read access at all, to avoid leaking bot existence.
+		resp, err := th.Client.UpdateUserActive(context.Background(), bot.UserId, false)
+		require.Error(t, err)
+		require.True(t, resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound,
+			"expected 403 or 404, got %d", resp.StatusCode)
+
+		// Confirm the bot is still active.
+		botUser, _, err := th.SystemAdminClient.GetUser(context.Background(), bot.UserId, "")
+		require.NoError(t, err)
+		require.False(t, botUser.DeleteAt > 0, "bot should still be active")
+	})
+
+	t.Run("user with bot management permissions can deactivate bot accounts via user active endpoint", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.EnableBotAccountCreation = true
+		})
+
+		bot, botResp, err := th.SystemAdminClient.CreateBot(context.Background(), &model.Bot{
+			Username:    GenerateTestUsername(),
+			DisplayName: "Test Bot",
+			Description: "bot for permission test",
+		})
+		require.NoError(t, err)
+		CheckCreatedStatus(t, botResp)
+		defer func() {
+			appErr := th.App.PermanentDeleteBot(th.Context, bot.UserId)
+			assert.Nil(t, appErr)
+		}()
+
+		// Assign both user-management and bot-management permissions to BasicUser.
+		th.AddPermissionToRole(t, model.PermissionSysconsoleWriteUserManagementUsers.Id, model.SystemUserRoleId)
+		defer th.RemovePermissionFromRole(t, model.PermissionSysconsoleWriteUserManagementUsers.Id, model.SystemUserRoleId)
+		th.AddPermissionToRole(t, model.PermissionManageOthersBots.Id, model.SystemUserRoleId)
+		defer th.RemovePermissionFromRole(t, model.PermissionManageOthersBots.Id, model.SystemUserRoleId)
+
+		th.LoginBasic(t)
+
+		// A user with ManageOthersBots should be allowed.
+		_, err = th.Client.UpdateUserActive(context.Background(), bot.UserId, false)
+		require.NoError(t, err)
+
+		// Re-activate using system admin to leave state clean.
+		_, err = th.SystemAdminClient.UpdateUserActive(context.Background(), bot.UserId, true)
+		require.NoError(t, err)
+	})
 }
 
 func TestGetUsers(t *testing.T) {

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -3176,7 +3176,7 @@ func TestUpdateUserActive(t *testing.T) {
 		// Confirm the bot is still active.
 		botUser, _, err := th.SystemAdminClient.GetUser(context.Background(), bot.UserId, "")
 		require.NoError(t, err)
-		require.False(t, botUser.DeleteAt > 0, "bot should still be active")
+		require.Zero(t, botUser.DeleteAt, "bot should still be active")
 	})
 
 	t.Run("user with bot management permissions can deactivate bot accounts via user active endpoint", func(t *testing.T) {

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -3166,12 +3166,12 @@ func TestUpdateUserActive(t *testing.T) {
 		th.LoginBasic(t)
 
 		// A User Manager without bot permissions must be blocked.
-		// SessionHasPermissionToManageBot returns 404 (not 403) when the caller
-		// has no bot read access at all, to avoid leaking bot existence.
+		// Because the caller has neither PermissionReadOthersBots nor
+		// PermissionManageOthersBots, SessionHasPermissionToManageBot always
+		// returns 404 to avoid leaking the bot's existence.
 		resp, err := th.Client.UpdateUserActive(context.Background(), bot.UserId, false)
 		require.Error(t, err)
-		require.True(t, resp.StatusCode == http.StatusForbidden || resp.StatusCode == http.StatusNotFound,
-			"expected 403 or 404, got %d", resp.StatusCode)
+		CheckNotFoundStatus(t, resp)
 
 		// Confirm the bot is still active.
 		botUser, _, err := th.SystemAdminClient.GetUser(context.Background(), bot.UserId, "")

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -3211,9 +3211,10 @@ func TestUpdateUserActive(t *testing.T) {
 		_, err = th.Client.UpdateUserActive(context.Background(), bot.UserId, false)
 		require.NoError(t, err)
 
-		// Re-activate using system admin to leave state clean.
-		_, err = th.SystemAdminClient.UpdateUserActive(context.Background(), bot.UserId, true)
+		// Confirm the bot is now inactive.
+		botUser, _, err := th.SystemAdminClient.GetUser(context.Background(), bot.UserId, "")
 		require.NoError(t, err)
+		require.True(t, botUser.DeleteAt > 0, "bot should be inactive after deactivation")
 	})
 }
 


### PR DESCRIPTION
#### Summary
Update user active endpoint

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68686

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Introduces an additional authorization check for bot accounts in the user active endpoint, which could change behavior for users/managers who previously could deactivate bots; mostly isolated to the user-active flow and covered by new tests but still modifies authorization logic.  
**QA Recommendation:** Manual QA recommended to validate both denied and allowed bot deactivation paths (user managers with and without bot-management permission) and run standard regression tests for user deactivation flows.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->