### PR TITLE
Fix MM-57406: prevent IPv6 hex segments from parsing as emoji

### DIFF
--- a/webapp/channels/babel.config.js
+++ b/webapp/channels/babel.config.js
@@ -11,7 +11,7 @@ const config = {
                 chrome: 110,
                 firefox: 102,
                 edge: 110,
-                safari: '16.2',
+                safari: '16.4',
             },
             corejs: corejsVersion,
             useBuiltIns: 'usage',

--- a/webapp/channels/src/utils/emoticons.test.tsx
+++ b/webapp/channels/src/utils/emoticons.test.tsx
@@ -53,9 +53,9 @@ describe('Emoticons', () => {
                 toEqual('/$MM_EMOTICON0$..$MM_EMOTICON1$)');
         });
 
-        test('should replace emoticons separated by text', () => {
+        test('should not replace emoticons surrounded by word chars (matches server semantics)', () => {
             expect(Emoticons.handleEmoticons('asdf:goat:asdf:dash:asdf', new Map())).
-                toEqual('asdf$MM_EMOTICON0$asdf$MM_EMOTICON1$asdf');
+                toEqual('asdf:goat:asdf:dash:asdf');
         });
 
         test('shouldn\'t replace invalid emoticons', () => {
@@ -96,6 +96,31 @@ describe('Emoticons', () => {
         test('shouldn\'t render text-based emoticons as emoji when renderEmoticonsAsEmoji is false', () => {
             expect(Emoticons.handleEmoticons('":P"', new Map(), false)).
                 toEqual('":P"');
+        });
+
+        test('should not treat IPv6 hex segments as emoji', () => {
+            expect(Emoticons.handleEmoticons('2001:18:1:beef::/64', new Map())).
+                toEqual('2001:18:1:beef::/64');
+        });
+
+        test('should still match :emoji::emoji: back-to-back', () => {
+            expect(Emoticons.handleEmoticons(':beef::dash:', new Map())).
+                toEqual('$MM_EMOTICON0$$MM_EMOTICON1$');
+        });
+
+        test('should still match emoji wrapped in parens', () => {
+            expect(Emoticons.handleEmoticons('(:beef:)', new Map())).
+                toEqual('($MM_EMOTICON0$)');
+        });
+
+        test('should still match emoji followed by punctuation', () => {
+            expect(Emoticons.handleEmoticons(':beef:.', new Map())).
+                toEqual('$MM_EMOTICON0$.');
+        });
+
+        test('should not treat broader IPv6 forms as emoji', () => {
+            expect(Emoticons.handleEmoticons('2001:cafe:1:dead::/64', new Map())).
+                toEqual('2001:cafe:1:dead::/64');
         });
     });
 
@@ -162,6 +187,16 @@ describe('Emoticons', () => {
         test('shouldn\'t render emoticons in multiline links', () => {
             expect(Emoticons.matchEmoticons('[link](www.google.com/:goat:) \n [link](www.google.com/:smile:)')).
                 toEqual(null);
+        });
+
+        test('should return null for IPv6-shaped strings', () => {
+            expect(Emoticons.matchEmoticons('2001:18:1:beef::/64')).
+                toEqual(null);
+        });
+
+        test('should still match :emoji::emoji: back-to-back', () => {
+            expect(Emoticons.matchEmoticons(':beef::dash:')).
+                toEqual([':beef:', ':dash:']);
         });
     });
 });

--- a/webapp/channels/src/utils/emoticons.tsx
+++ b/webapp/channels/src/utils/emoticons.tsx
@@ -25,7 +25,7 @@ export const emoticonPatterns: { [key: string]: RegExp } = {
     broken_heart: /(^|\B)(\\?<\/3|\\?&lt;\/3)($|\b)/g, // </3
 };
 
-export const EMOJI_PATTERN = /(?<![A-Za-z0-9_])(:([a-zA-Z0-9_+-]+):)(?![A-Za-z0-9_])/g;
+export const EMOJI_PATTERN = /(?<!\w)(:([\w+-]+):)(?!\w)/g;
 
 export function matchEmoticons(text: string): string[] | null {
     const markdownCleanedText = formatWithRenderer(text, new PlainRenderer());

--- a/webapp/channels/src/utils/emoticons.tsx
+++ b/webapp/channels/src/utils/emoticons.tsx
@@ -25,7 +25,7 @@ export const emoticonPatterns: { [key: string]: RegExp } = {
     broken_heart: /(^|\B)(\\?<\/3|\\?&lt;\/3)($|\b)/g, // </3
 };
 
-export const EMOJI_PATTERN = /(:([a-zA-Z0-9_+-]+):)/g;
+export const EMOJI_PATTERN = /(?<![A-Za-z0-9_])(:([a-zA-Z0-9_+-]+):)(?![A-Za-z0-9_])/g;
 
 export function matchEmoticons(text: string): string[] | null {
     const markdownCleanedText = formatWithRenderer(text, new PlainRenderer());


### PR DESCRIPTION
#### Summary

The webapp's named-emoji regex (`EMOJI_PATTERN` in `webapp/channels/src/utils/emoticons.tsx`) had no boundary check on either side of the colons, so any colon-wrapped alphanumeric run was tokenized as an emoji. In IPv6 addresses like `2001:18:1:beef::/64`, both `:18:` and `:beef:` matched; `:beef:` rendered as a custom emoji image whenever one was defined.

This PR adds lookbehind and lookahead boundary checks so a `:name:` token only matches when neither side abuts an alphanumeric/underscore character. The new semantics match the server parser at `server/public/shared/markdown/emoji.go`, which already rejects this case via a prev-char guard and a trailing `\B` anchor.

Lookbehind is a regex *syntax* feature and is not lowered by `@babel/preset-env`, so this PR also bumps the webapp's babel `safari` target from `16.2` to `16.4`. The real minimum supported Safari is well above `16.4`, so the previous target was stale.

Behavior changes:
  - `2001:18:1:beef::/64`, `2001:cafe:1:dead::/64`, `100:100:100:100:100:100` — no longer tokenized.
  - `asdf:goat:asdf` — no longer tokenized (matches existing server behavior, e.g. `Thisisnotan:emoji:` at `server/public/shared/markdown/emoji_test.go:182`).
  - `:beef:`, `(:beef:)`, `:beef:.`, `:beef::dash:` — still tokenized.

QA steps:
1. Create a custom emoji named `beef`.
2. Post `2001:18:1:beef::/64` in a channel.
3. Expected: the message renders as literal text with no emoji image; previously the `:beef:` segment rendered as the emoji.
4. Confirm `:beef:` on its own still renders as the emoji.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-57406
Fixes: https://github.com/mattermost/mattermost/issues/26538

#### Release Note

```release-note
Fixed IPv6 addresses containing hex segments (e.g. `:beef:`) being incorrectly rendered as custom emoji in the webapp.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is confined to the emoji-parsing regex in a webapp utility and a minor Babel target bump; added tests cover IPv6 and edge cases, minimizing regression risk.  
**QA Recommendation:** Standard QA — verify custom emoji rendering and that IPv6-like segments (e.g., `2001:18:1:beef::/64`, `asdf:goat:asdf`) remain literal while standalone/punctuation-wrapped `:name:` still render as emoji.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36541)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->