### PR TITLE
Add configurable Cursor co-author hook

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+commit_msg_file=$1
+coauthor_username=${CURSOR_COMMIT_COAUTHOR_GH_USERNAME:-}
+coauthor_email=${CURSOR_COMMIT_COAUTHOR_GH_EMAIL:-}
+
+if [[ -z "$coauthor_username" || -z "$coauthor_email" ]]; then
+    exit 0
+fi
+
+coauthor_trailer="Co-authored-by: ${coauthor_username} <${coauthor_email}>"
+
+if grep -Fqx "$coauthor_trailer" "$commit_msg_file"; then
+    exit 0
+fi
+
+{
+    printf '\n\n'
+    printf '%s\n' "$coauthor_trailer"
+} >> "$commit_msg_file"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Adds a repo-level `commit-msg` hook that appends a configurable co-author trailer when `CURSOR_COMMIT_COAUTHOR_GH_USERNAME` and `CURSOR_COMMIT_COAUTHOR_GH_EMAIL` are set.

#### Release Note
```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-95d53d05-1328-4e0c-99f2-560d4b561e84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-95d53d05-1328-4e0c-99f2-560d4b561e84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

