### PR TITLE
Update E2E test workflows to use context names and server images and bump playwright workers to 10

### DIFF
--- a/.github/e2e-tests-workflows.md
+++ b/.github/e2e-tests-workflows.md
@@ -283,10 +283,16 @@ The wrappers (`e2e-tests-cypress.yml`, `e2e-tests-playwright.yml`) accept these 
 | `ref_branch` | _(empty)_ | Source branch name for webhook messages (e.g., `master` or `release-11.4`) |
 
 The automation dashboard branch name is derived from context:
-- PR: `server-pr-<pr_number>` (e.g., `server-pr-35205`)
-- Master merge: `server-master-<image_tag>` (e.g., `server-master-abc1234_def5678`)
-- Release merge: `server-release-<version>-<image_tag>` (e.g., `server-release-11.4-abc1234_def5678`)
-- Fallback: `server-commit-<image_tag>`
+- PR: `pr-<pr_number>` (e.g., `pr-35205`)
+- Master merge: `master`
+- Release merge: `release-<version>` (e.g., `release-11.7`)
+- Fallback: `commit-<short_sha>` (e.g., `commit-abc1234`)
+
+Master and release runs use the real branch verbatim so the
+`/reports/{repo}/{branch}` view aggregates every build on that branch
+into one history. PR runs use a `pr-<n>` token because there's no real
+branch to use; the commit-only fallback uses a `commit-<short_sha>`
+token (defensive — no current caller hits this path).
 
 The test type suffix (`-smoke` or `-full`) is appended by the template.
 

--- a/.github/workflows/e2e-tests-cypress-template-v2.yml
+++ b/.github/workflows/e2e-tests-cypress-template-v2.yml
@@ -228,8 +228,8 @@ jobs:
           cypress-sort-last: ${{ inputs.cypress_sort_last }}
           post-pr-comment: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          test-type: ${{ inputs.test_type }}
-          server-edition: ${{ inputs.server_edition }}
+          context-name: ${{ inputs.context_name }}
+          server-image: ${{ env.SERVER_IMAGE }}
 
   workers:
     name: dispatch-run-${{ matrix.worker_index }}
@@ -334,14 +334,13 @@ jobs:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
           composite-identity: ${{ needs.dispatch-begin.outputs.composite-identity-json }}
           framework: cypress
-          test-type: ${{ inputs.test_type }}
           report-type: ${{ inputs.report_type }}
           image-tag: ${{ inputs.server_image_tag }}
           image-aliases: ${{ inputs.server_image_aliases }}
           server-image: ${{ env.SERVER_IMAGE }}
           pr-number: ${{ inputs.pr_number }}
           ref-branch: ${{ inputs.ref_branch }}
-          server-edition: ${{ inputs.server_edition }}
+          context-name: ${{ inputs.context_name }}
           post-pr-comment: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: ci/publish-webhook

--- a/.github/workflows/e2e-tests-cypress.yml
+++ b/.github/workflows/e2e-tests-cypress.yml
@@ -99,14 +99,19 @@ jobs:
           fi
           echo "server_image_tag=${SERVER_IMAGE_TAG}" >> $GITHUB_OUTPUT
 
-          # Generate branch name
+          # Generate branch name. For master/release runs we pass the real
+          # ref_branch through verbatim (`master`, `release-11.7`) so the
+          # dashboard's /reports/{repo}/{branch} grouping aggregates every
+          # build on that branch instead of treating each image tag as its
+          # own "branch". PR and commit-only fallback paths keep their
+          # synthetic prefix because there's no real branch to use.
           REF_BRANCH="${{ inputs.ref_branch }}"
           if [ -n "$PR_NUMBER" ]; then
-            echo "branch=server-pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
+            echo "branch=pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
           elif [ -n "$REF_BRANCH" ]; then
-            echo "branch=server-${REF_BRANCH}-${SERVER_IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "branch=${REF_BRANCH}" >> $GITHUB_OUTPUT
           else
-            echo "branch=server-commit-${SERVER_IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "branch=commit-${COMMIT_SHA::7}" >> $GITHUB_OUTPUT
           fi
 
           # Determine server image name

--- a/.github/workflows/e2e-tests-playwright-template-v2.yml
+++ b/.github/workflows/e2e-tests-playwright-template-v2.yml
@@ -188,8 +188,8 @@ jobs:
           playwright-project: ${{ inputs.playwright_project }}
           post-pr-comment: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          test-type: full
-          server-edition: ${{ inputs.server_edition }}
+          context-name: ${{ inputs.context_name }}
+          server-image: ${{ env.SERVER_IMAGE }}
 
   workers:
     name: dispatch-run-${{ matrix.worker_index }}
@@ -291,14 +291,13 @@ jobs:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
           composite-identity: ${{ needs.dispatch-begin.outputs.composite-identity-json }}
           framework: playwright
-          test-type: full
           report-type: ${{ inputs.report_type }}
           image-tag: ${{ inputs.server_image_tag }}
           image-aliases: ${{ inputs.server_image_aliases }}
           server-image: ${{ env.SERVER_IMAGE }}
           pr-number: ${{ inputs.pr_number }}
           ref-branch: ${{ inputs.ref_branch }}
-          server-edition: ${{ inputs.server_edition }}
+          context-name: ${{ inputs.context_name }}
           post-pr-comment: 'true'
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: ci/publish-webhook

--- a/.github/workflows/e2e-tests-playwright.yml
+++ b/.github/workflows/e2e-tests-playwright.yml
@@ -93,14 +93,19 @@ jobs:
           fi
           echo "server_image_tag=${SERVER_IMAGE_TAG}" >> $GITHUB_OUTPUT
 
-          # Generate branch name
+          # Generate branch name. For master/release runs we pass the real
+          # ref_branch through verbatim (`master`, `release-11.7`) so the
+          # dashboard's /reports/{repo}/{branch} grouping aggregates every
+          # build on that branch instead of treating each image tag as its
+          # own "branch". PR and commit-only fallback paths keep their
+          # synthetic prefix because there's no real branch to use.
           REF_BRANCH="${{ inputs.ref_branch }}"
           if [ -n "$PR_NUMBER" ]; then
-            echo "branch=server-pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
+            echo "branch=pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
           elif [ -n "$REF_BRANCH" ]; then
-            echo "branch=server-${REF_BRANCH}-${SERVER_IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "branch=${REF_BRANCH}" >> $GITHUB_OUTPUT
           else
-            echo "branch=server-commit-${SERVER_IMAGE_TAG}" >> $GITHUB_OUTPUT
+            echo "branch=commit-${COMMIT_SHA::7}" >> $GITHUB_OUTPUT
           fi
 
           # Determine server image name

--- a/.github/workflows/e2e-tests-playwright.yml
+++ b/.github/workflows/e2e-tests-playwright.yml
@@ -208,7 +208,7 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/e2e-tests-playwright-template-v2.yml
     with:
-      workers: 8
+      workers: 10
       enabled_docker_services: "postgres inbucket"
       commit_sha: ${{ inputs.commit_sha }}
       branch: ${{ needs.generate-build-variables.outputs.branch }}


### PR DESCRIPTION
#### Summary
Update E2E test workflows to use context names and server images and bump playwright workers to 10

#### Ticket Link
none

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Changes modify multiple CI workflows (Cypress and Playwright templates, build variable generation, and test-system-io action inputs) and branch naming used for aggregation/reporting; this can break CI dispatch/reporting and dashboard grouping if external consumers expect the previous inputs or branch formats. Risk is moderate because no application code is changed but CI/reporting integrations and downstream dashboards are impacted.

**QA Recommendation:** Run and verify a set of CI runs (PR and master/release scenarios) to confirm Playwright/Cypress jobs start, complete, and that test-system-io dispatch/reporting and dashboard branch aggregation behave as expected; monitor commit-status contexts and reporting for regressions after merging.

*Generated by CodeRabbitAI*

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36496)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->