### PR TITLE
[MM-68405] MBE Phase 6: fire MessagesWillBeConsumed on the edit path

### DIFF
--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -6,6 +6,7 @@ package app
 import (
 	"bytes"
 	_ "embed"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -1797,6 +1798,171 @@ func TestHookMessagesWillBeConsumed(t *testing.T) {
 		require.Nil(t, err)
 		assert.Equal(t, "mwbc_plugin:message", post.Message)
 	})
+}
+
+func TestUpdatePostFiresConsumeHook(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	th := SetupConfig(t, func(cfg *model.Config) {
+		cfg.FeatureFlags.ConsumePostHook = true
+	}).InitBasic(t)
+
+	var mockAPI plugintest.API
+	mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
+	mockAPI.On("LogDebug", mock.Anything).Return(nil)
+
+	tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{`
+		package main
+
+		import (
+			"strings"
+
+			"github.com/mattermost/mattermost/server/public/plugin"
+			"github.com/mattermost/mattermost/server/public/model"
+		)
+
+		type MyPlugin struct {
+			plugin.MattermostPlugin
+		}
+
+		func (p *MyPlugin) MessagesWillBeConsumed(posts []*model.Post) []*model.Post {
+			for _, post := range posts {
+				post.Message = strings.ToUpper(post.Message)
+			}
+			return posts
+		}
+
+		func main() {
+			plugin.ClientMain(&MyPlugin{})
+		}
+	`}, th.App, func(*model.Manifest) plugin.API { return &mockAPI })
+	t.Cleanup(tearDown)
+
+	wsMessages, closeWS := connectFakeWebSocket(t, th, th.BasicUser.Id, "", []model.WebsocketEventType{
+		model.WebsocketEventPosted,
+		model.WebsocketEventPostEdited,
+	})
+	defer closeWS()
+
+	basePost, _, err := th.App.CreatePost(th.Context, &model.Post{
+		UserId:    th.BasicUser.Id,
+		ChannelId: th.BasicChannel.Id,
+		Message:   "original body",
+	}, th.BasicChannel, model.CreatePostFlags{SetOnline: false})
+	require.Nil(t, err)
+
+	drainTimeout := time.After(500 * time.Millisecond)
+drainLoop:
+	for {
+		select {
+		case <-wsMessages:
+		case <-drainTimeout:
+			break drainLoop
+		}
+	}
+
+	editedMessage := "edited body"
+	patchedPost, _, err := th.App.PatchPost(th.Context, basePost.Id, &model.PostPatch{
+		Message: &editedMessage,
+	}, nil)
+	require.Nil(t, err)
+
+	require.Equal(t, "EDITED BODY", patchedPost.Message)
+
+	timeout := time.After(5 * time.Second)
+	for {
+		select {
+		case ev := <-wsMessages:
+			if ev.EventType() != model.WebsocketEventPostEdited {
+				continue
+			}
+			postJSON, ok := ev.GetData()["post"].(string)
+			require.True(t, ok, "post field in websocket event should be a JSON string")
+			var wsPost model.Post
+			require.NoError(t, json.Unmarshal([]byte(postJSON), &wsPost))
+			assert.Equal(t, "EDITED BODY", wsPost.Message)
+			return
+		case <-timeout:
+			require.Fail(t, "timed out waiting for post_edited websocket event")
+		}
+	}
+}
+
+func TestUpdatePostNoConsumeHookWhenFlagDisabled(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	th := SetupConfig(t, func(cfg *model.Config) {
+		cfg.FeatureFlags.ConsumePostHook = false
+	}).InitBasic(t)
+
+	var mockAPI plugintest.API
+	mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
+	mockAPI.On("LogDebug", mock.Anything).Return(nil)
+
+	tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{`
+		package main
+
+		import (
+			"strings"
+
+			"github.com/mattermost/mattermost/server/public/plugin"
+			"github.com/mattermost/mattermost/server/public/model"
+		)
+
+		type MyPlugin struct {
+			plugin.MattermostPlugin
+		}
+
+		func (p *MyPlugin) MessagesWillBeConsumed(posts []*model.Post) []*model.Post {
+			for _, post := range posts {
+				post.Message = strings.ToUpper(post.Message)
+			}
+			return posts
+		}
+
+		func main() {
+			plugin.ClientMain(&MyPlugin{})
+		}
+	`}, th.App, func(*model.Manifest) plugin.API { return &mockAPI })
+	t.Cleanup(tearDown)
+
+	basePost, _, err := th.App.CreatePost(th.Context, &model.Post{
+		UserId:    th.BasicUser.Id,
+		ChannelId: th.BasicChannel.Id,
+		Message:   "original body",
+	}, th.BasicChannel, model.CreatePostFlags{SetOnline: false})
+	require.Nil(t, err)
+
+	editedMessage := "edited body"
+	patchedPost, _, err := th.App.PatchPost(th.Context, basePost.Id, &model.PostPatch{
+		Message: &editedMessage,
+	}, nil)
+	require.Nil(t, err)
+
+	assert.Equal(t, "edited body", patchedPost.Message)
+}
+
+func TestUpdatePostNoOpWhenNoPlugin(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	th := SetupConfig(t, func(cfg *model.Config) {
+		cfg.FeatureFlags.ConsumePostHook = true
+	}).InitBasic(t)
+
+	basePost, _, err := th.App.CreatePost(th.Context, &model.Post{
+		UserId:    th.BasicUser.Id,
+		ChannelId: th.BasicChannel.Id,
+		Message:   "original body",
+	}, th.BasicChannel, model.CreatePostFlags{SetOnline: false})
+	require.Nil(t, err)
+
+	editedMessage := "edited body"
+	patchedPost, _, err := th.App.PatchPost(th.Context, basePost.Id, &model.PostPatch{
+		Message: &editedMessage,
+	}, nil)
+	require.Nil(t, err)
+
+	assert.Equal(t, "edited body", patchedPost.Message)
 }
 
 func TestHookPreferencesHaveChanged(t *testing.T) {

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -930,6 +930,8 @@ func (a *App) UpdatePost(rctx request.CTX, receivedUpdatedPost *model.Post, upda
 		}
 	}
 
+	a.applyPostWillBeConsumedHook(&rpost)
+
 	message := model.NewWebSocketEvent(model.WebsocketEventPostEdited, "", rpost.ChannelId, "", nil, "")
 
 	appErr = a.publishWebsocketEventForPost(rctx, rpost, message)


### PR DESCRIPTION
#### Summary

Phase 6 fixes `app.UpdatePost`, so it now does what `app.CreatePost` does for the `MessagesWillBeConsumed` plugin hook: today the hook fires on create but not on edit, so any plugin transforming `Message` (the CME placeholder→plaintext swap, but also the public auto-translation use case) sees the create path but is silently skipped on the edit path. 

The hook is documented as firing "before it is returned to the client." Delivering the edited post to the editor via HTTP response and to channel members via websocket is delivery to a client. I'm assuming that the prior omission was an oversight, not intentional design. We'll have to document this for existing plugins that may be using the `MessagesWillBeConsumed` hook, but they shouldn't be surprised since it's now doing what it says it should be doing.

Companion plugin PR: https://github.com/mattermost/message-based-encryption/pull/8

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68405

#### Release Note

```release-note
The `MessagesWillBeConsumed` plugin hook now fires on the edit path in addition to the create path, making `UpdatePost` symmetric with `CreatePost`. Plugins implementing the hook will see their `Message` transformations applied to the editor's HTTP response and the `post_edited` websocket event. This aligns the runtime behavior with the documented contract ("before it is returned to the client"); plugins relying on the prior edit-path no-op may observe a behavior change.
```