### PR TITLE
Fix: Global Threads view shows only 1 quick reaction emoji instead of 3 (MM-68681)

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/messaging/emoji_recently_used_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/emoji_recently_used_spec.js
@@ -237,7 +237,7 @@ describe('Messaging', () => {
         } else if (location === 'RHS_ROOT' || location === 'RHS_COMMENT') {
             idPrefix = 'rhsPost';
             numReactions = 1;
-        } else if (location === 'RHS_EXPANDED' || location === 'GLOBAL_THREADS') {
+        } else if (location === 'GLOBAL_THREADS') {
             idPrefix = 'rhsPost';
         }
 

--- a/e2e-tests/cypress/tests/integration/channels/messaging/emoji_recently_used_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/emoji_recently_used_spec.js
@@ -8,7 +8,7 @@
 // ***************************************************************
 
 // Stage: @prod
-// Group: @channels @messaging
+// Group: @channels @messaging @collapsed_reply_threads
 
 import timeouts from '@/fixtures/timeouts';
 
@@ -177,6 +177,57 @@ describe('Messaging', () => {
         });
     });
 
+    it('MM-T4261_3 One-Click Reactions in Global Threads view show 3 emojis', () => {
+        // # Re-enable emoji picker (MM-T4261_2 disables it) and configure CRT server-side
+        cy.apiAdminLogin();
+        cy.apiUpdateConfig({
+            ServiceSettings: {
+                EnableEmojiPicker: true,
+                ThreadAutoFollow: true,
+                CollapsedThreads: 'default_off',
+            },
+        });
+
+        // # Create a fresh user with CRT turned on so threads appear in the Threads view
+        cy.apiCreateUser({prefix: 'crtUser'}).then(({user: crtUser}) => {
+            cy.apiAddUserToTeam(testTeam.id, crtUser.id);
+            cy.apiSaveCRTPreference(crtUser.id, 'on');
+            cy.apiLogin(crtUser);
+        });
+
+        cy.visit(offTopicPath);
+
+        // # Enable one-click reactions for this user
+        cy.uiOpenSettingsModal('Display').within(() => {
+            cy.findByText('Display', {timeout: timeouts.ONE_MIN}).click();
+            cy.findByText('Quick reactions on messages').click();
+            cy.findByLabelText('On').click();
+            cy.uiSaveAndClose();
+        });
+
+        // # Post a root message and a reply so a followed thread exists
+        cy.apiGetChannelByName(testTeam.name, 'off-topic').then(({channel}) => {
+            cy.apiCreatePost(channel.id, 'Root post for Global Threads emoji test', '', {}).then((rootResp) => {
+                const rootPostId = rootResp.body.id;
+
+                cy.apiCreatePost(channel.id, 'Reply to follow the thread', rootPostId, {});
+
+                // # Navigate to Global Threads
+                cy.uiClickSidebarItem('threads');
+
+                // # Click the thread to open the full-width thread panel
+                cy.get('div.ThreadItem').should('have.lengthOf.at.least', 1).first().click();
+
+                // * Root post is visible in the thread pane
+                cy.get(`#rhsPost_${rootPostId}`).should('be.visible');
+
+                // * Hovering over the post in Global Threads shows 3 quick reaction emojis —
+                //   the same count as the center channel, not the 1 shown in a narrow RHS sidebar.
+                validateQuickReactions(rootPostId, 'GLOBAL_THREADS', defaultEmojis);
+            });
+        });
+    });
+
     function validateQuickReactions(postId, location, emojis) {
         let idPrefix;
         let numReactions = 3;
@@ -186,7 +237,7 @@ describe('Messaging', () => {
         } else if (location === 'RHS_ROOT' || location === 'RHS_COMMENT') {
             idPrefix = 'rhsPost';
             numReactions = 1;
-        } else if (location === 'RHS_EXPANDED') {
+        } else if (location === 'RHS_EXPANDED' || location === 'GLOBAL_THREADS') {
             idPrefix = 'rhsPost';
         }
 

--- a/webapp/channels/src/components/post/index.tsx
+++ b/webapp/channels/src/components/post/index.tsx
@@ -33,6 +33,7 @@ import {getBurnOnReadDurationMinutes} from 'selectors/burn_on_read';
 import {isBurnOnReadPost, shouldDisplayConcealedPlaceholder} from 'selectors/burn_on_read_posts';
 import {getShortcutReactToLastPostEmittedFrom, getOneClickReactionEmojis} from 'selectors/emojis';
 import {getIsPostBeingEdited, getIsPostBeingEditedInRHS, isEmbedVisible} from 'selectors/posts';
+import {getIsGlobalThreadsView} from 'selectors/lhs';
 import {getHighlightedPostId, getRhsState, getSelectedPostCard} from 'selectors/rhs';
 import {getIsMobileView} from 'selectors/views/browser';
 
@@ -219,7 +220,7 @@ function makeMapStateToProps() {
             recentEmojis: emojis,
             center: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_CENTERED,
             isCollapsedThreadsEnabled: isCollapsedThreadsEnabled(state),
-            isExpanded: state.views.rhs.isSidebarExpanded || state.views.rhsSuppressed,
+            isExpanded: state.views.rhs.isSidebarExpanded || getIsGlobalThreadsView(state),
             isPostBeingEdited: ownProps.location === Locations.CENTER ? !getIsPostBeingEditedInRHS(state, post.id) && getIsPostBeingEdited(state, post.id) : getIsPostBeingEditedInRHS(state, post.id),
             isMobileView: getIsMobileView(state),
             previewCollapsed,

--- a/webapp/channels/src/components/post/index.tsx
+++ b/webapp/channels/src/components/post/index.tsx
@@ -219,7 +219,7 @@ function makeMapStateToProps() {
             recentEmojis: emojis,
             center: get(state, Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.CHANNEL_DISPLAY_MODE, Preferences.CHANNEL_DISPLAY_MODE_DEFAULT) === Preferences.CHANNEL_DISPLAY_MODE_CENTERED,
             isCollapsedThreadsEnabled: isCollapsedThreadsEnabled(state),
-            isExpanded: state.views.rhs.isSidebarExpanded,
+            isExpanded: state.views.rhs.isSidebarExpanded || state.views.rhsSuppressed,
             isPostBeingEdited: ownProps.location === Locations.CENTER ? !getIsPostBeingEditedInRHS(state, post.id) && getIsPostBeingEdited(state, post.id) : getIsPostBeingEditedInRHS(state, post.id),
             isMobileView: getIsMobileView(state),
             previewCollapsed,

--- a/webapp/channels/src/components/post/index.tsx
+++ b/webapp/channels/src/components/post/index.tsx
@@ -32,8 +32,8 @@ import {closeRightHandSide, selectPost, setRhsExpanded, selectPostCard, selectPo
 import {getBurnOnReadDurationMinutes} from 'selectors/burn_on_read';
 import {isBurnOnReadPost, shouldDisplayConcealedPlaceholder} from 'selectors/burn_on_read_posts';
 import {getShortcutReactToLastPostEmittedFrom, getOneClickReactionEmojis} from 'selectors/emojis';
-import {getIsPostBeingEdited, getIsPostBeingEditedInRHS, isEmbedVisible} from 'selectors/posts';
 import {getIsGlobalThreadsView} from 'selectors/lhs';
+import {getIsPostBeingEdited, getIsPostBeingEditedInRHS, isEmbedVisible} from 'selectors/posts';
 import {getHighlightedPostId, getRhsState, getSelectedPostCard} from 'selectors/rhs';
 import {getIsMobileView} from 'selectors/views/browser';
 

--- a/webapp/channels/src/components/post/post_options.test.tsx
+++ b/webapp/channels/src/components/post/post_options.test.tsx
@@ -3,140 +3,124 @@
 
 import React from 'react';
 
+import {Permissions} from 'mattermost-redux/constants';
+import type {SystemEmoji} from '@mattermost/types/emojis';
+
 import {renderWithContext, screen} from 'tests/react_testing_utils';
 import {Locations} from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
 
 import PostOptions from './post_options';
 
-// Mock connected/complex child components so the test doesn't need a full Redux setup
-jest.mock('components/post_view/post_recent_reactions', () => {
-    return {
-        __esModule: true,
-        default: ({size}: {size: number}) => (
-            <div data-testid='post-recent-reactions' data-size={size}/>
-        ),
-    };
+// Minimal Redux state: grant ADD_REACTION to the current user so that
+// ChannelPermissionGate lets the quick-reaction emoji buttons render.
+const currentUserId = 'currentUser';
+const channel = TestHelper.getChannelMock({team_id: 'team1'});
+const baseState = {
+    entities: {
+        roles: {
+            roles: {
+                system_user: TestHelper.getRoleMock({permissions: [Permissions.ADD_REACTION]}),
+            },
+        },
+        users: {
+            currentUserId,
+            profiles: {
+                [currentUserId]: TestHelper.getUserMock({id: currentUserId, roles: 'system_user'}),
+            },
+        },
+    },
+};
+
+// Proper SystemEmoji shapes — getEmojiName() reads `short_name` for system emojis.
+const makeSystemEmoji = (shortName: string): SystemEmoji => ({
+    name: shortName,
+    short_name: shortName,
+    short_names: [shortName],
+    category: 'people',
+    unified: shortName.toUpperCase(),
 });
 
-jest.mock('components/dot_menu', () => {
-    return {
-        __esModule: true,
-        default: () => <div data-testid='dot-menu'/>,
-    };
-});
+const post = TestHelper.getPostMock({type: '', channel_id: channel.id});
 
-jest.mock('components/actions_menu', () => {
-    return {
-        __esModule: true,
-        default: () => <div data-testid='actions-menu'/>,
-    };
-});
-
-jest.mock('components/post_view/post_reaction', () => {
-    return {
-        __esModule: true,
-        default: () => <div data-testid='post-reaction'/>,
-    };
-});
-
-jest.mock('components/post_view/post_flag_icon', () => {
-    return {
-        __esModule: true,
-        default: () => <div data-testid='post-flag-icon'/>,
-    };
-});
-
-jest.mock('components/common/comment_icon', () => {
-    return {
-        __esModule: true,
-        default: () => <div data-testid='comment-icon'/>,
-    };
-});
-
-jest.mock('components/common/hooks/usePluginVisibilityInSharedChannel', () => ({
-    usePluginVisibilityInSharedChannel: () => true,
-}));
+const baseProps = {
+    post,
+    teamId: channel.team_id,
+    isFlagged: false,
+    removePost: jest.fn(),
+    enableEmojiPicker: true,
+    isReadOnly: false,
+    channelIsArchived: false,
+    handleDropdownOpened: jest.fn(),
+    oneClickReactionsEnabled: true,
+    recentEmojis: [
+        makeSystemEmoji('thumbsup'),
+        makeSystemEmoji('grinning'),
+        makeSystemEmoji('white_check_mark'),
+    ],
+    isMobileView: false,
+    location: Locations.RHS_ROOT as keyof typeof Locations,
+    pluginActions: [],
+    isChannelAutotranslated: false,
+    actions: {
+        emitShortcutReactToLastPostFrom: jest.fn(),
+    },
+};
 
 describe('PostOptions - quick reaction count (MM-68681)', () => {
-    // Use type: '' for a regular (non-system) post so reactions are enabled
-    const post = TestHelper.getPostMock({type: ''});
-
-    const baseProps = {
-        post,
-        teamId: 'team1',
-        isFlagged: false,
-        removePost: jest.fn(),
-        enableEmojiPicker: true,
-        isReadOnly: false,
-        channelIsArchived: false,
-        handleDropdownOpened: jest.fn(),
-        oneClickReactionsEnabled: true,
-        // Provide 3 emojis so that the slice(0, size) logic has enough to return
-        recentEmojis: [
-            {name: 'thumbsup', category: 'people'} as any,
-            {name: 'grinning', category: 'people'} as any,
-            {name: 'white_check_mark', category: 'symbols'} as any,
-        ],
-        hover: true, // simulate hover so hoverLocal is true
-        isMobileView: false,
-        location: Locations.RHS_ROOT as keyof typeof Locations,
-        pluginActions: [],
-        isChannelAutotranslated: false,
-        actions: {
-            emitShortcutReactToLastPostFrom: jest.fn(),
-        },
-    };
-
-    test('shows 3 quick reaction emojis in CENTER location', () => {
+    test('CENTER location always shows 3 quick reaction emojis', () => {
         renderWithContext(
             <PostOptions
                 {...baseProps}
                 location={Locations.CENTER}
                 isExpanded={false}
+                hover={true}
             />,
+            baseState,
         );
 
-        const recentReactions = screen.getByTestId('post-recent-reactions');
-        expect(recentReactions).toHaveAttribute('data-size', '3');
+        expect(screen.getAllByTestId('post-menu__item_emoji')).toHaveLength(3);
     });
 
-    test('shows 1 quick reaction emoji in RHS_ROOT when isExpanded is false (narrow RHS)', () => {
+    test('RHS_ROOT with isExpanded false (narrow sidebar) shows 1 quick reaction emoji', () => {
         renderWithContext(
             <PostOptions
                 {...baseProps}
                 location={Locations.RHS_ROOT}
                 isExpanded={false}
+                hover={true}
             />,
+            baseState,
         );
 
-        const recentReactions = screen.getByTestId('post-recent-reactions');
-        expect(recentReactions).toHaveAttribute('data-size', '1');
+        expect(screen.getAllByTestId('post-menu__item_emoji')).toHaveLength(1);
     });
 
-    test('shows 3 quick reaction emojis in RHS_ROOT when isExpanded is true (expanded RHS or Global Threads view)', () => {
+    test('RHS_ROOT with isExpanded true (expanded sidebar or Global Threads view) shows 3 quick reaction emojis', () => {
         renderWithContext(
             <PostOptions
                 {...baseProps}
                 location={Locations.RHS_ROOT}
                 isExpanded={true}
+                hover={true}
             />,
+            baseState,
         );
 
-        const recentReactions = screen.getByTestId('post-recent-reactions');
-        expect(recentReactions).toHaveAttribute('data-size', '3');
+        expect(screen.getAllByTestId('post-menu__item_emoji')).toHaveLength(3);
     });
 
-    test('shows 3 quick reaction emojis in RHS_COMMENT when isExpanded is true', () => {
+    test('RHS_COMMENT with isExpanded true shows 3 quick reaction emojis', () => {
         renderWithContext(
             <PostOptions
                 {...baseProps}
                 location={Locations.RHS_COMMENT}
                 isExpanded={true}
+                hover={true}
             />,
+            baseState,
         );
 
-        const recentReactions = screen.getByTestId('post-recent-reactions');
-        expect(recentReactions).toHaveAttribute('data-size', '3');
+        expect(screen.getAllByTestId('post-menu__item_emoji')).toHaveLength(3);
     });
 });

--- a/webapp/channels/src/components/post/post_options.test.tsx
+++ b/webapp/channels/src/components/post/post_options.test.tsx
@@ -38,7 +38,7 @@ const makeSystemEmoji = (shortName: string): SystemEmoji => ({
     name: shortName,
     short_name: shortName,
     short_names: [shortName],
-    category: 'people',
+    category: 'people-body',
     unified: shortName.toUpperCase(),
 });
 

--- a/webapp/channels/src/components/post/post_options.test.tsx
+++ b/webapp/channels/src/components/post/post_options.test.tsx
@@ -114,7 +114,7 @@ describe('PostOptions - quick reaction count (MM-68681)', () => {
         expect(recentReactions).toHaveAttribute('data-size', '1');
     });
 
-    test('shows 3 quick reaction emojis in RHS_ROOT when isExpanded is true (expanded RHS or suppressed RHS / Global Threads)', () => {
+    test('shows 3 quick reaction emojis in RHS_ROOT when isExpanded is true (expanded RHS or Global Threads view)', () => {
         renderWithContext(
             <PostOptions
                 {...baseProps}

--- a/webapp/channels/src/components/post/post_options.test.tsx
+++ b/webapp/channels/src/components/post/post_options.test.tsx
@@ -3,8 +3,9 @@
 
 import React from 'react';
 
-import {Permissions} from 'mattermost-redux/constants';
 import type {SystemEmoji} from '@mattermost/types/emojis';
+
+import {Permissions} from 'mattermost-redux/constants';
 
 import {renderWithContext, screen} from 'tests/react_testing_utils';
 import {Locations} from 'utils/constants';

--- a/webapp/channels/src/components/post/post_options.test.tsx
+++ b/webapp/channels/src/components/post/post_options.test.tsx
@@ -1,0 +1,142 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {renderWithContext, screen} from 'tests/react_testing_utils';
+import {Locations} from 'utils/constants';
+import {TestHelper} from 'utils/test_helper';
+
+import PostOptions from './post_options';
+
+// Mock connected/complex child components so the test doesn't need a full Redux setup
+jest.mock('components/post_view/post_recent_reactions', () => {
+    return {
+        __esModule: true,
+        default: ({size}: {size: number}) => (
+            <div data-testid='post-recent-reactions' data-size={size}/>
+        ),
+    };
+});
+
+jest.mock('components/dot_menu', () => {
+    return {
+        __esModule: true,
+        default: () => <div data-testid='dot-menu'/>,
+    };
+});
+
+jest.mock('components/actions_menu', () => {
+    return {
+        __esModule: true,
+        default: () => <div data-testid='actions-menu'/>,
+    };
+});
+
+jest.mock('components/post_view/post_reaction', () => {
+    return {
+        __esModule: true,
+        default: () => <div data-testid='post-reaction'/>,
+    };
+});
+
+jest.mock('components/post_view/post_flag_icon', () => {
+    return {
+        __esModule: true,
+        default: () => <div data-testid='post-flag-icon'/>,
+    };
+});
+
+jest.mock('components/common/comment_icon', () => {
+    return {
+        __esModule: true,
+        default: () => <div data-testid='comment-icon'/>,
+    };
+});
+
+jest.mock('components/common/hooks/usePluginVisibilityInSharedChannel', () => ({
+    usePluginVisibilityInSharedChannel: () => true,
+}));
+
+describe('PostOptions - quick reaction count (MM-68681)', () => {
+    // Use type: '' for a regular (non-system) post so reactions are enabled
+    const post = TestHelper.getPostMock({type: ''});
+
+    const baseProps = {
+        post,
+        teamId: 'team1',
+        isFlagged: false,
+        removePost: jest.fn(),
+        enableEmojiPicker: true,
+        isReadOnly: false,
+        channelIsArchived: false,
+        handleDropdownOpened: jest.fn(),
+        oneClickReactionsEnabled: true,
+        // Provide 3 emojis so that the slice(0, size) logic has enough to return
+        recentEmojis: [
+            {name: 'thumbsup', category: 'people'} as any,
+            {name: 'grinning', category: 'people'} as any,
+            {name: 'white_check_mark', category: 'symbols'} as any,
+        ],
+        hover: true, // simulate hover so hoverLocal is true
+        isMobileView: false,
+        location: Locations.RHS_ROOT as keyof typeof Locations,
+        pluginActions: [],
+        isChannelAutotranslated: false,
+        actions: {
+            emitShortcutReactToLastPostFrom: jest.fn(),
+        },
+    };
+
+    test('shows 3 quick reaction emojis in CENTER location', () => {
+        renderWithContext(
+            <PostOptions
+                {...baseProps}
+                location={Locations.CENTER}
+                isExpanded={false}
+            />,
+        );
+
+        const recentReactions = screen.getByTestId('post-recent-reactions');
+        expect(recentReactions).toHaveAttribute('data-size', '3');
+    });
+
+    test('shows 1 quick reaction emoji in RHS_ROOT when isExpanded is false (narrow RHS)', () => {
+        renderWithContext(
+            <PostOptions
+                {...baseProps}
+                location={Locations.RHS_ROOT}
+                isExpanded={false}
+            />,
+        );
+
+        const recentReactions = screen.getByTestId('post-recent-reactions');
+        expect(recentReactions).toHaveAttribute('data-size', '1');
+    });
+
+    test('shows 3 quick reaction emojis in RHS_ROOT when isExpanded is true (expanded RHS or suppressed RHS / Global Threads)', () => {
+        renderWithContext(
+            <PostOptions
+                {...baseProps}
+                location={Locations.RHS_ROOT}
+                isExpanded={true}
+            />,
+        );
+
+        const recentReactions = screen.getByTestId('post-recent-reactions');
+        expect(recentReactions).toHaveAttribute('data-size', '3');
+    });
+
+    test('shows 3 quick reaction emojis in RHS_COMMENT when isExpanded is true', () => {
+        renderWithContext(
+            <PostOptions
+                {...baseProps}
+                location={Locations.RHS_COMMENT}
+                isExpanded={true}
+            />,
+        );
+
+        const recentReactions = screen.getByTestId('post-recent-reactions');
+        expect(recentReactions).toHaveAttribute('data-size', '3');
+    });
+});

--- a/webapp/channels/src/selectors/lhs.test.ts
+++ b/webapp/channels/src/selectors/lhs.test.ts
@@ -4,6 +4,7 @@
 import * as PreferencesSelectors from 'mattermost-redux/selectors/entities/preferences';
 
 import type {GlobalState} from 'types/store';
+import {LhsPage} from 'types/store/lhs';
 
 import * as Lhs from './lhs';
 
@@ -24,6 +25,41 @@ describe('Selectors.Lhs', () => {
 
     beforeEach(() => {
         state = {};
+    });
+
+    describe('getIsGlobalThreadsView', () => {
+        it('returns true when currentStaticPageId is the Threads page', () => {
+            state = {
+                views: {
+                    lhs: {
+                        currentStaticPageId: LhsPage.Threads,
+                    },
+                },
+            };
+            expect(Lhs.getIsGlobalThreadsView(state as GlobalState)).toBe(true);
+        });
+
+        it('returns false when currentStaticPageId is a different static page', () => {
+            state = {
+                views: {
+                    lhs: {
+                        currentStaticPageId: LhsPage.Drafts,
+                    },
+                },
+            };
+            expect(Lhs.getIsGlobalThreadsView(state as GlobalState)).toBe(false);
+        });
+
+        it('returns false when no static page is active (channel view)', () => {
+            state = {
+                views: {
+                    lhs: {
+                        currentStaticPageId: '',
+                    },
+                },
+            };
+            expect(Lhs.getIsGlobalThreadsView(state as GlobalState)).toBe(false);
+        });
     });
 
     describe('should return the open state of the sidebar menu', () => {

--- a/webapp/channels/src/selectors/lhs.ts
+++ b/webapp/channels/src/selectors/lhs.ts
@@ -26,11 +26,6 @@ export function getCurrentStaticPageId(state: GlobalState): string {
     return state.views.lhs.currentStaticPageId;
 }
 
-/**
- * Returns true when the Global Threads page is the active view in the LHS.
- * The Global Threads thread panel renders at full center-channel width, so
- * post hover controls should behave the same as they do in the center channel.
- */
 export function getIsGlobalThreadsView(state: GlobalState): boolean {
     return state.views.lhs.currentStaticPageId === LhsPage.Threads;
 }

--- a/webapp/channels/src/selectors/lhs.ts
+++ b/webapp/channels/src/selectors/lhs.ts
@@ -11,6 +11,7 @@ import {makeGetDraftsCount} from 'selectors/drafts';
 import type {SidebarSize} from 'components/resizable_sidebar/constants';
 
 import type {GlobalState} from 'types/store';
+import {LhsPage} from 'types/store/lhs';
 import type {StaticPage} from 'types/store/lhs';
 
 export function getIsLhsOpen(state: GlobalState): boolean {
@@ -23,6 +24,15 @@ export function getLhsSize(state: GlobalState): SidebarSize {
 
 export function getCurrentStaticPageId(state: GlobalState): string {
     return state.views.lhs.currentStaticPageId;
+}
+
+/**
+ * Returns true when the Global Threads page is the active view in the LHS.
+ * The Global Threads thread panel renders at full center-channel width, so
+ * post hover controls should behave the same as they do in the center channel.
+ */
+export function getIsGlobalThreadsView(state: GlobalState): boolean {
+    return state.views.lhs.currentStaticPageId === LhsPage.Threads;
 }
 
 export const getDraftsCount = makeGetDraftsCount();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

When hovering over a post in the Global Threads view, the hover toolbar showed only 1 quick reaction emoji instead of the 3 shown in the center channel and expanded RHS.

**Root cause:** `PostOptions` decides between `size={3}` and `size={1}` for `PostRecentReactions` based on `props.isExpanded || location === 'CENTER' || #sidebar-right width > 640`. In the Global Threads view, posts use `RHS_ROOT`/`RHS_COMMENT` locations (not `CENTER`), the `#sidebar-right` element is hidden (width = 0), and `isExpanded` was derived only from `state.views.rhs.isSidebarExpanded` (false when no RHS sidebar is open). None of the three conditions were true, so only 1 emoji was shown.

**Fix:** `state.views.lhs.currentStaticPageId` is already set to `LhsPage.Threads` (`'threads'`) by `global_threads.tsx` when the Global Threads view mounts — the existing canonical signal for that view. A new `getIsGlobalThreadsView()` selector wraps this field, and `isExpanded` in `post/index.tsx` now includes it: `state.views.rhs.isSidebarExpanded || getIsGlobalThreadsView(state)`.

This approach was preferred over checking `state.views.rhsSuppressed` (too broad — also true for the Drafts view) and over adding new Redux state (no need: the LHS already tracks which static page is active).

**QA steps:**
1. Enable one-click reactions (`Preferences → Display → Quick reactions on messages`).
2. Open a channel that has a thread.
3. Hover over a post in the center channel — confirm **3** emoji reaction chips appear.
4. Click **Threads** in the left sidebar to open Global Threads, select the thread.
5. Hover over a post in the full-width thread panel — confirm **3** emoji reaction chips appear (previously showed 1).
6. Also verify: opening the same thread in the **collapsed RHS** (narrow sidebar) still shows **1** chip.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68681

#### Screenshots

Before (bug — 1 emoji in Global Threads):
![Before: 1 emoji in Global Threads hover toolbar](https://cursor.com/artifacts/c/art-08686a94-fa0d-4428-b5ab-2a35596a33db)

After (fix — 3 emojis in Global Threads, matching center channel):
![After: 3 emojis in Global Threads hover toolbar](https://cursor.com/artifacts/c/art-17363943-9639-4b41-88a6-57344c6e174c)

[mm68681-fix-verification-3-emojis-in-global-threads.mp4](https://cursor.com/agents/bc-e4361d88-5eae-4467-b93e-b32c3138d36d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fmm68681-fix-verification-3-emojis-in-global-threads.mp4)

#### Release Note

```release-note
Fixed an issue where the Global Threads view showed only 1 quick reaction emoji in the post hover toolbar instead of 3.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4361d88-5eae-4467-b93e-b32c3138d36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4361d88-5eae-4467-b93e-b32c3138d36d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Targeted, isolated change limited to emoji display logic; adds a simple selector and updates a single isExpanded condition with unit and e2e coverage, so risk of unintended regressions is minimal.  
**QA Recommendation:** Quick manual smoke check recommended (verify 3 quick-reaction emojis in Global Threads and unchanged behavior in center channel and collapsed RHS); existing unit and e2e tests cover the change.

*Generated by CodeRabbitAI*

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36512)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->