### PR TITLE
Prevent CSV formula injection in exported user reports

### DIFF
--- a/server/channels/app/report.go
+++ b/server/channels/app/report.go
@@ -26,12 +26,38 @@ func (a *App) SaveReportChunk(format string, prefix string, count int, reportDat
 	return model.NewAppError("SaveReportChunk", "app.save_report_chunk.unsupported_format", nil, "unsupported report format", http.StatusBadRequest)
 }
 
+// dangerousCSVPrefixes are leading characters a spreadsheet application may
+// interpret as the start of a formula. encoding/csv only quotes for CSV
+// structural correctness and does not defend against formula injection, so
+// fields beginning with one of these are neutralized before being written.
+var dangerousCSVPrefixes = [...]byte{'=', '+', '-', '@', '\t', '\r'}
+
+// neutralizeCSVField prefixes a single quote to any field a spreadsheet could
+// evaluate as a formula, preventing CSV formula injection when an exported
+// report is opened in Excel, LibreOffice Calc, or Google Sheets. The report
+// data includes user-controlled values (display name, nickname, etc.).
+func neutralizeCSVField(field string) string {
+	if field == "" {
+		return field
+	}
+	for _, c := range dangerousCSVPrefixes {
+		if field[0] == c {
+			return "'" + field
+		}
+	}
+	return field
+}
+
 func (a *App) saveCSVChunk(prefix string, count int, reportData []model.ReportableObject) *model.AppError {
 	var buf bytes.Buffer
 	w := csv.NewWriter(&buf)
 
 	for _, report := range reportData {
-		err := w.Write(report.ToReport())
+		record := report.ToReport()
+		for i := range record {
+			record[i] = neutralizeCSVField(record[i])
+		}
+		err := w.Write(record)
 		if err != nil {
 			return model.NewAppError("saveCSVChunk", "app.save_csv_chunk.write_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}


### PR DESCRIPTION
#### Summary

Exported user-report CSVs are written through `encoding/csv` without neutralizing values that a spreadsheet application interprets as a formula. `encoding/csv` only quotes fields for CSV *structural* correctness (embedded commas, quotes, newlines); it does not defend against formula evaluation.

User-report rows include user-controlled values (display name, nickname, first/last name), which have no character restrictions beyond a length check. A value beginning with `=`, `+`, `-`, `@`, tab, or carriage return is therefore evaluated when an administrator opens the exported file in Excel, LibreOffice Calc, or Google Sheets — a low-privilege user can store such a value in their own profile, and it executes in the context of the administrator who runs and opens the export.

#### Fix

`saveCSVChunk` now neutralizes every field of each record before writing: if a field begins with one of the dangerous lead characters, it is prefixed with a single quote. Applied centrally so every `ReportableObject.ToReport()` row is covered, and scoped to the CSV writer only (other output formats are unaffected).

#### Changes

- `server/channels/app/report.go`: add `neutralizeCSVField` and apply it per field in `saveCSVChunk`.

#### Test

- `gofmt` clean; change is self-contained. Existing report exports are unaffected for normal values (usernames/emails do not begin with the neutralized characters); display names that do begin with them are rendered literally instead of evaluated.

#### Notes

The enterprise compliance exporters (Global Relay / Actiance / compliance CSV) consume the same unvalidated fields and should receive the identical neutralization in a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is highly isolated to the CSV export functionality, specifically the `saveCSVChunk` function where neutralization is applied uniformly to all fields. This is a defensive sanitization that only adds a single quote prefix to values beginning with dangerous characters (=, +, -, @, tab, CR), leaving normal values completely unaffected and preserving existing CSV structural behavior.

**QA Recommendation:** Minimal manual QA required beyond automated test coverage. Focus testing on: (1) CSV exports of user reports with display names/fields starting with dangerous characters to verify they render literally without formula evaluation, and (2) spot-check normal CSV exports to confirm no formatting regressions. This is a protective change with low risk of side effects.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36587)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->