### PR TITLE
ci: backport reporter-config.json to release-10.11

### DIFF
--- a/e2e-tests/cypress/reporter-config.json
+++ b/e2e-tests/cypress/reporter-config.json
@@ -1,0 +1,15 @@
+{
+  "reporterEnabled": "mocha-junit-reporter, mochawesome",
+  "mochaJunitReporterReporterOptions": {
+    "mochaFile": "results/junit/test_results[hash].xml",
+    "toConsole": false
+  },
+  "mochawesomeReporterOptions": {
+    "reportDir": "results/mochawesome-report",
+    "reportFilename": "json/tests/[name]",
+    "quiet": true,
+    "overwrite": false,
+    "html": false,
+    "json": true
+  }
+}


### PR DESCRIPTION
## Summary

`e2e-tests/.ci/server.run_specs.sh` on this branch invokes Cypress with

```
npx cypress run --spec "$SPEC_FILES" \
  --reporter cypress-multi-reporters \
  --reporter-options configFile=reporter-config.json
```

but `e2e-tests/cypress/reporter-config.json` does not exist on `release-10.11`. The file was added on `master` in 981ff0bc46 (#34868) as part of a larger CI refactor, and was never backported. Without it, `cypress-multi-reporters` fails with `ENOENT: no such file or directory, open '…/e2e-tests/cypress/reporter-config.json'` before the first spec executes.

## What changed

Adds a single 15-line JSON file, byte-identical to the version on `master` (blob `f70990ff0ad95a7a8e598527d022d030fcd84d6c`):

- `e2e-tests/cypress/reporter-config.json`

No other code, workflow, or `cypress.config.ts` change is required — `run_specs.sh` already references this exact path.

#### Release Note

```release-note
NONE
```