### PR TITLE
E2E/Test: disable flaky autotranslation tests

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/autotranslation/autotranslation.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/autotranslation/autotranslation.spec.ts
@@ -834,7 +834,7 @@ test.fixme(
     },
 );
 
-test(
+test.fixme(
     'message actions include Show translation',
     {
         tag: ['@autotranslation'],

--- a/e2e-tests/playwright/specs/functional/channels/autotranslation/autotranslation.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/autotranslation/autotranslation.spec.ts
@@ -171,7 +171,7 @@ test(
     },
 );
 
-test(
+test.fixme(
     'only new messages are translated after enable; old messages unchanged',
     {
         tag: ['@autotranslation'],
@@ -351,7 +351,7 @@ test(
     },
 );
 
-test(
+test.fixme(
     'auto-translation is ON by default for new channel members',
     {
         tag: ['@autotranslation'],
@@ -458,7 +458,7 @@ test(
     },
 );
 
-test(
+test.fixme(
     'disabling for self reverts translated messages to original',
     {
         tag: ['@autotranslation'],
@@ -536,7 +536,7 @@ test(
     },
 );
 
-test(
+test.fixme(
     'messages only translate when source differs from user language',
     {
         tag: ['@autotranslation'],
@@ -639,7 +639,7 @@ test(
     },
 );
 
-test(
+test.fixme(
     'message indicator only on actually translated message',
     {
         tag: ['@autotranslation'],

--- a/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_plugin_hook_toggle.spec.ts
+++ b/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_plugin_hook_toggle.spec.ts
@@ -5,7 +5,7 @@ import {expect, test} from '@mattermost/playwright-lib';
 
 import {setupDemoPlugin} from '../../helpers';
 
-test('should toggle hooks on and off via /demo_plugin command', async ({pw}) => {
+test.fixme('should toggle hooks on and off via /demo_plugin command', async ({pw}) => {
     // 1. Setup: install and activate the demo plugin
     const {adminClient, user, team} = await pw.initSetup();
     await setupDemoPlugin(adminClient, pw);


### PR DESCRIPTION
#### Summary
Disable flaky autotranslation tests. Note that this has been disabled in master to stabilize tests, then will fix separately.

Note: 
- This will be cherry-picked to release-11.6 (see recent runs - https://test-io.test.mattermost.com/reports/mattermost/release-11.6).
- Not applicable to release-11.5.

#### Ticket Link
none

#### Release Note
```release-note
NONE
```
