### PR TITLE
Add `Session` field to `Subject`

### DIFF
--- a/server/public/model/access_request.go
+++ b/server/public/model/access_request.go
@@ -18,6 +18,7 @@ type Subject struct {
 	// An attribute may be single-valued or multi-valued and can be a primitive type
 	// (string, boolean, number) or a complex type like a JSON object or array.
 	Attributes map[string]any `json:"attributes"`
+	Session    map[string]any `json:"session"`
 }
 
 type SubjectSearchOptions struct {


### PR DESCRIPTION
#### Summary
I ended up merging https://github.com/mattermost/enterprise/pull/2161 prematurely which broke master. Since https://github.com/mattermost/mattermost/pull/36511 is still under review, this change should fix the build.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change adds a new `Session` field to the `Subject` struct in the public model API, which is consumed across access control, API endpoints, and storage layers. While it's an additive change that maintains backward compatibility, the field is not currently being populated by the store layer or anywhere else in the codebase. This incomplete implementation could cause issues if downstream systems (like the referenced enterprise PR) expect this field to be populated with actual session data.

**QA Recommendation:** Manual testing should focus on access control API endpoints and authorization flows to verify that the unpopulated Session field doesn't cause unexpected behavior in clients or policies that may depend on it. Verify that existing access control workflows continue to function correctly and check integration with dependent enterprise features once they're merged.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36523)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->