### PR TITLE
MM-68708 - Fix TestCreatePost shared DM/GM subtests when env pins feature flag

### DIFF
--- a/server/channels/app/post_test.go
+++ b/server/channels/app/post_test.go
@@ -999,7 +999,9 @@ func TestDeletePostDeletesPersistentNotification(t *testing.T) {
 }
 
 func TestCreatePost(t *testing.T) {
-	mainHelper.Parallel(t)
+	// This test is intentionally not parallel: two subtests below call t.Setenv
+	// to pin MM_FEATUREFLAGS_EnableSharedChannelsDMs, which Go disallows under a
+	// parallel ancestor.
 	t.Run("call PreparePostForClient before returning", func(t *testing.T) {
 		mainHelper.Parallel(t)
 		th := Setup(t).InitBasic(t)
@@ -1219,7 +1221,10 @@ func TestCreatePost(t *testing.T) {
 	})
 
 	t.Run("Should not allow to create posts on shared DMs", func(t *testing.T) {
-		mainHelper.Parallel(t)
+		// The env override is reapplied on every config Set, so UpdateConfig cannot
+		// pin the flag; t.Setenv is the only safe way (and requires no parallel ancestor).
+		t.Setenv("MM_FEATUREFLAGS_EnableSharedChannelsDMs", "false")
+
 		th := setupSharedChannels(t).InitBasic(t)
 
 		user1 := th.CreateUser(t)
@@ -1258,7 +1263,10 @@ func TestCreatePost(t *testing.T) {
 	})
 
 	t.Run("Should not allow to create posts on shared GMs", func(t *testing.T) {
-		mainHelper.Parallel(t)
+		// The env override is reapplied on every config Set, so UpdateConfig cannot
+		// pin the flag; t.Setenv is the only safe way (and requires no parallel ancestor).
+		t.Setenv("MM_FEATUREFLAGS_EnableSharedChannelsDMs", "false")
+
 		th := setupSharedChannels(t).InitBasic(t)
 
 		user1 := th.CreateUser(t)


### PR DESCRIPTION
#### Summary
The two shared DM/GM subtests in TestCreatePost rely on FeatureFlags.EnableSharedChannelsDMs being false, but the config store reapplies MM_FEATUREFLAGS_* env overrides on every Set, so an UpdateConfig pin gets clobbered.   The means that the unit tests fail if `MM_FEATUREFLAGS_EnableSharedChannelsDMs` is set true via an env var, such as on a developer's machine.

This PR fixes that by using `t.Setenv` to force the flag false for the duration of each subtest, and drop the parent's `mainHelper.Parallel(t)` so Go's "no Setenv under a parallel ancestor" rule is satisfied. Sibling subtests still parallelize via their own `mainHelper.Parallel(t)` calls.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68708

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is a test-only change with no production code modifications. The alteration fixes test reliability by properly isolating feature flag configuration, reducing the likelihood of flaky tests caused by environment variable overrides.

**QA Recommendation:** Manual QA can be skipped given the isolated, test-only nature of the changes. Automated testing of the shared channels feature should be sufficient to verify correctness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->