### PR TITLE
MM-68425 Tighten attachment field validation

### DIFF
--- a/server/public/model/message_attachment.go
+++ b/server/public/model/message_attachment.go
@@ -8,9 +8,12 @@ import (
 	"reflect"
 	"regexp"
 	"slices"
+	"unicode/utf8"
 
 	"github.com/hashicorp/go-multierror"
 )
+
+const MessageAttachmentFieldValueMaxRunes = PostMessageMaxRunesV2
 
 var (
 	linkWithTextRegex = regexp.MustCompile(`<([^<\|]+)\|([^>]+)>`)
@@ -203,8 +206,12 @@ func (s *MessageAttachmentField) IsValid() error {
 	var multiErr *multierror.Error
 
 	if s.Value != nil {
-		switch s.Value.(type) {
-		case string, int:
+		switch v := s.Value.(type) {
+		case string:
+			if utf8.RuneCountInString(v) > MessageAttachmentFieldValueMaxRunes {
+				multiErr = multierror.Append(multiErr, fmt.Errorf("attachment field value is too long"))
+			}
+		case int:
 			// Valid types
 		default:
 			multiErr = multierror.Append(multiErr, fmt.Errorf("value must be either a string or int"))

--- a/server/public/model/message_attachment_test.go
+++ b/server/public/model/message_attachment_test.go
@@ -4,6 +4,7 @@
 package model
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -166,6 +167,57 @@ func TestMessageAttachment_IsValid(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMessageAttachmentField_ValueBounds(t *testing.T) {
+	limit := MessageAttachmentFieldValueMaxRunes
+
+	t.Run("rejects_overlong_string", func(t *testing.T) {
+		att := &MessageAttachment{
+			Fields: []*MessageAttachmentField{
+				{Title: "t", Value: strings.Repeat("a", limit+1)},
+			},
+		}
+		err := att.IsValid()
+		assert.ErrorContains(t, err, "attachment field value is too long")
+	})
+
+	t.Run("accepts_string_at_limit", func(t *testing.T) {
+		att := &MessageAttachment{
+			Fields: []*MessageAttachmentField{
+				{Title: "t", Value: strings.Repeat("b", limit)},
+			},
+		}
+		assert.NoError(t, att.IsValid())
+	})
+
+	t.Run("accepts_int_value", func(t *testing.T) {
+		att := &MessageAttachment{
+			Fields: []*MessageAttachmentField{
+				{Title: "t", Value: 999999},
+			},
+		}
+		assert.NoError(t, att.IsValid())
+	})
+
+	t.Run("rejects_overlong_unicode_by_runes", func(t *testing.T) {
+		att := &MessageAttachment{
+			Fields: []*MessageAttachmentField{
+				{Title: "t", Value: strings.Repeat("\u0100", limit+1)},
+			},
+		}
+		err := att.IsValid()
+		assert.ErrorContains(t, err, "attachment field value is too long")
+	})
+
+	t.Run("accepts_unicode_at_limit", func(t *testing.T) {
+		att := &MessageAttachment{
+			Fields: []*MessageAttachmentField{
+				{Title: "t", Value: strings.Repeat("\u0100", limit)},
+			},
+		}
+		assert.NoError(t, att.IsValid())
+	})
 }
 
 func TestParseMessageAttachment(t *testing.T) {


### PR DESCRIPTION
#### Summary

Adds length bounds for message attachment field string values in model validation.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68425

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change introduces stricter validation on MessageAttachmentField.Value strings that could reject previously accepted attachment field values from webhooks, incoming webhooks, bots, and Slack integrations exceeding the 16,383-rune limit. Since MessageAttachmentField is consumed across 19+ files including Slack compatibility, notification processing, email rendering, and Elasticsearch indexing, existing integrations sending larger field values may encounter validation failures at the API boundary.

**QA Recommendation:** Verify compatibility with existing webhook integrations, Slack-compatible bots, and third-party API clients. Test notification email rendering and Slack message processing with various field value sizes, particularly with Unicode-heavy content (the limit is measured in runes, not bytes). Validate that the rune-counting validation properly handles multi-byte characters across different scripts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36508)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->