### PR TITLE
Fix webhook list ordering instability when paginating (MM-65732)

### DIFF
--- a/server/channels/store/sqlstore/webhook_store.go
+++ b/server/channels/store/sqlstore/webhook_store.go
@@ -299,7 +299,8 @@ func (s SqlWebhookStore) GetOutgoingByChannelByUser(channelId string, userId str
 		Where(sq.And{
 			sq.Eq{"ChannelId": channelId},
 			sq.Eq{"DeleteAt": 0},
-		})
+		}).
+		OrderBy("DisplayName", "Id")
 
 	if userId != "" {
 		query = query.Where(sq.Eq{"CreatorId": userId})

--- a/server/channels/store/sqlstore/webhook_store.go
+++ b/server/channels/store/sqlstore/webhook_store.go
@@ -166,6 +166,7 @@ func (s SqlWebhookStore) GetIncomingListByUser(userId string, offset, limit int)
 
 	query := s.incomingWebhookSelectQuery.
 		Where(sq.Eq{"DeleteAt": 0}).
+		OrderBy("DisplayName", "Id").
 		Limit(uint64(limit)).
 		Offset(uint64(offset))
 
@@ -188,6 +189,7 @@ func (s SqlWebhookStore) GetIncomingByTeamByUser(teamId string, userId string, o
 			sq.Eq{"TeamId": teamId},
 			sq.Eq{"DeleteAt": 0},
 		}).
+		OrderBy("DisplayName", "Id").
 		Limit(uint64(limit)).
 		Offset(uint64(offset))
 
@@ -271,6 +273,7 @@ func (s SqlWebhookStore) GetOutgoingListByUser(userId string, offset, limit int)
 		Where(sq.And{
 			sq.Eq{"DeleteAt": 0},
 		}).
+		OrderBy("DisplayName", "Id").
 		Limit(uint64(limit)).
 		Offset(uint64(offset))
 
@@ -323,7 +326,8 @@ func (s SqlWebhookStore) GetOutgoingByTeamByUser(teamId string, userId string, o
 		Where(sq.And{
 			sq.Eq{"TeamId": teamId},
 			sq.Eq{"DeleteAt": 0},
-		})
+		}).
+		OrderBy("DisplayName", "Id")
 
 	if userId != "" {
 		query = query.Where(sq.Eq{"CreatorId": userId})

--- a/server/channels/store/storetest/webhook_store.go
+++ b/server/channels/store/storetest/webhook_store.go
@@ -21,8 +21,10 @@ func TestWebhookStore(t *testing.T, rctx request.CTX, ss store.Store) {
 	t.Run("GetIncoming", func(t *testing.T) { testWebhookStoreGetIncoming(t, rctx, ss) })
 	t.Run("GetIncomingList", func(t *testing.T) { testWebhookStoreGetIncomingList(t, rctx, ss) })
 	t.Run("GetIncomingListByUser", func(t *testing.T) { testWebhookStoreGetIncomingListByUser(t, rctx, ss) })
+	t.Run("GetIncomingListByUserOrdering", func(t *testing.T) { testWebhookStoreGetIncomingListByUserOrdering(t, rctx, ss) })
 	t.Run("GetIncomingByTeam", func(t *testing.T) { testWebhookStoreGetIncomingByTeam(t, rctx, ss) })
 	t.Run("GetIncomingByTeamByUser", func(t *testing.T) { TestWebhookStoreGetIncomingByTeamByUser(t, rctx, ss) })
+	t.Run("GetIncomingByTeamByUserOrdering", func(t *testing.T) { testWebhookStoreGetIncomingByTeamByUserOrdering(t, rctx, ss) })
 	t.Run("GetIncomingByTeamByChannel", func(t *testing.T) { testWebhookStoreGetIncomingByChannel(t, rctx, ss) })
 	t.Run("DeleteIncoming", func(t *testing.T) { testWebhookStoreDeleteIncoming(t, rctx, ss) })
 	t.Run("DeleteIncomingByChannel", func(t *testing.T) { testWebhookStoreDeleteIncomingByChannel(t, rctx, ss) })
@@ -31,10 +33,12 @@ func TestWebhookStore(t *testing.T, rctx request.CTX, ss store.Store) {
 	t.Run("GetOutgoing", func(t *testing.T) { testWebhookStoreGetOutgoing(t, rctx, ss) })
 	t.Run("GetOutgoingList", func(t *testing.T) { testWebhookStoreGetOutgoingList(t, rctx, ss) })
 	t.Run("GetOutgoingListByUser", func(t *testing.T) { testWebhookStoreGetOutgoingListByUser(t, rctx, ss) })
+	t.Run("GetOutgoingListByUserOrdering", func(t *testing.T) { testWebhookStoreGetOutgoingListByUserOrdering(t, rctx, ss) })
 	t.Run("GetOutgoingByChannel", func(t *testing.T) { testWebhookStoreGetOutgoingByChannel(t, rctx, ss) })
 	t.Run("GetOutgoingByChannelByUser", func(t *testing.T) { testWebhookStoreGetOutgoingByChannelByUser(t, rctx, ss) })
 	t.Run("GetOutgoingByTeam", func(t *testing.T) { testWebhookStoreGetOutgoingByTeam(t, rctx, ss) })
 	t.Run("GetOutgoingByTeamByUser", func(t *testing.T) { testWebhookStoreGetOutgoingByTeamByUser(t, rctx, ss) })
+	t.Run("GetOutgoingByTeamByUserOrdering", func(t *testing.T) { testWebhookStoreGetOutgoingByTeamByUserOrdering(t, rctx, ss) })
 	t.Run("DeleteOutgoing", func(t *testing.T) { testWebhookStoreDeleteOutgoing(t, rctx, ss) })
 	t.Run("DeleteOutgoingByChannel", func(t *testing.T) { testWebhookStoreDeleteOutgoingByChannel(t, rctx, ss) })
 	t.Run("DeleteOutgoingByUser", func(t *testing.T) { testWebhookStoreDeleteOutgoingByUser(t, rctx, ss) })
@@ -614,4 +618,106 @@ func testWebhookStoreCountOutgoing(t *testing.T, rctx request.CTX, ss store.Stor
 	r, err := ss.Webhook().AnalyticsOutgoingCount("")
 	require.NoError(t, err)
 	require.NotEqual(t, 0, r, "should have at least 1 outgoing hook")
+}
+
+// testWebhookStoreGetIncomingListByUserOrdering verifies that GetIncomingListByUser returns
+// webhooks sorted by DisplayName then Id, so paginated views remain stable across page navigations.
+func testWebhookStoreGetIncomingListByUserOrdering(t *testing.T, rctx request.CTX, ss store.Store) {
+	userId := model.NewId()
+
+	hookC := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: model.NewId(), DisplayName: "Charlie"}
+	hookA := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: model.NewId(), DisplayName: "Alpha"}
+	hookB := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: model.NewId(), DisplayName: "Bravo"}
+
+	var err error
+	hookC, err = ss.Webhook().SaveIncoming(hookC)
+	require.NoError(t, err)
+	hookA, err = ss.Webhook().SaveIncoming(hookA)
+	require.NoError(t, err)
+	hookB, err = ss.Webhook().SaveIncoming(hookB)
+	require.NoError(t, err)
+
+	hooks, err := ss.Webhook().GetIncomingListByUser(userId, 0, 100)
+	require.NoError(t, err)
+	require.Len(t, hooks, 3)
+	require.Equal(t, hookA.Id, hooks[0].Id, "first result should be Alpha (alphabetical order)")
+	require.Equal(t, hookB.Id, hooks[1].Id, "second result should be Bravo (alphabetical order)")
+	require.Equal(t, hookC.Id, hooks[2].Id, "third result should be Charlie (alphabetical order)")
+}
+
+// testWebhookStoreGetIncomingByTeamByUserOrdering verifies that GetIncomingByTeamByUser returns
+// webhooks sorted by DisplayName then Id, so paginated views remain stable across page navigations.
+func testWebhookStoreGetIncomingByTeamByUserOrdering(t *testing.T, rctx request.CTX, ss store.Store) {
+	teamId := model.NewId()
+	userId := model.NewId()
+
+	hookC := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: teamId, DisplayName: "Charlie"}
+	hookA := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: teamId, DisplayName: "Alpha"}
+	hookB := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: teamId, DisplayName: "Bravo"}
+
+	var err error
+	hookC, err = ss.Webhook().SaveIncoming(hookC)
+	require.NoError(t, err)
+	hookA, err = ss.Webhook().SaveIncoming(hookA)
+	require.NoError(t, err)
+	hookB, err = ss.Webhook().SaveIncoming(hookB)
+	require.NoError(t, err)
+
+	hooks, err := ss.Webhook().GetIncomingByTeamByUser(teamId, userId, 0, 100)
+	require.NoError(t, err)
+	require.Len(t, hooks, 3)
+	require.Equal(t, hookA.Id, hooks[0].Id, "first result should be Alpha (alphabetical order)")
+	require.Equal(t, hookB.Id, hooks[1].Id, "second result should be Bravo (alphabetical order)")
+	require.Equal(t, hookC.Id, hooks[2].Id, "third result should be Charlie (alphabetical order)")
+}
+
+// testWebhookStoreGetOutgoingListByUserOrdering verifies that GetOutgoingListByUser returns
+// webhooks sorted by DisplayName then Id, so paginated views remain stable across page navigations.
+func testWebhookStoreGetOutgoingListByUserOrdering(t *testing.T, rctx request.CTX, ss store.Store) {
+	creatorId := model.NewId()
+
+	hookC := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: model.NewId(), CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Charlie"}
+	hookA := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: model.NewId(), CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Alpha"}
+	hookB := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: model.NewId(), CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Bravo"}
+
+	var err error
+	hookC, err = ss.Webhook().SaveOutgoing(hookC)
+	require.NoError(t, err)
+	hookA, err = ss.Webhook().SaveOutgoing(hookA)
+	require.NoError(t, err)
+	hookB, err = ss.Webhook().SaveOutgoing(hookB)
+	require.NoError(t, err)
+
+	hooks, err := ss.Webhook().GetOutgoingListByUser(creatorId, 0, 100)
+	require.NoError(t, err)
+	require.Len(t, hooks, 3)
+	require.Equal(t, hookA.Id, hooks[0].Id, "first result should be Alpha (alphabetical order)")
+	require.Equal(t, hookB.Id, hooks[1].Id, "second result should be Bravo (alphabetical order)")
+	require.Equal(t, hookC.Id, hooks[2].Id, "third result should be Charlie (alphabetical order)")
+}
+
+// testWebhookStoreGetOutgoingByTeamByUserOrdering verifies that GetOutgoingByTeamByUser returns
+// webhooks sorted by DisplayName then Id, so paginated views remain stable across page navigations.
+func testWebhookStoreGetOutgoingByTeamByUserOrdering(t *testing.T, rctx request.CTX, ss store.Store) {
+	teamId := model.NewId()
+	creatorId := model.NewId()
+
+	hookC := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: teamId, CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Charlie"}
+	hookA := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: teamId, CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Alpha"}
+	hookB := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: teamId, CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Bravo"}
+
+	var err error
+	hookC, err = ss.Webhook().SaveOutgoing(hookC)
+	require.NoError(t, err)
+	hookA, err = ss.Webhook().SaveOutgoing(hookA)
+	require.NoError(t, err)
+	hookB, err = ss.Webhook().SaveOutgoing(hookB)
+	require.NoError(t, err)
+
+	hooks, err := ss.Webhook().GetOutgoingByTeamByUser(teamId, creatorId, 0, 100)
+	require.NoError(t, err)
+	require.Len(t, hooks, 3)
+	require.Equal(t, hookA.Id, hooks[0].Id, "first result should be Alpha (alphabetical order)")
+	require.Equal(t, hookB.Id, hooks[1].Id, "second result should be Bravo (alphabetical order)")
+	require.Equal(t, hookC.Id, hooks[2].Id, "third result should be Charlie (alphabetical order)")
 }

--- a/server/channels/store/storetest/webhook_store.go
+++ b/server/channels/store/storetest/webhook_store.go
@@ -462,8 +462,8 @@ func testWebhookStoreGetOutgoingByChannelByUser(t *testing.T, rctx request.CTX, 
 	o1.TeamId = model.NewId()
 	o1.CallbackURLs = []string{"http://nowhere.com/"}
 
-	o1, err := ss.Webhook().SaveOutgoing(o1)
-	require.NoError(t, err)
+	o1, errSave := ss.Webhook().SaveOutgoing(o1)
+	require.NoError(t, errSave)
 
 	o2 := &model.OutgoingWebhook{}
 	o2.ChannelId = o1.ChannelId
@@ -471,8 +471,8 @@ func testWebhookStoreGetOutgoingByChannelByUser(t *testing.T, rctx request.CTX, 
 	o2.TeamId = model.NewId()
 	o2.CallbackURLs = []string{"http://nowhere.com/"}
 
-	_, err = ss.Webhook().SaveOutgoing(o2)
-	require.NoError(t, err)
+	_, errSave = ss.Webhook().SaveOutgoing(o2)
+	require.NoError(t, errSave)
 
 	t.Run("GetOutgoingByChannelByUser, no user filter", func(t *testing.T) {
 		hooks, err := ss.Webhook().GetOutgoingByChannel(o1.ChannelId, 0, 100)
@@ -491,6 +491,27 @@ func testWebhookStoreGetOutgoingByChannelByUser(t *testing.T, rctx request.CTX, 
 		hooks, err := ss.Webhook().GetOutgoingByChannelByUser(o1.ChannelId, "123465", 0, 100)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(hooks))
+	})
+
+	t.Run("GetOutgoingByChannelByUser, ordered alphabetically by display name", func(t *testing.T) {
+		channelId := model.NewId()
+		hookC := &model.OutgoingWebhook{ChannelId: channelId, CreatorId: model.NewId(), TeamId: model.NewId(), CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Charlie"}
+		hookA := &model.OutgoingWebhook{ChannelId: channelId, CreatorId: model.NewId(), TeamId: model.NewId(), CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Alpha"}
+		hookB := &model.OutgoingWebhook{ChannelId: channelId, CreatorId: model.NewId(), TeamId: model.NewId(), CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Bravo"}
+
+		hookC, err := ss.Webhook().SaveOutgoing(hookC)
+		require.NoError(t, err)
+		hookA, err = ss.Webhook().SaveOutgoing(hookA)
+		require.NoError(t, err)
+		hookB, err = ss.Webhook().SaveOutgoing(hookB)
+		require.NoError(t, err)
+
+		hooks, err := ss.Webhook().GetOutgoingByChannel(channelId, 0, 100)
+		require.NoError(t, err)
+		require.Len(t, hooks, 3)
+		require.Equal(t, hookA.Id, hooks[0].Id, "first result should be Alpha (alphabetical order)")
+		require.Equal(t, hookB.Id, hooks[1].Id, "second result should be Bravo (alphabetical order)")
+		require.Equal(t, hookC.Id, hooks[2].Id, "third result should be Charlie (alphabetical order)")
 	})
 }
 

--- a/server/channels/store/storetest/webhook_store.go
+++ b/server/channels/store/storetest/webhook_store.go
@@ -132,8 +132,8 @@ func testWebhookStoreGetIncomingListByUser(t *testing.T, rctx request.CTX, ss st
 	o1.UserId = model.NewId()
 	o1.TeamId = model.NewId()
 
-	o1, err := ss.Webhook().SaveIncoming(o1)
-	require.NoError(t, err)
+	o1, errSave := ss.Webhook().SaveIncoming(o1)
+	require.NoError(t, errSave)
 
 	t.Run("GetIncomingListByUser, known user filtered", func(t *testing.T) {
 		hooks, err := ss.Webhook().GetIncomingListByUser(o1.UserId, 0, 100)
@@ -154,7 +154,7 @@ func testWebhookStoreGetIncomingListByUser(t *testing.T, rctx request.CTX, ss st
 		hookA := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: model.NewId(), DisplayName: "Alpha"}
 		hookB := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: model.NewId(), DisplayName: "Bravo"}
 
-		hookC, err = ss.Webhook().SaveIncoming(hookC)
+		hookC, err := ss.Webhook().SaveIncoming(hookC)
 		require.NoError(t, err)
 		hookA, err = ss.Webhook().SaveIncoming(hookA)
 		require.NoError(t, err)
@@ -187,16 +187,14 @@ func testWebhookStoreGetIncomingByTeam(t *testing.T, rctx request.CTX, ss store.
 }
 
 func TestWebhookStoreGetIncomingByTeamByUser(t *testing.T, rctx request.CTX, ss store.Store) {
-	var err error
-
 	o1 := buildIncomingWebhook()
-	o1, err = ss.Webhook().SaveIncoming(o1)
-	require.NoError(t, err)
+	o1, errSave := ss.Webhook().SaveIncoming(o1)
+	require.NoError(t, errSave)
 
 	o2 := buildIncomingWebhook()
 	o2.TeamId = o1.TeamId //Set both to the same team
-	o2, err = ss.Webhook().SaveIncoming(o2)
-	require.NoError(t, err)
+	o2, errSave = ss.Webhook().SaveIncoming(o2)
+	require.NoError(t, errSave)
 
 	t.Run("GetIncomingByTeamByUser, no user filter", func(t *testing.T) {
 		hooks, err := ss.Webhook().GetIncomingByTeam(o1.TeamId, 0, 100)
@@ -224,7 +222,7 @@ func TestWebhookStoreGetIncomingByTeamByUser(t *testing.T, rctx request.CTX, ss 
 		hookA := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: teamId, DisplayName: "Alpha"}
 		hookB := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: teamId, DisplayName: "Bravo"}
 
-		hookC, err = ss.Webhook().SaveIncoming(hookC)
+		hookC, err := ss.Webhook().SaveIncoming(hookC)
 		require.NoError(t, err)
 		hookA, err = ss.Webhook().SaveIncoming(hookA)
 		require.NoError(t, err)
@@ -515,16 +513,14 @@ func testWebhookStoreGetOutgoingByTeam(t *testing.T, rctx request.CTX, ss store.
 }
 
 func testWebhookStoreGetOutgoingByTeamByUser(t *testing.T, rctx request.CTX, ss store.Store) {
-	var err error
-
 	o1 := &model.OutgoingWebhook{}
 	o1.ChannelId = model.NewId()
 	o1.CreatorId = model.NewId()
 	o1.TeamId = model.NewId()
 	o1.CallbackURLs = []string{"http://nowhere.com/"}
 
-	o1, err = ss.Webhook().SaveOutgoing(o1)
-	require.NoError(t, err)
+	o1, errSave := ss.Webhook().SaveOutgoing(o1)
+	require.NoError(t, errSave)
 
 	o2 := &model.OutgoingWebhook{}
 	o2.ChannelId = model.NewId()
@@ -532,8 +528,8 @@ func testWebhookStoreGetOutgoingByTeamByUser(t *testing.T, rctx request.CTX, ss 
 	o2.TeamId = o1.TeamId
 	o2.CallbackURLs = []string{"http://nowhere.com/"}
 
-	o2, err = ss.Webhook().SaveOutgoing(o2)
-	require.NoError(t, err)
+	o2, errSave = ss.Webhook().SaveOutgoing(o2)
+	require.NoError(t, errSave)
 
 	t.Run("GetOutgoingByTeamByUser, no user filter", func(t *testing.T) {
 		hooks, err := ss.Webhook().GetOutgoingByTeam(o1.TeamId, 0, 100)
@@ -561,7 +557,7 @@ func testWebhookStoreGetOutgoingByTeamByUser(t *testing.T, rctx request.CTX, ss 
 		hookA := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: teamId, CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Alpha"}
 		hookB := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: teamId, CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Bravo"}
 
-		hookC, err = ss.Webhook().SaveOutgoing(hookC)
+		hookC, err := ss.Webhook().SaveOutgoing(hookC)
 		require.NoError(t, err)
 		hookA, err = ss.Webhook().SaveOutgoing(hookA)
 		require.NoError(t, err)
@@ -701,4 +697,3 @@ func testWebhookStoreCountOutgoing(t *testing.T, rctx request.CTX, ss store.Stor
 	require.NoError(t, err)
 	require.NotEqual(t, 0, r, "should have at least 1 outgoing hook")
 }
-

--- a/server/channels/store/storetest/webhook_store.go
+++ b/server/channels/store/storetest/webhook_store.go
@@ -21,10 +21,8 @@ func TestWebhookStore(t *testing.T, rctx request.CTX, ss store.Store) {
 	t.Run("GetIncoming", func(t *testing.T) { testWebhookStoreGetIncoming(t, rctx, ss) })
 	t.Run("GetIncomingList", func(t *testing.T) { testWebhookStoreGetIncomingList(t, rctx, ss) })
 	t.Run("GetIncomingListByUser", func(t *testing.T) { testWebhookStoreGetIncomingListByUser(t, rctx, ss) })
-	t.Run("GetIncomingListByUserOrdering", func(t *testing.T) { testWebhookStoreGetIncomingListByUserOrdering(t, rctx, ss) })
 	t.Run("GetIncomingByTeam", func(t *testing.T) { testWebhookStoreGetIncomingByTeam(t, rctx, ss) })
 	t.Run("GetIncomingByTeamByUser", func(t *testing.T) { TestWebhookStoreGetIncomingByTeamByUser(t, rctx, ss) })
-	t.Run("GetIncomingByTeamByUserOrdering", func(t *testing.T) { testWebhookStoreGetIncomingByTeamByUserOrdering(t, rctx, ss) })
 	t.Run("GetIncomingByTeamByChannel", func(t *testing.T) { testWebhookStoreGetIncomingByChannel(t, rctx, ss) })
 	t.Run("DeleteIncoming", func(t *testing.T) { testWebhookStoreDeleteIncoming(t, rctx, ss) })
 	t.Run("DeleteIncomingByChannel", func(t *testing.T) { testWebhookStoreDeleteIncomingByChannel(t, rctx, ss) })
@@ -33,12 +31,10 @@ func TestWebhookStore(t *testing.T, rctx request.CTX, ss store.Store) {
 	t.Run("GetOutgoing", func(t *testing.T) { testWebhookStoreGetOutgoing(t, rctx, ss) })
 	t.Run("GetOutgoingList", func(t *testing.T) { testWebhookStoreGetOutgoingList(t, rctx, ss) })
 	t.Run("GetOutgoingListByUser", func(t *testing.T) { testWebhookStoreGetOutgoingListByUser(t, rctx, ss) })
-	t.Run("GetOutgoingListByUserOrdering", func(t *testing.T) { testWebhookStoreGetOutgoingListByUserOrdering(t, rctx, ss) })
 	t.Run("GetOutgoingByChannel", func(t *testing.T) { testWebhookStoreGetOutgoingByChannel(t, rctx, ss) })
 	t.Run("GetOutgoingByChannelByUser", func(t *testing.T) { testWebhookStoreGetOutgoingByChannelByUser(t, rctx, ss) })
 	t.Run("GetOutgoingByTeam", func(t *testing.T) { testWebhookStoreGetOutgoingByTeam(t, rctx, ss) })
 	t.Run("GetOutgoingByTeamByUser", func(t *testing.T) { testWebhookStoreGetOutgoingByTeamByUser(t, rctx, ss) })
-	t.Run("GetOutgoingByTeamByUserOrdering", func(t *testing.T) { testWebhookStoreGetOutgoingByTeamByUserOrdering(t, rctx, ss) })
 	t.Run("DeleteOutgoing", func(t *testing.T) { testWebhookStoreDeleteOutgoing(t, rctx, ss) })
 	t.Run("DeleteOutgoingByChannel", func(t *testing.T) { testWebhookStoreDeleteOutgoingByChannel(t, rctx, ss) })
 	t.Run("DeleteOutgoingByUser", func(t *testing.T) { testWebhookStoreDeleteOutgoingByUser(t, rctx, ss) })
@@ -151,6 +147,27 @@ func testWebhookStoreGetIncomingListByUser(t *testing.T, rctx request.CTX, ss st
 		require.NoError(t, err)
 		require.Equal(t, 0, len(hooks))
 	})
+
+	t.Run("GetIncomingListByUser, ordered alphabetically by display name", func(t *testing.T) {
+		userId := model.NewId()
+		hookC := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: model.NewId(), DisplayName: "Charlie"}
+		hookA := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: model.NewId(), DisplayName: "Alpha"}
+		hookB := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: model.NewId(), DisplayName: "Bravo"}
+
+		hookC, err = ss.Webhook().SaveIncoming(hookC)
+		require.NoError(t, err)
+		hookA, err = ss.Webhook().SaveIncoming(hookA)
+		require.NoError(t, err)
+		hookB, err = ss.Webhook().SaveIncoming(hookB)
+		require.NoError(t, err)
+
+		hooks, err := ss.Webhook().GetIncomingListByUser(userId, 0, 100)
+		require.NoError(t, err)
+		require.Len(t, hooks, 3)
+		require.Equal(t, hookA.Id, hooks[0].Id, "first result should be Alpha (alphabetical order)")
+		require.Equal(t, hookB.Id, hooks[1].Id, "second result should be Bravo (alphabetical order)")
+		require.Equal(t, hookC.Id, hooks[2].Id, "third result should be Charlie (alphabetical order)")
+	})
 }
 
 func testWebhookStoreGetIncomingByTeam(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -198,6 +215,28 @@ func TestWebhookStoreGetIncomingByTeamByUser(t *testing.T, rctx request.CTX, ss 
 		hooks, err := ss.Webhook().GetIncomingByTeamByUser(o2.TeamId, "123465", 0, 100)
 		require.NoError(t, err)
 		require.Equal(t, len(hooks), 0)
+	})
+
+	t.Run("GetIncomingByTeamByUser, ordered alphabetically by display name", func(t *testing.T) {
+		teamId := model.NewId()
+		userId := model.NewId()
+		hookC := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: teamId, DisplayName: "Charlie"}
+		hookA := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: teamId, DisplayName: "Alpha"}
+		hookB := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: teamId, DisplayName: "Bravo"}
+
+		hookC, err = ss.Webhook().SaveIncoming(hookC)
+		require.NoError(t, err)
+		hookA, err = ss.Webhook().SaveIncoming(hookA)
+		require.NoError(t, err)
+		hookB, err = ss.Webhook().SaveIncoming(hookB)
+		require.NoError(t, err)
+
+		hooks, err := ss.Webhook().GetIncomingByTeamByUser(teamId, userId, 0, 100)
+		require.NoError(t, err)
+		require.Len(t, hooks, 3)
+		require.Equal(t, hookA.Id, hooks[0].Id, "first result should be Alpha (alphabetical order)")
+		require.Equal(t, hookB.Id, hooks[1].Id, "second result should be Bravo (alphabetical order)")
+		require.Equal(t, hookC.Id, hooks[2].Id, "third result should be Charlie (alphabetical order)")
 	})
 }
 
@@ -335,6 +374,27 @@ func testWebhookStoreGetOutgoingListByUser(t *testing.T, rctx request.CTX, ss st
 		hooks, err := ss.Webhook().GetOutgoingListByUser("123465", 0, 100)
 		require.NoError(t, err)
 		require.Equal(t, 0, len(hooks))
+	})
+
+	t.Run("GetOutgoingListByUser, ordered alphabetically by display name", func(t *testing.T) {
+		creatorId := model.NewId()
+		hookC := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: model.NewId(), CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Charlie"}
+		hookA := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: model.NewId(), CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Alpha"}
+		hookB := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: model.NewId(), CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Bravo"}
+
+		hookC, err := ss.Webhook().SaveOutgoing(hookC)
+		require.NoError(t, err)
+		hookA, err = ss.Webhook().SaveOutgoing(hookA)
+		require.NoError(t, err)
+		hookB, err = ss.Webhook().SaveOutgoing(hookB)
+		require.NoError(t, err)
+
+		hooks, err := ss.Webhook().GetOutgoingListByUser(creatorId, 0, 100)
+		require.NoError(t, err)
+		require.Len(t, hooks, 3)
+		require.Equal(t, hookA.Id, hooks[0].Id, "first result should be Alpha (alphabetical order)")
+		require.Equal(t, hookB.Id, hooks[1].Id, "second result should be Bravo (alphabetical order)")
+		require.Equal(t, hookC.Id, hooks[2].Id, "third result should be Charlie (alphabetical order)")
 	})
 }
 
@@ -493,6 +553,28 @@ func testWebhookStoreGetOutgoingByTeamByUser(t *testing.T, rctx request.CTX, ss 
 		require.NoError(t, err)
 		require.Equal(t, len(hooks), 0)
 	})
+
+	t.Run("GetOutgoingByTeamByUser, ordered alphabetically by display name", func(t *testing.T) {
+		teamId := model.NewId()
+		creatorId := model.NewId()
+		hookC := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: teamId, CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Charlie"}
+		hookA := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: teamId, CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Alpha"}
+		hookB := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: teamId, CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Bravo"}
+
+		hookC, err = ss.Webhook().SaveOutgoing(hookC)
+		require.NoError(t, err)
+		hookA, err = ss.Webhook().SaveOutgoing(hookA)
+		require.NoError(t, err)
+		hookB, err = ss.Webhook().SaveOutgoing(hookB)
+		require.NoError(t, err)
+
+		hooks, err := ss.Webhook().GetOutgoingByTeamByUser(teamId, creatorId, 0, 100)
+		require.NoError(t, err)
+		require.Len(t, hooks, 3)
+		require.Equal(t, hookA.Id, hooks[0].Id, "first result should be Alpha (alphabetical order)")
+		require.Equal(t, hookB.Id, hooks[1].Id, "second result should be Bravo (alphabetical order)")
+		require.Equal(t, hookC.Id, hooks[2].Id, "third result should be Charlie (alphabetical order)")
+	})
 }
 
 func testWebhookStoreDeleteOutgoing(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -620,104 +702,3 @@ func testWebhookStoreCountOutgoing(t *testing.T, rctx request.CTX, ss store.Stor
 	require.NotEqual(t, 0, r, "should have at least 1 outgoing hook")
 }
 
-// testWebhookStoreGetIncomingListByUserOrdering verifies that GetIncomingListByUser returns
-// webhooks sorted by DisplayName then Id, so paginated views remain stable across page navigations.
-func testWebhookStoreGetIncomingListByUserOrdering(t *testing.T, rctx request.CTX, ss store.Store) {
-	userId := model.NewId()
-
-	hookC := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: model.NewId(), DisplayName: "Charlie"}
-	hookA := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: model.NewId(), DisplayName: "Alpha"}
-	hookB := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: model.NewId(), DisplayName: "Bravo"}
-
-	var err error
-	hookC, err = ss.Webhook().SaveIncoming(hookC)
-	require.NoError(t, err)
-	hookA, err = ss.Webhook().SaveIncoming(hookA)
-	require.NoError(t, err)
-	hookB, err = ss.Webhook().SaveIncoming(hookB)
-	require.NoError(t, err)
-
-	hooks, err := ss.Webhook().GetIncomingListByUser(userId, 0, 100)
-	require.NoError(t, err)
-	require.Len(t, hooks, 3)
-	require.Equal(t, hookA.Id, hooks[0].Id, "first result should be Alpha (alphabetical order)")
-	require.Equal(t, hookB.Id, hooks[1].Id, "second result should be Bravo (alphabetical order)")
-	require.Equal(t, hookC.Id, hooks[2].Id, "third result should be Charlie (alphabetical order)")
-}
-
-// testWebhookStoreGetIncomingByTeamByUserOrdering verifies that GetIncomingByTeamByUser returns
-// webhooks sorted by DisplayName then Id, so paginated views remain stable across page navigations.
-func testWebhookStoreGetIncomingByTeamByUserOrdering(t *testing.T, rctx request.CTX, ss store.Store) {
-	teamId := model.NewId()
-	userId := model.NewId()
-
-	hookC := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: teamId, DisplayName: "Charlie"}
-	hookA := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: teamId, DisplayName: "Alpha"}
-	hookB := &model.IncomingWebhook{ChannelId: model.NewId(), UserId: userId, TeamId: teamId, DisplayName: "Bravo"}
-
-	var err error
-	hookC, err = ss.Webhook().SaveIncoming(hookC)
-	require.NoError(t, err)
-	hookA, err = ss.Webhook().SaveIncoming(hookA)
-	require.NoError(t, err)
-	hookB, err = ss.Webhook().SaveIncoming(hookB)
-	require.NoError(t, err)
-
-	hooks, err := ss.Webhook().GetIncomingByTeamByUser(teamId, userId, 0, 100)
-	require.NoError(t, err)
-	require.Len(t, hooks, 3)
-	require.Equal(t, hookA.Id, hooks[0].Id, "first result should be Alpha (alphabetical order)")
-	require.Equal(t, hookB.Id, hooks[1].Id, "second result should be Bravo (alphabetical order)")
-	require.Equal(t, hookC.Id, hooks[2].Id, "third result should be Charlie (alphabetical order)")
-}
-
-// testWebhookStoreGetOutgoingListByUserOrdering verifies that GetOutgoingListByUser returns
-// webhooks sorted by DisplayName then Id, so paginated views remain stable across page navigations.
-func testWebhookStoreGetOutgoingListByUserOrdering(t *testing.T, rctx request.CTX, ss store.Store) {
-	creatorId := model.NewId()
-
-	hookC := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: model.NewId(), CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Charlie"}
-	hookA := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: model.NewId(), CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Alpha"}
-	hookB := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: model.NewId(), CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Bravo"}
-
-	var err error
-	hookC, err = ss.Webhook().SaveOutgoing(hookC)
-	require.NoError(t, err)
-	hookA, err = ss.Webhook().SaveOutgoing(hookA)
-	require.NoError(t, err)
-	hookB, err = ss.Webhook().SaveOutgoing(hookB)
-	require.NoError(t, err)
-
-	hooks, err := ss.Webhook().GetOutgoingListByUser(creatorId, 0, 100)
-	require.NoError(t, err)
-	require.Len(t, hooks, 3)
-	require.Equal(t, hookA.Id, hooks[0].Id, "first result should be Alpha (alphabetical order)")
-	require.Equal(t, hookB.Id, hooks[1].Id, "second result should be Bravo (alphabetical order)")
-	require.Equal(t, hookC.Id, hooks[2].Id, "third result should be Charlie (alphabetical order)")
-}
-
-// testWebhookStoreGetOutgoingByTeamByUserOrdering verifies that GetOutgoingByTeamByUser returns
-// webhooks sorted by DisplayName then Id, so paginated views remain stable across page navigations.
-func testWebhookStoreGetOutgoingByTeamByUserOrdering(t *testing.T, rctx request.CTX, ss store.Store) {
-	teamId := model.NewId()
-	creatorId := model.NewId()
-
-	hookC := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: teamId, CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Charlie"}
-	hookA := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: teamId, CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Alpha"}
-	hookB := &model.OutgoingWebhook{ChannelId: model.NewId(), CreatorId: creatorId, TeamId: teamId, CallbackURLs: []string{"http://nowhere.com/"}, DisplayName: "Bravo"}
-
-	var err error
-	hookC, err = ss.Webhook().SaveOutgoing(hookC)
-	require.NoError(t, err)
-	hookA, err = ss.Webhook().SaveOutgoing(hookA)
-	require.NoError(t, err)
-	hookB, err = ss.Webhook().SaveOutgoing(hookB)
-	require.NoError(t, err)
-
-	hooks, err := ss.Webhook().GetOutgoingByTeamByUser(teamId, creatorId, 0, 100)
-	require.NoError(t, err)
-	require.Len(t, hooks, 3)
-	require.Equal(t, hookA.Id, hooks[0].Id, "first result should be Alpha (alphabetical order)")
-	require.Equal(t, hookB.Id, hooks[1].Id, "second result should be Bravo (alphabetical order)")
-	require.Equal(t, hookC.Id, hooks[2].Id, "third result should be Charlie (alphabetical order)")
-}

--- a/webapp/channels/src/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.test.tsx
+++ b/webapp/channels/src/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.test.tsx
@@ -1,0 +1,157 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {screen, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import type {IncomingWebhook} from '@mattermost/types/integrations';
+
+import InstalledIncomingWebhooks from 'components/integrations/installed_incoming_webhooks/installed_incoming_webhooks';
+
+import {renderWithContext} from 'tests/react_testing_utils';
+import {TestHelper} from 'utils/test_helper';
+
+jest.mock('components/integrations/delete_integration_link', () => {
+    const ReactMock = require('react'); // eslint-disable-line @typescript-eslint/no-var-requires, global-require
+    return {
+        __esModule: true,
+        default: (props: {onDelete: () => void}) => ReactMock.createElement('button', {onClick: props.onDelete}, 'Delete'),
+    };
+});
+
+describe('components/integrations/InstalledIncomingWebhooks', () => {
+    const team = TestHelper.getTeamMock({id: 'teamId', name: 'test'});
+    const user = TestHelper.getUserMock({id: 'userId'});
+    const channel = TestHelper.getChannelMock({
+        id: 'channelId',
+        display_name: 'Town Square',
+    });
+
+    const hookAlpha: IncomingWebhook = TestHelper.getIncomingWebhookMock({
+        id: 'hook-alpha',
+        display_name: 'Alpha Webhook',
+        channel_id: 'channelId',
+        team_id: 'teamId',
+        user_id: 'userId',
+    });
+    const hookCharlie: IncomingWebhook = TestHelper.getIncomingWebhookMock({
+        id: 'hook-charlie',
+        display_name: 'Charlie Webhook',
+        channel_id: 'channelId',
+        team_id: 'teamId',
+        user_id: 'userId',
+    });
+    const hookBravo: IncomingWebhook = TestHelper.getIncomingWebhookMock({
+        id: 'hook-bravo',
+        display_name: 'Bravo Webhook',
+        channel_id: 'channelId',
+        team_id: 'teamId',
+        user_id: 'userId',
+    });
+
+    const initialState = {
+        entities: {
+            general: {config: {}},
+            users: {currentUserId: 'userId'},
+        },
+    };
+
+    const defaultProps = {
+        team,
+        user,
+        incomingHooks: [hookAlpha, hookCharlie, hookBravo],
+        incomingHooksTotalCount: 3,
+        channels: {channelId: channel},
+        users: {userId: user},
+        canManageOthersWebhooks: true,
+        enableIncomingWebhooks: true,
+        actions: {
+            removeIncomingHook: jest.fn(),
+            loadIncomingHooksAndProfilesForTeam: jest.fn().mockResolvedValue({data: []}),
+        },
+    };
+
+    test('renders webhooks sorted alphabetically by display name', async () => {
+        renderWithContext(
+            <InstalledIncomingWebhooks {...defaultProps} />,
+            initialState,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Alpha Webhook')).toBeInTheDocument();
+        });
+
+        const items = screen.getAllByText(/Webhook/);
+        const names = items.map((el) => el.textContent);
+
+        const alphaIdx = names.findIndex((n) => n?.includes('Alpha'));
+        const bravoIdx = names.findIndex((n) => n?.includes('Bravo'));
+        const charlieIdx = names.findIndex((n) => n?.includes('Charlie'));
+
+        expect(alphaIdx).toBeLessThan(bravoIdx);
+        expect(bravoIdx).toBeLessThan(charlieIdx);
+    });
+
+    test('does not mutate the incomingHooks prop array when sorting', async () => {
+        const hooks: IncomingWebhook[] = [hookAlpha, hookCharlie, hookBravo];
+        const originalOrder = hooks.map((h) => h.id);
+
+        const props = {...defaultProps, incomingHooks: hooks};
+
+        renderWithContext(
+            <InstalledIncomingWebhooks {...props} />,
+            initialState,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Alpha Webhook')).toBeInTheDocument();
+        });
+
+        // The original array passed as prop must not be mutated by the sort
+        expect(hooks.map((h) => h.id)).toEqual(originalOrder);
+    });
+
+    test('compares hooks with missing display_name symmetrically using channel name fallback', async () => {
+        const noNameHookA: IncomingWebhook = TestHelper.getIncomingWebhookMock({
+            id: 'hook-no-name-a',
+            display_name: '',
+            channel_id: 'channelId',
+            team_id: 'teamId',
+            user_id: 'userId',
+        });
+        const namedHook: IncomingWebhook = TestHelper.getIncomingWebhookMock({
+            id: 'hook-named',
+            display_name: 'Zeta Webhook',
+            channel_id: 'channelId',
+            team_id: 'teamId',
+            user_id: 'userId',
+        });
+
+        // channel display_name is "Town Square" — this should sort before "Zeta Webhook"
+        const props = {
+            ...defaultProps,
+            incomingHooks: [namedHook, noNameHookA],
+            incomingHooksTotalCount: 2,
+        };
+
+        renderWithContext(
+            <InstalledIncomingWebhooks {...props} />,
+            initialState,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText('Zeta Webhook')).toBeInTheDocument();
+        });
+
+        // "Town Square" (channel fallback) < "Zeta Webhook" alphabetically
+        const townSquareEl = screen.getByText('Town Square');
+        const zetaEl = screen.getByText('Zeta Webhook');
+
+        expect(townSquareEl).toBeInTheDocument();
+        expect(zetaEl).toBeInTheDocument();
+
+        // Verify DOM order: Town Square should come before Zeta Webhook
+        const position = townSquareEl.compareDocumentPosition(zetaEl);
+        expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+});

--- a/webapp/channels/src/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.test.tsx
+++ b/webapp/channels/src/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.test.tsx
@@ -11,14 +11,6 @@ import InstalledIncomingWebhooks from 'components/integrations/installed_incomin
 import {renderWithContext} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';
 
-jest.mock('components/integrations/delete_integration_link', () => {
-    const ReactMock = require('react'); // eslint-disable-line @typescript-eslint/no-var-requires, global-require
-    return {
-        __esModule: true,
-        default: (props: {onDelete: () => void}) => ReactMock.createElement('button', {onClick: props.onDelete}, 'Delete'),
-    };
-});
-
 describe('components/integrations/InstalledIncomingWebhooks', () => {
     const team = TestHelper.getTeamMock({id: 'teamId', name: 'test'});
     const user = TestHelper.getUserMock({id: 'userId'});
@@ -67,7 +59,7 @@ describe('components/integrations/InstalledIncomingWebhooks', () => {
         enableIncomingWebhooks: true,
         actions: {
             removeIncomingHook: jest.fn(),
-            loadIncomingHooksAndProfilesForTeam: jest.fn().mockResolvedValue({data: []}),
+            loadIncomingHooksAndProfilesForTeam: jest.fn().mockReturnValue(Promise.resolve()),
         },
     };
 
@@ -116,8 +108,8 @@ describe('components/integrations/InstalledIncomingWebhooks', () => {
     });
 
     test('compares hooks with missing display_name symmetrically using channel name fallback', async () => {
-        const noNameHookA: IncomingWebhook = TestHelper.getIncomingWebhookMock({
-            id: 'hook-no-name-a',
+        const noNameHook: IncomingWebhook = TestHelper.getIncomingWebhookMock({
+            id: 'hook-no-name',
             display_name: '',
             channel_id: 'channelId',
             team_id: 'teamId',
@@ -131,10 +123,10 @@ describe('components/integrations/InstalledIncomingWebhooks', () => {
             user_id: 'userId',
         });
 
-        // channel display_name is "Town Square" — this should sort before "Zeta Webhook"
+        // channel display_name is "Town Square" which sorts before "Zeta Webhook"
         const props = {
             ...defaultProps,
-            incomingHooks: [namedHook, noNameHookA],
+            incomingHooks: [namedHook, noNameHook],
             incomingHooksTotalCount: 2,
         };
 
@@ -149,14 +141,13 @@ describe('components/integrations/InstalledIncomingWebhooks', () => {
             expect(screen.getByText('Zeta Webhook')).toBeInTheDocument();
         });
 
-        // "Town Square" (channel fallback) < "Zeta Webhook" alphabetically
         const townSquareEl = screen.getByText('Town Square');
         const zetaEl = screen.getByText('Zeta Webhook');
 
         expect(townSquareEl).toBeInTheDocument();
         expect(zetaEl).toBeInTheDocument();
 
-        // Verify DOM order: Town Square should come before Zeta Webhook
+        // Verify DOM order: Town Square (channel fallback) should appear before Zeta Webhook
         const position = townSquareEl.compareDocumentPosition(zetaEl);
         expect(position & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
     });

--- a/webapp/channels/src/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.test.tsx
+++ b/webapp/channels/src/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.test.tsx
@@ -73,7 +73,9 @@ describe('components/integrations/InstalledIncomingWebhooks', () => {
 
     test('renders webhooks sorted alphabetically by display name', async () => {
         renderWithContext(
-            <InstalledIncomingWebhooks {...defaultProps} />,
+            <InstalledIncomingWebhooks
+                {...defaultProps}
+            />,
             initialState,
         );
 
@@ -99,7 +101,9 @@ describe('components/integrations/InstalledIncomingWebhooks', () => {
         const props = {...defaultProps, incomingHooks: hooks};
 
         renderWithContext(
-            <InstalledIncomingWebhooks {...props} />,
+            <InstalledIncomingWebhooks
+                {...props}
+            />,
             initialState,
         );
 
@@ -135,7 +139,9 @@ describe('components/integrations/InstalledIncomingWebhooks', () => {
         };
 
         renderWithContext(
-            <InstalledIncomingWebhooks {...props} />,
+            <InstalledIncomingWebhooks
+                {...props}
+            />,
             initialState,
         );
 

--- a/webapp/channels/src/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.tsx
+++ b/webapp/channels/src/components/integrations/installed_incoming_webhooks/installed_incoming_webhooks.tsx
@@ -95,11 +95,20 @@ export default class InstalledIncomingWebhooks extends React.PureComponent<Props
             }
         }
 
-        const displayNameB = b.display_name;
+        let displayNameB = b.display_name;
+        if (!displayNameB) {
+            const channelB = this.props.channels[b.channel_id];
+            if (channelB) {
+                displayNameB = channelB.display_name;
+            } else {
+                displayNameB = Utils.localizeMessage({id: 'installed_incoming_webhooks.unknown_channel', defaultMessage: 'A Private Webhook'});
+            }
+        }
+
         return displayNameA.localeCompare(displayNameB);
     };
 
-    incomingWebhooks = (filter: string) => this.props.incomingHooks.
+    incomingWebhooks = (filter: string) => [...this.props.incomingHooks].
         sort(this.incomingWebhookCompare).
         filter((incomingWebhook: IncomingWebhook) => matchesFilter(incomingWebhook, this.props.channels[incomingWebhook.channel_id], filter)).
         map((incomingWebhook: IncomingWebhook) => {

--- a/webapp/channels/src/components/integrations/installed_outgoing_webhooks/installed_outgoing_webhooks.tsx
+++ b/webapp/channels/src/components/integrations/installed_outgoing_webhooks/installed_outgoing_webhooks.tsx
@@ -136,7 +136,7 @@ export default class InstalledOutgoingWebhooks extends React.PureComponent<Props
         return displayNameA.localeCompare(displayNameB);
     };
 
-    outgoingWebhooks = (filter: string) => this.props.outgoingWebhooks.
+    outgoingWebhooks = (filter: string) => [...this.props.outgoingWebhooks].
         sort(this.outgoingWebhookCompare).
         filter((outgoingWebhook) => matchesFilter(outgoingWebhook, this.props.channels[outgoingWebhook.channel_id], filter)).
         map((outgoingWebhook) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Fixes the ordering instability in the Incoming Webhooks view where entries appeared sorted by date-added on initial load, then re-sorted alphabetically after loading additional pages (and navigating back).

**Root causes fixed:**
1. **Server (SQL):** All five paginated webhook listing functions (`GetIncomingByTeamByUser`, `GetIncomingListByUser`, `GetOutgoingByTeamByUser`, `GetOutgoingListByUser`, `GetOutgoingByChannelByUser`) had no `ORDER BY` clause. The database returned rows in heap/insertion order, not alphabetical order.
2. **Client (incoming webhooks comparator):** `incomingWebhookCompare` resolved the channel-name fallback for argument `a` but not for `b`, making the comparator asymmetric and the sort unstable.
3. **Client (prop mutation):** Both `InstalledIncomingWebhooks` and `InstalledOutgoingWebhooks` called `Array.prototype.sort()` directly on the props array, mutating a selector-memoised array.

**Fix:**
- Add `ORDER BY DisplayName, Id` to all five listing SQL queries so API pages always return in alphabetical order. With a stable server order, client-side re-sorting of merged pages produces the same slice for each page number regardless of how many pages have been loaded.
- Symmetrise `incomingWebhookCompare` so the channel-name and "A Private Webhook" fallback is applied to `b` as well as `a`.
- Sort a copy (`[...hooks].sort(...)`) in both webhook list components so the original prop arrays are never mutated.

**QA steps:**
1. Create more than 200 incoming webhooks on a team (or use an existing instance with many webhooks).
2. Navigate to **Integrations → Incoming Webhooks**.
3. Note the list on page 1 — all entries should be sorted alphabetically.
4. Click **Next** to go to page 2.
5. Click **Previous** to return to page 1.
6. Confirm the list on page 1 shows the same alphabetically-sorted entries as in step 3.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-65732

#### Screenshots

**Before fix** — the bottom of page 1 changes after navigating to page 2 and back (ends with Whale/Xenial/Yak/Zebra before, then Webhook 72-78 after):
<a href="https://cursor.com/agents/bc-74a63a4f-9365-4fcf-a1ad-4494eabfd4cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwebhook_ordering_before_fix.mp4"><img src="https://cursor.com/artifacts/c/art-f81c9697-59ae-42b5-94eb-d15b5b884bbb" alt="webhook_ordering_before_fix.mp4" /></a>

**After fix** — page 1 is stable; the same items appear at the bottom before and after navigating to page 2:
<a href="https://cursor.com/agents/bc-74a63a4f-9365-4fcf-a1ad-4494eabfd4cc/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwebhook_ordering_after_fix_pagination.mp4"><img src="https://cursor.com/artifacts/c/art-35697fd5-6107-4e2d-a235-05c4a85ad329" alt="webhook_ordering_after_fix_pagination.mp4" /></a>

#### Release Note
```release-note
Fixed an issue where the Incoming Webhooks list reordered entries between page navigations.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-74a63a4f-9365-4fcf-a1ad-4494eabfd4cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-74a63a4f-9365-4fcf-a1ad-4494eabfd4cc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes touch webhook listing queries across multiple code paths (5 SQL functions) and modify sorting behavior in two React components. While the fixes are targeted at ordering determinism and the test coverage is comprehensive, there is moderate risk of unexpected ordering changes affecting dependent features or integrations relying on webhook list ordering.

**QA Recommendation:** Manual QA should focus on webhook pagination workflows: verify alphabetical ordering is consistent across pagination, test scenarios where webhooks lack display names (channel fallback), and verify no UI regressions in webhook list rendering. Automated test coverage appears sufficient for the core ordering logic.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36470)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->