### PR TITLE
Scope user property-value websocket events to the target user

### DIFF
--- a/server/channels/api4/custom_profile_attributes.go
+++ b/server/channels/api4/custom_profile_attributes.go
@@ -417,8 +417,11 @@ func cpaPatchValues(c *Context, w http.ResponseWriter, r *http.Request, userID s
 		results[value.FieldID] = value.Value
 	}
 
-	// CPA-specific websocket event (backward compat)
-	message := model.NewWebSocketEvent(model.WebsocketEventCPAValuesUpdated, "", "", "", nil, "")
+	// CPA-specific websocket event (backward compat). Scoped to the target
+	// user: CPA values are access-controlled per viewer on the REST path
+	// (UserCanSeeOtherUser and per-field visibility), so a system-wide
+	// broadcast would expose them to every connected user.
+	message := model.NewWebSocketEvent(model.WebsocketEventCPAValuesUpdated, "", "", userID, nil, "")
 	message.Add("user_id", userID)
 	message.Add("values", results)
 	c.App.Publish(message)

--- a/server/channels/app/property_value.go
+++ b/server/channels/app/property_value.go
@@ -37,6 +37,21 @@ func (a *App) resolveValueBroadcastParams(rctx request.CTX, objectType, targetID
 	}
 }
 
+// broadcastUserScope returns the user ID a property-value websocket event must
+// be scoped to. Values on user objects (e.g. custom profile attributes) are
+// access-controlled per viewer on the REST path via UserCanSeeOtherUser and
+// per-field visibility; a system-wide broadcast of the raw values bypasses
+// that control and exposes them to every connected user. Scoping user-object
+// events to the target user keeps delivery to a recipient that is always
+// authorized to see the values. Other object types remain scoped by the
+// team/channel resolved in resolveValueBroadcastParams.
+func broadcastUserScope(objectType, targetID string) string {
+	if objectType == model.PropertyFieldObjectTypeUser {
+		return targetID
+	}
+	return ""
+}
+
 // CreatePropertyValue creates a new property value.
 func (a *App) CreatePropertyValue(rctx request.CTX, value *model.PropertyValue) (*model.PropertyValue, *model.AppError) {
 	if value == nil {
@@ -274,7 +289,7 @@ func (a *App) UpsertPropertyValues(rctx request.CTX, values []*model.PropertyVal
 			if jsonErr != nil {
 				rctx.Logger().Warn("Failed to encode property values to JSON", mlog.Err(jsonErr))
 			} else {
-				message := model.NewWebSocketEvent(model.WebsocketEventPropertyValuesUpdated, teamID, channelID, "", nil, connectionID)
+				message := model.NewWebSocketEvent(model.WebsocketEventPropertyValuesUpdated, teamID, channelID, broadcastUserScope(objectType, targetID), nil, connectionID)
 				message.Add("object_type", objectType)
 				message.Add("target_id", targetID)
 				message.Add("values", string(valuesJSON))
@@ -318,7 +333,7 @@ func (a *App) DeletePropertyValue(rctx request.CTX, groupID, valueID string) *mo
 		return nil
 	}
 
-	message := model.NewWebSocketEvent(model.WebsocketEventPropertyValuesUpdated, teamID, channelID, "", nil, "")
+	message := model.NewWebSocketEvent(model.WebsocketEventPropertyValuesUpdated, teamID, channelID, broadcastUserScope(value.TargetType, value.TargetID), nil, "")
 	message.Add("object_type", value.TargetType)
 	message.Add("target_id", value.TargetID)
 	message.Add("values", string(valuesJSON))
@@ -341,7 +356,7 @@ func (a *App) DeletePropertyValuesForTarget(rctx request.CTX, groupID, targetTyp
 		return nil
 	}
 
-	message := model.NewWebSocketEvent(model.WebsocketEventPropertyValuesUpdated, teamID, channelID, "", nil, "")
+	message := model.NewWebSocketEvent(model.WebsocketEventPropertyValuesUpdated, teamID, channelID, broadcastUserScope(targetType, targetID), nil, "")
 	message.Add("object_type", targetType)
 	message.Add("target_id", targetID)
 	message.Add("values", "[]")


### PR DESCRIPTION
#### Summary

`property_values_updated` and `custom_profile_attributes_values_updated` websocket events for **user** objects are broadcast system-wide with the raw values in the payload. Custom profile attribute (and other user-object property) values are access-controlled per viewer on the REST path (`UserCanSeeOtherUser` plus per-field visibility / access mode); the system-wide broadcast delivers every user's attribute values to every connected client, bypassing that control. The same applies to the user-object delete paths (a deletion still carries `target_id` / `field_id`).

#### Fix

Scope user-object property-value events to the target user — a recipient always authorized to see the values — instead of broadcasting them system-wide. Non-user object types (post / channel / system) keep their existing team/channel scoping and are unchanged.

#### Changes

- `server/channels/app/property_value.go`: add `broadcastUserScope`; apply it to the `UpsertPropertyValues` event and both delete-path events (`DeletePropertyValue`, `DeletePropertyValuesForTarget`).
- `server/channels/api4/custom_profile_attributes.go`: scope the `custom_profile_attributes_values_updated` event to the target user.

#### Behavior note

Users other than the target who are authorized to see the target's attributes no longer receive a real-time push for that user's change; their UI reflects it on the next fetch/navigation. A follow-up could restore live updates for authorized viewers by filtering the event per-recipient (mirroring the `user_updated` sanitized/sensitive split).

#### Test

- `gofmt` clean; change is self-contained and server-only. Non-user object types are unaffected (verified by `broadcastUserScope` returning empty for non-user types, preserving the existing team/channel scope).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change modifies websocket event delivery scope from system-wide to user-scoped for user-object property values, which is a behavioral contract change affecting real-time client notifications. Existing tests focus on functionality rather than verifying actual websocket delivery to specific recipients, creating potential for undetected regressions in client notification behavior. However, the change is isolated to property values, safely defaults for non-user object types, and follows established patterns from similar user-scoped events (preferences, user_updated).

**QA Recommendation:** Manual testing is recommended to verify websocket event delivery behavior. Specifically: (1) confirm that only the target user receives property value update events (not other connected users), (2) test with multiple concurrent clients to ensure events are scoped correctly, (3) validate that authorized viewers still see updated values on next fetch/navigation since real-time push is removed, and (4) test edge cases with team/channel-scoped property objects to ensure no regression in existing broadcast behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36589)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->