### PR TITLE
Update Playbooks plugin to v2.9.0 (incl. FIPS)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -162,7 +162,7 @@ PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.4
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.1
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.2
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.0
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.8.1
+PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.9.0
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.3
@@ -178,7 +178,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.8.1%2Bac0a223-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.9.0%2Bdfb5b30-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.3%2Bcab391a-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4%2B5855fe1-fips
 endif


### PR DESCRIPTION
#### Summary
Update Playbooks plugin to v2.9.0 (FIPS and non-FIPS).

The non-FIPS pin is bumped from v2.8.1 to v2.9.0 in the same commit.

The FIPS build is produced from the [`fips.v2.9.0` branch](https://github.com/mattermost/mattermost-plugin-playbooks/pull/2265) of `mattermost-plugin-playbooks`, signed and uploaded via the [`Sign Plugin PR Artifacts` workflow](https://github.com/mattermost/delivery-platform/actions/runs/25871382583).

Source commit on the Playbooks repo: [`dfb5b30`](https://github.com/mattermost/mattermost-plugin-playbooks/commit/dfb5b3075720a52d34d780a41dd2cc064ecd5642).

The signed FIPS bundle is reachable at [https://plugins.releases.mattermost.com/release/mattermost-plugin-playbooks-v2.9.0%2Bdfb5b30-fips-linux-amd64.tar.gz](https://plugins.releases.mattermost.com/release/mattermost-plugin-playbooks-v2.9.0%2Bdfb5b30-fips-linux-amd64.tar.gz).

This needs to be cherry-picked to the active release branch once merged.

#### Ticket Link
[MM-68341](https://mattermost.atlassian.net/browse/MM-68341)

#### Screenshots
--

#### Release Note
```release-note
Update Playbooks plugin to v2.9.0.
```

[MM-68341]: https://mattermost.atlassian.net/browse/MM-68341?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is an isolated dependency version bump in the Makefile with no code changes to the core Mattermost server. Plugin version updates follow a well-established pattern and do not introduce behavioral changes to the application itself. The change affects only the prepackaged-plugins download mechanism.

**QA Recommendation:** Minimal manual QA required. Verify that the Playbooks plugin v2.9.0 loads correctly in both FIPS and non-FIPS builds and that basic Playbooks functionality operates as expected. Automated plugin loading tests should provide sufficient coverage for this straightforward version update.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36570)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[Playbooks v2.9.0 release](https://github.com/mattermost/mattermost-plugin-playbooks/releases/tag/v2.9.0)