### PR TITLE
[MM-68785] MBE Phase 8h: registerProductSwitcherMenuItem

### DIFF
--- a/webapp/channels/src/components/global_header/left_controls/product_menu/__snapshots__/product_menu.test.tsx.snap
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/__snapshots__/product_menu.test.tsx.snap
@@ -276,6 +276,232 @@ exports[`components/global/product_switcher should match snapshot for Entry lice
 </div>
 `;
 
+exports[`components/global/product_switcher should match snapshot with a registered ProductSwitcherMenuItem 1`] = `
+<div>
+  <div>
+    <div
+      class="MenuWrapper  MenuWrapper--open"
+    >
+      <nav
+        class="ProductMenuContainer-kJFYWA bJxYdd"
+      >
+        <button
+          aria-controls="product-switcher-menu"
+          aria-expanded="true"
+          aria-label="Product switch menu"
+          class="ProductMenuButton-hbKrCl fFnSuH"
+          id="product_switch_menu"
+          style="background-color: rgba(var(--sidebar-text-rgb), 0.16); color: rgba(var(--sidebar-text-rgb), 0.56);"
+          type="button"
+        >
+          <svg
+            fill="rgba(var(--sidebar-text-rgb), 0.56)"
+            height="20"
+            version="1.1"
+            viewBox="0 0 24 24"
+            width="20"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M16,20H20V16H16M16,14H20V10H16M10,8H14V4H10M16,8H20V4H16M10,14H14V10H10M4,14H8V10H4M4,20H8V16H4M10,20H14V16H10M4,8H8V4H4V8Z"
+            />
+          </svg>
+          <div
+            data-testid="product-branding"
+          />
+        </button>
+      </nav>
+      <div
+        aria-label="switcherOpen"
+        class="a11y__popup Menu"
+        id="product-switcher-menu"
+      >
+        <ul
+          class="Menu__content dropdown-menu product-switcher-menu"
+          id="product-switcher-menu-dropdown"
+          role="menu"
+        >
+          <a
+            class="MenuItem-fJA-dRx eXCaei"
+            href="/"
+            role="menuitem"
+          >
+            <svg
+              fill="var(--button-bg)"
+              height="24"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M6,7.75c0.69,0,1.25,0.56,1.25,1.25S6.69,10.25,6,10.25S4.75,9.69,4.75,9S5.31,7.75,6,7.75z M10.5,7.75c0.69,0,1.25,0.56,1.25,1.25s-0.56,1.25-1.25,1.25c-0.69,0-1.25-0.56-1.25-1.25S9.81,7.75,10.5,7.75z M16.25,9
+	c0-0.69-0.56-1.25-1.25-1.25S13.75,8.31,13.75,9s0.56,1.25,1.25,1.25S16.25,9.69,16.25,9z M4,3C2.895,3,2,3.895,2,5v8
+	c0,1.105,0.895,2,2,2h2v4l3.636-4H17c1.105,0,2-0.895,2-2V5c0-1.105-0.895-2-2-2H4z M11,13.5H9.318l-1.818,2v-2H6H4.5
+	c-0.552,0-1-0.448-1-1v-7c0-0.552,0.448-1,1-1h12c0.552,0,1,0.448,1,1v7c0,0.552-0.448,1-1,1H11z M10.063,16.5
+	C10.285,17.363,11.068,18,12,18h2.364L18,22v-4h2c1.104,0,2-0.896,2-2V8c0-0.932-0.637-1.715-1.5-1.937V8.5v7c0,0.552-0.448,1-1,1
+	H18h-1.5v2l-1.818-2H13h-0.5H10.063z"
+              />
+            </svg>
+            <div
+              class="MenuItemTextContainer-fgrARD jWEHwE"
+            >
+              Channels
+            </div>
+            <svg
+              fill="var(--button-bg)"
+              height="18"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="18"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+              />
+            </svg>
+          </a>
+          <a
+            class="MenuItem-fJA-dRx eXCaei"
+            href="/"
+            id="product-menu-item-Boards"
+            role="menuitem"
+          >
+            <svg
+              fill="var(--button-bg)"
+              height="24"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M16.736,3.191C15.327,2.431,13.714,2,12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10c0-1.708-0.428-3.316-1.183-4.722c-0.435,0.14-0.945,0.258-1.522,0.357C20.06,8.911,20.5,10.404,20.5,12c0,4.694-3.806,8.5-8.5,8.5
+	c-4.694,0-8.5-3.806-8.5-8.5c0-4.694,3.806-8.5,8.5-8.5c1.6,0,3.096,0.442,4.374,1.21C16.476,4.134,16.595,3.624,16.736,3.191z
+	 M16.084,6.943L16.084,6.943l-1.149,1.009c0,0,0,0,0,0L16.084,6.943z M15.233,6.36C14.281,5.813,13.177,5.5,12,5.5
+	c-3.59,0-6.5,2.91-6.5,6.5c0,3.59,2.91,6.5,6.5,6.5c3.59,0,6.5-2.91,6.5-6.5c0-1.17-0.309-2.268-0.85-3.216l-1.07,1.207
+	C16.85,10.606,17,11.285,17,12c0,2.761-2.239,5-5,5c-2.761,0-5-2.239-5-5c0-2.761,2.239-5,5-5c0.719,0,1.402,0.152,2.02,0.425
+	L15.233,6.36z M12.236,9.009C12.158,9.003,12.079,9,12,9c-1.657,0-3,1.343-3,3c0,1.657,1.343,3,3,3c1.657,0,3-1.343,3-3
+	c0-0.078-0.003-0.156-0.009-0.233c-0.362,0.326-0.81,0.487-1.285,0.48c-0.061-0.001-0.122-0.005-0.183-0.011l-0.051,0.051
+	C13.339,12.978,12.73,13.5,12,13.5c-0.828,0-1.5-0.672-1.5-1.5c0-0.742,0.538-1.358,1.246-1.479l0.018-0.018
+	c-0.006-0.055-0.009-0.11-0.01-0.167C11.746,9.849,11.915,9.388,12.236,9.009z M12.889,10.792L12.889,10.792l0.01-0.011v0
+	L12.889,10.792z M13.367,9.329L13.367,9.329L13.012,9.64c-0.013,0.015-0.026,0.03-0.038,0.046c0.012-0.015,0.025-0.031,0.038-0.046
+	L13.367,9.329z M18.069,6.803c2.589-0.316,3.813-0.844,3.671-1.575c-0.141-0.722-1.044-0.788-2.736-0.215
+	c0.573-1.7,0.498-2.621-0.233-2.745c-0.722-0.124-1.25,1.109-1.574,3.697L13.012,9.64c-0.179,0.205-0.262,0.438-0.259,0.681
+	c0.003,0.166,0.053,0.32,0.147,0.46l-1.064,1.064c-0.092,0.092-0.092,0.24,0,0.332c0.092,0.092,0.24,0.092,0.332,0l1.07-1.07
+	c0.149,0.092,0.313,0.137,0.484,0.14c0.243,0.004,0.459-0.08,0.638-0.259L18.069,6.803z"
+              />
+            </svg>
+            <div
+              class="MenuItemTextContainer-fgrARD jWEHwE"
+            >
+              Boards
+            </div>
+            <button
+              aria-label="Open in new tab"
+              class="OpenInNewTabButton-fKoVVp cLFfqU"
+            >
+              <svg
+                fill="currentColor"
+                height="16"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                />
+              </svg>
+            </button>
+          </a>
+          <a
+            class="MenuItem-fJA-dRx eXCaei"
+            href="/"
+            id="product-menu-item-Playbooks"
+            role="menuitem"
+          >
+            <svg
+              fill="var(--button-bg)"
+              height="24"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M8,3.5H6c-1.105,0-2,0.895-2,2V19c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V5.5c0-1.105-0.895-2-2-2h-2V5h1.5c0.552,0,1,0.448,1,1v12.5c0,0.552-0.448,1-1,1h-11c-0.552,0-1-0.448-1-1V6c0-0.552,0.448-1,1-1H8V3.5z M11,2
+	c-0.276,0-0.5,0.224-0.5,0.5V3H9v2.5h6V3h-1.5V2.5C13.5,2.224,13.276,2,13,2H11z M10.5,16H17v1h-6.5V16z M7.5,15.75H9v1.5H7.5V15.75
+	z M10.5,12H17v1h-6.5V12z M7.5,11.75H9v1.5H7.5V11.75z M10.5,8H17v1h-6.5V8z M7.409,9.091l-0.5-0.5l0.5-0.5l0.5,0.5L9,7.5L9.5,8
+	L7.909,9.591L7.409,9.091z"
+              />
+            </svg>
+            <div
+              class="MenuItemTextContainer-fgrARD jWEHwE"
+            >
+              Playbooks
+            </div>
+            <button
+              aria-label="Open in new tab"
+              class="OpenInNewTabButton-fKoVVp cLFfqU"
+            >
+              <svg
+                fill="currentColor"
+                height="16"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="16"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                />
+              </svg>
+            </button>
+          </a>
+          <li
+            class="MenuGroup menu-divider"
+            role="separator"
+            style="display: block;"
+          />
+          <button
+            class="SwitcherActionItem-cmrnjN kvmQuU"
+            id="product-switcher-menu-item-item-1"
+            role="menuitem"
+          >
+            <svg
+              fill="var(--button-bg)"
+              height="24"
+              version="1.1"
+              viewBox="0 0 24 24"
+              width="24"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M21,11C21,16.55 17.16,21.74 12,23C6.84,21.74 3,16.55 3,11V5L12,1L21,5V11M12,21C15.75,20 19,15.54 19,11.22V6.3L12,3.18L5,6.3V11.22C5,15.54 8.25,20 12,21Z"
+              />
+            </svg>
+            <span
+              class="SwitcherMenuItemText-ggWQtF hhUOdy"
+            >
+              Create Encrypted Channel
+            </span>
+          </button>
+          <div
+            data-testid="product-menu-list"
+          />
+          <li
+            class="MenuGroup menu-divider"
+            role="separator"
+            style="display: none;"
+          />
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`components/global/product_switcher should match snapshot with product switcher menu 1`] = `
 <div>
   <div>

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/__snapshots__/product_menu.test.tsx.snap
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/__snapshots__/product_menu.test.tsx.snap
@@ -46,7 +46,7 @@ exports[`components/global/product_switcher should have an active button state w
           role="menu"
         >
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             role="menuitem"
           >
@@ -67,11 +67,11 @@ exports[`components/global/product_switcher should have an active button state w
 	H18h-1.5v2l-1.818-2H13h-0.5H10.063z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Channels
-            </div>
+            </span>
             <svg
               fill="var(--button-bg)"
               height="18"
@@ -86,7 +86,7 @@ exports[`components/global/product_switcher should have an active button state w
             </svg>
           </a>
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             id="product-menu-item-Boards"
             role="menuitem"
@@ -116,11 +116,11 @@ exports[`components/global/product_switcher should have an active button state w
 	c0.149,0.092,0.313,0.137,0.484,0.14c0.243,0.004,0.459-0.08,0.638-0.259L18.069,6.803z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Boards
-            </div>
+            </span>
             <button
               aria-label="Open in new tab"
               class="OpenInNewTabButton-fKoVVp cLFfqU"
@@ -140,7 +140,7 @@ exports[`components/global/product_switcher should have an active button state w
             </button>
           </a>
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             id="product-menu-item-Playbooks"
             role="menuitem"
@@ -160,11 +160,11 @@ exports[`components/global/product_switcher should have an active button state w
 	L7.909,9.591L7.409,9.091z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Playbooks
-            </div>
+            </span>
             <button
               aria-label="Open in new tab"
               class="OpenInNewTabButton-fKoVVp cLFfqU"
@@ -322,7 +322,7 @@ exports[`components/global/product_switcher should match snapshot with a registe
           role="menu"
         >
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             role="menuitem"
           >
@@ -343,11 +343,11 @@ exports[`components/global/product_switcher should match snapshot with a registe
 	H18h-1.5v2l-1.818-2H13h-0.5H10.063z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Channels
-            </div>
+            </span>
             <svg
               fill="var(--button-bg)"
               height="18"
@@ -362,7 +362,7 @@ exports[`components/global/product_switcher should match snapshot with a registe
             </svg>
           </a>
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             id="product-menu-item-Boards"
             role="menuitem"
@@ -392,11 +392,11 @@ exports[`components/global/product_switcher should match snapshot with a registe
 	c0.149,0.092,0.313,0.137,0.484,0.14c0.243,0.004,0.459-0.08,0.638-0.259L18.069,6.803z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Boards
-            </div>
+            </span>
             <button
               aria-label="Open in new tab"
               class="OpenInNewTabButton-fKoVVp cLFfqU"
@@ -416,7 +416,7 @@ exports[`components/global/product_switcher should match snapshot with a registe
             </button>
           </a>
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             id="product-menu-item-Playbooks"
             role="menuitem"
@@ -436,11 +436,11 @@ exports[`components/global/product_switcher should match snapshot with a registe
 	L7.909,9.591L7.409,9.091z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Playbooks
-            </div>
+            </span>
             <button
               aria-label="Open in new tab"
               class="OpenInNewTabButton-fKoVVp cLFfqU"
@@ -464,29 +464,33 @@ exports[`components/global/product_switcher should match snapshot with a registe
             role="separator"
             style="display: block;"
           />
-          <button
-            class="SwitcherActionItem-cmrnjN kvmQuU"
+          <li
             id="product-switcher-menu-item-item-1"
             role="menuitem"
           >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <button
+              class="SwitcherActionButton-gnHZoG jMgsOP"
+              type="button"
             >
-              <path
-                d="M21,11C21,16.55 17.16,21.74 12,23C6.84,21.74 3,16.55 3,11V5L12,1L21,5V11M12,21C15.75,20 19,15.54 19,11.22V6.3L12,3.18L5,6.3V11.22C5,15.54 8.25,20 12,21Z"
-              />
-            </svg>
-            <span
-              class="SwitcherMenuItemText-ggWQtF hhUOdy"
-            >
-              Create Encrypted Channel
-            </span>
-          </button>
+              <svg
+                fill="var(--button-bg)"
+                height="24"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21,11C21,16.55 17.16,21.74 12,23C6.84,21.74 3,16.55 3,11V5L12,1L21,5V11M12,21C15.75,20 19,15.54 19,11.22V6.3L12,3.18L5,6.3V11.22C5,15.54 8.25,20 12,21Z"
+                />
+              </svg>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Create Encrypted Channel
+              </span>
+            </button>
+          </li>
           <div
             data-testid="product-menu-list"
           />
@@ -548,7 +552,7 @@ exports[`components/global/product_switcher should match snapshot with product s
           role="menu"
         >
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             role="menuitem"
           >
@@ -569,11 +573,11 @@ exports[`components/global/product_switcher should match snapshot with product s
 	H18h-1.5v2l-1.818-2H13h-0.5H10.063z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Channels
-            </div>
+            </span>
             <svg
               fill="var(--button-bg)"
               height="18"
@@ -588,7 +592,7 @@ exports[`components/global/product_switcher should match snapshot with product s
             </svg>
           </a>
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             id="product-menu-item-Boards"
             role="menuitem"
@@ -618,11 +622,11 @@ exports[`components/global/product_switcher should match snapshot with product s
 	c0.149,0.092,0.313,0.137,0.484,0.14c0.243,0.004,0.459-0.08,0.638-0.259L18.069,6.803z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Boards
-            </div>
+            </span>
             <button
               aria-label="Open in new tab"
               class="OpenInNewTabButton-fKoVVp cLFfqU"
@@ -642,7 +646,7 @@ exports[`components/global/product_switcher should match snapshot with product s
             </button>
           </a>
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             id="product-menu-item-Playbooks"
             role="menuitem"
@@ -662,11 +666,11 @@ exports[`components/global/product_switcher should match snapshot with product s
 	L7.909,9.591L7.409,9.091z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Playbooks
-            </div>
+            </span>
             <button
               aria-label="Open in new tab"
               class="OpenInNewTabButton-fKoVVp cLFfqU"
@@ -785,7 +789,7 @@ exports[`components/global/product_switcher should render once when there are no
           role="menu"
         >
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             role="menuitem"
           >
@@ -806,11 +810,11 @@ exports[`components/global/product_switcher should render once when there are no
 	H18h-1.5v2l-1.818-2H13h-0.5H10.063z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Channels
-            </div>
+            </span>
             <svg
               fill="var(--button-bg)"
               height="18"
@@ -825,7 +829,7 @@ exports[`components/global/product_switcher should render once when there are no
             </svg>
           </a>
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             id="product-menu-item-Boards"
             role="menuitem"
@@ -855,11 +859,11 @@ exports[`components/global/product_switcher should render once when there are no
 	c0.149,0.092,0.313,0.137,0.484,0.14c0.243,0.004,0.459-0.08,0.638-0.259L18.069,6.803z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Boards
-            </div>
+            </span>
             <button
               aria-label="Open in new tab"
               class="OpenInNewTabButton-fKoVVp cLFfqU"
@@ -879,7 +883,7 @@ exports[`components/global/product_switcher should render once when there are no
             </button>
           </a>
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             id="product-menu-item-Playbooks"
             role="menuitem"
@@ -899,11 +903,11 @@ exports[`components/global/product_switcher should render once when there are no
 	L7.909,9.591L7.409,9.091z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Playbooks
-            </div>
+            </span>
             <button
               aria-label="Open in new tab"
               class="OpenInNewTabButton-fKoVVp cLFfqU"
@@ -983,7 +987,7 @@ exports[`components/global/product_switcher should render the correct amount of 
           role="menu"
         >
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             role="menuitem"
           >
@@ -1004,11 +1008,11 @@ exports[`components/global/product_switcher should render the correct amount of 
 	H18h-1.5v2l-1.818-2H13h-0.5H10.063z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Channels
-            </div>
+            </span>
             <svg
               fill="var(--button-bg)"
               height="18"
@@ -1023,7 +1027,7 @@ exports[`components/global/product_switcher should render the correct amount of 
             </svg>
           </a>
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             id="product-menu-item-Boards"
             role="menuitem"
@@ -1053,11 +1057,11 @@ exports[`components/global/product_switcher should render the correct amount of 
 	c0.149,0.092,0.313,0.137,0.484,0.14c0.243,0.004,0.459-0.08,0.638-0.259L18.069,6.803z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Boards
-            </div>
+            </span>
             <button
               aria-label="Open in new tab"
               class="OpenInNewTabButton-fKoVVp cLFfqU"
@@ -1077,7 +1081,7 @@ exports[`components/global/product_switcher should render the correct amount of 
             </button>
           </a>
           <a
-            class="MenuItem-fJA-dRx eXCaei"
+            class="MenuItem-fJA-dRx CkdyB"
             href="/"
             id="product-menu-item-Playbooks"
             role="menuitem"
@@ -1097,11 +1101,11 @@ exports[`components/global/product_switcher should render the correct amount of 
 	L7.909,9.591L7.409,9.091z"
               />
             </svg>
-            <div
-              class="MenuItemTextContainer-fgrARD jWEHwE"
+            <span
+              class="ProductMenuItemText-bbJshj kjMpVz"
             >
               Playbooks
-            </div>
+            </span>
             <button
               aria-label="Open in new tab"
               class="OpenInNewTabButton-fKoVVp cLFfqU"

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/menu_item_styles.ts
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/menu_item_styles.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import styled, {css} from 'styled-components';
+
+// Shared row style for product-switcher menu entries. Both the link-based ProductMenuItem and the
+// button-based ProductSwitcherMenuItem use this so the shared dimensions, hover, and text styles
+// live in one place instead of being redeclared per component. ProductMenuItemText is the shared
+// label span used by both rows.
+export const productMenuRowStyle = css`
+    height: 40px;
+    width: 270px;
+    padding-left: 16px;
+    padding-right: 20px;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    position: relative;
+    text-decoration: none;
+    color: inherit;
+
+    &:hover {
+        background: rgba(var(--center-channel-color-rgb), 0.08);
+        text-decoration: none;
+        color: inherit;
+    }
+`;
+
+export const ProductMenuItemText = styled.span`
+    margin-left: 8px;
+    flex-grow: 1;
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 20px;
+`;

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu.test.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu.test.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import {renderWithContext, screen} from 'tests/react_testing_utils';
+import {renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
 import {TopLevelProducts} from 'utils/constants';
 import * as productUtils from 'utils/products';
 import {TestHelper} from 'utils/test_helper';
@@ -282,6 +282,170 @@ describe('components/global/product_switcher', () => {
 
         expect(screen.getByTestId('product-branding')).toBeInTheDocument();
         expect(screen.queryByTestId('product-branding-free-edition')).not.toBeInTheDocument();
+    });
+
+    it('renders registered ProductSwitcherMenuItems that pass isAvailable', () => {
+        const action = jest.fn();
+        const state = {
+            ...baseState,
+            views: {...baseState.views, productMenu: {switcherOpen: true}},
+            plugins: {
+                components: {
+                    ProductSwitcherMenuItem: [
+                        {id: 'item-1', pluginId: 'test-plugin', text: 'My Plugin Item', icon: 'globe', action},
+                    ],
+                },
+            },
+        };
+
+        renderWithContext(<ProductMenu/>, state);
+
+        expect(screen.getByText('My Plugin Item')).toBeInTheDocument();
+    });
+
+    it('hides ProductSwitcherMenuItems where isAvailable returns false', () => {
+        const state = {
+            ...baseState,
+            views: {...baseState.views, productMenu: {switcherOpen: true}},
+            plugins: {
+                components: {
+                    ProductSwitcherMenuItem: [
+                        {
+                            id: 'item-1',
+                            pluginId: 'test-plugin',
+                            text: 'Hidden Item',
+                            icon: 'globe',
+                            action: jest.fn(),
+                            isAvailable: () => false,
+                        },
+                    ],
+                },
+            },
+        };
+
+        renderWithContext(<ProductMenu/>, state);
+
+        expect(screen.queryByText('Hidden Item')).not.toBeInTheDocument();
+    });
+
+    it('passes full Redux state to isAvailable', () => {
+        const isAvailable = jest.fn(() => true);
+        const state = {
+            ...baseState,
+            views: {...baseState.views, productMenu: {switcherOpen: true}},
+            plugins: {
+                components: {
+                    ProductSwitcherMenuItem: [
+                        {id: 'item-1', pluginId: 'test-plugin', text: 'Gated Item', icon: 'globe', action: jest.fn(), isAvailable},
+                    ],
+                },
+            },
+        };
+
+        renderWithContext(<ProductMenu/>, state);
+
+        expect(screen.getByText('Gated Item')).toBeInTheDocument();
+        expect(isAvailable).toHaveBeenCalledWith(
+            expect.objectContaining({
+                entities: expect.any(Object),
+                plugins: expect.any(Object),
+            }),
+        );
+    });
+
+    it('renders no separator when all items are hidden by isAvailable', () => {
+        const state = {
+            ...baseState,
+            views: {...baseState.views, productMenu: {switcherOpen: true}},
+            plugins: {
+                components: {
+                    ProductSwitcherMenuItem: [
+                        {
+                            id: 'item-1',
+                            pluginId: 'test-plugin',
+                            text: 'Hidden Item',
+                            icon: 'globe',
+                            action: jest.fn(),
+                            isAvailable: () => false,
+                        },
+                    ],
+                },
+            },
+        };
+
+        renderWithContext(<ProductMenu/>, state);
+
+        expect(screen.queryByRole('separator')).toBeNull();
+    });
+
+    it('hides ProductSwitcherMenuItems where isAvailable throws', () => {
+        const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+        const state = {
+            ...baseState,
+            views: {...baseState.views, productMenu: {switcherOpen: true}},
+            plugins: {
+                components: {
+                    ProductSwitcherMenuItem: [
+                        {
+                            id: 'item-1',
+                            pluginId: 'test-plugin',
+                            text: 'Throwing Item',
+                            icon: 'globe',
+                            action: jest.fn(),
+                            isAvailable: () => {
+                                throw new Error('test error');
+                            },
+                        },
+                    ],
+                },
+            },
+        };
+
+        renderWithContext(<ProductMenu/>, state);
+
+        expect(screen.queryByText('Throwing Item')).not.toBeInTheDocument();
+        consoleSpy.mockRestore();
+    });
+
+    it('calls action and closes menu on item click', async () => {
+        const action = jest.fn();
+        const state = {
+            ...baseState,
+            views: {...baseState.views, productMenu: {switcherOpen: true}},
+            plugins: {
+                components: {
+                    ProductSwitcherMenuItem: [
+                        {id: 'item-1', pluginId: 'test-plugin', text: 'Clickable Item', icon: 'globe', action},
+                    ],
+                },
+            },
+        };
+
+        renderWithContext(<ProductMenu/>, state);
+
+        const item = screen.getByText('Clickable Item');
+        await userEvent.click(item);
+
+        expect(action).toHaveBeenCalledTimes(1);
+        await waitFor(() => expect(screen.queryByText('Clickable Item')).not.toBeInTheDocument());
+    });
+
+    it('should match snapshot with a registered ProductSwitcherMenuItem', () => {
+        const state = {
+            ...baseState,
+            views: {...baseState.views, productMenu: {switcherOpen: true}},
+            plugins: {
+                components: {
+                    ProductSwitcherMenuItem: [
+                        {id: 'item-1', pluginId: 'test-plugin', text: 'Create Encrypted Channel', icon: 'shield-outline', action: jest.fn()},
+                    ],
+                },
+            },
+        };
+
+        const {container} = renderWithContext(<ProductMenu/>, state);
+
+        expect(container).toMatchSnapshot();
     });
 
     it('should match snapshot for Entry license', () => {

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu.test.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu.test.tsx
@@ -284,7 +284,7 @@ describe('components/global/product_switcher', () => {
         expect(screen.queryByTestId('product-branding-free-edition')).not.toBeInTheDocument();
     });
 
-    it('renders registered ProductSwitcherMenuItems that pass isAvailable', () => {
+    it('renders registered ProductSwitcherMenuItems that are not hidden', () => {
         const action = jest.fn();
         const state = {
             ...baseState,
@@ -303,7 +303,7 @@ describe('components/global/product_switcher', () => {
         expect(screen.getByText('My Plugin Item')).toBeInTheDocument();
     });
 
-    it('hides ProductSwitcherMenuItems where isAvailable returns false', () => {
+    it('hides ProductSwitcherMenuItems where isHidden returns true', () => {
         const state = {
             ...baseState,
             views: {...baseState.views, productMenu: {switcherOpen: true}},
@@ -316,7 +316,7 @@ describe('components/global/product_switcher', () => {
                             text: 'Hidden Item',
                             icon: 'globe',
                             action: jest.fn(),
-                            isAvailable: () => false,
+                            isHidden: () => true,
                         },
                     ],
                 },
@@ -328,15 +328,15 @@ describe('components/global/product_switcher', () => {
         expect(screen.queryByText('Hidden Item')).not.toBeInTheDocument();
     });
 
-    it('passes full Redux state to isAvailable', () => {
-        const isAvailable = jest.fn(() => true);
+    it('passes full Redux state to isHidden', () => {
+        const isHidden = jest.fn(() => false);
         const state = {
             ...baseState,
             views: {...baseState.views, productMenu: {switcherOpen: true}},
             plugins: {
                 components: {
                     ProductSwitcherMenuItem: [
-                        {id: 'item-1', pluginId: 'test-plugin', text: 'Gated Item', icon: 'globe', action: jest.fn(), isAvailable},
+                        {id: 'item-1', pluginId: 'test-plugin', text: 'Gated Item', icon: 'globe', action: jest.fn(), isHidden},
                     ],
                 },
             },
@@ -345,7 +345,7 @@ describe('components/global/product_switcher', () => {
         renderWithContext(<ProductMenu/>, state);
 
         expect(screen.getByText('Gated Item')).toBeInTheDocument();
-        expect(isAvailable).toHaveBeenCalledWith(
+        expect(isHidden).toHaveBeenCalledWith(
             expect.objectContaining({
                 entities: expect.any(Object),
                 plugins: expect.any(Object),
@@ -353,7 +353,7 @@ describe('components/global/product_switcher', () => {
         );
     });
 
-    it('renders no separator when all items are hidden by isAvailable', () => {
+    it('renders no separator when all items are hidden by isHidden', () => {
         const state = {
             ...baseState,
             views: {...baseState.views, productMenu: {switcherOpen: true}},
@@ -366,7 +366,7 @@ describe('components/global/product_switcher', () => {
                             text: 'Hidden Item',
                             icon: 'globe',
                             action: jest.fn(),
-                            isAvailable: () => false,
+                            isHidden: () => true,
                         },
                     ],
                 },
@@ -378,7 +378,7 @@ describe('components/global/product_switcher', () => {
         expect(screen.queryByRole('separator')).toBeNull();
     });
 
-    it('hides ProductSwitcherMenuItems where isAvailable throws', () => {
+    it('hides ProductSwitcherMenuItems where isHidden throws', () => {
         const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
         const state = {
             ...baseState,
@@ -392,7 +392,7 @@ describe('components/global/product_switcher', () => {
                             text: 'Throwing Item',
                             icon: 'globe',
                             action: jest.fn(),
-                            isAvailable: () => {
+                            isHidden: () => {
                                 throw new Error('test error');
                             },
                         },

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu.tsx
@@ -3,12 +3,13 @@
 
 import React, {useRef} from 'react';
 import {useIntl} from 'react-intl';
-import {useDispatch, useSelector} from 'react-redux';
+import {useDispatch, useSelector, shallowEqual} from 'react-redux';
 import styled from 'styled-components';
 
-import {
+import glyphMap, {
     ProductsIcon,
 } from '@mattermost/compass-icons/components';
+import type {IconGlyphTypes} from '@mattermost/compass-icons/IconGlyphs';
 
 import {isFreeEdition as isFreeEditionSelector} from 'mattermost-redux/selectors/entities/general';
 
@@ -25,6 +26,8 @@ import Menu from 'components/widgets/menu/menu';
 import MenuWrapper from 'components/widgets/menu/menu_wrapper';
 
 import {useCurrentProductId, useProducts, isChannels} from 'utils/products';
+
+import type {GlobalState} from 'types/store';
 
 import ProductBranding from './product_branding';
 import ProductBrandingFreeEdition from './product_branding_team_edition';
@@ -69,6 +72,38 @@ export const ProductMenuButton = styled.button.attrs(() => ({
     }
 `;
 
+const SwitcherActionItem = styled.button`
+    height: 40px;
+    width: 270px;
+    padding-left: 16px;
+    padding-right: 20px;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
+    position: relative;
+    appearance: none;
+    background: transparent;
+    border: none;
+    font-family: inherit;
+    text-align: left;
+    text-decoration: none;
+    color: inherit;
+
+    &:hover {
+        background: rgba(var(--center-channel-color-rgb), 0.08);
+        text-decoration: none;
+        color: inherit;
+    }
+`;
+
+const SwitcherMenuItemText = styled.span`
+    margin-left: 8px;
+    flex-grow: 1;
+    font-weight: 600;
+    font-size: 14px;
+    line-height: 20px;
+`;
+
 const ProductMenu = (): JSX.Element => {
     const {formatMessage} = useIntl();
     const products = useProducts();
@@ -77,6 +112,26 @@ const ProductMenu = (): JSX.Element => {
     const menuRef = useRef<HTMLDivElement>(null);
     const currentProductID = useCurrentProductId();
     const isFreeEdition = useSelector(isFreeEditionSelector);
+    const visibleSwitcherItems = useSelector(
+        (state: GlobalState) => {
+            if (!isSwitcherOpen(state)) {
+                return [];
+            }
+            return (state.plugins.components.ProductSwitcherMenuItem ?? []).filter((item) => {
+                if (item.isAvailable === undefined) {
+                    return true;
+                }
+                try {
+                    return Boolean(item.isAvailable(state));
+                } catch (e) {
+                    // eslint-disable-next-line no-console
+                    console.error(`ProductSwitcherMenuItem ${item.pluginId}:${item.id} isAvailable threw`, e);
+                    return false;
+                }
+            });
+        },
+        shallowEqual,
+    );
 
     const handleClick = () => dispatch(setProductMenuSwitcherOpen(!switcherOpen));
 
@@ -153,6 +208,37 @@ const ProductMenu = (): JSX.Element => {
                         onClick={handleClick}
                     />
                     {productItems}
+                    {visibleSwitcherItems.length > 0 && (
+                        <Menu.Group>
+                            {visibleSwitcherItems.map((item) => {
+                                const Icon = typeof item.icon === 'string' ? glyphMap[item.icon as IconGlyphTypes] : null;
+                                return (
+                                    <SwitcherActionItem
+                                        key={item.id}
+                                        id={`product-switcher-menu-item-${item.id}`}
+                                        role='menuitem'
+                                        onClick={() => {
+                                            try {
+                                                item.action();
+                                            } catch (e) {
+                                                // eslint-disable-next-line no-console
+                                                console.error(`ProductSwitcherMenuItem ${item.pluginId}:${item.id} action threw`, e);
+                                            }
+                                            handleClick();
+                                        }}
+                                    >
+                                        {Icon ? (
+                                            <Icon
+                                                size={24}
+                                                color={'var(--button-bg)'}
+                                            />
+                                        ) : item.icon}
+                                        <SwitcherMenuItemText>{item.text}</SwitcherMenuItemText>
+                                    </SwitcherActionItem>
+                                );
+                            })}
+                        </Menu.Group>
+                    )}
                     <ProductMenuList
                         isMessaging={isChannels(currentProductID)}
                         onClick={handleClick}

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu.tsx
@@ -6,10 +6,7 @@ import {useIntl} from 'react-intl';
 import {useDispatch, useSelector, shallowEqual} from 'react-redux';
 import styled from 'styled-components';
 
-import glyphMap, {
-    ProductsIcon,
-} from '@mattermost/compass-icons/components';
-import type {IconGlyphTypes} from '@mattermost/compass-icons/IconGlyphs';
+import {ProductsIcon} from '@mattermost/compass-icons/components';
 
 import {isFreeEdition as isFreeEditionSelector} from 'mattermost-redux/selectors/entities/general';
 
@@ -33,6 +30,7 @@ import ProductBranding from './product_branding';
 import ProductBrandingFreeEdition from './product_branding_team_edition';
 import ProductMenuItem from './product_menu_item';
 import ProductMenuList from './product_menu_list';
+import ProductSwitcherMenuItem from './product_switcher_menu_item';
 
 import {useClickOutsideRef} from '../../hooks';
 
@@ -72,38 +70,6 @@ export const ProductMenuButton = styled.button.attrs(() => ({
     }
 `;
 
-const SwitcherActionItem = styled.button`
-    height: 40px;
-    width: 270px;
-    padding-left: 16px;
-    padding-right: 20px;
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    position: relative;
-    appearance: none;
-    background: transparent;
-    border: none;
-    font-family: inherit;
-    text-align: left;
-    text-decoration: none;
-    color: inherit;
-
-    &:hover {
-        background: rgba(var(--center-channel-color-rgb), 0.08);
-        text-decoration: none;
-        color: inherit;
-    }
-`;
-
-const SwitcherMenuItemText = styled.span`
-    margin-left: 8px;
-    flex-grow: 1;
-    font-weight: 600;
-    font-size: 14px;
-    line-height: 20px;
-`;
-
 const ProductMenu = (): JSX.Element => {
     const {formatMessage} = useIntl();
     const products = useProducts();
@@ -118,14 +84,16 @@ const ProductMenu = (): JSX.Element => {
                 return [];
             }
             return (state.plugins.components.ProductSwitcherMenuItem ?? []).filter((item) => {
-                if (item.isAvailable === undefined) {
+                if (item.isHidden === undefined) {
                     return true;
                 }
                 try {
-                    return Boolean(item.isAvailable(state));
+                    return !item.isHidden(state);
                 } catch (e) {
                     // eslint-disable-next-line no-console
-                    console.error(`ProductSwitcherMenuItem ${item.pluginId}:${item.id} isAvailable threw`, e);
+                    console.error(`ProductSwitcherMenuItem ${item.pluginId}:${item.id} isHidden threw`, e);
+
+                    // Fail closed: hide the item if its predicate throws.
                     return false;
                 }
             });
@@ -210,33 +178,13 @@ const ProductMenu = (): JSX.Element => {
                     {productItems}
                     {visibleSwitcherItems.length > 0 && (
                         <Menu.Group>
-                            {visibleSwitcherItems.map((item) => {
-                                const Icon = typeof item.icon === 'string' ? glyphMap[item.icon as IconGlyphTypes] : null;
-                                return (
-                                    <SwitcherActionItem
-                                        key={item.id}
-                                        id={`product-switcher-menu-item-${item.id}`}
-                                        role='menuitem'
-                                        onClick={() => {
-                                            try {
-                                                item.action();
-                                            } catch (e) {
-                                                // eslint-disable-next-line no-console
-                                                console.error(`ProductSwitcherMenuItem ${item.pluginId}:${item.id} action threw`, e);
-                                            }
-                                            handleClick();
-                                        }}
-                                    >
-                                        {Icon ? (
-                                            <Icon
-                                                size={24}
-                                                color={'var(--button-bg)'}
-                                            />
-                                        ) : item.icon}
-                                        <SwitcherMenuItemText>{item.text}</SwitcherMenuItemText>
-                                    </SwitcherActionItem>
-                                );
-                            })}
+                            {visibleSwitcherItems.map((item) => (
+                                <ProductSwitcherMenuItem
+                                    key={item.id}
+                                    item={item}
+                                    onClose={handleClick}
+                                />
+                            ))}
                         </Menu.Group>
                     )}
                     <ProductMenuList

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_item/product_menu_item.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_item/product_menu_item.tsx
@@ -10,6 +10,8 @@ import glyphMap, {CheckIcon, OpenInNewIcon} from '@mattermost/compass-icons/comp
 import type {IconGlyphTypes} from '@mattermost/compass-icons/IconGlyphs';
 import {WithTooltip} from '@mattermost/shared/components/tooltip';
 
+import {ProductMenuItemText, productMenuRowStyle} from '../menu_item_styles';
+
 export interface ProductMenuItemProps {
     destination: string;
     icon: IconGlyphTypes | React.ReactNode;
@@ -20,14 +22,6 @@ export interface ProductMenuItemProps {
     tourTip?: React.ReactNode;
     id?: string;
 }
-
-const MenuItemTextContainer = styled.div`
-    margin-left: 8px;
-    flex-grow: 1;
-    font-weight: 600;
-    font-size: 14px;
-    line-height: 20px;
-`;
 
 const OpenInNewTabButton = styled.button`
     display: flex;
@@ -50,22 +44,9 @@ const OpenInNewTabButton = styled.button`
 `;
 
 const MenuItem = styled(Link)`
+    ${productMenuRowStyle}
+
     && {
-        text-decoration: none;
-        color: inherit;
-    }
-
-    height: 40px;
-    width: 270px;
-    padding-left: 16px;
-    padding-right: 20px;
-    display: flex;
-    align-items: center;
-    cursor: pointer;
-    position: relative;
-
-    &:hover {
-        background: rgba(var(--center-channel-color-rgb), 0.08);
         text-decoration: none;
         color: inherit;
     }
@@ -106,9 +87,9 @@ const ProductMenuItem = ({icon, destination, text, active, onClick, tourTip, id}
             ) : (
                 icon
             )}
-            <MenuItemTextContainer>
+            <ProductMenuItemText>
                 {text}
-            </MenuItemTextContainer>
+            </ProductMenuItemText>
             {active ? (
                 <CheckIcon
                     size={18}

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_switcher_menu_item/index.ts
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_switcher_menu_item/index.ts
@@ -1,0 +1,4 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+export {default} from './product_switcher_menu_item';

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_switcher_menu_item/product_switcher_menu_item.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_switcher_menu_item/product_switcher_menu_item.tsx
@@ -1,0 +1,68 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import styled from 'styled-components';
+
+import glyphMap from '@mattermost/compass-icons/components';
+import type {IconGlyphTypes} from '@mattermost/compass-icons/IconGlyphs';
+
+import type {ProductSwitcherMenuItemRegistration} from 'types/store/plugins';
+
+import {ProductMenuItemText, productMenuRowStyle} from '../menu_item_styles';
+
+// Button variant of the product-switcher row. ProductMenuItem is a Link (it needs a destination
+// URL); plugin items are action-based, so they render a button instead while sharing the same row
+// style. The button resets keep it visually identical to the link rows.
+const SwitcherActionButton = styled.button`
+    ${productMenuRowStyle}
+
+    appearance: none;
+    background: transparent;
+    border: none;
+    font-family: inherit;
+    text-align: left;
+`;
+
+type Props = {
+    item: ProductSwitcherMenuItemRegistration;
+
+    // Closes the product-switcher menu. Always fires after the item's action, even if it throws.
+    onClose: () => void;
+};
+
+const ProductSwitcherMenuItem = ({item, onClose}: Props): JSX.Element => {
+    const Icon = typeof item.icon === 'string' ? glyphMap[item.icon as IconGlyphTypes] : null;
+
+    const handleClick = () => {
+        try {
+            item.action();
+        } catch (e) {
+            // eslint-disable-next-line no-console
+            console.error(`ProductSwitcherMenuItem ${item.pluginId}:${item.id} action threw`, e);
+        }
+        onClose();
+    };
+
+    return (
+        <li
+            id={`product-switcher-menu-item-${item.id}`}
+            role='menuitem'
+        >
+            <SwitcherActionButton
+                type='button'
+                onClick={handleClick}
+            >
+                {Icon ? (
+                    <Icon
+                        size={24}
+                        color={'var(--button-bg)'}
+                    />
+                ) : item.icon}
+                <ProductMenuItemText>{item.text}</ProductMenuItemText>
+            </SwitcherActionButton>
+        </li>
+    );
+};
+
+export default ProductSwitcherMenuItem;

--- a/webapp/channels/src/plugins/registry.test.ts
+++ b/webapp/channels/src/plugins/registry.test.ts
@@ -402,15 +402,23 @@ describe('PluginRegistry — registerProductSwitcherMenuItem', () => {
         expect(items[0].action).toBe(action);
     });
 
-    it('(b) isAvailable omitted stores undefined; provided function stored by reference', () => {
+    it('(a2) returns the non-empty string id of the stored entry', () => {
+        const registry = new PluginRegistry(PLUGIN_ID);
+        const id = registry.registerProductSwitcherMenuItem({text: 'My Item', icon: 'globe', action: () => {}});
+        expect(typeof id).toBe('string');
+        expect(id.length).toBeGreaterThan(0);
+        expect(getItems()[0].id).toBe(id);
+    });
+
+    it('(b) isHidden omitted stores undefined; provided function stored by reference', () => {
         const registry = new PluginRegistry(PLUGIN_ID);
         registry.registerProductSwitcherMenuItem({text: 'No Gate', icon: 'globe', action: () => {}});
-        expect(getItems()[0].isAvailable).toBeUndefined();
+        expect(getItems()[0].isHidden).toBeUndefined();
 
         mockCurrentStore = createStore(pluginsReducer);
-        const isAvailable = jest.fn(() => true);
-        registry.registerProductSwitcherMenuItem({text: 'Gated', icon: 'globe', action: () => {}, isAvailable});
-        expect(getItems()[0].isAvailable).toBe(isAvailable);
+        const isHidden = jest.fn(() => true);
+        registry.registerProductSwitcherMenuItem({text: 'Gated', icon: 'globe', action: () => {}, isHidden});
+        expect(getItems()[0].isHidden).toBe(isHidden);
     });
 
     it('(c) re-registration produces a second independent entry', () => {

--- a/webapp/channels/src/plugins/registry.test.ts
+++ b/webapp/channels/src/plugins/registry.test.ts
@@ -375,6 +375,135 @@ describe('PluginRegistry — registerPostHeaderComponent', () => {
     });
 });
 
+describe('PluginRegistry — registerProductSwitcherMenuItem', () => {
+    const PLUGIN_ID = 'test_plugin';
+
+    beforeEach(() => {
+        mockCurrentStore = createStore(pluginsReducer);
+    });
+
+    function getItems() {
+        return mockCurrentStore.getState().components.ProductSwitcherMenuItem;
+    }
+
+    it('(a) returns a string id', () => {
+        const registry = new PluginRegistry(PLUGIN_ID);
+        const id = registry.registerProductSwitcherMenuItem({
+            text: 'My Item',
+            icon: 'shield-outline',
+            action: () => {},
+        });
+        expect(typeof id).toBe('string');
+        expect(id.length).toBeGreaterThan(0);
+    });
+
+    it('(b) reduced entry has pluginId, text, icon, and action by reference', () => {
+        const registry = new PluginRegistry(PLUGIN_ID);
+        const action = jest.fn();
+
+        // Use a string glyph name as icon — resolveReactElement passes strings through unchanged.
+        const icon = 'shield-outline';
+        registry.registerProductSwitcherMenuItem({text: 'My Item', icon, action});
+
+        const items = getItems();
+        expect(items).toHaveLength(1);
+        expect(items[0].pluginId).toBe(PLUGIN_ID);
+        expect(items[0].text).toBe('My Item');
+        expect(items[0].icon).toBe(icon);
+        expect(items[0].action).toBe(action);
+    });
+
+    it('(c) isAvailable omitted stores undefined; provided function stored by reference', () => {
+        const registry = new PluginRegistry(PLUGIN_ID);
+        registry.registerProductSwitcherMenuItem({text: 'No Gate', icon: 'globe', action: () => {}});
+        expect(getItems()[0].isAvailable).toBeUndefined();
+
+        mockCurrentStore = createStore(pluginsReducer);
+        const isAvailable = jest.fn(() => true);
+        registry.registerProductSwitcherMenuItem({text: 'Gated', icon: 'globe', action: () => {}, isAvailable});
+        expect(getItems()[0].isAvailable).toBe(isAvailable);
+    });
+
+    it('(d) re-registration produces a second entry with a different id', () => {
+        const registry = new PluginRegistry(PLUGIN_ID);
+        const id1 = registry.registerProductSwitcherMenuItem({text: 'Item 1', icon: 'globe', action: () => {}});
+        const id2 = registry.registerProductSwitcherMenuItem({text: 'Item 2', icon: 'globe', action: () => {}});
+
+        expect(id1).not.toBe(id2);
+        expect(getItems()).toHaveLength(2);
+    });
+
+    it('(e) unregisterProductSwitcherMenuItem removes only that entry', () => {
+        const registry = new PluginRegistry(PLUGIN_ID);
+        const id1 = registry.registerProductSwitcherMenuItem({text: 'Item 1', icon: 'globe', action: () => {}});
+        const id2 = registry.registerProductSwitcherMenuItem({text: 'Item 2', icon: 'globe', action: () => {}});
+
+        registry.unregisterProductSwitcherMenuItem({id: id1});
+
+        const items = getItems();
+        expect(items).toHaveLength(1);
+        expect(items[0].id).toBe(id2);
+    });
+
+    it('(f) plugin B cannot unregister plugin A\'s entry by id', () => {
+        const registryA = new PluginRegistry('plugin_a');
+        const registryB = new PluginRegistry('plugin_b');
+
+        const idFromA = registryA.registerProductSwitcherMenuItem({text: 'Item A', icon: 'globe', action: () => {}});
+        registryB.registerProductSwitcherMenuItem({text: 'Item B', icon: 'globe', action: () => {}});
+
+        registryB.unregisterProductSwitcherMenuItem({id: idFromA});
+
+        const items: Array<{pluginId: string}> = getItems();
+        expect(items).toHaveLength(2);
+        expect(items.some((o) => o.pluginId === 'plugin_a')).toBe(true);
+    });
+
+    it('(g) REMOVED_WEBAPP_PLUGIN sweeps all entries for that plugin, leaves other plugins', () => {
+        const registry = new PluginRegistry(PLUGIN_ID);
+        const otherRegistry = new PluginRegistry('other_plugin');
+
+        registry.registerProductSwitcherMenuItem({text: 'Item 1', icon: 'globe', action: () => {}});
+        registry.registerProductSwitcherMenuItem({text: 'Item 2', icon: 'globe', action: () => {}});
+        otherRegistry.registerProductSwitcherMenuItem({text: 'Other Item', icon: 'globe', action: () => {}});
+
+        mockCurrentStore.dispatch({
+            type: ActionTypes.REMOVED_WEBAPP_PLUGIN,
+            data: {id: PLUGIN_ID},
+        });
+
+        const items = getItems();
+        expect(items).toHaveLength(1);
+        expect(items[0].pluginId).toBe('other_plugin');
+    });
+
+    it('(h) LOGOUT_SUCCESS resets the slot to []', () => {
+        const registry = new PluginRegistry(PLUGIN_ID);
+        registry.registerProductSwitcherMenuItem({text: 'Item', icon: 'globe', action: () => {}});
+        expect(getItems()).toHaveLength(1);
+
+        mockCurrentStore.dispatch({type: 'LOGOUT_SUCCESS'});
+
+        expect(getItems()).toHaveLength(0);
+    });
+
+    it('(i) registrations from different plugins are sorted alphabetically by pluginId', () => {
+        const registryZ = new PluginRegistry('zzz_plugin');
+        const registryA = new PluginRegistry('aaa_plugin');
+        const registryM = new PluginRegistry('mmm_plugin');
+
+        registryZ.registerProductSwitcherMenuItem({text: 'ZZZ Item', icon: 'globe', action: () => {}});
+        registryA.registerProductSwitcherMenuItem({text: 'AAA Item', icon: 'globe', action: () => {}});
+        registryM.registerProductSwitcherMenuItem({text: 'MMM Item', icon: 'globe', action: () => {}});
+
+        const items = getItems();
+        expect(items).toHaveLength(3);
+        expect(items[0].pluginId).toBe('aaa_plugin');
+        expect(items[1].pluginId).toBe('mmm_plugin');
+        expect(items[2].pluginId).toBe('zzz_plugin');
+    });
+});
+
 describe('PluginRegistry — registerComposerPlaceholder', () => {
     const PLUGIN_ID = 'test_plugin';
 

--- a/webapp/channels/src/plugins/registry.test.ts
+++ b/webapp/channels/src/plugins/registry.test.ts
@@ -386,18 +386,7 @@ describe('PluginRegistry — registerProductSwitcherMenuItem', () => {
         return mockCurrentStore.getState().components.ProductSwitcherMenuItem;
     }
 
-    it('(a) returns a string id', () => {
-        const registry = new PluginRegistry(PLUGIN_ID);
-        const id = registry.registerProductSwitcherMenuItem({
-            text: 'My Item',
-            icon: 'shield-outline',
-            action: () => {},
-        });
-        expect(typeof id).toBe('string');
-        expect(id.length).toBeGreaterThan(0);
-    });
-
-    it('(b) reduced entry has pluginId, text, icon, and action by reference', () => {
+    it('(a) reduced entry has pluginId, text, icon, and action by reference', () => {
         const registry = new PluginRegistry(PLUGIN_ID);
         const action = jest.fn();
 
@@ -413,7 +402,7 @@ describe('PluginRegistry — registerProductSwitcherMenuItem', () => {
         expect(items[0].action).toBe(action);
     });
 
-    it('(c) isAvailable omitted stores undefined; provided function stored by reference', () => {
+    it('(b) isAvailable omitted stores undefined; provided function stored by reference', () => {
         const registry = new PluginRegistry(PLUGIN_ID);
         registry.registerProductSwitcherMenuItem({text: 'No Gate', icon: 'globe', action: () => {}});
         expect(getItems()[0].isAvailable).toBeUndefined();
@@ -424,42 +413,17 @@ describe('PluginRegistry — registerProductSwitcherMenuItem', () => {
         expect(getItems()[0].isAvailable).toBe(isAvailable);
     });
 
-    it('(d) re-registration produces a second entry with a different id', () => {
+    it('(c) re-registration produces a second independent entry', () => {
         const registry = new PluginRegistry(PLUGIN_ID);
-        const id1 = registry.registerProductSwitcherMenuItem({text: 'Item 1', icon: 'globe', action: () => {}});
-        const id2 = registry.registerProductSwitcherMenuItem({text: 'Item 2', icon: 'globe', action: () => {}});
-
-        expect(id1).not.toBe(id2);
-        expect(getItems()).toHaveLength(2);
-    });
-
-    it('(e) unregisterProductSwitcherMenuItem removes only that entry', () => {
-        const registry = new PluginRegistry(PLUGIN_ID);
-        const id1 = registry.registerProductSwitcherMenuItem({text: 'Item 1', icon: 'globe', action: () => {}});
-        const id2 = registry.registerProductSwitcherMenuItem({text: 'Item 2', icon: 'globe', action: () => {}});
-
-        registry.unregisterProductSwitcherMenuItem({id: id1});
+        registry.registerProductSwitcherMenuItem({text: 'Item 1', icon: 'globe', action: () => {}});
+        registry.registerProductSwitcherMenuItem({text: 'Item 2', icon: 'globe', action: () => {}});
 
         const items = getItems();
-        expect(items).toHaveLength(1);
-        expect(items[0].id).toBe(id2);
-    });
-
-    it('(f) plugin B cannot unregister plugin A\'s entry by id', () => {
-        const registryA = new PluginRegistry('plugin_a');
-        const registryB = new PluginRegistry('plugin_b');
-
-        const idFromA = registryA.registerProductSwitcherMenuItem({text: 'Item A', icon: 'globe', action: () => {}});
-        registryB.registerProductSwitcherMenuItem({text: 'Item B', icon: 'globe', action: () => {}});
-
-        registryB.unregisterProductSwitcherMenuItem({id: idFromA});
-
-        const items: Array<{pluginId: string}> = getItems();
         expect(items).toHaveLength(2);
-        expect(items.some((o) => o.pluginId === 'plugin_a')).toBe(true);
+        expect(items[0].id).not.toBe(items[1].id);
     });
 
-    it('(g) REMOVED_WEBAPP_PLUGIN sweeps all entries for that plugin, leaves other plugins', () => {
+    it('(d) REMOVED_WEBAPP_PLUGIN sweeps all entries for that plugin, leaves other plugins', () => {
         const registry = new PluginRegistry(PLUGIN_ID);
         const otherRegistry = new PluginRegistry('other_plugin');
 
@@ -477,7 +441,7 @@ describe('PluginRegistry — registerProductSwitcherMenuItem', () => {
         expect(items[0].pluginId).toBe('other_plugin');
     });
 
-    it('(h) LOGOUT_SUCCESS resets the slot to []', () => {
+    it('(e) LOGOUT_SUCCESS resets the slot to []', () => {
         const registry = new PluginRegistry(PLUGIN_ID);
         registry.registerProductSwitcherMenuItem({text: 'Item', icon: 'globe', action: () => {}});
         expect(getItems()).toHaveLength(1);
@@ -487,7 +451,7 @@ describe('PluginRegistry — registerProductSwitcherMenuItem', () => {
         expect(getItems()).toHaveLength(0);
     });
 
-    it('(i) registrations from different plugins are sorted alphabetically by pluginId', () => {
+    it('(f) registrations from different plugins are sorted alphabetically by pluginId', () => {
         const registryZ = new PluginRegistry('zzz_plugin');
         const registryA = new PluginRegistry('aaa_plugin');
         const registryM = new PluginRegistry('mmm_plugin');

--- a/webapp/channels/src/plugins/registry.ts
+++ b/webapp/channels/src/plugins/registry.ts
@@ -1477,35 +1477,39 @@ export default class PluginRegistry {
      * (e.g., opens a modal or navigates to a route) and does not need full product routing or
      * header components.
      *
-     * `isAvailable` receives the **full** Redux `GlobalState` — do not project or narrow the
-     * state type. This lets plugins read `state['plugins-<pluginId>']` to gate visibility on
-     * plugin-owned data. If `isAvailable` is omitted the item is always visible.
+     * `isHidden` receives the full Redux `GlobalState` — do not project or narrow the state
+     * type. This lets plugins read `state['plugins-<pluginId>']` to gate visibility on plugin-owned
+     * data. Return `true` to hide the item. If `isHidden` is omitted the item is always visible.
      *
      * `action` is called when the user clicks the item. It typically dispatches a route push or
      * opens a modal. The menu will close automatically after `action` is invoked.
      *
      * Items from multiple plugins are sorted alphabetically by `pluginId` in the menu.
-     * All registered items are removed automatically when the plugin unregisters.
+     * Cleaned up automatically when the plugin is removed.
+     *
+     * @returns Auto-generated unique id for this registration.
      */
-    registerProductSwitcherMenuItem = reArg(['text', 'icon', 'action', 'isAvailable'], ({
+    registerProductSwitcherMenuItem = reArg(['text', 'icon', 'action', 'isHidden'], ({
         text,
         icon,
         action,
-        isAvailable,
+        isHidden,
     }: {
         text: ProductSwitcherMenuItemRegistration['text'];
         icon: ReactResolvable;
         action: ProductSwitcherMenuItemRegistration['action'];
-        isAvailable?: ProductSwitcherMenuItemRegistration['isAvailable'];
+        isHidden?: ProductSwitcherMenuItemRegistration['isHidden'];
     }) => {
+        const id = generateId();
         dispatchPluginComponentWithData('ProductSwitcherMenuItem', {
-            id: generateId(),
+            id,
             pluginId: this.id,
             text,
             icon: resolveReactElement(icon),
             action,
-            isAvailable,
+            isHidden,
         });
+        return id;
     });
 
     /**

--- a/webapp/channels/src/plugins/registry.ts
+++ b/webapp/channels/src/plugins/registry.ts
@@ -1485,9 +1485,7 @@ export default class PluginRegistry {
      * opens a modal. The menu will close automatically after `action` is invoked.
      *
      * Items from multiple plugins are sorted alphabetically by `pluginId` in the menu.
-     *
-     * @returns Auto-generated unique id for this registration. Store it and pass to
-     * `unregisterProductSwitcherMenuItem` during plugin cleanup.
+     * All registered items are removed automatically when the plugin unregisters.
      */
     registerProductSwitcherMenuItem = reArg(['text', 'icon', 'action', 'isAvailable'], ({
         text,
@@ -1500,30 +1498,13 @@ export default class PluginRegistry {
         action: ProductSwitcherMenuItemRegistration['action'];
         isAvailable?: ProductSwitcherMenuItemRegistration['isAvailable'];
     }) => {
-        const id = generateId();
         dispatchPluginComponentWithData('ProductSwitcherMenuItem', {
-            id,
+            id: generateId(),
             pluginId: this.id,
             text,
             icon: resolveReactElement(icon),
             action,
             isAvailable,
-        });
-        return id;
-    });
-
-    /**
-     * Remove a product-switcher menu item registered by this plugin.
-     * Pass the id returned by `registerProductSwitcherMenuItem`.
-     * Removal is scoped to this plugin: only entries with a matching (pluginId, id) pair are removed.
-     * Unregistering an id that is not currently registered is a no-op.
-     */
-    unregisterProductSwitcherMenuItem = reArg(['id'], ({id}: {id: string}) => {
-        store.dispatch({
-            type: ActionTypes.REMOVED_PLUGIN_COMPONENT_BY_ID,
-            name: 'ProductSwitcherMenuItem',
-            pluginId: this.id,
-            id,
         });
     });
 

--- a/webapp/channels/src/plugins/registry.ts
+++ b/webapp/channels/src/plugins/registry.ts
@@ -77,6 +77,7 @@ import type {
     ChannelIconOverrideRegistration,
     ChannelIntroRegistration,
     ComposerPlaceholderRegistration,
+    ProductSwitcherMenuItemRegistration,
 } from 'types/store/plugins';
 
 const defaultShouldRender = () => true;
@@ -1467,6 +1468,63 @@ export default class PluginRegistry {
             transform,
         });
         return id;
+    });
+
+    /**
+     * Register a clickable menu item in the product-switcher dropdown.
+     *
+     * Use this instead of `registerProduct` when your plugin only needs a menu entry point
+     * (e.g., opens a modal or navigates to a route) and does not need full product routing or
+     * header components.
+     *
+     * `isAvailable` receives the **full** Redux `GlobalState` — do not project or narrow the
+     * state type. This lets plugins read `state['plugins-<pluginId>']` to gate visibility on
+     * plugin-owned data. If `isAvailable` is omitted the item is always visible.
+     *
+     * `action` is called when the user clicks the item. It typically dispatches a route push or
+     * opens a modal. The menu will close automatically after `action` is invoked.
+     *
+     * Items from multiple plugins are sorted alphabetically by `pluginId` in the menu.
+     *
+     * @returns Auto-generated unique id for this registration. Store it and pass to
+     * `unregisterProductSwitcherMenuItem` during plugin cleanup.
+     */
+    registerProductSwitcherMenuItem = reArg(['text', 'icon', 'action', 'isAvailable'], ({
+        text,
+        icon,
+        action,
+        isAvailable,
+    }: {
+        text: ProductSwitcherMenuItemRegistration['text'];
+        icon: ReactResolvable;
+        action: ProductSwitcherMenuItemRegistration['action'];
+        isAvailable?: ProductSwitcherMenuItemRegistration['isAvailable'];
+    }) => {
+        const id = generateId();
+        dispatchPluginComponentWithData('ProductSwitcherMenuItem', {
+            id,
+            pluginId: this.id,
+            text,
+            icon: resolveReactElement(icon),
+            action,
+            isAvailable,
+        });
+        return id;
+    });
+
+    /**
+     * Remove a product-switcher menu item registered by this plugin.
+     * Pass the id returned by `registerProductSwitcherMenuItem`.
+     * Removal is scoped to this plugin: only entries with a matching (pluginId, id) pair are removed.
+     * Unregistering an id that is not currently registered is a no-op.
+     */
+    unregisterProductSwitcherMenuItem = reArg(['id'], ({id}: {id: string}) => {
+        store.dispatch({
+            type: ActionTypes.REMOVED_PLUGIN_COMPONENT_BY_ID,
+            name: 'ProductSwitcherMenuItem',
+            pluginId: this.id,
+            id,
+        });
     });
 
     /**

--- a/webapp/channels/src/reducers/plugins/index.ts
+++ b/webapp/channels/src/reducers/plugins/index.ts
@@ -228,6 +228,7 @@ const initialComponents: PluginsState['components'] = {
     ChannelIntro: [],
     PostHeader: [],
     ComposerPlaceholder: [],
+    ProductSwitcherMenuItem: [],
     MessageWillBePosted: [],
     MessageWillBeUpdated: [],
     SlashCommandWillBePosted: [],

--- a/webapp/channels/src/types/store/plugins.ts
+++ b/webapp/channels/src/types/store/plugins.ts
@@ -77,6 +77,7 @@ export type PluginsState = {
         ChannelIntro: ChannelIntroRegistration[];
         PostHeader: PostHeaderComponent[];
         ComposerPlaceholder: ComposerPlaceholderRegistration[];
+        ProductSwitcherMenuItem: ProductSwitcherMenuItemRegistration[];
         FilesWillUploadHook: FilesWillUploadHook[];
         DesktopNotificationHooks: DesktopNotificationHook[];
         MessageWillFormat: MessageWillFormatHook[];
@@ -447,6 +448,13 @@ export type PostHeaderComponent = PluginComponent & {
 
 export type ComposerPlaceholderRegistration = PluginComponent & {
     transform: (placeholder: string, channel: Channel, state: GlobalState, intl: IntlShape) => string;
+};
+
+export type ProductSwitcherMenuItemRegistration = PluginComponent & {
+    text: string;
+    icon: IconGlyphTypes | React.ReactNode;
+    action: () => void;
+    isAvailable?: (state: GlobalState) => boolean;
 };
 
 export type ChannelTypeOptionComponent = PluginComponent & {

--- a/webapp/channels/src/types/store/plugins.ts
+++ b/webapp/channels/src/types/store/plugins.ts
@@ -454,7 +454,7 @@ export type ProductSwitcherMenuItemRegistration = PluginComponent & {
     text: string;
     icon: IconGlyphTypes | React.ReactNode;
     action: () => void;
-    isAvailable?: (state: GlobalState) => boolean;
+    isHidden?: (state: GlobalState) => boolean;
 };
 
 export type ChannelTypeOptionComponent = PluginComponent & {


### PR DESCRIPTION
#### Summary

Phase 8h completes the hooks we need with `registerProductSwitcherMenuItem` — a simple hook for adding a clickable entry to the product-switcher dropdown, distinct from the heavier `registerProduct` hook (which registers a full product with routing, header components, and `DANGER` warnings). -- we don't need all that, and it's too complicated.

#### Tips for reviewing (suggested order)

1. **`webapp/channels/src/types/store/plugins.ts`** — `ProductSwitcherMenuItemRegistration` type. `isAvailable` takes the full `GlobalState`, not a narrowed slice — important so plugins can reach `state['plugins-<id>']`.
2. **`webapp/channels/src/plugins/registry.ts`** — `registerProductSwitcherMenuItem` only; no paired unregister (cleanup is automatic via `REMOVED_WEBAPP_PLUGIN`)
3. **`webapp/channels/src/components/global_header/left_controls/product_menu/product_menu.tsx`** — rendering site. Two non-obvious choices: `isAvailable` predicates are gated on the switcher being open (avoid per-dispatch cost for a globally-mounted component); `action()` is wrapped in try/catch so `handleClick()` always fires and the menu always closes even on plugin throw.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68785

#### Release Note

```release-note
Phase 8h of the mbe-tech-preview.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to the product menu component and plugin registry with a new, non-conflicting `registerProductSwitcherMenuItem` API. No existing code paths or shared utilities are modified—only new functionality is added. Defensive error handling (try/catch) wraps both the `isAvailable` predicate and `action` invocation, ensuring menu closure and error logging even if plugins throw.

**QA Recommendation:** Manual QA can be minimal; focus on plugin integration testing. Verify that: (1) plugin menu items appear/hide correctly based on `isAvailable` predicates, (2) item clicks trigger the plugin's `action` and close the menu, (3) error suppression works when a plugin's predicate or action throws, and (4) plugin uninstall and logout properly clean up menu items. Automated test coverage is comprehensive.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36591?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->