### PR TITLE
ci: gate flaky PR comments on recovered retries only

### DIFF
--- a/.github/workflows/server-ci-report.yml
+++ b/.github/workflows/server-ci-report.yml
@@ -109,14 +109,14 @@ jobs:
 
       - name: Report retried tests (pull request)
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
-        if: ${{ steps.report.outputs.flaky_summary != '<table><tr><th>Test</th><th>Retries</th></tr></table>' && github.event.workflow_run.event == 'pull_request' }}
+        if: ${{ steps.report.outputs.flaky_summary != '<table><tr><th>Test</th><th>Retries</th></tr></table>' && steps.report.outputs.failed == '0' && github.event.workflow_run.event == 'pull_request' }}
         env:
           TEST_NAME: "${{ matrix.test.name }}"
           FLAKY_SUMMARY: "${{ steps.report.outputs.flaky_summary }}"
           PR_NUMBER: "${{ steps.incoming-pr.outputs.NUMBER }}"
         with:
           script: |
-            const body = `#### ⚠️  One or more flaky tests detected ⚠️\n* Failing job: [github.com/mattermost/mattermost:${process.env.TEST_NAME}](${{ github.event.workflow_run.html_url }})\n* Double check your code to ensure you haven't introduced a flaky test.\n* If this seems to be unrelated to your changes, submit a separate pull request to skip the flaky tests (e.g. [23360](https://github.com/mattermost/mattermost/pull/23360)) and file JIRA ticket (e.g. [MM-52743](https://mattermost.atlassian.net/browse/MM-52743)) for later investigation.\n\n${process.env.FLAKY_SUMMARY}`
+            const body = `#### ⚠️  One or more flaky tests detected ⚠️\n* Workflow run: [github.com/mattermost/mattermost:${process.env.TEST_NAME}](${{ github.event.workflow_run.html_url }})\n* Double check your code to ensure you have not introduced a flaky test.\n\n${process.env.FLAKY_SUMMARY}`
 
             await github.rest.issues.createComment({
               issue_number: process.env.PR_NUMBER,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

`mikepenz/action-junit-report` made a change starting v6.1+ where `retries` in the report includes also retries for tests that never pass and should be considered failures. This is causing unnecessary noise around flaky tests where failures will just surface with the pipeline failure directly. 

This PR now adds an extra condition to check for  zero merged failures (`failed == 0`) besides the existing check of non-empty flaky summary. That matches tests that retried and ultimately passed after `check_retries` merging, and excludes runs where every retry failed.

A side effect would be that when failures happen and there are flaky tests as well in the same run, it would not be reported until a green pass. This would be acceptable in order to reduce noise from regular failures and eventually needs a green run where it can surface. 

**Post Comment text change:**
The comment body no longer tells contributors to open a skip PR or JIRA ticket to retire this manual process (currently not followed) in favor of an automation (in progress). 

**Note:**
Because this workflow is triggered by `workflow_run`, the updated behavior is exercised from the default branch after this PR is merged, not from the PR that introduces the change.

#### Release Note
```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2bf4b355-ab73-48f0-a712-7e927f5697a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2bf4b355-ab73-48f0-a712-7e927f5697a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This change is isolated to CI/CD workflow reporting logic and adds a gating condition (`failed == '0'`) to prevent flaky-test comments when tests have unresolved failures. The risk of regression is minimal since it only affects when PR comments are posted and doesn't modify any core application code, data handling, or test execution logic itself. The update addresses a change in `mikepenz/action-junit-report` behavior with a narrower, more accurate trigger condition.

**QA Recommendation:** No manual QA required. This is a workflow configuration change affecting only CI reporting comments. Automated CI testing will naturally validate the behavior as PRs are run post-merge on the default branch (as noted, changes to this workflow take effect after merge, not from this PR).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->