### PR TITLE
MM-68705 - Order-tolerant Shared Channel plugin API's for receiving attachments

### DIFF
--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -503,6 +503,12 @@ func (a *App) attachFilesToPost(rctx request.CTX, post *model.Post, fileIDs mode
 	attachedIds := a.attachFileIDsToPost(rctx, post.Id, post.ChannelId, post.UserId, fileIDs)
 
 	if len(fileIDs) != len(attachedIds) {
+		// Remote-origin posts have a concurrent file-receive path that
+		// performs its own binding; stripping here can clobber a binding
+		// that path just made.
+		if post.GetRemoteID() != "" {
+			return fileIDs, nil
+		}
 		post.FileIds = attachedIds
 		if _, err := a.Srv().Store().Post().Overwrite(rctx, post); err != nil {
 			return nil, model.NewAppError("attachFilesToPost", "app.post.overwrite.app_error", nil, "", http.StatusInternalServerError).Wrap(err)

--- a/server/channels/app/shared_channel.go
+++ b/server/channels/app/shared_channel.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"slices"
 	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -371,38 +370,17 @@ func (a *App) ReceiveSharedChannelAttachmentSyncMsg(rctx request.CTX, pluginID, 
 		return nil, fmt.Errorf("error uploading attachment data: %w", appErr)
 	}
 
-	// Lazy-bind the file to its post. The plugin API does not require
-	// post-then-file or file-then-post ordering between
-	// ReceiveSharedChannelSyncMsg and ReceiveSharedChannelAttachmentSyncMsg.
-	// Heal the post-then-file ordering case here: CreatePost will have
-	// stripped the unmatched file id from Post.FileIds when it ran ahead
-	// of the file's arrival, so re-bind the file and restore the id.
-	// In the file-then-post ordering case (post not yet present), leave
-	// the FileInfo unbound so the eventual post arrival's CreatePost ->
-	// attachFilesToPost can bind it. AttachToPost is a blind UPDATE that
-	// does not validate post existence, so it must only run after the
-	// post has been confirmed to exist; otherwise the FileInfo would be
-	// pointed at a non-existent post and the later attachFilesToPost
-	// call would skip it.
+	// Bind the FileInfo to its post. AttachToPost is atomic against the
+	// post-receive path's parallel call for the same id, so whichever
+	// arrives second sees PostId already set and is a no-op. The
+	// post-receive path does not strip unmatched FileIds for remote-origin
+	// posts, so Post.FileIds does not need to be touched here.
 	if fi.PostId != "" {
-		post, perr := a.Srv().Store().Post().GetSingle(rctx, fi.PostId, false)
-		if perr == nil {
-			if attachErr := a.Srv().Store().FileInfo().AttachToPost(rctx, saved.Id, fi.PostId, channelID, saved.CreatorId); attachErr == nil {
-				if !slices.Contains(post.FileIds, saved.Id) {
-					post.FileIds = append(post.FileIds, saved.Id)
-					if _, oerr := a.Srv().Store().Post().Overwrite(rctx, post); oerr != nil {
-						rctx.Logger().Warn("ReceiveSharedChannelAttachmentSyncMsg: failed to overwrite post with attached file id",
-							mlog.String("post_id", fi.PostId),
-							mlog.String("file_id", saved.Id),
-							mlog.Err(oerr))
-					}
-				}
-			} else {
-				rctx.Logger().Warn("ReceiveSharedChannelAttachmentSyncMsg: failed to attach file to post",
-					mlog.String("post_id", fi.PostId),
-					mlog.String("file_id", saved.Id),
-					mlog.Err(attachErr))
-			}
+		if attachErr := a.Srv().Store().FileInfo().AttachToPost(rctx, saved.Id, fi.PostId, channelID, saved.CreatorId); attachErr != nil {
+			rctx.Logger().Debug("ReceiveSharedChannelAttachmentSyncMsg: AttachToPost did not bind",
+				mlog.String("post_id", fi.PostId),
+				mlog.String("file_id", saved.Id),
+				mlog.Err(attachErr))
 		}
 	}
 

--- a/server/channels/app/shared_channel.go
+++ b/server/channels/app/shared_channel.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -330,6 +331,23 @@ func (a *App) ReceiveSharedChannelAttachmentSyncMsg(rctx request.CTX, pluginID, 
 			map[string]any{"channelId": channelID}, "", http.StatusRequestEntityTooLarge)
 	}
 
+	// Idempotency: if a FileInfo with the sender's id already exists for
+	// this channel and creator, this is a retry of a previously successful
+	// receive (e.g. caller re-delivered the same payload after a transient
+	// ack failure). Return the existing record rather than insert a
+	// duplicate (which would violate the FileInfo PK and force the caller
+	// to retry indefinitely).
+	if fi.Id != "" {
+		if existing, getErr := a.Srv().Store().FileInfo().Get(fi.Id); getErr == nil {
+			if existing.ChannelId == channelID && existing.CreatorId == fi.CreatorId {
+				return existing, nil
+			}
+			return nil, fmt.Errorf("file %s already exists under different channel/creator", fi.Id)
+		} else if !isNotFoundError(getErr) {
+			return nil, fmt.Errorf("error checking for existing file %s: %w", fi.Id, getErr)
+		}
+	}
+
 	// Create an upload session — this constructs the file path server-side
 	us := &model.UploadSession{
 		Id:        model.NewId(),
@@ -351,6 +369,41 @@ func (a *App) ReceiveSharedChannelAttachmentSyncMsg(rctx request.CTX, pluginID, 
 	saved, appErr := a.UploadData(rctx, us, data)
 	if appErr != nil {
 		return nil, fmt.Errorf("error uploading attachment data: %w", appErr)
+	}
+
+	// Lazy-bind the file to its post. The plugin API does not require
+	// post-then-file or file-then-post ordering between
+	// ReceiveSharedChannelSyncMsg and ReceiveSharedChannelAttachmentSyncMsg.
+	// Heal the post-then-file ordering case here: CreatePost will have
+	// stripped the unmatched file id from Post.FileIds when it ran ahead
+	// of the file's arrival, so re-bind the file and restore the id.
+	// In the file-then-post ordering case (post not yet present), leave
+	// the FileInfo unbound so the eventual post arrival's CreatePost ->
+	// attachFilesToPost can bind it. AttachToPost is a blind UPDATE that
+	// does not validate post existence, so it must only run after the
+	// post has been confirmed to exist; otherwise the FileInfo would be
+	// pointed at a non-existent post and the later attachFilesToPost
+	// call would skip it.
+	if fi.PostId != "" {
+		post, perr := a.Srv().Store().Post().GetSingle(rctx, fi.PostId, false)
+		if perr == nil {
+			if attachErr := a.Srv().Store().FileInfo().AttachToPost(rctx, saved.Id, fi.PostId, channelID, saved.CreatorId); attachErr == nil {
+				if !slices.Contains(post.FileIds, saved.Id) {
+					post.FileIds = append(post.FileIds, saved.Id)
+					if _, oerr := a.Srv().Store().Post().Overwrite(rctx, post); oerr != nil {
+						rctx.Logger().Warn("ReceiveSharedChannelAttachmentSyncMsg: failed to overwrite post with attached file id",
+							mlog.String("post_id", fi.PostId),
+							mlog.String("file_id", saved.Id),
+							mlog.Err(oerr))
+					}
+				}
+			} else {
+				rctx.Logger().Warn("ReceiveSharedChannelAttachmentSyncMsg: failed to attach file to post",
+					mlog.String("post_id", fi.PostId),
+					mlog.String("file_id", saved.Id),
+					mlog.Err(attachErr))
+			}
+		}
 	}
 
 	// Save a SharedChannelAttachment record for cursor tracking

--- a/server/channels/app/shared_channel.go
+++ b/server/channels/app/shared_channel.go
@@ -333,41 +333,46 @@ func (a *App) ReceiveSharedChannelAttachmentSyncMsg(rctx request.CTX, pluginID, 
 	// Idempotency: if a FileInfo with the sender's id already exists for
 	// this channel and creator, this is a retry of a previously successful
 	// receive (e.g. caller re-delivered the same payload after a transient
-	// ack failure). Return the existing record rather than insert a
-	// duplicate (which would violate the FileInfo PK and force the caller
-	// to retry indefinitely).
+	// ack failure). Reuse the existing record rather than insert a duplicate
+	// (which would violate the FileInfo PK and force the caller to retry
+	// indefinitely). The bind/upsert tail still runs below so that a partial
+	// prior receive (FileInfo persisted but lazy-bind or attachment record
+	// never committed) self-heals on retry.
+	var saved *model.FileInfo
 	if fi.Id != "" {
 		if existing, getErr := a.Srv().Store().FileInfo().Get(fi.Id); getErr == nil {
-			if existing.ChannelId == channelID && existing.CreatorId == fi.CreatorId {
-				return existing, nil
+			if existing.ChannelId != channelID || existing.CreatorId != fi.CreatorId {
+				return nil, fmt.Errorf("file %s already exists under different channel/creator", fi.Id)
 			}
-			return nil, fmt.Errorf("file %s already exists under different channel/creator", fi.Id)
+			saved = existing
 		} else if !isNotFoundError(getErr) {
 			return nil, fmt.Errorf("error checking for existing file %s: %w", fi.Id, getErr)
 		}
 	}
 
-	// Create an upload session — this constructs the file path server-side
-	us := &model.UploadSession{
-		Id:        model.NewId(),
-		Type:      model.UploadTypeAttachment,
-		UserId:    fi.CreatorId,
-		ChannelId: channelID,
-		Filename:  fi.Name,
-		FileSize:  fi.Size,
-		RemoteId:  rc.RemoteId,
-		ReqFileId: fi.Id,
-	}
+	if saved == nil {
+		// Create an upload session, which constructs the file path server-side.
+		us := &model.UploadSession{
+			Id:        model.NewId(),
+			Type:      model.UploadTypeAttachment,
+			UserId:    fi.CreatorId,
+			ChannelId: channelID,
+			Filename:  fi.Name,
+			FileSize:  fi.Size,
+			RemoteId:  rc.RemoteId,
+			ReqFileId: fi.Id,
+		}
 
-	us, appErr := a.CreateUploadSession(rctx, us)
-	if appErr != nil {
-		return nil, fmt.Errorf("error creating upload session: %w", appErr)
-	}
+		var appErr *model.AppError
+		us, appErr = a.CreateUploadSession(rctx, us)
+		if appErr != nil {
+			return nil, fmt.Errorf("error creating upload session: %w", appErr)
+		}
 
-	// Upload the file data through the standard upload path
-	saved, appErr := a.UploadData(rctx, us, data)
-	if appErr != nil {
-		return nil, fmt.Errorf("error uploading attachment data: %w", appErr)
+		saved, appErr = a.UploadData(rctx, us, data)
+		if appErr != nil {
+			return nil, fmt.Errorf("error uploading attachment data: %w", appErr)
+		}
 	}
 
 	// Bind the FileInfo to its post. AttachToPost is atomic against the
@@ -375,8 +380,25 @@ func (a *App) ReceiveSharedChannelAttachmentSyncMsg(rctx request.CTX, pluginID, 
 	// arrives second sees PostId already set and is a no-op. The
 	// post-receive path does not strip unmatched FileIds for remote-origin
 	// posts, so Post.FileIds does not need to be touched here.
+	//
+	// On a successful bind, publish a post_edited event so connected clients
+	// re-render the post with the now-resolvable attachment without needing
+	// a channel reload. The event is skipped when the post is not yet
+	// present (file-then-post ordering): the post-receive path will publish
+	// its own posted event with correct metadata once it arrives.
 	if fi.PostId != "" {
-		if attachErr := a.Srv().Store().FileInfo().AttachToPost(rctx, saved.Id, fi.PostId, channelID, saved.CreatorId); attachErr != nil {
+		if attachErr := a.Srv().Store().FileInfo().AttachToPost(rctx, saved.Id, fi.PostId, channelID, saved.CreatorId); attachErr == nil {
+			if post, perr := a.Srv().Store().Post().GetSingle(rctx, fi.PostId, false); perr == nil {
+				preparedPost := a.PreparePostForClient(rctx, post, &model.PreparePostForClientOpts{})
+				message := model.NewWebSocketEvent(model.WebsocketEventPostEdited, "", channelID, "", nil, "")
+				if pubErr := a.publishWebsocketEventForPost(rctx, preparedPost, message); pubErr != nil {
+					rctx.Logger().Warn("ReceiveSharedChannelAttachmentSyncMsg: failed to publish post_edited event",
+						mlog.String("post_id", fi.PostId),
+						mlog.String("file_id", saved.Id),
+						mlog.Err(pubErr))
+				}
+			}
+		} else {
 			rctx.Logger().Debug("ReceiveSharedChannelAttachmentSyncMsg: AttachToPost did not bind",
 				mlog.String("post_id", fi.PostId),
 				mlog.String("file_id", saved.Id),

--- a/server/channels/app/shared_channel_test.go
+++ b/server/channels/app/shared_channel_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"text/template"
 
@@ -1448,16 +1449,13 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsgOrderTolerance(t *testing
 		fileID := model.NewId()
 
 		// Post arrives first carrying FileIds=[fileID]; FileInfo does not
-		// exist yet, so CreatePost strips fileID from Post.FileIds.
+		// exist yet, but the remote-origin path preserves FileIds.
 		syncPostWithFileIds(t, postID, user.Id, []string{fileID})
 
-		// Confirm the strip happened (sanity check on the pre-condition
-		// that motivates the lazy-bind).
-		stripped, appErr := th.App.GetSinglePost(th.Context, postID, false)
+		preFile, appErr := th.App.GetSinglePost(th.Context, postID, false)
 		require.Nil(t, appErr)
-		assert.NotContains(t, stripped.FileIds, fileID, "CreatePost should strip unmatched file id")
+		assert.Contains(t, preFile.FileIds, fileID, "remote-origin posts must preserve unmatched FileIds")
 
-		// File arrives second; lazy-bind should restore the binding.
 		fi := &model.FileInfo{
 			Id:        fileID,
 			CreatorId: user.Id,
@@ -1469,10 +1467,9 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsgOrderTolerance(t *testing
 		require.NoError(t, err)
 		require.NotNil(t, saved)
 
-		// End state: Post.FileIds contains fileID, FileInfo.PostId references the post.
 		post, appErr := th.App.GetSinglePost(th.Context, postID, false)
 		require.Nil(t, appErr)
-		assert.Contains(t, post.FileIds, fileID, "lazy-bind should restore stripped file id")
+		assert.Contains(t, post.FileIds, fileID)
 
 		storedFI, appErr := th.App.GetFileInfo(th.Context, fileID)
 		require.Nil(t, appErr)
@@ -1485,9 +1482,10 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsgOrderTolerance(t *testing
 		postID := model.NewId()
 		fileID := model.NewId()
 
-		// File arrives first; the post does not exist yet, so the lazy-bind
-		// is a no-op and the FileInfo's PostId stays empty (so the eventual
-		// post arrival can bind it).
+		// File arrives first. The lazy-bind eagerly sets FileInfo.PostId
+		// even though the post is not yet present; the post-receive path
+		// preserves FileIds for remote-origin posts, so the post's later
+		// arrival converges without overwriting either side.
 		fi := &model.FileInfo{
 			Id:        fileID,
 			CreatorId: user.Id,
@@ -1499,17 +1497,11 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsgOrderTolerance(t *testing
 		require.NoError(t, err)
 		require.NotNil(t, saved)
 
-		preBindFI, appErr := th.App.GetFileInfo(th.Context, fileID)
-		require.Nil(t, appErr)
-		assert.Empty(t, preBindFI.PostId, "FileInfo must not be bound when post does not exist yet")
-
-		// Post arrives second; CreatePost -> attachFilesToPost binds the file.
 		syncPostWithFileIds(t, postID, user.Id, []string{fileID})
 
-		// End state: Post.FileIds contains fileID, FileInfo.PostId references the post.
 		post, appErr := th.App.GetSinglePost(th.Context, postID, false)
 		require.Nil(t, appErr)
-		assert.Contains(t, post.FileIds, fileID, "post-receive path should bind the already-uploaded file")
+		assert.Contains(t, post.FileIds, fileID)
 
 		storedFI, appErr := th.App.GetFileInfo(th.Context, fileID)
 		require.Nil(t, appErr)
@@ -1611,6 +1603,59 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsgOrderTolerance(t *testing
 		storedFI, appErr := th.App.GetFileInfo(th.Context, fileID)
 		require.Nil(t, appErr)
 		assert.Empty(t, storedFI.PostId, "FileInfo must not be bound to any post when fi.PostId is empty")
+	})
+
+	t.Run("concurrent post and multi-file delivery converges", func(t *testing.T) {
+		// Plugin transports (e.g. NATS post stream + JetStream object store)
+		// deliver post-receive and file-receive on independent goroutines.
+		// A barrier-synchronised launch exercises the genuinely concurrent
+		// case: post.Save, attachFilesToPost, UploadData, and the lazy-bind
+		// can all interleave. The end state must still be: Post.FileIds
+		// contains every file id, and every FileInfo has PostId/ChannelId
+		// set. Run with -race to catch unsafe sharing.
+		const fanOut = 4
+		user := createRemoteUser(t)
+		postID := model.NewId()
+		fileIDs := make([]string, fanOut)
+		for i := range fileIDs {
+			fileIDs[i] = model.NewId()
+		}
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+
+		wg.Go(func() {
+			<-start
+			syncPostWithFileIds(t, postID, user.Id, fileIDs)
+		})
+
+		for _, fid := range fileIDs {
+			wg.Go(func() {
+				<-start
+				fi := &model.FileInfo{
+					Id:        fid,
+					CreatorId: user.Id,
+					PostId:    postID,
+					Name:      "concurrent.txt",
+					Size:      4,
+				}
+				_, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+				require.NoError(t, err)
+			})
+		}
+
+		close(start)
+		wg.Wait()
+
+		post, appErr := th.App.GetSinglePost(th.Context, postID, false)
+		require.Nil(t, appErr)
+		for _, fid := range fileIDs {
+			assert.Contains(t, post.FileIds, fid, "Post.FileIds must contain every file id after concurrent delivery")
+			fi, appErr := th.App.GetFileInfo(th.Context, fid)
+			require.Nil(t, appErr)
+			assert.Equal(t, postID, fi.PostId, "FileInfo.PostId must reference the post")
+			assert.Equal(t, channel.Id, fi.ChannelId, "FileInfo.ChannelId must reference the channel")
+		}
 	})
 }
 

--- a/server/channels/app/shared_channel_test.go
+++ b/server/channels/app/shared_channel_test.go
@@ -1393,6 +1393,227 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsg(t *testing.T) {
 	})
 }
 
+// TestPluginAPIReceiveSharedChannelAttachmentSyncMsgOrderTolerance covers MM-68705:
+// the file-receive API must produce the same end state regardless of whether the
+// post or the file arrives first, and must be idempotent against re-delivery.
+func TestPluginAPIReceiveSharedChannelAttachmentSyncMsgOrderTolerance(t *testing.T) {
+	th := setupSharedChannels(t).InitBasic(t)
+
+	channel := th.CreateChannel(t, th.BasicTeam)
+	pluginID := "com.test.attachment-order-plugin"
+	rc := registerPluginRemoteForTest(t, th, pluginID, channel)
+
+	api := NewPluginAPI(th.App, th.Context, &model.Manifest{Id: pluginID})
+
+	// createRemoteUser builds a user owned by rc and inserts it directly so the
+	// test does not depend on a prior user-sync call ordering.
+	createRemoteUser := func(t *testing.T) *model.User {
+		t.Helper()
+		u := &model.User{
+			Email:    model.NewId() + "@remote.test",
+			Username: "remote-order-" + model.NewId()[:8],
+			Password: model.NewTestPassword(),
+			RemoteId: model.NewPointer(rc.RemoteId),
+		}
+		u, appErr := th.App.CreateUser(th.Context, u)
+		require.Nil(t, appErr)
+		return u
+	}
+
+	// syncPostWithFileIds sends a post via ReceiveSharedChannelSyncMsg with the
+	// given fileIDs preset on Post.FileIds. CreatePost on the receiving side
+	// will strip any fileID whose FileInfo does not yet exist.
+	syncPostWithFileIds := func(t *testing.T, postID, userID string, fileIDs []string) {
+		t.Helper()
+		msg := model.NewSyncMsg(channel.Id)
+		msg.Posts = []*model.Post{
+			{
+				Id:        postID,
+				ChannelId: channel.Id,
+				UserId:    userID,
+				Message:   "post with attachments",
+				FileIds:   fileIDs,
+				CreateAt:  model.GetMillis(),
+				RemoteId:  model.NewPointer(rc.RemoteId),
+			},
+		}
+		resp, err := api.ReceiveSharedChannelSyncMsg(rc.RemoteId, msg)
+		require.NoError(t, err)
+		assert.Empty(t, resp.PostErrors)
+	}
+
+	t.Run("post-then-file ordering binds correctly", func(t *testing.T) {
+		user := createRemoteUser(t)
+		postID := model.NewId()
+		fileID := model.NewId()
+
+		// Post arrives first carrying FileIds=[fileID]; FileInfo does not
+		// exist yet, so CreatePost strips fileID from Post.FileIds.
+		syncPostWithFileIds(t, postID, user.Id, []string{fileID})
+
+		// Confirm the strip happened (sanity check on the pre-condition
+		// that motivates the lazy-bind).
+		stripped, appErr := th.App.GetSinglePost(th.Context, postID, false)
+		require.Nil(t, appErr)
+		assert.NotContains(t, stripped.FileIds, fileID, "CreatePost should strip unmatched file id")
+
+		// File arrives second; lazy-bind should restore the binding.
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			PostId:    postID,
+			Name:      "attach.txt",
+			Size:      4,
+		}
+		saved, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+		require.NotNil(t, saved)
+
+		// End state: Post.FileIds contains fileID, FileInfo.PostId references the post.
+		post, appErr := th.App.GetSinglePost(th.Context, postID, false)
+		require.Nil(t, appErr)
+		assert.Contains(t, post.FileIds, fileID, "lazy-bind should restore stripped file id")
+
+		storedFI, appErr := th.App.GetFileInfo(th.Context, fileID)
+		require.Nil(t, appErr)
+		assert.Equal(t, postID, storedFI.PostId)
+		assert.Equal(t, channel.Id, storedFI.ChannelId)
+	})
+
+	t.Run("file-then-post ordering binds correctly", func(t *testing.T) {
+		user := createRemoteUser(t)
+		postID := model.NewId()
+		fileID := model.NewId()
+
+		// File arrives first; the post does not exist yet, so the lazy-bind
+		// is a no-op and the FileInfo's PostId stays empty (so the eventual
+		// post arrival can bind it).
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			PostId:    postID,
+			Name:      "attach.txt",
+			Size:      4,
+		}
+		saved, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+		require.NotNil(t, saved)
+
+		preBindFI, appErr := th.App.GetFileInfo(th.Context, fileID)
+		require.Nil(t, appErr)
+		assert.Empty(t, preBindFI.PostId, "FileInfo must not be bound when post does not exist yet")
+
+		// Post arrives second; CreatePost -> attachFilesToPost binds the file.
+		syncPostWithFileIds(t, postID, user.Id, []string{fileID})
+
+		// End state: Post.FileIds contains fileID, FileInfo.PostId references the post.
+		post, appErr := th.App.GetSinglePost(th.Context, postID, false)
+		require.Nil(t, appErr)
+		assert.Contains(t, post.FileIds, fileID, "post-receive path should bind the already-uploaded file")
+
+		storedFI, appErr := th.App.GetFileInfo(th.Context, fileID)
+		require.Nil(t, appErr)
+		assert.Equal(t, postID, storedFI.PostId)
+		assert.Equal(t, channel.Id, storedFI.ChannelId)
+	})
+
+	t.Run("repeated receive returns existing FileInfo without duplicate", func(t *testing.T) {
+		user := createRemoteUser(t)
+		fileID := model.NewId()
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			Name:      "retry.txt",
+			Size:      4,
+		}
+
+		first, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+		require.NotNil(t, first)
+
+		// Re-deliver with the same id, channel, and creator: must not error
+		// and must return the same FileInfo (no duplicate row, no new
+		// upload session).
+		second, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+		require.NotNil(t, second)
+		assert.Equal(t, first.Id, second.Id)
+		assert.Equal(t, first.Path, second.Path, "re-delivery must not produce a new server-side path")
+	})
+
+	t.Run("repeated receive with mismatched channel rejects", func(t *testing.T) {
+		user := createRemoteUser(t)
+		fileID := model.NewId()
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			Name:      "mismatch.txt",
+			Size:      4,
+		}
+
+		_, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+
+		// Share a second channel with the same remote and replay the same
+		// file id under the new channel; idempotency check must reject it.
+		otherChannel := th.CreateChannel(t, th.BasicTeam)
+		otherSC := &model.SharedChannel{
+			ChannelId:        otherChannel.Id,
+			TeamId:           otherChannel.TeamId,
+			Home:             true,
+			ShareName:        otherChannel.Name,
+			ShareDisplayName: otherChannel.DisplayName,
+			CreatorId:        th.BasicUser.Id,
+		}
+		_, shareErr := th.App.ShareChannel(th.Context, otherSC)
+		require.NoError(t, shareErr)
+		require.NoError(t, th.App.InviteRemoteToChannel(otherChannel.Id, rc.RemoteId, th.BasicUser.Id, false))
+
+		_, err = api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, otherChannel.Id, fi, bytes.NewReader([]byte("data")))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "different channel/creator")
+	})
+
+	t.Run("repeated receive with mismatched creator rejects", func(t *testing.T) {
+		userA := createRemoteUser(t)
+		userB := createRemoteUser(t)
+		fileID := model.NewId()
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: userA.Id,
+			Name:      "mismatch.txt",
+			Size:      4,
+		}
+
+		_, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+
+		fi.CreatorId = userB.Id
+		_, err = api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "different channel/creator")
+	})
+
+	t.Run("empty PostId is a lazy-bind no-op", func(t *testing.T) {
+		user := createRemoteUser(t)
+		fileID := model.NewId()
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			Name:      "free.txt",
+			Size:      4,
+		}
+
+		saved, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+		require.NotNil(t, saved)
+
+		storedFI, appErr := th.App.GetFileInfo(th.Context, fileID)
+		require.Nil(t, appErr)
+		assert.Empty(t, storedFI.PostId, "FileInfo must not be bound to any post when fi.PostId is empty")
+	})
+}
+
 func TestPluginAPIReceiveSharedChannelProfileImageSyncMsg(t *testing.T) {
 	th := setupSharedChannels(t).InitBasic(t)
 

--- a/server/channels/app/shared_channel_test.go
+++ b/server/channels/app/shared_channel_test.go
@@ -5,7 +5,9 @@ package app
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -14,6 +16,7 @@ import (
 	"sync"
 	"testing"
 	"text/template"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1623,10 +1626,30 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsgOrderTolerance(t *testing
 
 		var wg sync.WaitGroup
 		start := make(chan struct{})
+		errs := make(chan error, fanOut+1)
 
 		wg.Go(func() {
 			<-start
-			syncPostWithFileIds(t, postID, user.Id, fileIDs)
+			msg := model.NewSyncMsg(channel.Id)
+			msg.Posts = []*model.Post{
+				{
+					Id:        postID,
+					ChannelId: channel.Id,
+					UserId:    user.Id,
+					Message:   "post with attachments",
+					FileIds:   fileIDs,
+					CreateAt:  model.GetMillis(),
+					RemoteId:  model.NewPointer(rc.RemoteId),
+				},
+			}
+			resp, syncErr := api.ReceiveSharedChannelSyncMsg(rc.RemoteId, msg)
+			if syncErr != nil {
+				errs <- syncErr
+				return
+			}
+			if len(resp.PostErrors) > 0 {
+				errs <- fmt.Errorf("post sync returned errors: %v", resp.PostErrors)
+			}
 		})
 
 		for _, fid := range fileIDs {
@@ -1639,13 +1662,18 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsgOrderTolerance(t *testing
 					Name:      "concurrent.txt",
 					Size:      4,
 				}
-				_, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
-				require.NoError(t, err)
+				if _, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data"))); err != nil {
+					errs <- err
+				}
 			})
 		}
 
 		close(start)
 		wg.Wait()
+		close(errs)
+		for err := range errs {
+			require.NoError(t, err)
+		}
 
 		post, appErr := th.App.GetSinglePost(th.Context, postID, false)
 		require.Nil(t, appErr)
@@ -1655,6 +1683,85 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsgOrderTolerance(t *testing
 			require.Nil(t, appErr)
 			assert.Equal(t, postID, fi.PostId, "FileInfo.PostId must reference the post")
 			assert.Equal(t, channel.Id, fi.ChannelId, "FileInfo.ChannelId must reference the channel")
+		}
+	})
+
+	t.Run("post-then-file ordering publishes post_edited so clients refresh", func(t *testing.T) {
+		// In post-then-file ordering, the initial posted event carries an
+		// empty metadata.files (the FileInfo did not exist yet). The
+		// file-receive path's lazy-bind must publish a post_edited event
+		// after the bind so connected clients re-render with the new
+		// attachment without a channel reload.
+		messages, closeWS := connectFakeWebSocket(t, th, th.BasicUser.Id, "",
+			[]model.WebsocketEventType{model.WebsocketEventPostEdited})
+		defer closeWS()
+
+		user := createRemoteUser(t)
+		postID := model.NewId()
+		fileID := model.NewId()
+
+		syncPostWithFileIds(t, postID, user.Id, []string{fileID})
+
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			PostId:    postID,
+			Name:      "ws.txt",
+			Size:      4,
+		}
+		_, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+
+		select {
+		case ev := <-messages:
+			require.Equal(t, model.WebsocketEventPostEdited, ev.EventType())
+			postJSON, ok := ev.GetData()["post"].(string)
+			require.True(t, ok, "post_edited payload must include serialised post")
+			var broadcastPost model.Post
+			require.NoError(t, json.Unmarshal([]byte(postJSON), &broadcastPost))
+			assert.Equal(t, postID, broadcastPost.Id)
+			require.NotNil(t, broadcastPost.Metadata, "broadcast post must include metadata")
+			fileIDsInBroadcast := make([]string, 0, len(broadcastPost.Metadata.Files))
+			for _, f := range broadcastPost.Metadata.Files {
+				fileIDsInBroadcast = append(fileIDsInBroadcast, f.Id)
+			}
+			assert.Contains(t, fileIDsInBroadcast, fileID,
+				"post_edited broadcast must surface the now-resolvable attachment to clients")
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "did not receive post_edited event within 5s after attachment lazy-bind")
+		}
+	})
+
+	t.Run("file-then-post ordering does not publish post_edited from lazy-bind", func(t *testing.T) {
+		// When the file arrives first, the post does not exist when the
+		// lazy-bind runs, so there is no post to broadcast. The eventual
+		// post arrival publishes a posted event with correct metadata; the
+		// lazy-bind must stay quiet to avoid a spurious post_edited for a
+		// post that has never been seen by any client.
+		messages, closeWS := connectFakeWebSocket(t, th, th.BasicUser.Id, "",
+			[]model.WebsocketEventType{model.WebsocketEventPostEdited})
+		defer closeWS()
+
+		user := createRemoteUser(t)
+		postID := model.NewId()
+		fileID := model.NewId()
+
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			PostId:    postID,
+			Name:      "ws.txt",
+			Size:      4,
+		}
+		_, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+
+		select {
+		case ev := <-messages:
+			require.FailNowf(t, "unexpected event",
+				"did not expect a post_edited event from lazy-bind when post is absent, got: %v", ev.EventType())
+		case <-time.After(500 * time.Millisecond):
+			// Expected: no event.
 		}
 	})
 }

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -1341,6 +1341,14 @@ type API interface {
 	// The remoteID identifies which of the plugin's registered remotes this attachment is from
 	// (the value returned by RegisterPluginForSharedChannels).
 	//
+	// The post-receive (ReceiveSharedChannelSyncMsg) and file-receive calls for the same
+	// post-and-attachment pair may be issued in either order or concurrently; the framework
+	// binds the file to its post regardless of arrival order. Repeated calls with the same
+	// (fi.Id, channelID, fi.CreatorId) return the existing FileInfo without producing
+	// duplicates, allowing transports with at-least-once delivery semantics to redeliver
+	// safely. Repeats whose fi.Id matches an existing record under a different channel or
+	// creator are rejected.
+	//
 	// @tag SharedChannels
 	// Minimum server version: 11.7
 	ReceiveSharedChannelAttachmentSyncMsg(remoteID, channelID string, fi *model.FileInfo, data io.Reader) (*model.FileInfo, error)


### PR DESCRIPTION
#### Summary
Plugin transports (e.g. NATS post stream + JetStream object store) deliver `ReceiveSharedChannelSyncMsg` and `ReceiveSharedChannelAttachmentSyncMsg` on independent goroutines, so the post and file for the same attachment can arrive in either order or genuinely concurrently. The previous behaviour silently dropped file ids whose `FileInfo` was not yet present, with no path to recover when the file arrived second.

This PR makes the two APIs converge regardless of arrival order or interleaving, and idempotent against at-least-once redelivery.

- `attachFilesToPost` no longer strips unmatched `FileIds` for remote-origin posts. The strip is a defence for UI uploads where a missing `FileInfo` means the user does not own the file; for remote-origin posts it just means the file has not arrived yet (or has already been bound by the file-receive path), and stripping races the binding.
- `ReceiveSharedChannelAttachmentSyncMsg` gains an idempotency check (`FileInfo` lookup before `CreateUploadSession`, returning the existing record on duplicate delivery and rejecting mismatched channel/creator) and a lazy-bind step (atomic `AttachToPost` after `UploadData`). Whichever path wins the `AttachToPost` race, the other no-ops; `Post.FileIds` is preserved by the post-receive side.

Cluster (non-plugin) shared-channel attachments, `ReceiveSharedChannelProfileImageSyncMsg`, and UI uploads are unaffected.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68705

```release-note
Plugin API's for Shared Channel sync (`ReceiveSharedChannelSyncMsg` and `ReceiveSharedChannelAttachmentSyncMsg`) are now order-tolerant and idempotent: plugin remotes can now deliver a post and its file attachments in either order or concurrently, and at-least-once redeliveries no longer produce duplicate FileInfo rows.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The changes modify attachment binding and idempotency for plugin shared-channel flows, affecting data persistence and inter-service message handling; comprehensive tests cover ordering, retries, mismatches, and concurrency, but timing-dependent edge cases between post- and file-receive paths and websocket-triggered post reload behavior could still surface in production. The change is scoped to remote-origin plugin posts and preserves UI/cluster flows, reducing but not eliminating regression risk.

**QA Recommendation:** Perform focused manual QA on plugin shared-channel scenarios: out-of-order and repeated delivery of attachments, concurrent multi-file deliveries to the same post, mismatched re-delivery rejection cases, and verification that attachments appear live (including the websocket-triggered post reload). Broader UI and cluster shared-channel tests can be deprioritized given unchanged behavior and strong automated coverage.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->