### PR TITLE
Update plugin-calls to v1.11.5

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -158,7 +158,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.4
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.5
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.1
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.2
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.0


### PR DESCRIPTION
#### Summary
- Update prepackaged Calls to v1.11.5

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-68340


#### Release Note
```release-note
Mattermost Calls was updated to v1.11.5, supporting self-signed/private CA certificates with offloader/recorder/transcriber
```

Calls v1.11.5 https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v1.11.5.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is an isolated version bump of a prepackaged plugin with no changes to core system logic, authentication, data handling, or shared utilities. The Calls plugin is a self-contained optional component, minimizing risk of regression to other system components.

**QA Recommendation:** Minimal manual QA required; verify plugin downloads and basic instantiation in standard Mattermost setup. No regression testing needed for core functionality since this is a plugin version update.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36574)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->