### PR TITLE
[release-10.11] Update jira prepackaged version (#36442)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -145,7 +145,7 @@ PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
 PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.4
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.2
-PLUGIN_PACKAGES += mattermost-plugin-jira-v4.5.0
+PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.0
 # We need to prepackage both versions of playbooks and install the correct one based on the server license. See MM-60025.
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v1.41.1
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.4.5


### PR DESCRIPTION
Manual cherry-pick of #36442 to release-10.11.

Bumps the prepackaged Jira plugin from v4.5.0 to v4.7.0. The auto cherry-pick failed due to a Makefile conflict — only the `mattermost-plugin-jira` line was changed; the dual-prepackage `mattermost-plugin-playbooks` setup (v1.41.1 + v2.4.5, see MM-60025) and all other plugin versions on this branch are unchanged. The lockfile change from the original PR was dropped because it doesn't apply cleanly here and is not relevant to the plugin bump.

/cc @amyblais

Original PR: #36442
