### PR TITLE
MM-65058 Make Direct Messages modal load GMs when needed

### DIFF
--- a/e2e-tests/playwright/lib/src/ui/components/channels/direct_channels_modal.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/direct_channels_modal.ts
@@ -31,10 +31,10 @@ export default class DirectChannelsModal {
             .locator('.more-modal__row:not(:has(.more-modal__gm-icon))')
             .getByText(`@${user.username}`, {exact: false});
 
-        await row.click({force: true});
+        await row.click();
 
         await expect(
-            this.container.getByRole('button', {name: `Remove ${user.username}`, includeHidden: true}),
+            this.container.getByRole('button', {name: `Remove ${user.username}`}),
         ).toBeVisible();
     }
 

--- a/e2e-tests/playwright/lib/src/ui/components/channels/direct_channels_modal.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/direct_channels_modal.ts
@@ -33,9 +33,7 @@ export default class DirectChannelsModal {
 
         await row.click();
 
-        await expect(
-            this.container.getByRole('button', {name: `Remove ${user.username}`}),
-        ).toBeVisible();
+        await expect(this.container.getByRole('button', {name: `Remove ${user.username}`})).toBeVisible();
     }
 
     async toHaveNUsersSelected(count: number) {

--- a/e2e-tests/playwright/lib/src/ui/components/channels/direct_channels_modal.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/direct_channels_modal.ts
@@ -1,0 +1,64 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {UserProfile} from '@mattermost/types/users';
+import {Locator, expect} from '@playwright/test';
+
+export default class DirectChannelsModal {
+    readonly container;
+
+    readonly goButton;
+    readonly results;
+    readonly searchInput;
+
+    constructor(container: Locator) {
+        this.container = container;
+
+        this.goButton = container.getByRole('button', {name: 'Go'});
+        this.results = container.locator('.more-modal__list');
+        this.searchInput = container.getByRole('combobox', {name: 'Search for people'});
+    }
+
+    async toBeVisible() {
+        await expect(this.container).toBeVisible();
+    }
+
+    async selectUser(user: UserProfile) {
+        await this.fillSearchInput(user.username);
+
+        // This may fail if there's too many group channels containing the provided user
+        const row = this.results
+            .locator('.more-modal__row:not(:has(.more-modal__gm-icon))')
+            .getByText(`@${user.username}`, {exact: false});
+
+        await row.click({force: true});
+
+        await expect(
+            this.container.getByRole('button', {name: `Remove ${user.username}`, includeHidden: true}),
+        ).toBeVisible();
+    }
+
+    async toHaveNUsersSelected(count: number) {
+        await expect(this.results.locator('.react-select_multi-value')).toHaveCount(count);
+    }
+
+    async goToChannel() {
+        await this.goButton.click();
+
+        await expect(this.container).not.toBeAttached();
+    }
+
+    async toHaveNResults(count: number) {
+        await expect(this.results.locator('.more-modal__row')).toHaveCount(count);
+    }
+
+    async fillSearchInput(text: string) {
+        await this.searchInput.fill(text);
+    }
+
+    async toHaveUserAsNthResult(user: UserProfile, index: number) {
+        const row = this.results.locator('.more-modal__row').nth(index);
+
+        await expect(row).toContainText(`@${user.username}`);
+    }
+}

--- a/e2e-tests/playwright/lib/src/ui/components/channels/sidebar_left.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/sidebar_left.ts
@@ -11,6 +11,7 @@ export default class ChannelsSidebarLeft {
     readonly findChannelButton;
     readonly scheduledPostBadge;
     readonly unreadChannelFilter;
+    readonly openDirectMessageButton;
 
     constructor(container: Locator) {
         this.container = container;
@@ -20,6 +21,7 @@ export default class ChannelsSidebarLeft {
         this.findChannelButton = container.getByRole('button', {name: 'Find Channels'});
         this.scheduledPostBadge = container.locator('span.scheduledPostBadge');
         this.unreadChannelFilter = container.locator('.SidebarFilters_filterButton');
+        this.openDirectMessageButton = container.getByRole('button', {name: 'Write a direct message'});
     }
 
     async toBeVisible() {

--- a/e2e-tests/playwright/lib/src/ui/components/index.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/index.ts
@@ -174,6 +174,7 @@ export {
     FlagPostConfirmationDialog,
     NewChannelModal,
     BrowseChannelsModal,
+    DirectChannelsModal,
     GenericConfirmModal,
     InvitePeopleModal,
     MembersInvitedModal,

--- a/e2e-tests/playwright/lib/src/ui/components/index.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/index.ts
@@ -21,6 +21,7 @@ import ChannelsSidebarRight from './channels/sidebar_right';
 import DeletePostConfirmationDialog from './channels/delete_post_confirmation_dialog';
 import DeletePostModal from './channels/delete_post_modal';
 import DeleteScheduledPostModal from './channels/delete_scheduled_post_modal';
+import DirectChannelsModal from './channels/direct_channels_modal';
 import DraftPost from './channels/draft_post';
 import EmojiGifPicker from './channels/emoji_gif_picker';
 import FindChannelsModal from './channels/find_channels_modal';
@@ -89,6 +90,7 @@ const components = {
     DeletePostConfirmationDialog,
     DeletePostModal,
     DeleteScheduledPostModal,
+    DirectChannelsModal,
     DraftPost,
     EmojiGifPicker,
     FindChannelsModal,

--- a/e2e-tests/playwright/lib/src/ui/pages/channels.ts
+++ b/e2e-tests/playwright/lib/src/ui/pages/channels.ts
@@ -38,6 +38,7 @@ export default class ChannelsPage {
     readonly findChannelsModal;
     readonly newChannelModal;
     readonly browseChannelsModal;
+    readonly directChannelsModal;
     public invitePeopleModal: InvitePeopleModal | undefined;
     public membersInvitedModal: MembersInvitedModal | undefined;
     readonly profileModal;
@@ -77,6 +78,9 @@ export default class ChannelsPage {
         this.findChannelsModal = new components.FindChannelsModal(page.getByRole('dialog', {name: 'Find Channels'}));
         this.newChannelModal = new NewChannelModal(page.getByRole('dialog', {name: 'Create a new channel'}));
         this.browseChannelsModal = new BrowseChannelsModal(page.getByRole('dialog', {name: 'Browse Channels'}));
+        this.directChannelsModal = new components.DirectChannelsModal(
+            page.getByRole('dialog', {name: 'Direct Messages'}),
+        );
         this.profileModal = new components.ProfileModal(page.getByRole('dialog', {name: 'Profile'}));
         this.settingsModal = new components.SettingsModal(page.getByRole('dialog', {name: 'Settings'}));
         this.teamSettingsModal = new components.TeamSettingsModal(page.getByRole('dialog', {name: 'Team Settings'}));
@@ -240,6 +244,13 @@ export default class ChannelsPage {
         await this.browseChannelsModal.toBeVisible();
 
         return this.browseChannelsModal;
+    }
+
+    async openDirectChannelsModal() {
+        await this.sidebarLeft.openDirectMessageButton.click();
+        await this.directChannelsModal.toBeVisible();
+
+        return this.directChannelsModal;
     }
 
     async openCreateTeamForm(): Promise<CreateTeamForm> {

--- a/e2e-tests/playwright/specs/functional/channels/direct_messages_modal/group_message_profiles.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/direct_messages_modal/group_message_profiles.spec.ts
@@ -73,7 +73,7 @@ test(
         const otherGms = gmChannels.slice(1);
 
         // # Refresh the app and go back to Town Square
-        channelsPage.goto(team.name, 'town-square');
+        await channelsPage.goto(team.name, 'town-square');
 
         // * Verify the target GM is not present in the sidebar to ensure that the sidebar hasn't loaded it
         await expect(page.locator(`#sidebarItem_${targetGm.channel.name}`)).toHaveCount(0);

--- a/e2e-tests/playwright/specs/functional/channels/direct_messages_modal/group_message_profiles.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/direct_messages_modal/group_message_profiles.spec.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {Channel} from '@mattermost/types/channels';
+import type {UserProfile} from '@mattermost/types/users';
+import type {Page} from '@playwright/test';
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+/**
+ * @objective Verify that a group message whose channel has fallen out of the sidebar (because the user
+ * has more DMs/GMs than the configured "Number of direct messages to show" limit) still appears in the
+ * Direct Messages modal with its members fully loaded — i.e. with a non-zero member count and the
+ * participant usernames as its name.
+ */
+test(
+    "MM-65058 Direct Messages modal should load group members for GMs which haven't been loaded otherwise",
+    {tag: '@direct_messages'},
+    async ({pw}) => {
+        const {adminClient, user, userClient, team} = await pw.initSetup({withDefaultProfileImage: false});
+
+        // Use a lower visible DM limit than the UI normally lets you use to speed up this test
+        const totalGms = 2;
+        const visibleLimit = 1;
+
+        // # Limit the user's visible DMs/GMs in the sidebar so one GM falls off the sidebar
+        await userClient.savePreferences(user.id, [
+            {
+                user_id: user.id,
+                category: 'sidebar_settings',
+                name: 'limit_visible_dms_gms',
+                value: visibleLimit.toString(),
+            },
+        ]);
+
+        // # Create enough users to populate 11 GMs with unique users
+        const users = [];
+        for (let i = 0; i < totalGms * 2; i++) {
+            const user = await pw.createNewUserProfile(adminClient, {prefix: `mm65058gm${i}`});
+            users.push(user);
+        }
+
+        // # Log the user in and open the channels page
+        const {page, channelsPage} = await pw.testBrowser.login(user);
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        // # Create 11 GMs using the Direct Channels modal
+        const gmChannels = [];
+        for (let i = 0; i < totalGms; i++) {
+            const memberA = users[i * 2];
+            const memberB = users[i * 2 + 1];
+
+            // # Open the modal
+            const dialog = await channelsPage.openDirectChannelsModal();
+
+            // # Select the users and create the channel
+            await dialog.selectUser(memberA);
+            await dialog.selectUser(memberB);
+            await dialog.goToChannel();
+
+            // # Make a post in the channel to ensure that it has a last_post_at value
+            await channelsPage.postMessage(`gm message ${i}`);
+
+            // # Save the channel's information for later
+            gmChannels.push({
+                channel: await getCurrentChannel(page),
+                members: [memberA, memberB],
+            });
+        }
+
+        const targetGm = gmChannels[0];
+        const otherGms = gmChannels.slice(1);
+
+        // # Refresh the app and go back to Town Square
+        channelsPage.goto(team.name, 'town-square');
+
+        // * Verify the target GM is not present in the sidebar to ensure that the sidebar hasn't loaded it
+        await expect(page.locator(`#sidebarItem_${targetGm.channel.name}`)).toHaveCount(0);
+
+        // * Wait until the other GMs are loaded and present in the sidebar
+        for (const otherGm of otherGms) {
+            const otherGmEntry = page.locator(`#sidebarItem_${otherGm.channel.name}`);
+
+            await expect(otherGmEntry).toHaveCount(1);
+            await expect(otherGmEntry).toContainText(gmChannelDisplayName(otherGm.members));
+        }
+
+        // * Verify that the members of the target GM haven't been loaded and the members of other GMs have
+        await assertChannelUsersNotLoaded(page, targetGm.channel.id);
+        for (const otherGm of otherGms) {
+            await assertChannelUsersLoaded(page, otherGm.channel.id, otherGm.members);
+        }
+
+        // # Open the Direct Messages modal again
+        const dialog = await channelsPage.openDirectChannelsModal();
+
+        // # Wait for the list to populate
+        const rows = dialog.container.locator('#multiSelectList .more-modal__row');
+        await expect.poll(async () => rows.count()).toBeGreaterThanOrEqual(totalGms);
+
+        // * Verify the modal contains an entry for every GM the user has, including the one that fell
+        // * out of the sidebar
+        for (const {channel, members} of gmChannels) {
+            // Each GM row renders the member usernames joined by ', '. We use the second member's
+            // username (which is unique per GM) to locate the corresponding row.
+            const usernameMarker = `@${members[1].username}`;
+            const gmRow = rows.filter({hasText: usernameMarker});
+
+            // * Verify the row is rendered
+            await expect(gmRow, `expected to find a row in the DM modal for GM ${channel.id}`).toHaveCount(1);
+
+            // * Verify the GM icon shows the correct member count (channel members minus current user)
+            await expect(
+                gmRow.locator('.more-modal__gm-icon'),
+                `expected GM ${channel.id} to show a member count of ${members.length}`,
+            ).toHaveText(members.length.toString());
+
+            // * Verify the row's name section includes every participant's username
+            const nameContainer = gmRow.locator('.more-modal__name');
+            for (const participant of members) {
+                await expect(
+                    nameContainer,
+                    `expected GM ${channel.id} to include @${participant.username} in its name`,
+                ).toContainText(`@${participant.username}`);
+            }
+        }
+
+        // * Double check that the members of the target GM have been loaded now
+        await assertChannelUsersLoaded(page, targetGm.channel.id, targetGm.members);
+    },
+);
+
+async function getCurrentChannel(page: Page) {
+    return await page.evaluate<Channel>(
+        'store.getState().entities.channels.channels[store.getState().entities.channels.currentChannelId]',
+    );
+}
+
+function gmChannelDisplayName(users: UserProfile[]) {
+    return users
+        .toSorted((a, b) => {
+            return a.username.localeCompare(b.username, undefined, {numeric: true});
+        })
+        .map((user) => user.username)
+        .join(', ');
+}
+
+async function assertChannelUsersLoaded(page: Page, channelId: string, expectedUsers: UserProfile[]) {
+    // profilesInChannel contains Sets which aren't serializable for return from page.evaluate
+    const loadedIds = await page.evaluate(
+        `Array.from(store.getState().entities.users.profilesInChannel['${channelId}'])`,
+    );
+
+    await expect(loadedIds).toHaveLength(expectedUsers.length);
+    await expect(loadedIds).toEqual(expect.arrayContaining(expectedUsers.map((user) => user.id)));
+}
+
+async function assertChannelUsersNotLoaded(page: Page, channelId: string) {
+    const loadedIds = await page.evaluate(`store.getState().entities.users.profilesInChannel['${channelId}']`);
+
+    await expect(loadedIds).toBeUndefined();
+}

--- a/webapp/channels/src/components/common/hooks/useUserIdsInGroupChannel.ts
+++ b/webapp/channels/src/components/common/hooks/useUserIdsInGroupChannel.ts
@@ -14,7 +14,7 @@ import {makeUseEntity} from './useEntity';
  * Returns a Set of user IDs in a given group channel. Those users are loaded from the server when needed.
  */
 export const useUserIdsInGroupChannel = makeUseEntity<Set<UserProfile['id']>>({
-    name: 'useProfilesInGroupChannel',
+    name: 'useUserIdsInGroupChannel',
     fetch: (channelId: string) => batchGetProfilesInGroupChannel(channelId),
     selector: (state: GlobalState, channelId: string) => {
         return getUserIdsInChannels(state)[channelId];

--- a/webapp/channels/src/components/common/hooks/useUserIdsInGroupChannel.ts
+++ b/webapp/channels/src/components/common/hooks/useUserIdsInGroupChannel.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {UserProfile} from '@mattermost/types/users';
+
+import {batchGetProfilesInGroupChannel} from 'mattermost-redux/actions/users';
+import {getUserIdsInChannels} from 'mattermost-redux/selectors/entities/users';
+
+import type {GlobalState} from 'types/store';
+
+import {makeUseEntity} from './useEntity';
+
+/**
+ * Returns a Set of user IDs in a given group channel. Those users are loaded from the server when needed.
+ */
+export const useUserIdsInGroupChannel = makeUseEntity<Set<UserProfile['id']>>({
+    name: 'useProfilesInGroupChannel',
+    fetch: (channelId: string) => batchGetProfilesInGroupChannel(channelId),
+    selector: (state: GlobalState, channelId: string) => {
+        return getUserIdsInChannels(state)[channelId];
+    },
+});

--- a/webapp/channels/src/components/drafts/draft_title/draft_title.tsx
+++ b/webapp/channels/src/components/drafts/draft_title/draft_title.tsx
@@ -8,7 +8,7 @@ import {useDispatch} from 'react-redux';
 import type {Channel} from '@mattermost/types/channels';
 import type {UserProfile} from '@mattermost/types/users';
 
-import {batchGetProfilesInChannel, getMissingProfilesByIds} from 'mattermost-redux/actions/users';
+import {batchGetProfilesInGroupChannel, getMissingProfilesByIds} from 'mattermost-redux/actions/users';
 
 import Avatar from 'components/widgets/users/avatar';
 
@@ -51,7 +51,7 @@ function DraftTitle({
         // The action uses a data loader so it is safe to call do this for multiple
         // scheduled posts for the same GM without causing any duplicate API calls.
         if (channel.type === Constants.GM_CHANNEL && !membersCount) {
-            dispatch(batchGetProfilesInChannel(channel.id));
+            dispatch(batchGetProfilesInGroupChannel(channel.id));
         }
     }, [channel.id, channel.type, dispatch, membersCount]);
 

--- a/webapp/channels/src/components/more_direct_channels/index.ts
+++ b/webapp/channels/src/components/more_direct_channels/index.ts
@@ -29,7 +29,6 @@ import {
 
 import {openDirectChannelToUserId, openGroupChannelToUserIds} from 'actions/channel_actions';
 import {loadStatusesForProfilesList, loadProfilesMissingStatus} from 'actions/status_actions';
-import {loadProfilesForGroupChannels} from 'actions/user_actions';
 import {setModalSearchTerm} from 'actions/views/search';
 
 import type {GlobalState} from 'types/store';
@@ -98,7 +97,6 @@ function mapDispatchToProps(dispatch: Dispatch) {
             loadProfilesMissingStatus,
             getTotalUsersStats,
             loadStatusesForProfilesList,
-            loadProfilesForGroupChannels,
             openDirectChannelToUserId,
             openGroupChannelToUserIds,
             searchProfiles,

--- a/webapp/channels/src/components/more_direct_channels/list_item/list_item.tsx
+++ b/webapp/channels/src/components/more_direct_channels/list_item/list_item.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import React, {useCallback} from 'react';
 import {useIntl} from 'react-intl';
 
+import {useUserIdsInGroupChannel} from 'components/common/hooks/useUserIdsInGroupChannel';
 import Timestamp from 'components/timestamp';
 
 import UserDetails from './user_details';
@@ -96,6 +97,9 @@ export default ListItem;
 
 function GMDetails(props: {option: GroupChannel}) {
     const {option} = props;
+
+    // Indirectly populate option.profiles when needed
+    useUserIdsInGroupChannel(option.id);
 
     return (
         <>

--- a/webapp/channels/src/components/more_direct_channels/more_direct_channels.test.tsx
+++ b/webapp/channels/src/components/more_direct_channels/more_direct_channels.test.tsx
@@ -74,7 +74,6 @@ describe('components/MoreDirectChannels', () => {
             searchGroupChannels: jest.fn().mockResolvedValue({data: true}),
             setModalSearchTerm: jest.fn().mockResolvedValue({data: true}),
             loadStatusesForProfilesList: jest.fn().mockResolvedValue({data: true}),
-            loadProfilesForGroupChannels: jest.fn().mockResolvedValue({data: true}),
             openDirectChannelToUserId: jest.fn().mockResolvedValue({data: {name: 'dm'}}),
             openGroupChannelToUserIds: jest.fn().mockResolvedValue({data: {name: 'group'}}),
             getTotalUsersStats: jest.fn().mockImplementation(() => {

--- a/webapp/channels/src/components/more_direct_channels/more_direct_channels.tsx
+++ b/webapp/channels/src/components/more_direct_channels/more_direct_channels.tsx
@@ -52,7 +52,6 @@ export type Props = {
         loadProfilesMissingStatus: (users: UserProfile[]) => void;
         getTotalUsersStats: () => void;
         loadStatusesForProfilesList: (users: UserProfile[]) => void;
-        loadProfilesForGroupChannels: (groupChannels: Channel[]) => void;
         openDirectChannelToUserId: (userId: string) => Promise<ActionResult>;
         openGroupChannelToUserIds: (userIds: string[]) => Promise<ActionResult>;
         searchProfiles: (term: string, options: any) => Promise<ActionResult<UserProfile[]>>;
@@ -157,15 +156,12 @@ export default class MoreDirectChannels extends React.PureComponent<Props, State
                 this.searchTimeoutId = setTimeout(
                     async () => {
                         this.setUsersLoadingState(true);
-                        const [{data: profilesData}, {data: groupChannelsData}] = await Promise.all([
+                        const [{data: profilesData}] = await Promise.all([
                             this.props.actions.searchProfiles(searchTerm, {team_id: teamId}),
                             this.props.actions.searchGroupChannels(searchTerm),
                         ]);
                         if (profilesData) {
                             this.props.actions.loadStatusesForProfilesList(profilesData);
-                        }
-                        if (groupChannelsData) {
-                            this.props.actions.loadProfilesForGroupChannels(groupChannelsData);
                         }
                         this.resetPaging();
                         this.setUsersLoadingState(false);

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/users.ts
@@ -352,17 +352,17 @@ export function getProfilesInChannel(channelId: string, page: number, perPage: n
     };
 }
 
-export function batchGetProfilesInChannel(channelId: string): ActionFuncAsync<Array<Channel['id']>> {
+export function batchGetProfilesInGroupChannel(channelId: string): ActionFuncAsync<Array<Channel['id']>> {
     return async (dispatch, getState, {loaders}: any) => {
-        if (!loaders.profilesInChannelLoader) {
-            loaders.profilesInChannelLoader = new DelayedDataLoader<Channel['id']>({
-                fetchBatch: (channelIds) => dispatch(getProfilesInChannel(channelIds[0], 0)),
-                maxBatchSize: 1,
+        if (!loaders.profilesInGroupChannelLoader) {
+            loaders.profilesInGroupChannelLoader = new DelayedDataLoader<Channel['id']>({
+                fetchBatch: (channelIds) => dispatch(getProfilesInGroupChannels(channelIds)),
+                maxBatchSize: General.MAX_GROUP_CHANNELS_FOR_PROFILES,
                 wait: missingProfilesWait,
             });
         }
 
-        await loaders.profilesInChannelLoader.queueAndWait([channelId]);
+        await loaders.profilesInGroupChannelLoader.queueAndWait([channelId]);
         return {};
     };
 }


### PR DESCRIPTION
#### Summary
The Direct Messages modal doesn't always load the members for the initial GMs displayed when it opens, so if something else doesn't load them (like the sidebar), they can appear as blank entries. I changed it so that they can now load their users themselves using a `makeUseEntity`-based hook.

#### Ticket Link
MM-65058

#### Screenshots
These use an artificially low number of GMs in the LHS to force this to happen

Before|After
-|-
<img width="1533" height="1326" alt="Screenshot 2026-05-13 at 9 44 43 AM" src="https://github.com/user-attachments/assets/53803f72-c880-4405-94fc-46b67e0ecdcf" />|<img width="1533" height="1326" alt="Screenshot 2026-05-13 at 9 45 12 AM" src="https://github.com/user-attachments/assets/573e82fb-75e5-4a3c-9b08-328afae00e08" />

https://github.com/user-attachments/assets/61a42e91-fa03-46d6-a814-4e3447f25905

#### Release Note
```release-note
Fixed group channels in the Direct Messages modal sometimes displaying incorrectly
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The changes modify GM profile-loading from a centralized eager path to a batched on-demand loader and add a hook used across GM UI components, which may introduce timing/state-sync edge cases in components that previously relied on eager loading. Risk is mitigated by added e2e coverage, but race conditions around hook initialization and modal lifecycle remain possible.

**QA Recommendation:** Perform focused manual QA on the Direct Messages modal and sidebar with varying visible GM limits, verifying GM member counts, usernames, searches, drafts, and refresh/navigation flows to catch timing/synchronization issues.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36548)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36548)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->