### PR TITLE
MM-68702: Reject demoting bot accounts to guest

### DIFF
--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -6746,6 +6746,14 @@ func TestDemoteUserToGuest(t *testing.T) {
 	t.Run("cannot demote bot account", func(t *testing.T) {
 		th.App.Srv().SetLicense(model.NewTestLicense("guest_accounts"))
 
+		prevBotCreation := *th.App.Config().ServiceSettings.EnableBotAccountCreation
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.EnableBotAccountCreation = true
+		})
+		defer th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.EnableBotAccountCreation = prevBotCreation
+		})
+
 		createdBot, resp, err := th.SystemAdminClient.CreateBot(context.Background(), &model.Bot{
 			Username:    "botdemote" + model.NewId(),
 			DisplayName: "Demote Test Bot",
@@ -6753,6 +6761,10 @@ func TestDemoteUserToGuest(t *testing.T) {
 		})
 		require.NoError(t, err)
 		CheckCreatedStatus(t, resp)
+		defer func() {
+			appErr := th.App.PermanentDeleteBot(th.Context, createdBot.UserId)
+			require.Nil(t, appErr)
+		}()
 
 		demoteResp, err := th.SystemAdminClient.DemoteUserToGuest(context.Background(), createdBot.UserId)
 		CheckBadRequestStatus(t, demoteResp)

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -6743,6 +6743,22 @@ func TestDemoteUserToGuest(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("cannot demote bot account", func(t *testing.T) {
+		th.App.Srv().SetLicense(model.NewTestLicense("guest_accounts"))
+
+		createdBot, resp, err := th.SystemAdminClient.CreateBot(context.Background(), &model.Bot{
+			Username:    "botdemote" + model.NewId(),
+			DisplayName: "Demote Test Bot",
+			Description: "test",
+		})
+		require.NoError(t, err)
+		CheckCreatedStatus(t, resp)
+
+		demoteResp, err := th.SystemAdminClient.DemoteUserToGuest(context.Background(), createdBot.UserId)
+		CheckBadRequestStatus(t, demoteResp)
+		CheckErrorID(t, err, "api.user.demote_user_to_guest.bot_not_allowed.app_error")
+	})
+
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, c *model.Client4) {
 		_, _, err := c.GetUser(context.Background(), user.Id, "")
 		require.NoError(t, err)

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -2724,6 +2724,10 @@ func (a *App) PromoteGuestToUser(rctx request.CTX, user *model.User, requestorId
 // DemoteUserToGuest Convert user's roles and all his membership's roles from
 // regular user roles to guest roles.
 func (a *App) DemoteUserToGuest(rctx request.CTX, user *model.User) *model.AppError {
+	if user.IsBot {
+		return model.NewAppError("DemoteUserToGuest", "api.user.demote_user_to_guest.bot_not_allowed.app_error", nil, "", http.StatusBadRequest)
+	}
+
 	demotedUser, nErr := a.ch.srv.userService.DemoteUserToGuest(user)
 	a.InvalidateCacheForUser(user.Id)
 	if nErr != nil {

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -2012,6 +2012,18 @@ func TestDemoteUserToGuest(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)
 
+	t.Run("Must reject bot user", func(t *testing.T) {
+		bot := th.CreateBot(t)
+		user, err := th.App.GetUser(bot.UserId)
+		require.Nil(t, err)
+		require.True(t, user.IsBot)
+
+		appErr := th.App.DemoteUserToGuest(th.Context, user)
+		require.NotNil(t, appErr)
+		assert.Equal(t, "api.user.demote_user_to_guest.bot_not_allowed.app_error", appErr.Id)
+		assert.Equal(t, http.StatusBadRequest, appErr.StatusCode)
+	})
+
 	t.Run("Must invalidate channel stats cache when demoting a user", func(t *testing.T) {
 		user := th.CreateUser(t)
 		require.Equal(t, "system_user", user.Roles)

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -4679,6 +4679,10 @@
     "translation": "Unable to convert the user to guest because is already a guest."
   },
   {
+    "id": "api.user.demote_user_to_guest.bot_not_allowed.app_error",
+    "translation": "Bot accounts cannot be converted to guest accounts."
+  },
+  {
     "id": "api.user.email_to_ldap.not_available.app_error",
     "translation": "AD/LDAP not available on this server."
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

`DemoteUserToGuest` (used by `POST /api/v4/users/{id}/demote` and the same local API route) now returns `400 Bad Request` when the target user is a bot, with error id `api.user.demote_user_to_guest.bot_not_allowed.app_error`. This blocks User Managers with `PermissionDemoteToGuest` (from User Management) from persistently degrading bot accounts to guests without bot-administration permissions.

The guard lives on `App.DemoteUserToGuest`, so every caller (REST API, mmctl, etc.) is covered consistently.

QA: enable Guest Accounts and guest accounts setting; create a bot as System Admin; call demote on the bot user id as a User Manager without Integrations access — expect `400` and unchanged bot roles.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68702

#### Release Note

```release-note
POST /api/v4/users/{user_id}/demote now returns 400 when ``user_id`` is a bot account; bot accounts cannot be converted to guests.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-35cb5ca0-9cca-44aa-b319-57441dbb715b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-35cb5ca0-9cca-44aa-b319-57441dbb715b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change adds an early-return validation in DemoteUserToGuest to reject bot accounts; it does not modify existing demotion logic for non-bot users and does not touch shared utilities or widely-imported modules. Risk is low given focused scope and added unit tests covering the new behavior.

**QA Recommendation:** Minimal manual QA recommended—verify demotion of regular users remains unchanged and confirm attempting to demote bot accounts returns 400 with the new error id; spot-check bots with special roles or integrations access.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->