### PR TITLE
Add .envrc to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,6 +160,7 @@ docker-compose.override.yaml
 .notice-work/
 .aider*
 .env
+.envrc
 .planning/
 
 **/CLAUDE.local.md


### PR DESCRIPTION
#### Summary
We already have `.env` files in there, but `.envrc` let you do some more stuff (like local variables) that `.env` files don't, so you can do stuff like

```envrc
local PORT=8066
export MM_SERVICESETTINGS_SITEURL="http://localhost:${PORT}"
export MM_SERVICESETTINGS_LISTENADDRESS=":${PORT}"
export MM_SERVICESETTINGS_LOCALMODESOCKETLOCATION="/var/tmp/mattermost-${PORT}.socket"
export PW_BASE_URL="http://localhost:${PORT}"
```

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** None. This is a metadata-only change to `.gitignore` that adds a single entry and has zero impact on code execution or application runtime behavior.

**QA Recommendation:** No manual QA needed. Configuration file changes to `.gitignore` require no testing and have no affected code paths to verify.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36567)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->