### PR TITLE
store: use noTimeoutContext for schema dump queries

### DIFF
--- a/server/channels/store/sqlstore/schema_dump.go
+++ b/server/channels/store/sqlstore/schema_dump.go
@@ -88,7 +88,7 @@ func (ss *SqlStore) getDatabaseCollation() (string, error) {
 		return "", errors.Wrap(err, "failed to build database collation query")
 	}
 
-	err = ss.GetMaster().DB.QueryRow(sqlString, args...).Scan(&dbCollation)
+	err = ss.GetMaster().QueryRowContext(ss.noTimeoutContext(), sqlString, args...).Scan(&dbCollation)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get database collation")
 	}
@@ -112,7 +112,7 @@ func (ss *SqlStore) getDatabaseEncoding() (string, error) {
 		return "", errors.Wrap(err, "failed to build database encoding query")
 	}
 
-	err = ss.GetMaster().DB.QueryRow(sqlString, args...).Scan(&dbEncoding)
+	err = ss.GetMaster().QueryRowContext(ss.noTimeoutContext(), sqlString, args...).Scan(&dbEncoding)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get database encoding")
 	}
@@ -142,7 +142,7 @@ func (ss *SqlStore) getTableOptions() (map[string]map[string]string, error) {
 		return nil, errors.Wrap(err, "failed to build table options query")
 	}
 
-	optionsRows, err := ss.GetMaster().DB.Query(optionsSql, optionsArgs...)
+	optionsRows, err := ss.GetMaster().QueryContext(ss.noTimeoutContext(), optionsSql, optionsArgs...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to query table options")
 	}
@@ -204,7 +204,7 @@ func (ss *SqlStore) getTableSchemaInformation() (map[string]*model.DatabaseTable
 		return nil, nil, errors.Wrap(err, "failed to build schema information query")
 	}
 
-	rows, err := ss.GetMaster().DB.Query(schemaSql, schemaArgs...)
+	rows, err := ss.GetMaster().QueryContext(ss.noTimeoutContext(), schemaSql, schemaArgs...)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "failed to query schema information")
 	}
@@ -275,7 +275,7 @@ func (ss *SqlStore) getTableIndexes() (map[string][]model.DatabaseIndex, error) 
 		return nil, errors.Wrap(err, "failed to build index query")
 	}
 
-	rows, err := ss.GetMaster().DB.Query(indexSql, indexArgs...)
+	rows, err := ss.GetMaster().QueryContext(ss.noTimeoutContext(), indexSql, indexArgs...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to query index information")
 	}

--- a/server/channels/store/sqlstore/store.go
+++ b/server/channels/store/sqlstore/store.go
@@ -479,6 +479,11 @@ func (ss *SqlStore) analyticsContext() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(context.Background(), time.Duration(*ss.settings.AnalyticsQueryTimeout)*time.Second)
 }
 
+// noTimeoutContext should only be used with queries that expect no client-side timeout.
+func (ss *SqlStore) noTimeoutContext() context.Context {
+	return context.Background()
+}
+
 func (ss *SqlStore) monitorReplicas() {
 	t := time.NewTicker(time.Duration(*ss.settings.ReplicaMonitorIntervalSeconds) * time.Second)
 	defer func() {


### PR DESCRIPTION
#### Summary

This is the first in a set of changes to address unintentional query timeout bypasses in the SQL store. Schema dump queries (collation, encoding, table options, schema information, and indexes) are intentionally exempt from client-side timeouts.

Introduce a `noTimeoutContext` helper on `SqlStore` (returning `context.Background()`) that makes the intent explicit. All five schema dump query sites are updated to use it inline.

#### Ticket Link

Relates-to: https://mattermost.atlassian.net/browse/MM-68332

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes are confined to internal query execution within non-critical schema dump utilities used only for diagnostic/support packet generation. The modification is straightforward—replacing default context with explicit `context.Background()` in 5 helper methods—with no public API or method signature changes, making unintended breakage highly unlikely.

**QA Recommendation:** Minimal manual QA required beyond existing automated test coverage. Verify that support packet generation completes successfully and schema dump operations execute without client-side timeout issues on the test database.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36502)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->