### PR TITLE
MM-68773 Fix bug with HTML encoding in proxied image URL

### DIFF
--- a/webapp/channels/src/components/markdown/index.ts
+++ b/webapp/channels/src/components/markdown/index.ts
@@ -57,7 +57,6 @@ function makeMapStateToProps() {
             mentionKeys: ownProps.mentionKeys || getAllUserMentionKeys(state),
             siteURL: getSiteURL(),
             team: getCurrentTeam(state),
-            hasImageProxy: config.HasImageProxy === 'true',
             minimumHashtagLength: parseInt(config.MinimumHashtagLength || '', 10),
             emojiMap: getEmojiMap(state),
             channelId,

--- a/webapp/channels/src/components/markdown/markdown.test.tsx
+++ b/webapp/channels/src/components/markdown/markdown.test.tsx
@@ -7,7 +7,7 @@ import type {TeamType} from '@mattermost/types/teams';
 
 import Markdown from 'components/markdown';
 
-import {renderWithContext} from 'tests/react_testing_utils';
+import {renderWithContext, screen} from 'tests/react_testing_utils';
 import EmojiMap from 'utils/emoji_map';
 import {TestHelper} from 'utils/test_helper';
 
@@ -54,5 +54,64 @@ describe('components/Markdown', () => {
 
         const {container} = renderWithContext(<Markdown {...props}/>);
         expect(container).toMatchSnapshot();
+    });
+
+    describe('image proxy', () => {
+        const imageUrl = 'https://example.com/image.png';
+
+        test('when the proxy is enabled, images should be requested through the server', () => {
+            const props = {...baseProps, message: `![alt](${imageUrl})`};
+
+            renderWithContext(<Markdown {...props}/>, {
+                entities: {
+                    general: {
+                        config: {
+                            HasImageProxy: 'true',
+                        },
+                    },
+                },
+            });
+
+            const img = screen.getByRole('img');
+            expect(img).toBeInTheDocument();
+            expect(img).toHaveAttribute('src', expect.stringMatching(`/image\\?url=${encodeURIComponent(imageUrl)}$`));
+        });
+
+        test('when the proxy is disabled, images should not be requested through the server', () => {
+            const props = {...baseProps, message: `![alt](${imageUrl})`};
+
+            renderWithContext(<Markdown {...props}/>, {
+                entities: {
+                    general: {
+                        config: {
+                            HasImageProxy: 'false',
+                        },
+                    },
+                },
+            });
+
+            const img = screen.getByRole('img');
+            expect(img).toBeInTheDocument();
+            expect(img).toHaveAttribute('src', imageUrl);
+        });
+
+        test('when the proxy is enabled, image URLs containing query parameters should be correctly encoded', () => {
+            const urlWithParams = 'https://example.com/image.png?width=100&height=200';
+            const props = {...baseProps, message: `![alt](${urlWithParams})`};
+
+            renderWithContext(<Markdown {...props}/>, {
+                entities: {
+                    general: {
+                        config: {
+                            HasImageProxy: 'true',
+                        },
+                    },
+                },
+            });
+
+            const img = screen.getByRole('img');
+            expect(img).toBeInTheDocument();
+            expect(img).toHaveAttribute('src', expect.stringMatching(`/image\\?url=${encodeURIComponent(urlWithParams)}$`));
+        });
     });
 });

--- a/webapp/channels/src/components/markdown/markdown.tsx
+++ b/webapp/channels/src/components/markdown/markdown.tsx
@@ -26,11 +26,6 @@ export type OwnProps = {
     options?: Partial<TextFormattingOptions>;
 
     /**
-     * Whether or not to proxy image URLs
-     */
-    proxyImages?: boolean;
-
-    /**
      * prop for passed down to image component for dimensions
      */
     imagesMetadata?: Record<string, PostImage>;
@@ -88,7 +83,6 @@ export type OwnProps = {
 
 function Markdown({
     options = {},
-    proxyImages = true,
     imagesMetadata = {},
     postId = '', // Needed to avoid proptypes console errors for cases like channel header, which doesn't have a proper value
     editedAt = 0,
@@ -105,7 +99,6 @@ function Markdown({
     messageMetadata,
     enableFormatting,
     siteURL,
-    hasImageProxy,
     team,
     minimumHashtagLength,
     managedResourcePaths,
@@ -128,7 +121,6 @@ function Markdown({
         highlightKeys,
         atMentions: true,
         channelNamesMap,
-        proxyImages: hasImageProxy && proxyImages,
         team,
         minimumHashtagLength,
         managedResourcePaths,

--- a/webapp/channels/src/components/post_markdown/post_markdown.tsx
+++ b/webapp/channels/src/components/post_markdown/post_markdown.tsx
@@ -111,8 +111,6 @@ export default class PostMarkdown extends React.PureComponent<Props> {
             );
         }
 
-        // Proxy images if we have an image proxy and the server hasn't already rewritten the this.props.post's image URLs.
-        const proxyImages = !this.props.post || !this.props.post.message_source || this.props.post.message === this.props.post.message_source;
         const channelNamesMap = isChannelNamesMap(this.props.post?.props?.channel_mentions) ? this.props.post?.props?.channel_mentions : undefined;
 
         this.props.pluginHooks?.forEach((o) => {
@@ -143,7 +141,6 @@ export default class PostMarkdown extends React.PureComponent<Props> {
             <Markdown
                 imageProps={this.props.imageProps}
                 message={message}
-                proxyImages={proxyImages}
                 mentionKeys={this.props.mentionKeys}
                 highlightKeys={highlightKeys}
                 options={options}

--- a/webapp/channels/src/utils/markdown/renderer.tsx
+++ b/webapp/channels/src/utils/markdown/renderer.tsx
@@ -5,7 +5,6 @@ import marked from 'marked';
 import type {MarkedOptions} from 'marked';
 
 import EmojiMap from 'utils/emoji_map';
-import * as PostUtils from 'utils/post_utils';
 import * as TextFormatting from 'utils/text_formatting';
 import {mightTriggerExternalRequest, getScheme, isUrlSafe, shouldOpenInNewTab} from 'utils/url';
 
@@ -111,8 +110,8 @@ export default class Renderer extends marked.Renderer {
     public image(href: string, title: string, text: string) {
         const dimensions = parseImageDimensions(href);
 
-        let src = dimensions.href;
-        src = PostUtils.getImageSrc(src, this.formattingOptions.proxyImages);
+        // Don't pass the image through the proxy yet because that's handled by MarkdownImage
+        const src = dimensions.href;
 
         let out = `<img src="${src}" alt="${text}"`;
         if (title) {

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -168,13 +168,6 @@ export interface TextFormattingOptionsBase {
     team: Team;
 
     /**
-     * If specified, images are proxied.
-     *
-     * Defaults to `false`.
-     */
-    proxyImages: boolean;
-
-    /**
      * An array of paths on the server that are managed by another server. Any path provided will be treated as an
      * external link that will not by handled by react-router.
      *
@@ -251,7 +244,6 @@ const DEFAULT_OPTIONS: TextFormattingOptions = {
     atSumOfMembersMentions: false,
     atPlanMentions: false,
     minimumHashtagLength: 3,
-    proxyImages: false,
     editedAt: 0,
     postId: '',
     unsafeLinks: false,


### PR DESCRIPTION
#### Summary
`getImageSrc` is used to ensure external image URLs go through the image proxy, and when doing that, it ensures the image URL is proparly percent-encoded. When it's called in the Markdown renderer though, that URL has been HTML-encoded by the Markdown renderer, so any ampersands have been encoded as `&amp;` which then gets percent-encoded and mangles the HTML-encoding.

We could manually undo the HTML-encoding there, but we don't actually need to call `getImageSrc` in the Markdown renderer because that gets handled later when it's transformed into a `MarkdownImage`

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68773

#### Release Note
```release-note
Fixed incorrect encoding of image URLs containing query parameters when using an image proxy
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The PR refactors image proxy handling by moving it from the markdown renderer layer to the MarkdownImage component. While test coverage has been improved with 60 new test lines validating image proxy scenarios, moving functionality between architectural layers introduces moderate risk that image rendering behavior could diverge from expectations, particularly for markdown-rendered images with query parameters.

**QA Recommendation:** Manual QA should focus on verifying image rendering with image proxy enabled and disabled configurations, particularly for markdown-embedded images with query parameters. Verify that the HTML encoding fix resolves the original issue and doesn't introduce regressions with special characters in image URLs. Automated test coverage improvements reduce the need for exhaustive manual testing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36555)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->