### PR TITLE
ci: consolidate openldap runner prep into a composite action

### DIFF
--- a/.github/actions/runner-prep-openldap/action.yml
+++ b/.github/actions/runner-prep-openldap/action.yml
@@ -1,0 +1,44 @@
+name: Runner prep for openldap
+description: |
+  Disable the Ubuntu 24.04 AppArmor user-namespace restriction and ensure
+  docker-compose >= 2.36.0 before starting any stack that includes openldap.
+
+  Background: Ubuntu 24.04 sets kernel.apparmor_restrict_unprivileged_userns=1
+  by default.  The osixia/openldap:1.4.0 init scripts rely on unprivileged
+  user namespaces; blocking them causes an immediate exit(1) with no useful
+  stderr ("dependency failed to start: container mmserver-openldap-1 exited (1)").
+  The container's own security_opt: apparmor:unconfined is insufficient — it
+  only unconfines the slapd process, not the entrypoint.  The fix must be at
+  the host-kernel level.
+
+  docker-compose 2.35.1 (shipped on some ubuntu-24.04 runner images) also has
+  a known `up` regression that surfaces as spurious dependency-failed errors
+  under load.  We upgrade to >= 2.36.0 when needed.
+
+runs:
+  using: composite
+  steps:
+    - name: Disable AppArmor user-namespace restriction and ensure docker-compose >= 2.36.0
+      shell: bash
+      run: |
+        echo "Before: docker compose version"
+        docker compose version || true
+
+        # Disable the AppArmor user-namespace restriction.  Idempotent;
+        # safe if the key doesn't exist (older kernel).
+        sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
+
+        # If docker-compose is older than 2.36.0, install a newer one to
+        # the user's cli-plugins dir (takes precedence over the system copy).
+        CURRENT=$(docker compose version --short 2>/dev/null || echo "0.0.0")
+        NEED="2.36.0"
+        if [ "$(printf '%s\n' "$NEED" "$CURRENT" | sort -V | head -n1)" != "$NEED" ]; then
+          echo "Upgrading docker-compose from ${CURRENT} to 2.39.1"
+          mkdir -p "$HOME/.docker/cli-plugins"
+          curl -SL -o "$HOME/.docker/cli-plugins/docker-compose" \
+            "https://github.com/docker/compose/releases/download/v2.39.1/docker-compose-linux-x86_64"
+          chmod +x "$HOME/.docker/cli-plugins/docker-compose"
+        fi
+
+        echo "After: docker compose version"
+        docker compose version

--- a/.github/workflows/e2e-tests-ci-template.yml
+++ b/.github/workflows/e2e-tests-ci-template.yml
@@ -223,6 +223,16 @@ jobs:
       ROLLING_RELEASE_COMMIT_SHA: "${{ inputs.ROLLING_RELEASE_commit_sha }}"
       ROLLING_RELEASE_SERVER_IMAGE: "${{ inputs.ROLLING_RELEASE_SERVER_IMAGE }}"
     steps:
+      - name: ci/checkout-actions
+        # Sparse-checkout just .github/actions from the triggering ref (master)
+        # so the composite action below is available before the full checkout
+        # overwrites the workspace with inputs.commit_sha.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: true
+      - name: ci/runner-prep-for-openldap
+        uses: ./.github/actions/runner-prep-openldap
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -244,44 +254,6 @@ jobs:
           node-version-file: ".nvmrc"
           cache: npm
           cache-dependency-path: ${{ needs.generate-build-variables.outputs.node-cache-dependency-path }}
-      - name: ci/runner-prep-for-openldap
-        # Observed failure: "dependency failed to start: container
-        # mmserver-openldap-1 exited (1)" on ubuntu-24.04 runners — kills
-        # every LDAP spec on the affected shard.
-        #
-        # Ubuntu 24.04 introduced an AppArmor profile that restricts the
-        # creation of unprivileged user namespaces. The osixia/openldap
-        # image's internal init scripts rely on this capability; blocking
-        # it produces an immediate exit(1) with no useful stderr. The
-        # container's own security_opt: apparmor:unconfined is not
-        # sufficient — that only unconfines slapd, not the container's
-        # entrypoint process. The actual switch is at the host-kernel level.
-        #
-        # Also ensure docker-compose is >= 2.36.0 — the 2.35.1 shipped on
-        # some ubuntu-24.04 images has a known `up` regression that
-        # manifests as random dependency-failed errors under load.
-        run: |
-          echo "Before: docker compose version"
-          docker compose version || true
-
-          # Disable the AppArmor user-namespace restriction. Idempotent;
-          # safe if the key doesn't exist (older kernel).
-          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
-
-          # If docker-compose is older than 2.36.0, install a newer one to
-          # the user's cli-plugins dir (takes precedence over the system copy).
-          CURRENT=$(docker compose version --short 2>/dev/null || echo "0.0.0")
-          NEED="2.36.0"
-          if [ "$(printf '%s\n' "$NEED" "$CURRENT" | sort -V | head -n1)" != "$NEED" ]; then
-            echo "Upgrading docker-compose from ${CURRENT} to 2.39.1"
-            mkdir -p "$HOME/.docker/cli-plugins"
-            curl -SL -o "$HOME/.docker/cli-plugins/docker-compose" \
-              "https://github.com/docker/compose/releases/download/v2.39.1/docker-compose-linux-x86_64"
-            chmod +x "$HOME/.docker/cli-plugins/docker-compose"
-          fi
-
-          echo "After: docker compose version"
-          docker compose version
       - name: ci/e2e-test
         run: |
           make cloud-init

--- a/.github/workflows/e2e-tests-cypress-template-v2.yml
+++ b/.github/workflows/e2e-tests-cypress-template-v2.yml
@@ -259,6 +259,16 @@ jobs:
       CWS_URL: "${{ secrets.CWS_URL }}"
       CWS_EXTRA_HTTP_HEADERS: "${{ secrets.CWS_EXTRA_HTTP_HEADERS }}"
     steps:
+      - name: ci/checkout-actions
+        # Sparse-checkout just .github/actions from the triggering ref (master)
+        # so the composite action below is available before the full checkout
+        # overwrites the workspace with inputs.commit_sha.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: true
+      - name: ci/runner-prep-for-openldap
+        uses: ./.github/actions/runner-prep-openldap
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/e2e-tests-playwright-template-v2.yml
+++ b/.github/workflows/e2e-tests-playwright-template-v2.yml
@@ -213,6 +213,16 @@ jobs:
       BUILD_ID: "${{ inputs.build_id }}"
       CI_BASE_URL: "full-test-${{ matrix.worker_index }}"
     steps:
+      - name: ci/checkout-actions
+        # Sparse-checkout just .github/actions from the triggering ref (master)
+        # so the composite action below is available before the full checkout
+        # overwrites the workspace with inputs.commit_sha.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: true
+      - name: ci/runner-prep-for-openldap
+        uses: ./.github/actions/runner-prep-openldap
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/e2e-tests-playwright-template.yml
+++ b/.github/workflows/e2e-tests-playwright-template.yml
@@ -159,6 +159,16 @@ jobs:
       BUILD_ID: "${{ inputs.build_id }}"
       CI_BASE_URL: "${{ inputs.test_type }}-test-${{ matrix.worker_index }}"
     steps:
+      - name: ci/checkout-actions
+        # Sparse-checkout just .github/actions from the triggering ref (master)
+        # so the composite action below is available before the full checkout
+        # overwrites the workspace with inputs.commit_sha.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: .github/actions
+          sparse-checkout-cone-mode: true
+      - name: ci/runner-prep-for-openldap
+        uses: ./.github/actions/runner-prep-openldap
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -173,45 +183,6 @@ jobs:
       - name: ci/get-webapp-node-modules
         working-directory: webapp
         run: make node_modules
-      - name: ci/runner-prep-for-openldap
-        # Observed failure: "dependency failed to start: container
-        # mmserver-openldap-1 exited (1)" on ubuntu-24.04 runners — kills
-        # every ABAC/LDAP spec on the affected shard.
-        #
-        # Ubuntu 24.04 introduced an AppArmor profile that restricts the
-        # creation of unprivileged user namespaces. The osixia/openldap
-        # image's internal init scripts rely on this capability; blocking
-        # it produces an immediate exit(1) with no useful stderr. The
-        # container's own security_opt: apparmor:unconfined (already set
-        # in server/build/docker-compose.common.yml) isn't sufficient —
-        # that only unconfines slapd, not the container's entrypoint
-        # process. The actual switch is at the host-kernel level.
-        #
-        # Also ensure docker-compose is >= 2.36.0 — the 2.35.1 shipped on
-        # some ubuntu-24.04 images has a known `up` regression that
-        # manifests as random dependency-failed errors under load.
-        run: |
-          echo "Before: docker compose version"
-          docker compose version || true
-
-          # Disable the AppArmor user-namespace restriction. Idempotent;
-          # safe if the key doesn't exist (older kernel).
-          sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 || true
-
-          # If docker-compose is older than 2.36.0, install a newer one to
-          # the user's cli-plugins dir (takes precedence over the system copy).
-          CURRENT=$(docker compose version --short 2>/dev/null || echo "0.0.0")
-          NEED="2.36.0"
-          if [ "$(printf '%s\n' "$NEED" "$CURRENT" | sort -V | head -n1)" != "$NEED" ]; then
-            echo "Upgrading docker-compose from ${CURRENT} to 2.39.1"
-            mkdir -p "$HOME/.docker/cli-plugins"
-            curl -SL -o "$HOME/.docker/cli-plugins/docker-compose" \
-              "https://github.com/docker/compose/releases/download/v2.39.1/docker-compose-linux-x86_64"
-            chmod +x "$HOME/.docker/cli-plugins/docker-compose"
-          fi
-
-          echo "After: docker compose version"
-          docker compose version
       - name: ci/restore-playwright-image-cache
         # Cache the Playwright Docker image tar by the SHA of the files that pin
         # its version. Cache busts automatically when either file is edited to bump

--- a/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_dialog_date.spec.ts
+++ b/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_dialog_date.spec.ts
@@ -63,18 +63,19 @@ test('should open /dialog date and post submit confirmation after selecting date
     // Click day 20 — reliably available in any month
     await channelsPage.page.getByRole('grid').getByText('20', {exact: true}).click();
 
-    // 8. Select date and time using the Meeting Date & Time picker
-    // The datetime picker renders a date-part button whose accessible name is
-    // 'Date Select date' (label 'Date' + placeholder 'Select date' from datetime_input.tsx).
-    // Note: 'Select date' (no article) differs from the date-only field's 'Select a date'.
-    await dialog
-        .getByRole('button', {name: /Select date/i})
-        .first()
-        .click();
+    // 8. Select date and time using the Meeting Date & Time picker.
+    // The datetime field renders via DateTimeInput which wraps its date part in
+    // <div class="dateTime__date"> — a class unique to DateTimeInput and absent
+    // from the date-only "Meeting Date" field (AppsFormDateField → DatePicker directly).
+    // Scoping by that wrapper is more reliable than accessible-name matching on the
+    // role="button" div, whose name includes a CSS icon-font glyph that browsers
+    // include in accname but which is invisible to textContent inspection.
+    await dialog.locator('.dateTime__date').getByRole('button').click();
     await expect(channelsPage.page.getByRole('grid')).toBeVisible();
     await channelsPage.page.getByRole('grid').getByText('22', {exact: true}).click();
 
-    // Select a time from the time picker
+    // Select a time from the time picker.  The time button carries aria-label="Time"
+    // (set explicitly in DateTimeInput), so the name-based locator is reliable here.
     await dialog
         .getByRole('button', {name: /Time|Select a time/i})
         .first()

--- a/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_dialog_date.spec.ts
+++ b/e2e-tests/playwright/specs/functional/plugins/demo_plugin/server/slash_commands/demo_dialog_date.spec.ts
@@ -64,8 +64,11 @@ test('should open /dialog date and post submit confirmation after selecting date
     await channelsPage.page.getByRole('grid').getByText('20', {exact: true}).click();
 
     // 8. Select date and time using the Meeting Date & Time picker
+    // The datetime picker renders a date-part button whose accessible name is
+    // 'Date Select date' (label 'Date' + placeholder 'Select date' from datetime_input.tsx).
+    // Note: 'Select date' (no article) differs from the date-only field's 'Select a date'.
     await dialog
-        .getByRole('button', {name: /Date.*Today|Select a date/i})
+        .getByRole('button', {name: /Select date/i})
         .first()
         .click();
     await expect(channelsPage.page.getByRole('grid')).toBeVisible();


### PR DESCRIPTION
## Summary

- **Root cause of master CI failure (run 25795711073):** `e2e-tests-cypress-template-v2.yml` and `e2e-tests-playwright-template-v2.yml` were missing the `ci/runner-prep-for-openldap` step entirely. The step existed only in the non-v2 templates (added in #36054), so every `dispatch-run` job using a v2 template hit the Ubuntu 24.04 AppArmor user-namespace restriction → `mmserver-openldap-1 exited (1)`.
- **Fix:** Extract the prep logic into `.github/actions/runner-prep-openldap/action.yml` (single source of truth). All four templates now use `uses: ./.github/actions/runner-prep-openldap` instead of copy-pasted inline `run:` blocks.
- **Checkout ordering:** A sparse `ci/checkout-actions` step runs first (no `ref:` = triggering ref = master) to make the composite action available before the full `ci/checkout-repo` at `inputs.commit_sha` overwrites the workspace.

## What the composite action does

1. Logs docker compose version before/after
2. `sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0` — disables Ubuntu 24.04 AppArmor restriction that blocks openldap's init scripts
3. Upgrades docker-compose to 2.39.1 if the installed version is < 2.36.0 (2.35.1 shipped on some ubuntu-24.04 images has a known `up` regression)

## Files changed

| File | Change |
|------|--------|
| `.github/actions/runner-prep-openldap/action.yml` | **New** — composite action, single source of truth |
| `e2e-tests-ci-template.yml` | Replace 40-line inline block with `uses:` + sparse checkout |
| `e2e-tests-playwright-template.yml` | Same |
| `e2e-tests-cypress-template-v2.yml` | **Add missing** step + sparse checkout |
| `e2e-tests-playwright-template-v2.yml` | **Add missing** step + sparse checkout |

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** Changes modify CI workflows and the runner host (sysctl and docker-compose upgrade), which don't touch application code but can affect all CI runs; upgrading docker-compose and changing host kernel settings introduces moderate risk to CI stability if unexpected interactions occur. The changes are localized to GitHub Actions and are reversible, but they affect untested runner-level behavior across jobs.

**QA Recommendation:** Run a full E2E pipeline on ubuntu-24.04 (at least one successful run) and validate OpenLDAP container start and a representative subset of E2E tests; monitor CI for a couple of consecutive runs before merging widely.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36563)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36563)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->