### PR TITLE
Fix invite modal autocomplete clipping

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/team_settings/invite_people_autocomplete.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/team_settings/invite_people_autocomplete.spec.ts
@@ -3,6 +3,21 @@
 
 import {decomposeKorean, expect, koreanTestPhrase, test, typeHangulCharacterWithIme} from '@mattermost/playwright-lib';
 
+async function openInvitePeopleModal(pw: any, adminUser: any, team: any) {
+    const {channelsPage} = await pw.testBrowser.login(adminUser);
+    await channelsPage.goto(team.name, 'town-square');
+    await channelsPage.toBeVisible();
+
+    await channelsPage.sidebarLeft.teamMenuButton.click();
+    await channelsPage.teamMenu.toBeVisible();
+    await channelsPage.teamMenu.clickInvitePeople();
+
+    const inviteModal = await channelsPage.getInvitePeopleModal(team.display_name);
+    await inviteModal.toBeVisible();
+
+    return inviteModal;
+}
+
 test('MM-66937 Invite modal results match the current input state', async ({pw}) => {
     const {adminUser, adminClient, team} = await pw.initSetup();
 
@@ -55,6 +70,80 @@ test('MM-66937 Invite modal results match the current input state', async ({pw})
     await expect(listbox.getByRole('option')).toHaveCount(1);
     await expect(listbox.getByRole('option', {name: `@${user1.username}`})).not.toBeAttached();
     await expect(listbox.getByRole('option', {name: `@${user2.username}`})).toBeVisible();
+});
+
+test('Invite modal autocomplete is not clipped vertically', async ({pw}) => {
+    const {adminUser, adminClient, team} = await pw.initSetup();
+
+    const randomPrefix = pw.random.id(8);
+    const users = await Promise.all([
+        adminClient.createUser(await pw.random.user(randomPrefix + 'a'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'b'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'c'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'd'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'e'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'f'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'g'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'h'), '', ''),
+    ]);
+
+    const inviteModal = await openInvitePeopleModal(pw, adminUser, team);
+
+    await inviteModal.inviteInput.pressSequentially(randomPrefix);
+
+    const modalContent = inviteModal.container.locator('.modal-content');
+    const listbox = inviteModal.container.getByRole('listbox');
+    const options = listbox.getByRole('option');
+    await expect(options).toHaveCount(users.length);
+
+    const lastOption = options.last();
+    await expect(lastOption).toBeVisible();
+
+    const geometry = await Promise.all([modalContent.boundingBox(), lastOption.boundingBox()]);
+    const [modalContentBox, lastOptionBox] = geometry;
+    expect(modalContentBox).not.toBeNull();
+    expect(lastOptionBox).not.toBeNull();
+    expect(lastOptionBox!.y + lastOptionBox!.height).toBeGreaterThan(modalContentBox!.y + modalContentBox!.height);
+
+    const modalContentOverflow = await modalContent.evaluate((element: HTMLElement) => {
+        const style = window.getComputedStyle(element);
+
+        return {
+            overflowX: style.overflowX,
+            overflowY: style.overflowY,
+        };
+    });
+
+    expect(modalContentOverflow.overflowX).toBe('visible');
+    expect(modalContentOverflow.overflowY).toBe('visible');
+});
+
+test('Invite modal remains width-constrained with long unbroken input', async ({pw}) => {
+    const {adminUser, team} = await pw.initSetup();
+    const inviteModal = await openInvitePeopleModal(pw, adminUser, team);
+
+    const modalContent = inviteModal.container.locator('.modal-content');
+    const initialModalContentBox = await modalContent.boundingBox();
+    expect(initialModalContentBox).not.toBeNull();
+
+    await inviteModal.inviteInput.pressSequentially(
+        'averyveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryveryverylongunbrokeninviteinput@example.com',
+    );
+
+    const modalContentMetrics = await modalContent.evaluate((element: HTMLElement) => {
+        const style = window.getComputedStyle(element);
+        const rect = element.getBoundingClientRect();
+
+        return {
+            width: Math.round(rect.width),
+            overflowX: style.overflowX,
+            overflowY: style.overflowY,
+        };
+    });
+
+    expect(modalContentMetrics.width).toBeLessThanOrEqual(Math.ceil(initialModalContentBox!.width));
+    expect(modalContentMetrics.overflowX).toBe('visible');
+    expect(modalContentMetrics.overflowY).toBe('visible');
 });
 
 test('MM-66937 Invite modal results match the current input state when typing in Korean', async ({browserName, pw}) => {

--- a/e2e-tests/playwright/specs/functional/channels/team_settings/invite_people_autocomplete.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/team_settings/invite_people_autocomplete.spec.ts
@@ -118,6 +118,47 @@ test('Invite modal autocomplete is not clipped vertically', async ({pw}) => {
     expect(modalContentOverflow.overflowY).toBe('visible');
 });
 
+test('Invite modal results are visible outside the modal', async ({pw}) => {
+    const {adminUser, adminClient, team} = await pw.initSetup();
+
+    // # Create enough users that the results will extend outside the modal until past when the result list is capped
+    const randomPrefix = pw.random.id(8);
+    const users = await Promise.all([
+        adminClient.createUser(await pw.random.user(randomPrefix + 'a'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'b'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'c'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'd'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'e'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'f'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'g'), '', ''),
+        adminClient.createUser(await pw.random.user(randomPrefix + 'h'), '', ''),
+    ]);
+
+    // # Open the Invite People modal
+    const inviteModal = await openInvitePeopleModal(pw, adminUser, team);
+
+    // # Type the prefix to filter out other users
+    await inviteModal.inviteInput.type(randomPrefix);
+
+    // At time of writing, 4 results are fully visible, the next is partly visible, and the rest are clipped
+    const visibleCount = 5;
+
+    for (let i = 0; i < users.length; i++) {
+        const user = users[i];
+
+        const option = await inviteModal.container.getByRole('option', {name: user.username, exact: false});
+        if (i < visibleCount) {
+            // * Verify that this user is in the list and on the screen
+            await expect(option).toBeVisible();
+            await expect(option).toBeInViewport();
+        } else {
+            // * Verify that this user is in the list but off the screen
+            await expect(option).toBeVisible();
+            await expect(option).not.toBeInViewport();
+        }
+    }
+});
+
 test('Invite modal remains width-constrained with long unbroken input', async ({pw}) => {
     const {adminUser, team} = await pw.initSetup();
     const inviteModal = await openInvitePeopleModal(pw, adminUser, team);

--- a/webapp/channels/src/components/invitation_modal/invitation_modal.scss
+++ b/webapp/channels/src/components/invitation_modal/invitation_modal.scss
@@ -16,7 +16,7 @@
     }
 
     .modal-content {
-        overflow: hidden;
+        overflow-x: hidden;
         max-width: 100%;
     }
 

--- a/webapp/channels/src/components/invitation_modal/invitation_modal.scss
+++ b/webapp/channels/src/components/invitation_modal/invitation_modal.scss
@@ -16,7 +16,8 @@
     }
 
     .modal-content {
-        overflow-x: hidden;
+        width: 100%;
+        min-width: 0;
         max-width: 100%;
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Fixed the invite modal autocomplete dropdown being clipped vertically (regression from https://github.com/mattermost/mattermost/pull/36241) by removing the modal content overflow clipping and constraining the modal content with width sizing instead. This preserves the prior width-overflow fix while allowing the react-select menu to render below the input.

Added Playwright regression coverage for both behaviors:
- Dropdown visibility: verifies autocomplete options render beyond `.modal-content` while modal content overflow remains visible.
- Width containment: verifies a long unbroken invite input does not widen `.modal-content` and overflow stays visible.

Validation covered both cases on a local Mattermost server:
- Browser screenshots were captured for the visual states below.
- Targeted Playwright spec passed: `PW_BASE_URL=http://localhost:8065 PW_HEADLESS=true npx playwright test specs/functional/channels/team_settings/invite_people_autocomplete.spec.ts --project=chrome`.
- Targeted checks passed: eslint, prettier check, and `npx tsc -b --pretty false` from `e2e-tests/playwright`.

#### Screenshots

Autocomplete dropdown remains fully visible:
![Invite modal autocomplete dropdown visible](https://cursor.com/artifacts/c/art-b46dece9-2cff-41cf-8391-75b272be8b48)

Long input remains contained within the modal width:
![Invite modal long input contained](https://cursor.com/artifacts/c/art-3efbb681-168e-4e47-9a1d-449d8c244a69)

#### Release Note

Not adding a release note because this was a regression from https://github.com/mattermost/mattermost/pull/36241 that hasn't been released. 

```release-note
None
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-757f7cd6-b779-4eaf-bf38-b904d7da7c60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-757f7cd6-b779-4eaf-bf38-b904d7da7c60"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Isolated CSS-only change to InvitationModal (.modal-content overflow removal and width constraints). Unlikely to break functionality; no shared utilities, APIs, or core logic touched.  
**QA Recommendation:** Minimal manual QA — verify autocomplete dropdown renders outside the modal and long unbroken inputs remain contained; rely on the added Playwright regression tests and visual checks.

*Generated by CodeRabbitAI*

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36505)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->