### PR TITLE
Add flaky test webhook notification

### DIFF
--- a/.github/workflows/server-ci-report.yml
+++ b/.github/workflows/server-ci-report.yml
@@ -145,6 +145,8 @@ jobs:
             '{repo:$repo, pr_number:$pr_number, flaky_summary:$flaky_summary}')
 
           curl -X POST -fsSL \
+            --connect-timeout 5 \
+            --max-time 30 \
             -H "Content-Type: application/json" \
             -d "$PAYLOAD" \
             "$WEBHOOK_URL_FLAKY_TEST"

--- a/.github/workflows/server-ci-report.yml
+++ b/.github/workflows/server-ci-report.yml
@@ -124,3 +124,27 @@ jobs:
               repo: context.repo.repo,
               body: body
             })
+
+      - name: Report retried tests to flaky-test webhook (pull request)
+        if: >-
+          steps.report.outputs.flaky_summary != '<table><tr><th>Test</th><th>Retries</th></tr></table>'
+          && steps.report.outputs.failed == '0'
+          && github.event.workflow_run.event == 'pull_request'
+          && env.WEBHOOK_URL_FLAKY_TEST != ''
+        continue-on-error: true
+        env:
+          WEBHOOK_URL_FLAKY_TEST: ${{ secrets.WEBHOOK_URL_FLAKY_TEST }}
+          FLAKY_SUMMARY: ${{ steps.report.outputs.flaky_summary }}
+          PR_NUMBER: ${{ steps.incoming-pr.outputs.NUMBER }}
+          REPO: ${{ github.repository }}
+        run: |
+          PAYLOAD=$(jq -n \
+            --arg repo "$REPO" \
+            --arg pr_number "$PR_NUMBER" \
+            --arg flaky_summary "$FLAKY_SUMMARY" \
+            '{repo:$repo, pr_number:$pr_number, flaky_summary:$flaky_summary}')
+
+          curl -X POST -fsSL \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD" \
+            "$WEBHOOK_URL_FLAKY_TEST"


### PR DESCRIPTION
#### Summary

Adds a webhook notification for flaky Server CI tests to tie to a cursor automation to handle flaky tests. The CI step is non-blocking in the pipeline and just fired off after the flaky report has retries with success. 

The webhook sends the repository, PR number, and flaky summary to `WEBHOOK_URL_FLAKY_TEST` without failing CI if the receiver is unavailable.

The automation will: 

- Try to reproduce the flake and if a root cause is determine, open a new PR with a fix. 
- If not able to reproduce, will create a JIRA ticket and skip the test. 

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is limited to a new, non-blocking CI workflow step that posts a webhook on retried/flaky test success; it includes a bounded request timeout and uses continue-on-error so it cannot break application behavior or CI pipelines. Risk is minimal and confined to CI reporting logic that only runs under specific conditions.

**QA Recommendation:** No manual QA required; automated CI conditions and fail-safe behavior make this notification-only change safe to merge.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36573)

<!-- review_stack_entry_end -->

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36573)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->