### PR TITLE
Remove global mutex for login attempts in favour of database serialization

### DIFF
--- a/server/channels/app/authentication.go
+++ b/server/channels/app/authentication.go
@@ -62,7 +62,7 @@ func (a *App) IsPasswordValid(rctx request.CTX, password string) *model.AppError
 	return nil
 }
 
-func (a *App) checkUserPassword(user *model.User, password string, invalidateCache bool) *model.AppError {
+func (a *App) checkUserPassword(user *model.User, password string) *model.AppError {
 	if user.Password == "" || password == "" {
 		return model.NewAppError("checkUserPassword", "api.user.check_user_password.invalid.app_error", nil, "user_id="+user.Id, http.StatusUnauthorized)
 	}
@@ -76,16 +76,6 @@ func (a *App) checkUserPassword(user *model.User, password string, invalidateCac
 	// Compare the password using the hasher that generated it
 	err = hasher.CompareHashAndPassword(phc, password)
 	if err != nil && errors.Is(err, hashers.ErrMismatchedHashAndPassword) {
-		// Increment the number of failed password attempts in case of
-		// mismatched hash and password
-		if passErr := a.Srv().Store().User().UpdateFailedPasswordAttempts(user.Id, user.FailedAttempts+1); passErr != nil {
-			return model.NewAppError("CheckPasswordAndAllCriteria", "app.user.update_failed_pwd_attempts.app_error", nil, "", http.StatusInternalServerError).Wrap(passErr)
-		}
-
-		if invalidateCache {
-			a.InvalidateCacheForUser(user.Id)
-		}
-
 		return model.NewAppError("checkUserPassword", "api.user.check_user_password.invalid.app_error", nil, "user_id="+user.Id, http.StatusUnauthorized).Wrap(err)
 	} else if err != nil {
 		return model.NewAppError("checkUserPassword", "app.valid_password_generic.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -118,11 +108,6 @@ func (a *App) migratePassword(user *model.User, password string) *model.AppError
 }
 
 func (a *App) CheckPasswordAndAllCriteria(rctx request.CTX, userID string, password string, mfaToken string) *model.AppError {
-	// MM-37585
-	// Use locks to avoid concurrently checking AND updating the failed login attempts.
-	a.ch.emailLoginAttemptsMut.Lock()
-	defer a.ch.emailLoginAttemptsMut.Unlock()
-
 	user, err := a.GetUser(userID)
 	if err != nil {
 		if err.Id != MissingAccountError {
@@ -137,16 +122,41 @@ func (a *App) CheckPasswordAndAllCriteria(rctx request.CTX, userID string, passw
 		return err
 	}
 
-	if err := a.checkUserPassword(user, password, false); err != nil {
+	// MM-37585: atomically claim a failed-attempt slot before doing the
+	// expensive password hash comparison. The conditional UPDATE caps
+	// concurrent in-flight authentications to MaximumLoginAttempts per user
+	// without any application-level locking; further attempts for the same
+	// user are rejected here while other users authenticate unhindered.
+	maxAttempts := *a.Config().ServiceSettings.MaximumLoginAttempts
+	claimed, claimErr := a.Srv().Store().User().TryIncrementFailedPasswordAttempts(user.Id, maxAttempts)
+	if claimErr != nil {
+		return model.NewAppError("CheckPasswordAndAllCriteria", "app.user.update_failed_pwd_attempts.app_error", nil, "", http.StatusInternalServerError).Wrap(claimErr)
+	}
+	if !claimed {
+		return model.NewAppError("checkUserLoginAttempts", "api.user.check_user_login_attempts.too_many.app_error", nil, "user_id="+user.Id, http.StatusUnauthorized)
+	}
+
+	if err := a.checkUserPassword(user, password); err != nil {
+		// Only keep the claimed slot when the failure is an actual
+		// credential mismatch; backend errors (hasher failures, migration
+		// failures, malformed stored hash) must not consume a slot or a
+		// transient infra issue could lock out a user with valid creds.
+		if err.Id != "api.user.check_user_password.invalid.app_error" {
+			if passErr := a.Srv().Store().User().DecrementFailedPasswordAttempts(user.Id); passErr != nil {
+				rctx.Logger().Warn("failed to refund login attempt slot", mlog.String("user_id", user.Id), mlog.Err(passErr))
+			}
+		}
 		return err
 	}
 
 	if err := a.CheckUserMfa(rctx, user, mfaToken); err != nil {
-		// If the mfaToken is not set, we assume the client used this as a pre-flight request to query the server
-		// about the MFA state of the user in question
-		if mfaToken != "" {
-			if passErr := a.Srv().Store().User().UpdateFailedPasswordAttempts(user.Id, user.FailedAttempts+1); passErr != nil {
-				return model.NewAppError("CheckPasswordAndAllCriteria", "app.user.update_failed_pwd_attempts.app_error", nil, "", http.StatusInternalServerError).Wrap(passErr)
+		// The slot we claimed already counts this as a failed attempt;
+		// the only special case is when no mfaToken was provided, which
+		// is treated as a pre-flight MFA-state probe rather than a real
+		// attempt — refund the slot so the probe is not counted.
+		if mfaToken == "" {
+			if passErr := a.Srv().Store().User().DecrementFailedPasswordAttempts(user.Id); passErr != nil {
+				rctx.Logger().Warn("failed to refund MFA probe slot", mlog.String("user_id", user.Id), mlog.Err(passErr))
 			}
 		}
 
@@ -166,11 +176,21 @@ func (a *App) CheckPasswordAndAllCriteria(rctx request.CTX, userID string, passw
 
 // This to be used for places we check the users password when they are already logged in
 func (a *App) DoubleCheckPassword(rctx request.CTX, user *model.User, password string) *model.AppError {
-	if err := checkUserLoginAttempts(user, *a.Config().ServiceSettings.MaximumLoginAttempts); err != nil {
-		return err
+	maxAttempts := *a.Config().ServiceSettings.MaximumLoginAttempts
+	claimed, claimErr := a.Srv().Store().User().TryIncrementFailedPasswordAttempts(user.Id, maxAttempts)
+	if claimErr != nil {
+		return model.NewAppError("DoubleCheckPassword", "app.user.update_failed_pwd_attempts.app_error", nil, "", http.StatusInternalServerError).Wrap(claimErr)
+	}
+	if !claimed {
+		return model.NewAppError("checkUserLoginAttempts", "api.user.check_user_login_attempts.too_many.app_error", nil, "user_id="+user.Id, http.StatusUnauthorized)
 	}
 
-	if err := a.checkUserPassword(user, password, true); err != nil {
+	if err := a.checkUserPassword(user, password); err != nil {
+		if err.Id != "api.user.check_user_password.invalid.app_error" {
+			if passErr := a.Srv().Store().User().DecrementFailedPasswordAttempts(user.Id); passErr != nil {
+				rctx.Logger().Warn("failed to refund login attempt slot", mlog.String("user_id", user.Id), mlog.Err(passErr))
+			}
+		}
 		return err
 	}
 
@@ -184,11 +204,7 @@ func (a *App) DoubleCheckPassword(rctx request.CTX, user *model.User, password s
 }
 
 func (a *App) checkLdapUserPasswordAndAllCriteria(rctx request.CTX, user *model.User, password, mfaToken string) (*model.User, *model.AppError) {
-	// MM-37585: Use locks to avoid concurrently checking AND updating the failed login attempts.
-	a.ch.ldapLoginAttemptsMut.Lock()
-	defer a.ch.ldapLoginAttemptsMut.Unlock()
-
-	// We need to get the latest value of the user from the database after we acquire the lock. user is nil for first-time LDAP users.
+	// We need to get the latest value of the user from the database. user.Id is empty for first-time LDAP users.
 	if user.Id != "" {
 		var err *model.AppError
 		user, err = a.GetUser(user.Id)
@@ -209,10 +225,23 @@ func (a *App) checkLdapUserPasswordAndAllCriteria(rctx request.CTX, user *model.
 		return nil, err
 	}
 
-	// First time LDAP users will not have a userID
+	maxAttempts := *a.Config().LdapSettings.MaximumLoginAttempts
+
+	// MM-37585: for existing LDAP users, atomically claim a failed-attempt
+	// slot before contacting the LDAP server. This caps concurrent in-flight
+	// authentications to MaximumLoginAttempts per user without serializing
+	// requests across users. First-time LDAP users have no local row yet, so
+	// we cannot pre-claim — they fall through to DoLogin which creates the
+	// row, and any failure is tracked unconditionally on that fresh row
+	// (preserving the prior behavior that first-time LDAP attempts are not
+	// rate-limited locally).
 	if user.Id != "" {
-		if err := checkUserLoginAttempts(user, *a.Config().LdapSettings.MaximumLoginAttempts); err != nil {
-			return nil, err
+		claimed, claimErr := a.Srv().Store().User().TryIncrementFailedPasswordAttempts(user.Id, maxAttempts)
+		if claimErr != nil {
+			return nil, model.NewAppError("checkLdapUserPasswordAndAllCriteria", "app.user.update_failed_pwd_attempts.app_error", nil, "", http.StatusInternalServerError).Wrap(claimErr)
+		}
+		if !claimed {
+			return nil, model.NewAppError("checkUserLoginAttempts", "api.user.check_user_login_attempts.too_many_ldap.app_error", nil, "user_id="+user.Id, http.StatusUnauthorized)
 		}
 	}
 
@@ -233,8 +262,21 @@ func (a *App) checkLdapUserPasswordAndAllCriteria(rctx request.CTX, user *model.
 		if err.Id == "ent.ldap.do_login.invalid_password.app_error" {
 			rctx.Logger().LogM(mlog.MlvlLDAPInfo, "A user tried to sign in, which matched an LDAP account, but the password was incorrect.", mlog.String("ldap_id", *ldapID))
 
-			if passErr := a.Srv().Store().User().UpdateFailedPasswordAttempts(ldapUser.Id, ldapUser.FailedAttempts+1); passErr != nil {
-				return nil, model.NewAppError("CheckPasswordAndAllCriteria", "app.user.update_failed_pwd_attempts.app_error", nil, "", http.StatusInternalServerError).Wrap(passErr)
+			// For existing users we already claimed the slot above, so the
+			// counter has already been bumped. For first-time users (the
+			// row was just created by DoLogin) we still need to count the
+			// failed attempt explicitly.
+			if user.Id == "" {
+				if passErr := a.Srv().Store().User().UpdateFailedPasswordAttempts(ldapUser.Id, ldapUser.FailedAttempts+1); passErr != nil {
+					return nil, model.NewAppError("checkLdapUserPasswordAndAllCriteria", "app.user.update_failed_pwd_attempts.app_error", nil, "", http.StatusInternalServerError).Wrap(passErr)
+				}
+			}
+		} else if user.Id != "" {
+			// Non-credential failure (LDAP unreachable, transient error,
+			// etc.) on an existing user must not consume the slot we
+			// pre-claimed, or an LDAP outage could lock out everyone.
+			if passErr := a.Srv().Store().User().DecrementFailedPasswordAttempts(user.Id); passErr != nil {
+				rctx.Logger().Warn("failed to refund LDAP login attempt slot", mlog.String("user_id", user.Id), mlog.Err(passErr))
 			}
 		}
 
@@ -243,11 +285,24 @@ func (a *App) checkLdapUserPasswordAndAllCriteria(rctx request.CTX, user *model.
 	}
 
 	if err = a.CheckUserMfa(rctx, ldapUser, mfaToken); err != nil {
-		// If the mfaToken is not set, we assume the client used this as a pre-flight request to query the server
-		// about the MFA state of the user in question
-		if mfaToken != "" && ldapUser.Id != "" {
+		// For existing LDAP users we pre-claimed a slot, so it already
+		// counts as a failed attempt. The only special case is when no
+		// mfaToken was provided, which is treated as a pre-flight
+		// MFA-state probe rather than a real attempt — refund the slot
+		// so the probe is not counted.
+		//
+		// For first-time LDAP users we did not pre-claim (no row to
+		// claim against), so a real MFA attempt with a non-empty token
+		// still needs to be counted explicitly against the freshly
+		// created row.
+		switch {
+		case user.Id == "" && mfaToken != "":
 			if passErr := a.Srv().Store().User().UpdateFailedPasswordAttempts(ldapUser.Id, ldapUser.FailedAttempts+1); passErr != nil {
-				return nil, model.NewAppError("CheckPasswordAndAllCriteria", "app.user.update_failed_pwd_attempts.app_error", nil, "", http.StatusInternalServerError).Wrap(passErr)
+				rctx.Logger().Warn("failed to record failed MFA attempt for first-time LDAP user", mlog.String("user_id", ldapUser.Id), mlog.Err(passErr))
+			}
+		case user.Id != "" && mfaToken == "":
+			if passErr := a.Srv().Store().User().DecrementFailedPasswordAttempts(ldapUser.Id); passErr != nil {
+				rctx.Logger().Warn("failed to refund LDAP MFA probe slot", mlog.String("user_id", ldapUser.Id), mlog.Err(passErr))
 			}
 		}
 		return nil, err
@@ -257,10 +312,8 @@ func (a *App) checkLdapUserPasswordAndAllCriteria(rctx request.CTX, user *model.
 		return nil, err
 	}
 
-	if ldapUser.FailedAttempts > 0 {
-		if passErr := a.Srv().Store().User().UpdateFailedPasswordAttempts(ldapUser.Id, 0); passErr != nil {
-			return nil, model.NewAppError("CheckPasswordAndAllCriteria", "app.user.update_failed_pwd_attempts.app_error", nil, "", http.StatusInternalServerError).Wrap(passErr)
-		}
+	if passErr := a.Srv().Store().User().UpdateFailedPasswordAttempts(ldapUser.Id, 0); passErr != nil {
+		return nil, model.NewAppError("checkLdapUserPasswordAndAllCriteria", "app.user.update_failed_pwd_attempts.app_error", nil, "", http.StatusInternalServerError).Wrap(passErr)
 	}
 
 	// user successfully authenticated

--- a/server/channels/app/authentication_test.go
+++ b/server/channels/app/authentication_test.go
@@ -96,6 +96,62 @@ func TestCheckPasswordAndAllCriteria(t *testing.T) {
 
 		appErr = th.App.CheckPasswordAndAllCriteria(th.Context, th.BasicUser.Id, password, token)
 		require.Nil(t, appErr)
+
+		updatedUser, appErr := th.App.GetUser(th.BasicUser.Id)
+		require.Nil(t, appErr)
+		require.Equal(t, 0, updatedUser.FailedAttempts, "successful login must reset FailedAttempts")
+	})
+
+	t.Run("MFA pre-flight probe does not consume a slot", func(t *testing.T) {
+		// An empty mfaToken on an MFA-enabled user is a pre-flight probe
+		// (the client is checking whether MFA is required) and must not
+		// count as a failed attempt.
+		err := th.App.Srv().Store().User().UpdateFailedPasswordAttempts(th.BasicUser.Id, 0)
+		require.NoError(t, err)
+
+		appErr := th.App.CheckPasswordAndAllCriteria(th.Context, th.BasicUser.Id, password, "")
+		require.NotNil(t, appErr)
+
+		updatedUser, appErr := th.App.GetUser(th.BasicUser.Id)
+		require.Nil(t, appErr)
+		require.Equal(t, 0, updatedUser.FailedAttempts, "MFA probe must not consume a slot")
+	})
+
+	t.Run("MFA real attempt with a wrong token consumes a slot", func(t *testing.T) {
+		// A non-empty bad mfaToken is a real attempt, not a probe; the
+		// slot the pre-claim consumed stays consumed.
+		err := th.App.Srv().Store().User().UpdateFailedPasswordAttempts(th.BasicUser.Id, 0)
+		require.NoError(t, err)
+
+		appErr := th.App.CheckPasswordAndAllCriteria(th.Context, th.BasicUser.Id, password, "123456")
+		require.NotNil(t, appErr)
+		require.Equal(t, "api.user.check_user_mfa.bad_code.app_error", appErr.Id)
+
+		updatedUser, appErr := th.App.GetUser(th.BasicUser.Id)
+		require.Nil(t, appErr)
+		require.Equal(t, 1, updatedUser.FailedAttempts, "real MFA failure must consume a slot")
+	})
+
+	t.Run("backend error refunds the slot", func(t *testing.T) {
+		// Backend errors during the password check (malformed stored hash,
+		// hasher misc failure, migration failure) must not consume a slot
+		// or a transient infra issue could lock out a user with valid
+		// credentials. We trigger this via an unparseable PHC string,
+		// which surfaces as invalid_hash.app_error.
+		badHashUser := th.CreateUser(t)
+		err := th.Server.Store().User().UpdatePassword(badHashUser.Id, "$pbkdf2$bogus")
+		require.NoError(t, err)
+		th.App.InvalidateCacheForUser(badHashUser.Id)
+		err = th.App.Srv().Store().User().UpdateFailedPasswordAttempts(badHashUser.Id, 0)
+		require.NoError(t, err)
+
+		appErr := th.App.CheckPasswordAndAllCriteria(th.Context, badHashUser.Id, "any-password", "")
+		require.NotNil(t, appErr)
+		require.Equal(t, "api.user.check_user_password.invalid_hash.app_error", appErr.Id)
+
+		updatedUser, appErr := th.App.GetUser(badHashUser.Id)
+		require.Nil(t, appErr)
+		require.Equal(t, 0, updatedUser.FailedAttempts, "backend error must not consume a slot")
 	})
 
 	t.Run("validate concurrent failed attempts to bypass checks", func(t *testing.T) {
@@ -156,6 +212,66 @@ func TestCheckPasswordAndAllCriteria(t *testing.T) {
 				require.Equal(t, maxFailedLoginAttempts, expectedErrsCount)
 			})
 		}
+	})
+}
+
+func TestDoubleCheckPassword(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	const maxFailedLoginAttempts = 3
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.MaximumLoginAttempts = maxFailedLoginAttempts
+	})
+
+	password := model.NewTestPassword()
+	appErr := th.App.UpdatePassword(th.Context, th.BasicUser, password)
+	require.Nil(t, appErr)
+
+	// DoubleCheckPassword does not re-fetch the user; it inspects user.Password
+	// directly. Pull a fresh struct that reflects the hash we just wrote.
+	user, appErr := th.App.GetUser(th.BasicUser.Id)
+	require.Nil(t, appErr)
+
+	t.Run("correct password succeeds and resets the counter", func(t *testing.T) {
+		err := th.App.Srv().Store().User().UpdateFailedPasswordAttempts(user.Id, maxFailedLoginAttempts-1)
+		require.NoError(t, err)
+
+		appErr := th.App.DoubleCheckPassword(th.Context, user, password)
+		require.Nil(t, appErr)
+
+		updatedUser, appErr := th.App.GetUser(user.Id)
+		require.Nil(t, appErr)
+		require.Equal(t, 0, updatedUser.FailedAttempts)
+	})
+
+	t.Run("rate limit is enforced once max attempts is reached", func(t *testing.T) {
+		err := th.App.Srv().Store().User().UpdateFailedPasswordAttempts(user.Id, maxFailedLoginAttempts)
+		require.NoError(t, err)
+
+		appErr := th.App.DoubleCheckPassword(th.Context, user, password)
+		require.NotNil(t, appErr)
+		require.Equal(t, "api.user.check_user_login_attempts.too_many.app_error", appErr.Id)
+	})
+
+	t.Run("backend error refunds the slot", func(t *testing.T) {
+		badHashUser := th.CreateUser(t)
+		err := th.Server.Store().User().UpdatePassword(badHashUser.Id, "$pbkdf2$bogus")
+		require.NoError(t, err)
+		th.App.InvalidateCacheForUser(badHashUser.Id)
+		err = th.App.Srv().Store().User().UpdateFailedPasswordAttempts(badHashUser.Id, 0)
+		require.NoError(t, err)
+
+		user, appErr := th.App.GetUser(badHashUser.Id)
+		require.Nil(t, appErr)
+
+		appErr = th.App.DoubleCheckPassword(th.Context, user, "any-password")
+		require.NotNil(t, appErr)
+		require.Equal(t, "api.user.check_user_password.invalid_hash.app_error", appErr.Id)
+
+		updatedUser, appErr := th.App.GetUser(badHashUser.Id)
+		require.Nil(t, appErr)
+		require.Equal(t, 0, updatedUser.FailedAttempts, "backend error must not consume a slot")
 	})
 }
 
@@ -256,6 +372,123 @@ func TestCheckLdapUserPasswordAndAllCriteria(t *testing.T) {
 			}
 		})
 	}
+
+	// The cases below cover paths the table loop above does not exercise:
+	// first-time LDAP users (user.Id == ""), LDAP backend errors that are
+	// not credential failures, and the MFA pre-flight probe refund. Each
+	// subtest builds its own mockLdap so expectations from previous
+	// subtests cannot match the wrong call.
+
+	createLdapUserWithMFA := func(t *testing.T, emailLocal string) (*model.User, *string) {
+		t.Helper()
+		userAuthData := model.NewRandomString(32)
+		created, appErr := th.App.CreateUser(th.Context, &model.User{
+			Email:         emailLocal + "@mattermost-customer.com",
+			Username:      emailLocal,
+			AuthService:   model.UserAuthServiceLdap,
+			AuthData:      &userAuthData,
+			EmailVerified: true,
+		})
+		require.Nil(t, appErr)
+		secret, appErr := th.App.GenerateMfaSecret(created.Id)
+		require.Nil(t, appErr)
+		require.NoError(t, th.Server.Store().User().UpdateMfaActive(created.Id, true))
+		require.NoError(t, th.Server.Store().User().UpdateMfaSecret(created.Id, secret.Secret))
+		require.NoError(t, th.App.Srv().Store().User().UpdateFailedPasswordAttempts(created.Id, 0))
+		created, appErr = th.App.GetUser(created.Id)
+		require.Nil(t, appErr)
+		created.AuthData = &userAuthData
+		return created, &userAuthData
+	}
+
+	t.Run("first-time LDAP user with wrong password increments counter", func(t *testing.T) {
+		// DoLogin in production creates the row before reporting a bad
+		// password; we pre-create it here so GetUserByAuth can resolve it.
+		firstAuthData := model.NewRandomString(32)
+		preCreated, appErr := th.App.CreateUser(th.Context, &model.User{
+			Email:         "ldapuser-first-bad-pwd@mattermost-customer.com",
+			Username:      "ldapuser-first-bad-pwd",
+			AuthService:   model.UserAuthServiceLdap,
+			AuthData:      &firstAuthData,
+			EmailVerified: true,
+		})
+		require.Nil(t, appErr)
+		require.NoError(t, th.App.Srv().Store().User().UpdateFailedPasswordAttempts(preCreated.Id, 0))
+
+		freshMock := &mocks.LdapInterface{}
+		th.App.Channels().Ldap = freshMock
+		t.Cleanup(func() { th.App.Channels().Ldap = mockLdap })
+		freshMock.Mock.On("DoLogin", th.Context, firstAuthData, wrongPassword).Return(nil, &model.AppError{Id: "ent.ldap.do_login.invalid_password.app_error"})
+
+		_, appErr = th.App.checkLdapUserPasswordAndAllCriteria(th.Context, &model.User{
+			AuthService: model.UserAuthServiceLdap,
+			AuthData:    &firstAuthData,
+		}, wrongPassword, "")
+		require.NotNil(t, appErr)
+
+		updatedUser, appErr := th.App.GetUser(preCreated.Id)
+		require.Nil(t, appErr)
+		require.Equal(t, 1, updatedUser.FailedAttempts, "first-time LDAP wrong password must be counted")
+	})
+
+	t.Run("first-time LDAP user with wrong MFA token increments counter", func(t *testing.T) {
+		// DoLogin returns the freshly created user struct; the function
+		// then calls CheckUserMfa, which fails on a wrong non-empty token.
+		preCreated, authDataPtr := createLdapUserWithMFA(t, "ldapuser-first-bad-mfa")
+
+		freshMock := &mocks.LdapInterface{}
+		th.App.Channels().Ldap = freshMock
+		t.Cleanup(func() { th.App.Channels().Ldap = mockLdap })
+		freshMock.Mock.On("DoLogin", th.Context, *authDataPtr, validPassword).Return(preCreated, nil)
+
+		_, appErr := th.App.checkLdapUserPasswordAndAllCriteria(th.Context, &model.User{
+			AuthService: model.UserAuthServiceLdap,
+			AuthData:    authDataPtr,
+		}, validPassword, "123456")
+		require.NotNil(t, appErr)
+		require.Equal(t, "api.user.check_user_mfa.bad_code.app_error", appErr.Id)
+
+		updatedUser, appErr := th.App.GetUser(preCreated.Id)
+		require.Nil(t, appErr)
+		require.Equal(t, 1, updatedUser.FailedAttempts, "first-time LDAP wrong MFA must be counted")
+	})
+
+	t.Run("existing LDAP user with LDAP backend error refunds the slot", func(t *testing.T) {
+		// A non-credential LDAP error (server unreachable, transient
+		// failure) on an existing user must not consume the pre-claimed
+		// slot, or an LDAP outage could lock out everyone.
+		require.NoError(t, th.App.Srv().Store().User().UpdateFailedPasswordAttempts(user.Id, 0))
+
+		freshMock := &mocks.LdapInterface{}
+		th.App.Channels().Ldap = freshMock
+		t.Cleanup(func() { th.App.Channels().Ldap = mockLdap })
+		freshMock.Mock.On("DoLogin", th.Context, authData, wrongPassword).Return(nil, &model.AppError{Id: "ent.ldap.do_login.unable_to_connect.app_error"})
+
+		_, appErr := th.App.checkLdapUserPasswordAndAllCriteria(th.Context, user, wrongPassword, "")
+		require.NotNil(t, appErr)
+
+		updatedUser, appErr := th.App.GetUser(user.Id)
+		require.Nil(t, appErr)
+		require.Equal(t, 0, updatedUser.FailedAttempts, "LDAP backend error must refund the slot")
+	})
+
+	t.Run("existing LDAP user MFA pre-flight probe refunds the slot", func(t *testing.T) {
+		// Empty mfaToken on an MFA-enabled LDAP user is a probe; the slot
+		// the pre-claim consumed is refunded.
+		preCreated, authDataPtr := createLdapUserWithMFA(t, "ldapuser-existing-mfa-probe")
+
+		freshMock := &mocks.LdapInterface{}
+		th.App.Channels().Ldap = freshMock
+		t.Cleanup(func() { th.App.Channels().Ldap = mockLdap })
+		freshMock.Mock.On("DoLogin", th.Context, *authDataPtr, validPassword).Return(preCreated, nil)
+
+		_, appErr := th.App.checkLdapUserPasswordAndAllCriteria(th.Context, preCreated, validPassword, "")
+		require.NotNil(t, appErr)
+
+		updatedUser, appErr := th.App.GetUser(preCreated.Id)
+		require.Nil(t, appErr)
+		require.Equal(t, 0, updatedUser.FailedAttempts, "MFA probe on existing LDAP user must not consume a slot")
+	})
 }
 
 func TestCheckLdapUserPasswordConcurrency(t *testing.T) {
@@ -400,13 +633,7 @@ func TestCheckUserPassword(t *testing.T) {
 
 	t.Run("valid password with current hashing", func(t *testing.T) {
 		user := createUserWithHash(pwdPBKDF2)
-		err := th.App.checkUserPassword(user, pwd, false)
-		require.Nil(t, err)
-	})
-
-	t.Run("valid password with current hashing and cache invalidation", func(t *testing.T) {
-		user := createUserWithHash(pwdPBKDF2)
-		err := th.App.checkUserPassword(user, pwd, true)
+		err := th.App.checkUserPassword(user, pwd)
 		require.Nil(t, err)
 	})
 
@@ -415,13 +642,16 @@ func TestCheckUserPassword(t *testing.T) {
 	t.Run("invalid password", func(t *testing.T) {
 		user := createUserWithHash(pwdPBKDF2)
 
-		err := th.App.checkUserPassword(user, wrongPassword, false)
+		err := th.App.checkUserPassword(user, wrongPassword)
 		require.NotNil(t, err)
 		require.Equal(t, "api.user.check_user_password.invalid.app_error", err.Id)
 
+		// checkUserPassword is now a pure check with no side effects on
+		// FailedAttempts; the counter is managed by the callers via
+		// TryIncrementFailedPasswordAttempts.
 		updatedUser, err := th.App.GetUser(user.Id)
 		require.Nil(t, err)
-		require.Equal(t, user.FailedAttempts+1, updatedUser.FailedAttempts)
+		require.Equal(t, user.FailedAttempts, updatedUser.FailedAttempts)
 	})
 
 	t.Run("password migration from outdated hash", func(t *testing.T) {
@@ -429,7 +659,7 @@ func TestCheckUserPassword(t *testing.T) {
 		require.Contains(t, user.Password, "$2a$10")
 		require.NotContains(t, user.Password, "pbkdf2")
 
-		err := th.App.checkUserPassword(user, pwd, false)
+		err := th.App.checkUserPassword(user, pwd)
 		require.Nil(t, err)
 
 		updatedUser, err := th.App.GetUser(user.Id)
@@ -438,20 +668,21 @@ func TestCheckUserPassword(t *testing.T) {
 		require.Contains(t, updatedUser.Password, "$pbkdf2")
 
 		// Re-check with updated password
-		err = th.App.checkUserPassword(user, pwd, false)
+		err = th.App.checkUserPassword(updatedUser, pwd)
 		require.Nil(t, err)
 	})
 
 	t.Run("password migration fails with invalid password", func(t *testing.T) {
 		user := createUserWithHash(pwdBcrypt)
 
-		err := th.App.checkUserPassword(user, wrongPassword, false)
+		err := th.App.checkUserPassword(user, wrongPassword)
 		require.NotNil(t, err)
 		require.Equal(t, "api.user.check_user_password.invalid.app_error", err.Id)
 
+		// checkUserPassword does not mutate FailedAttempts.
 		updatedUser, err := th.App.GetUser(user.Id)
 		require.Nil(t, err)
-		require.Equal(t, user.FailedAttempts+1, updatedUser.FailedAttempts)
+		require.Equal(t, user.FailedAttempts, updatedUser.FailedAttempts)
 	})
 
 	t.Run("empty password", func(t *testing.T) {
@@ -460,7 +691,7 @@ func TestCheckUserPassword(t *testing.T) {
 		user, err := th.App.GetUser(user.Id)
 		require.Nil(t, err)
 
-		err = th.App.checkUserPassword(user, "", false)
+		err = th.App.checkUserPassword(user, "")
 		require.NotNil(t, err)
 		require.Equal(t, "api.user.check_user_password.invalid.app_error", err.Id)
 	})
@@ -471,7 +702,7 @@ func TestCheckUserPassword(t *testing.T) {
 		user, err := th.App.GetUser(user.Id)
 		require.Nil(t, err)
 
-		err = th.App.checkUserPassword(user, pwd, false)
+		err = th.App.checkUserPassword(user, pwd)
 		require.NotNil(t, err)
 		require.Equal(t, "api.user.check_user_password.invalid.app_error", err.Id)
 	})
@@ -489,7 +720,7 @@ func TestCheckUserPassword(t *testing.T) {
 		// The user hash contains the old parameter
 		require.Contains(t, user.Password, "w=10000")
 
-		appErr := th.App.checkUserPassword(user, pwd, false)
+		appErr := th.App.checkUserPassword(user, pwd)
 		require.Nil(t, appErr)
 
 		updatedUser, appErr := th.App.GetUser(user.Id)
@@ -500,7 +731,7 @@ func TestCheckUserPassword(t *testing.T) {
 		require.NotContains(t, updatedUser.Password, "w=10000")
 
 		// Re-check with updated password
-		appErr = th.App.checkUserPassword(user, pwd, false)
+		appErr = th.App.checkUserPassword(updatedUser, pwd)
 		require.Nil(t, appErr)
 	})
 }
@@ -542,7 +773,7 @@ func TestMigratePassword(t *testing.T) {
 		require.Contains(t, updatedUser.Password, "$pbkdf2")
 
 		// Re-check with updated password
-		err = th.App.checkUserPassword(user, pwd, false)
+		err = th.App.checkUserPassword(updatedUser, pwd)
 		require.Nil(t, err)
 	})
 }

--- a/server/channels/app/channels.go
+++ b/server/channels/app/channels.go
@@ -92,11 +92,9 @@ type Channels struct {
 	postReminderMut  sync.Mutex
 	postReminderTask *model.ScheduledTask
 
-	interruptQuitChan     chan struct{}
-	scheduledPostMut      sync.Mutex
-	scheduledPostTask     *model.ScheduledTask
-	emailLoginAttemptsMut sync.Mutex
-	ldapLoginAttemptsMut  sync.Mutex
+	interruptQuitChan chan struct{}
+	scheduledPostMut  sync.Mutex
+	scheduledPostTask *model.ScheduledTask
 }
 
 func NewChannels(s *Server) (*Channels, error) {

--- a/server/channels/store/localcachelayer/user_layer.go
+++ b/server/channels/store/localcachelayer/user_layer.go
@@ -222,6 +222,25 @@ func (s *LocalCacheUserStore) UpdateFailedPasswordAttempts(userID string, attemp
 	return s.UserStore.UpdateFailedPasswordAttempts(userID, attempts)
 }
 
+func (s *LocalCacheUserStore) TryIncrementFailedPasswordAttempts(userID string, maxAttempts int) (bool, error) {
+	claimed, err := s.UserStore.TryIncrementFailedPasswordAttempts(userID, maxAttempts)
+	if err != nil {
+		return false, err
+	}
+	if claimed {
+		s.InvalidateProfileCacheForUser(userID)
+	}
+	return claimed, nil
+}
+
+func (s *LocalCacheUserStore) DecrementFailedPasswordAttempts(userID string) error {
+	if err := s.UserStore.DecrementFailedPasswordAttempts(userID); err != nil {
+		return err
+	}
+	s.InvalidateProfileCacheForUser(userID)
+	return nil
+}
+
 // Get is a cache wrapper around the SqlStore method to get a user profile by id.
 // It checks if the user entry is present in the cache, returning the entry from cache
 // if it is present. Otherwise, it fetches the entry from the store and stores it in the

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -17193,6 +17193,48 @@ func (s *RetryLayerUserStore) UpdateFailedPasswordAttempts(userID string, attemp
 
 }
 
+func (s *RetryLayerUserStore) TryIncrementFailedPasswordAttempts(userID string, maxAttempts int) (bool, error) {
+
+	tries := 0
+	for {
+		result, err := s.UserStore.TryIncrementFailedPasswordAttempts(userID, maxAttempts)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
+func (s *RetryLayerUserStore) DecrementFailedPasswordAttempts(userID string) error {
+
+	tries := 0
+	for {
+		err := s.UserStore.DecrementFailedPasswordAttempts(userID)
+		if err == nil {
+			return nil
+		}
+		if !isRepeatableError(err) {
+			return err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerUserStore) UpdateLastLogin(userID string, lastLogin int64) error {
 
 	tries := 0

--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -426,6 +426,45 @@ func (us SqlUserStore) UpdateFailedPasswordAttempts(userId string, attempts int)
 	return nil
 }
 
+// TryIncrementFailedPasswordAttempts atomically increments FailedAttempts by one
+// for the given user, only if FailedAttempts is strictly less than maxAttempts.
+// Returns true if the row was updated (a slot was claimed), false if the cap had
+// already been reached (or the user does not exist). The row lock taken by the
+// UPDATE serializes concurrent attempts on the same user, so the cap predicate
+// is enforced without any application-level locking.
+func (us SqlUserStore) TryIncrementFailedPasswordAttempts(userId string, maxAttempts int) (bool, error) {
+	res, err := us.GetMaster().Exec(
+		"UPDATE Users SET FailedAttempts = FailedAttempts + 1 WHERE Id = ? AND FailedAttempts < ?",
+		userId, maxAttempts,
+	)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to update User with userId=%s", userId)
+	}
+
+	rows, err := res.RowsAffected()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to read rows affected for userId=%s", userId)
+	}
+
+	return rows == 1, nil
+}
+
+// DecrementFailedPasswordAttempts atomically decrements FailedAttempts by one
+// for the given user, only if FailedAttempts is strictly greater than zero. It
+// is used to refund a slot previously claimed by TryIncrementFailedPasswordAttempts
+// when the in-flight authentication turns out not to be a credential-failure
+// event (e.g. a backend error or an MFA pre-flight probe).
+func (us SqlUserStore) DecrementFailedPasswordAttempts(userId string) error {
+	_, err := us.GetMaster().Exec(
+		"UPDATE Users SET FailedAttempts = FailedAttempts - 1 WHERE Id = ? AND FailedAttempts > 0",
+		userId,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "failed to update User with userId=%s", userId)
+	}
+	return nil
+}
+
 func (us SqlUserStore) UpdateAuthData(userId string, service string, authData *string, email string, resetMfa bool) (string, error) {
 	updateAt := model.GetMillis()
 

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -476,6 +476,8 @@ type UserStore interface {
 	GetEtagForAllProfiles() string
 	GetEtagForProfiles(teamID string) string
 	UpdateFailedPasswordAttempts(userID string, attempts int) error
+	TryIncrementFailedPasswordAttempts(userID string, maxAttempts int) (bool, error)
+	DecrementFailedPasswordAttempts(userID string) error
 	GetSystemAdminProfiles() (map[string]*model.User, error)
 	PermanentDelete(rctx request.CTX, userID string) error
 	AnalyticsActiveCount(timestamp int64, options model.UserCountOptions) (int64, error)

--- a/server/channels/store/storetest/mocks/UserStore.go
+++ b/server/channels/store/storetest/mocks/UserStore.go
@@ -2126,6 +2126,52 @@ func (_m *UserStore) UpdateFailedPasswordAttempts(userID string, attempts int) e
 	return r0
 }
 
+// TryIncrementFailedPasswordAttempts provides a mock function with given fields: userID, maxAttempts
+func (_m *UserStore) TryIncrementFailedPasswordAttempts(userID string, maxAttempts int) (bool, error) {
+	ret := _m.Called(userID, maxAttempts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for TryIncrementFailedPasswordAttempts")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, int) (bool, error)); ok {
+		return rf(userID, maxAttempts)
+	}
+	if rf, ok := ret.Get(0).(func(string, int) bool); ok {
+		r0 = rf(userID, maxAttempts)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(string, int) error); ok {
+		r1 = rf(userID, maxAttempts)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// DecrementFailedPasswordAttempts provides a mock function with given fields: userID
+func (_m *UserStore) DecrementFailedPasswordAttempts(userID string) error {
+	ret := _m.Called(userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DecrementFailedPasswordAttempts")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(userID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // UpdateLastLogin provides a mock function with given fields: userID, lastLogin
 func (_m *UserStore) UpdateLastLogin(userID string, lastLogin int64) error {
 	ret := _m.Called(userID, lastLogin)

--- a/server/channels/store/storetest/user_store.go
+++ b/server/channels/store/storetest/user_store.go
@@ -9,6 +9,8 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -54,6 +56,8 @@ func TestUserStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
 	t.Run("Update", func(t *testing.T) { testUserStoreUpdate(t, rctx, ss) })
 	t.Run("UpdateUpdateAt", func(t *testing.T) { testUserStoreUpdateUpdateAt(t, rctx, ss) })
 	t.Run("UpdateFailedPasswordAttempts", func(t *testing.T) { testUserStoreUpdateFailedPasswordAttempts(t, rctx, ss) })
+	t.Run("TryIncrementFailedPasswordAttempts", func(t *testing.T) { testUserStoreTryIncrementFailedPasswordAttempts(t, rctx, ss) })
+	t.Run("DecrementFailedPasswordAttempts", func(t *testing.T) { testUserStoreDecrementFailedPasswordAttempts(t, rctx, ss) })
 	t.Run("Get", func(t *testing.T) { testUserStoreGet(t, rctx, ss) })
 	t.Run("GetAllUsingAuthService", func(t *testing.T) { testGetAllUsingAuthService(t, rctx, ss) })
 	t.Run("GetAllProfiles", func(t *testing.T) { testUserStoreGetAllProfiles(t, rctx, ss) })
@@ -347,6 +351,161 @@ func testUserStoreUpdateFailedPasswordAttempts(t *testing.T, rctx request.CTX, s
 	user, err := ss.User().Get(context.Background(), u1.Id)
 	require.NoError(t, err)
 	require.Equal(t, 3, user.FailedAttempts, "FailedAttempts not updated correctly")
+}
+
+func testUserStoreTryIncrementFailedPasswordAttempts(t *testing.T, rctx request.CTX, ss store.Store) {
+	u1 := &model.User{}
+	u1.Email = MakeEmail()
+	_, err := ss.User().Save(rctx, u1)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
+	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1)
+	require.NoError(t, nErr)
+
+	const maxAttempts = 3
+
+	t.Run("claims a slot when below cap", func(t *testing.T) {
+		require.NoError(t, ss.User().UpdateFailedPasswordAttempts(u1.Id, 0))
+
+		claimed, err := ss.User().TryIncrementFailedPasswordAttempts(u1.Id, maxAttempts)
+		require.NoError(t, err)
+		require.True(t, claimed)
+
+		user, err := ss.User().Get(context.Background(), u1.Id)
+		require.NoError(t, err)
+		require.Equal(t, 1, user.FailedAttempts)
+	})
+
+	t.Run("does not claim a slot when at cap", func(t *testing.T) {
+		require.NoError(t, ss.User().UpdateFailedPasswordAttempts(u1.Id, maxAttempts))
+
+		claimed, err := ss.User().TryIncrementFailedPasswordAttempts(u1.Id, maxAttempts)
+		require.NoError(t, err)
+		require.False(t, claimed)
+
+		user, err := ss.User().Get(context.Background(), u1.Id)
+		require.NoError(t, err)
+		require.Equal(t, maxAttempts, user.FailedAttempts, "counter must not advance past the cap")
+	})
+
+	t.Run("does not claim a slot when above cap", func(t *testing.T) {
+		require.NoError(t, ss.User().UpdateFailedPasswordAttempts(u1.Id, maxAttempts+5))
+
+		claimed, err := ss.User().TryIncrementFailedPasswordAttempts(u1.Id, maxAttempts)
+		require.NoError(t, err)
+		require.False(t, claimed)
+
+		user, err := ss.User().Get(context.Background(), u1.Id)
+		require.NoError(t, err)
+		require.Equal(t, maxAttempts+5, user.FailedAttempts)
+	})
+
+	t.Run("does not claim a slot for unknown user", func(t *testing.T) {
+		claimed, err := ss.User().TryIncrementFailedPasswordAttempts(model.NewId(), maxAttempts)
+		require.NoError(t, err)
+		require.False(t, claimed)
+	})
+
+	t.Run("concurrent attempts cap at maxAttempts", func(t *testing.T) {
+		require.NoError(t, ss.User().UpdateFailedPasswordAttempts(u1.Id, 0))
+
+		const goroutines = 50
+		var wg sync.WaitGroup
+		var claimed atomic.Int64
+		start := make(chan struct{})
+		errCh := make(chan error, goroutines)
+		wg.Add(goroutines)
+		for range goroutines {
+			go func() {
+				defer wg.Done()
+				<-start
+				ok, err := ss.User().TryIncrementFailedPasswordAttempts(u1.Id, maxAttempts)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if ok {
+					claimed.Add(1)
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			require.NoError(t, err)
+		}
+
+		require.Equal(t, int64(maxAttempts), claimed.Load(), "exactly maxAttempts goroutines must have claimed a slot")
+
+		user, err := ss.User().Get(context.Background(), u1.Id)
+		require.NoError(t, err)
+		require.Equal(t, maxAttempts, user.FailedAttempts)
+	})
+}
+
+func testUserStoreDecrementFailedPasswordAttempts(t *testing.T, rctx request.CTX, ss store.Store) {
+	u1 := &model.User{}
+	u1.Email = MakeEmail()
+	_, err := ss.User().Save(rctx, u1)
+	require.NoError(t, err)
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, u1.Id)) }()
+	_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: model.NewId(), UserId: u1.Id}, -1)
+	require.NoError(t, nErr)
+
+	t.Run("decrements when above zero", func(t *testing.T) {
+		require.NoError(t, ss.User().UpdateFailedPasswordAttempts(u1.Id, 3))
+
+		require.NoError(t, ss.User().DecrementFailedPasswordAttempts(u1.Id))
+
+		user, err := ss.User().Get(context.Background(), u1.Id)
+		require.NoError(t, err)
+		require.Equal(t, 2, user.FailedAttempts)
+	})
+
+	t.Run("does not go below zero", func(t *testing.T) {
+		require.NoError(t, ss.User().UpdateFailedPasswordAttempts(u1.Id, 0))
+
+		require.NoError(t, ss.User().DecrementFailedPasswordAttempts(u1.Id))
+
+		user, err := ss.User().Get(context.Background(), u1.Id)
+		require.NoError(t, err)
+		require.Equal(t, 0, user.FailedAttempts)
+	})
+
+	t.Run("no-op for unknown user", func(t *testing.T) {
+		require.NoError(t, ss.User().DecrementFailedPasswordAttempts(model.NewId()))
+	})
+
+	t.Run("concurrent decrements never go below zero", func(t *testing.T) {
+		const initial = 10
+		const goroutines = 50
+		require.NoError(t, ss.User().UpdateFailedPasswordAttempts(u1.Id, initial))
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		errCh := make(chan error, goroutines)
+		wg.Add(goroutines)
+		for range goroutines {
+			go func() {
+				defer wg.Done()
+				<-start
+				if err := ss.User().DecrementFailedPasswordAttempts(u1.Id); err != nil {
+					errCh <- err
+				}
+			}()
+		}
+		close(start)
+		wg.Wait()
+		close(errCh)
+		for err := range errCh {
+			require.NoError(t, err)
+		}
+
+		user, err := ss.User().Get(context.Background(), u1.Id)
+		require.NoError(t, err)
+		require.Equal(t, 0, user.FailedAttempts, "decrement must clamp at zero under contention")
+	})
 }
 
 func testUserStoreGet(t *testing.T, rctx request.CTX, ss store.Store) {

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -13603,6 +13603,38 @@ func (s *TimerLayerUserStore) UpdateFailedPasswordAttempts(userID string, attemp
 	return err
 }
 
+func (s *TimerLayerUserStore) TryIncrementFailedPasswordAttempts(userID string, maxAttempts int) (bool, error) {
+	start := time.Now()
+
+	result, err := s.UserStore.TryIncrementFailedPasswordAttempts(userID, maxAttempts)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("UserStore.TryIncrementFailedPasswordAttempts", success, elapsed)
+	}
+	return result, err
+}
+
+func (s *TimerLayerUserStore) DecrementFailedPasswordAttempts(userID string) error {
+	start := time.Now()
+
+	err := s.UserStore.DecrementFailedPasswordAttempts(userID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("UserStore.DecrementFailedPasswordAttempts", success, elapsed)
+	}
+	return err
+}
+
 func (s *TimerLayerUserStore) UpdateLastLogin(userID string, lastLogin int64) error {
 	start := time.Now()
 


### PR DESCRIPTION
#### Summary
Use the database as a per-user serialization mechanism instead of having a global mutex for all user attempting to login. This approach has two main advantages:
1. Performance: We remove the global mutex that serialized all login attempts across all users (per cluster node). The serialization now happens for each user individually, so the contention is virtually zero.
2. Semantics: We no longer allow for `m*MaximumLoginAttempts`, where `m` is the number of nodes in a Mattermost cluster, but we honour `MaximumLoginAttempts` globally.

This is a clean re-roll of #36303. That PR collected a long iteration history (bot reviews, four load-test runs, several force-pushes for rebases and review fixes), so this PR squashes the same final state into four logical commits: the new store primitives, the regenerated layers, the auth-flow rewrite, and the app-layer tests. The net diff is byte-identical to the final state of #36303 and all review findings on that PR have been addressed here. Across six load-test runs on #36303 the new build averaged +44.5% supported users over the base; one more run will fire on this PR for confirmation. #36303 will be closed in favour of this one.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68732

#### Screenshots
--

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36514)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->