### PR TITLE
Cherry-pick Shared Channel plugin API fixes to release-11.7

### DIFF
--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -1476,6 +1476,10 @@ func (api *PluginAPI) UnregisterPluginForSharedChannels(pluginID string) error {
 	return api.app.UnregisterPluginForSharedChannels(pluginID)
 }
 
+func (api *PluginAPI) UnregisterPluginRemoteForSharedChannels(remoteID string) error {
+	return api.app.UnregisterPluginRemoteForSharedChannels(api.id, remoteID)
+}
+
 func (api *PluginAPI) ShareChannel(sc *model.SharedChannel) (*model.SharedChannel, error) {
 	scShared, err := api.app.ShareChannel(api.ctx, sc)
 	if errors.Is(err, model.ErrChannelAlreadyShared) {

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -503,6 +503,12 @@ func (a *App) attachFilesToPost(rctx request.CTX, post *model.Post, fileIDs mode
 	attachedIds := a.attachFileIDsToPost(rctx, post.Id, post.ChannelId, post.UserId, fileIDs)
 
 	if len(fileIDs) != len(attachedIds) {
+		// Remote-origin posts have a concurrent file-receive path that
+		// performs its own binding; stripping here can clobber a binding
+		// that path just made.
+		if post.GetRemoteID() != "" {
+			return fileIDs, nil
+		}
 		post.FileIds = attachedIds
 		if _, err := a.Srv().Store().Post().Overwrite(rctx, post); err != nil {
 			return nil, model.NewAppError("attachFilesToPost", "app.post.overwrite.app_error", nil, "", http.StatusInternalServerError).Wrap(err)

--- a/server/channels/app/post_test.go
+++ b/server/channels/app/post_test.go
@@ -953,7 +953,9 @@ func TestDeletePostInArchivedChannel(t *testing.T) {
 }
 
 func TestCreatePost(t *testing.T) {
-	mainHelper.Parallel(t)
+	// This test is intentionally not parallel: two subtests below call t.Setenv
+	// to pin MM_FEATUREFLAGS_EnableSharedChannelsDMs, which Go disallows under a
+	// parallel ancestor.
 	t.Run("call PreparePostForClient before returning", func(t *testing.T) {
 		mainHelper.Parallel(t)
 		th := Setup(t).InitBasic(t)
@@ -1173,7 +1175,10 @@ func TestCreatePost(t *testing.T) {
 	})
 
 	t.Run("Should not allow to create posts on shared DMs", func(t *testing.T) {
-		mainHelper.Parallel(t)
+		// The env override is reapplied on every config Set, so UpdateConfig cannot
+		// pin the flag; t.Setenv is the only safe way (and requires no parallel ancestor).
+		t.Setenv("MM_FEATUREFLAGS_EnableSharedChannelsDMs", "false")
+
 		th := setupSharedChannels(t).InitBasic(t)
 
 		user1 := th.CreateUser(t)
@@ -1212,7 +1217,10 @@ func TestCreatePost(t *testing.T) {
 	})
 
 	t.Run("Should not allow to create posts on shared GMs", func(t *testing.T) {
-		mainHelper.Parallel(t)
+		// The env override is reapplied on every config Set, so UpdateConfig cannot
+		// pin the flag; t.Setenv is the only safe way (and requires no parallel ancestor).
+		t.Setenv("MM_FEATUREFLAGS_EnableSharedChannelsDMs", "false")
+
 		th := setupSharedChannels(t).InitBasic(t)
 
 		user1 := th.CreateUser(t)

--- a/server/channels/app/remote_cluster.go
+++ b/server/channels/app/remote_cluster.go
@@ -62,9 +62,11 @@ func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.Regis
 		return rc.RemoteId, nil
 	}
 
-	// New connection.
+	// New connection. Name must satisfy the slug-style regex enforced by
+	// RemoteCluster.IsValid, so derive it from Displayname; the original
+	// human-readable label is preserved on DisplayName.
 	rc = &model.RemoteCluster{
-		Name:        opts.Displayname,
+		Name:        model.CleanRemoteName(opts.Displayname),
 		DisplayName: opts.Displayname,
 		SiteURL:     opts.SiteURL,
 		Token:       model.NewId(),

--- a/server/channels/app/remote_cluster.go
+++ b/server/channels/app/remote_cluster.go
@@ -6,6 +6,7 @@ package app
 import (
 	"database/sql"
 	"encoding/base64"
+	"fmt"
 	"net/http"
 
 	"github.com/pkg/errors"
@@ -19,24 +20,31 @@ import (
 )
 
 func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.RegisterPluginOpts) (remoteID string, err error) {
-	// check for pluginID already registered
-	rc, err := a.Srv().Store().RemoteCluster().GetByPluginID(opts.PluginID)
-	if err != nil {
-		if !errors.Is(err, sql.ErrNoRows) {
-			// anything other than not_found is unrecoverable
-			return "", err
-		}
+	// When SiteURL is empty, fall back to the legacy single-remote behavior
+	// using the "plugin_" prefix. This preserves compatibility for older plugins
+	// that haven't been updated to provide a SiteURL.
+	if opts.SiteURL == "" {
+		opts.SiteURL = model.SiteURLPlugin + opts.PluginID
 	}
 
-	// if plugin is already registered then treat this as an update.
+	// Check if this SiteURL is already registered.
+	rc, err := a.Srv().Store().RemoteCluster().GetBySiteURL(opts.SiteURL)
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return "", err
+	}
+
 	if rc != nil {
-		// plugin was deleted at some point
+		// SiteURL exists. Verify it belongs to this plugin.
+		if rc.PluginID != opts.PluginID {
+			return "", fmt.Errorf("SiteURL %q is already in use by remote %s (plugin %q)", opts.SiteURL, rc.RemoteId, rc.PluginID)
+		}
+
+		// Same plugin, same SiteURL: idempotent re-registration.
 		if rc.DeleteAt != 0 {
 			rctx.Logger().Debug("Restoring plugin registration for Shared Channels",
 				mlog.String("plugin_id", opts.PluginID),
 				mlog.String("remote_id", rc.RemoteId),
 			)
-
 			rc.DeleteAt = 0
 		} else {
 			rctx.Logger().Debug("Plugin already registered for Shared Channels",
@@ -54,10 +62,11 @@ func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.Regis
 		return rc.RemoteId, nil
 	}
 
+	// New connection.
 	rc = &model.RemoteCluster{
 		Name:        opts.Displayname,
 		DisplayName: opts.Displayname,
-		SiteURL:     model.SiteURLPlugin + opts.PluginID, // require a unique siteurl
+		SiteURL:     opts.SiteURL,
 		Token:       model.NewId(),
 		CreatorId:   opts.CreatorID,
 		PluginID:    opts.PluginID,
@@ -72,9 +81,10 @@ func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.Regis
 	rctx.Logger().Debug("Registered new plugin for Shared Channels",
 		mlog.String("plugin_id", opts.PluginID),
 		mlog.String("remote_id", rcSaved.RemoteId),
+		mlog.String("site_url", opts.SiteURL),
 	)
 
-	// ping the plugin remote immediately if the service is running
+	// Ping the plugin remote immediately if the service is running.
 	// If the service is not available the ping will happen once the
 	// service starts. This is expected since plugins start before the
 	// service.
@@ -86,14 +96,36 @@ func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.Regis
 	return rcSaved.RemoteId, nil
 }
 
+// UnregisterPluginForSharedChannels unregisters all remotes for the specified plugin.
+// Used in OnDeactivate for bulk cleanup.
 func (a *App) UnregisterPluginForSharedChannels(pluginID string) error {
-	rc, err := a.Srv().Store().RemoteCluster().GetByPluginID(pluginID)
+	remotes, err := a.Srv().Store().RemoteCluster().GetAllByPluginID(pluginID)
 	if err != nil {
 		return err
 	}
 
+	for _, rc := range remotes {
+		if _, appErr := a.DeleteRemoteCluster(rc.RemoteId); appErr != nil {
+			return appErr
+		}
+	}
+	return nil
+}
+
+// UnregisterPluginRemoteForSharedChannels unregisters a specific remote by its remoteID.
+// The pluginID is validated against the remote's PluginID to ensure a plugin can only
+// unregister its own remotes.
+func (a *App) UnregisterPluginRemoteForSharedChannels(pluginID, remoteID string) error {
+	rc, err := a.Srv().Store().RemoteCluster().Get(remoteID, true)
+	if err != nil {
+		return err
+	}
+
+	if rc.PluginID != pluginID {
+		return fmt.Errorf("remote %s does not belong to plugin %s", remoteID, pluginID)
+	}
+
 	if rc.DeleteAt != 0 {
-		// plugin already unregistered, nothing to do
 		return nil
 	}
 

--- a/server/channels/app/remote_cluster.go
+++ b/server/channels/app/remote_cluster.go
@@ -8,6 +8,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -18,6 +19,34 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/public/shared/request"
 )
+
+// pluginRemoteInitialPingDelay is how long the framework waits after
+// RegisterPluginForSharedChannels returns before firing the first ping to
+// the newly created or restored plugin remote. The delay gives the
+// calling plugin a chance to record the returned RemoteId in its own
+// state, so the synchronous OnSharedChannelsPing hook the framework
+// invokes can resolve the remote. Without the delay, the first ping for
+// every freshly registered SiteURL fails and the remote stays offline
+// until the periodic pingLoop refreshes it (up to PingFreq, default 1
+// minute). Declared as a var, not const, so tests can shorten it.
+var pluginRemoteInitialPingDelay = 5 * time.Second
+
+// schedulePluginRemoteInitialPing schedules a single deferred ping for a
+// freshly registered or restored plugin remote. The goroutine is launched
+// via Server.Go so it cannot outlive the server. The remote is re-read
+// before the ping fires because the plugin may have unregistered it
+// inside the delay window; pinging a soft-deleted row is harmless but
+// produces a stray "ping failed" warning.
+func (a *App) schedulePluginRemoteInitialPing(rcService remotecluster.RemoteClusterServiceIFace, rc *model.RemoteCluster) {
+	a.Srv().Go(func() {
+		time.Sleep(pluginRemoteInitialPingDelay)
+		current, err := a.Srv().Store().RemoteCluster().Get(rc.RemoteId, true)
+		if err != nil || current.DeleteAt != 0 {
+			return
+		}
+		rcService.PingNow(current)
+	})
+}
 
 func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.RegisterPluginOpts) (remoteID string, err error) {
 	// When SiteURL is empty, fall back to the legacy single-remote behavior
@@ -59,6 +88,18 @@ func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.Regis
 		if _, err = a.Srv().Store().RemoteCluster().Update(rc); err != nil {
 			return "", err
 		}
+
+		// Ping the restored plugin remote so its LastPingAt is refreshed
+		// before sync attempts. Deferred via a goroutine (see
+		// schedulePluginRemoteInitialPing) so the caller has a chance
+		// to record the returned RemoteId before the synchronous
+		// OnSharedChannelsPing hook fires. Without this the restored
+		// remote stays offline until the next pingLoop iteration (up to
+		// PingFreq), causing transient sync failures.
+		rcService, _ := a.GetRemoteClusterService()
+		if rcService != nil {
+			a.schedulePluginRemoteInitialPing(rcService, rc)
+		}
 		return rc.RemoteId, nil
 	}
 
@@ -86,13 +127,19 @@ func (a *App) RegisterPluginForSharedChannels(rctx request.CTX, opts model.Regis
 		mlog.String("site_url", opts.SiteURL),
 	)
 
-	// Ping the plugin remote immediately if the service is running.
-	// If the service is not available the ping will happen once the
-	// service starts. This is expected since plugins start before the
-	// service.
+	// Ping the new plugin remote, deferred via a goroutine so the
+	// calling plugin has a chance to record the returned RemoteId
+	// before the synchronous OnSharedChannelsPing hook fires for the
+	// first time. A synchronous ping here would invoke the hook
+	// before the caller's return statement, the plugin would fail to
+	// resolve the new RemoteId, the ping would be recorded as failed,
+	// and the remote would stay offline until the next pingLoop
+	// iteration (up to PingFreq, default 1 minute). If the service is
+	// not yet running the ping will fire from the periodic pingLoop
+	// once the service starts.
 	rcService, _ := a.GetRemoteClusterService()
 	if rcService != nil {
-		rcService.PingNow(rcSaved)
+		a.schedulePluginRemoteInitialPing(rcService, rcSaved)
 	}
 
 	return rcSaved.RemoteId, nil

--- a/server/channels/app/remote_cluster_test.go
+++ b/server/channels/app/remote_cluster_test.go
@@ -14,6 +14,7 @@ import (
 func setupRemoteCluster(tb testing.TB) *TestHelper {
 	return SetupConfig(tb, func(cfg *model.Config) {
 		*cfg.ConnectedWorkspacesSettings.EnableRemoteClusterService = true
+		*cfg.ConnectedWorkspacesSettings.EnableSharedChannels = true
 	})
 }
 
@@ -104,4 +105,167 @@ func TestUpdateRemoteCluster(t *testing.T) {
 		_, err = th.App.UpdateRemoteCluster(anotherExistingRemoteClustered)
 		require.Nil(t, err, "Updating remote cluster should work fine")
 	})
+}
+
+func TestRegisterPluginForSharedChannels(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := setupRemoteCluster(t).InitBasic(t)
+
+	t.Run("empty SiteURL defaults to plugin prefix", func(t *testing.T) {
+		pluginID := "com.test.legacy-" + model.NewId()
+		remoteID, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "legacy plugin",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+		})
+		require.NoError(t, err)
+
+		rc, err := th.App.Srv().Store().RemoteCluster().Get(remoteID, false)
+		require.NoError(t, err)
+		require.Equal(t, "plugin_"+pluginID, rc.SiteURL)
+	})
+
+	t.Run("cross-plugin SiteURL collision returns error", func(t *testing.T) {
+		siteURL := "nats://shared-" + model.NewId()
+
+		_, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "plugin A",
+			PluginID:    "com.test.pluginA-" + model.NewId(),
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     siteURL,
+		})
+		require.NoError(t, err)
+
+		_, err = th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "plugin B",
+			PluginID:    "com.test.pluginB-" + model.NewId(),
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     siteURL,
+		})
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "already in use")
+	})
+
+	t.Run("idempotent re-registration returns same remoteID", func(t *testing.T) {
+		pluginID := "com.test.idempotent-" + model.NewId()
+		siteURL := "nats://idempotent-" + model.NewId()
+
+		id1, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "first call",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     siteURL,
+		})
+		require.NoError(t, err)
+
+		id2, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "second call",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     siteURL,
+		})
+		require.NoError(t, err)
+		require.Equal(t, id1, id2)
+	})
+
+	t.Run("multi-remote registration returns distinct remoteIDs", func(t *testing.T) {
+		pluginID := "com.test.multi-" + model.NewId()
+
+		id1, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "remote 1",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     "nats://remote1-" + model.NewId(),
+		})
+		require.NoError(t, err)
+
+		id2, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "remote 2",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     "nats://remote2-" + model.NewId(),
+		})
+		require.NoError(t, err)
+		require.NotEqual(t, id1, id2)
+	})
+}
+
+func TestUnregisterPluginRemoteForSharedChannels(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := setupRemoteCluster(t).InitBasic(t)
+
+	t.Run("successful removal of own remote", func(t *testing.T) {
+		pluginID := "com.test.unregister-" + model.NewId()
+		remoteID, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "my remote",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     "nats://unregister-" + model.NewId(),
+		})
+		require.NoError(t, err)
+
+		err = th.App.UnregisterPluginRemoteForSharedChannels(pluginID, remoteID)
+		require.NoError(t, err)
+
+		// Verify the remote is actually deleted
+		rc, storeErr := th.App.Srv().Store().RemoteCluster().Get(remoteID, false)
+		require.Error(t, storeErr, "deleted remote should not be found with includeDeleted=false")
+		require.Nil(t, rc)
+
+		// Second call should be a no-op (idempotent)
+		err = th.App.UnregisterPluginRemoteForSharedChannels(pluginID, remoteID)
+		require.NoError(t, err)
+	})
+
+	t.Run("removing another plugins remote returns error", func(t *testing.T) {
+		pluginID := "com.test.owner-" + model.NewId()
+		remoteID, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "owned remote",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     "nats://owner-" + model.NewId(),
+		})
+		require.NoError(t, err)
+
+		err = th.App.UnregisterPluginRemoteForSharedChannels("com.test.other-plugin", remoteID)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "does not belong to plugin")
+	})
+
+	t.Run("removing non-existent remoteID returns error", func(t *testing.T) {
+		err := th.App.UnregisterPluginRemoteForSharedChannels("com.test.any", model.NewId())
+		require.Error(t, err)
+	})
+}
+
+func TestUnregisterPluginForSharedChannelsBulk(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := setupRemoteCluster(t).InitBasic(t)
+
+	pluginID := "com.test.bulk-" + model.NewId()
+
+	id1, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+		Displayname: "bulk remote 1",
+		PluginID:    pluginID,
+		CreatorID:   th.BasicUser.Id,
+		SiteURL:     "nats://bulk1-" + model.NewId(),
+	})
+	require.NoError(t, err)
+
+	id2, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+		Displayname: "bulk remote 2",
+		PluginID:    pluginID,
+		CreatorID:   th.BasicUser.Id,
+		SiteURL:     "nats://bulk2-" + model.NewId(),
+	})
+	require.NoError(t, err)
+	require.NotEqual(t, id1, id2)
+
+	err = th.App.UnregisterPluginForSharedChannels(pluginID)
+	require.NoError(t, err)
+
+	// Both should be deleted
+	remotes, err := th.App.Srv().Store().RemoteCluster().GetAllByPluginID(pluginID)
+	require.NoError(t, err)
+	require.Empty(t, remotes)
 }

--- a/server/channels/app/remote_cluster_test.go
+++ b/server/channels/app/remote_cluster_test.go
@@ -4,11 +4,13 @@
 package app
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/channels/testlib"
 )
 
 func setupRemoteCluster(tb testing.TB) *TestHelper {
@@ -16,6 +18,57 @@ func setupRemoteCluster(tb testing.TB) *TestHelper {
 		*cfg.ConnectedWorkspacesSettings.EnableRemoteClusterService = true
 		*cfg.ConnectedWorkspacesSettings.EnableSharedChannels = true
 	})
+}
+
+// TestSharedChannelServicesAvailableBeforePluginActivation guards the fix for
+// MM-68622. Plugins that call shared channels APIs from OnActivate previously
+// failed with "Shared Channels Service is disabled" because
+// startInterClusterServices ran after Channels().Start() initialized plugins.
+// Server.Start now starts the inter-cluster services first, so the services
+// must be available by the time plugin initialization begins.
+func TestSharedChannelServicesAvailableBeforePluginActivation(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := setupRemoteCluster(t).InitBasic(t)
+
+	require.NotNil(t, th.Server.GetRemoteClusterService(),
+		"remote cluster service must be initialized after Server.Start")
+	require.NotNil(t, th.Server.GetSharedChannelSyncService(),
+		"shared channel sync service must be initialized after Server.Start")
+
+	// Order check: scs.resume() logs "Shared Channel Service active" from
+	// scs.Start(), and initPlugins logs "Starting up plugins" from
+	// Channels().Start(). The first must precede the second, otherwise plugin
+	// OnActivate would observe a nil service.
+	require.NoError(t, th.TestLogger.Flush())
+	entries := testlib.ParseLogEntries(t, strings.NewReader(th.LogBuffer.String()))
+
+	scsActiveIdx, pluginInitIdx := -1, -1
+	for i, e := range entries {
+		if scsActiveIdx == -1 && e.Msg == "Shared Channel Service active" {
+			scsActiveIdx = i
+		}
+		if pluginInitIdx == -1 && e.Msg == "Starting up plugins" {
+			pluginInitIdx = i
+		}
+	}
+	require.NotEqual(t, -1, scsActiveIdx,
+		"expected log message 'Shared Channel Service active' from scs.resume()")
+	require.NotEqual(t, -1, pluginInitIdx,
+		"expected log message 'Starting up plugins' from initPlugins")
+	require.Less(t, scsActiveIdx, pluginInitIdx,
+		"shared channel service must activate before plugin initialization (MM-68622)")
+
+	// Plugin entry path: this is the App-layer call a plugin would make from
+	// OnActivate. Before MM-68622 it would return "Shared Channels Service is
+	// disabled" because GetSharedChannelSyncService() was still nil.
+	pluginID := "com.test.startup-" + model.NewId()
+	_, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+		Displayname: "startup test plugin",
+		PluginID:    pluginID,
+		CreatorID:   th.BasicUser.Id,
+	})
+	require.NoError(t, err,
+		"RegisterPluginForSharedChannels must succeed when shared channels is enabled")
 }
 
 func TestAddRemoteCluster(t *testing.T) {

--- a/server/channels/app/remote_cluster_test.go
+++ b/server/channels/app/remote_cluster_test.go
@@ -6,12 +6,38 @@ package app
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/channels/testlib"
+	"github.com/mattermost/mattermost/server/v8/platform/services/remotecluster"
 )
+
+// Shorten the deferred initial ping for tests so RegisterPluginForSharedChannels
+// teardown does not block on a 5s goroutine. No test in this package needs the
+// production headroom. The value is large enough that even a slow runner where
+// RegisterPluginForSharedChannels takes a couple hundred milliseconds still
+// has comfortable margin before the deferred goroutine fires.
+func init() {
+	pluginRemoteInitialPingDelay = 500 * time.Millisecond
+}
+
+// pingTrackingRCService wraps a real RemoteClusterServiceIFace and records the
+// time of every PingNow call without forwarding it. Embedding the interface
+// satisfies the other methods by delegation.
+type pingTrackingRCService struct {
+	remotecluster.RemoteClusterServiceIFace
+	pings chan time.Time
+}
+
+func (p *pingTrackingRCService) PingNow(rc *model.RemoteCluster) {
+	select {
+	case p.pings <- time.Now():
+	default:
+	}
+}
 
 func setupRemoteCluster(tb testing.TB) *TestHelper {
 	return SetupConfig(tb, func(cfg *model.Config) {
@@ -221,6 +247,46 @@ func TestRegisterPluginForSharedChannels(t *testing.T) {
 		require.Equal(t, id1, id2)
 	})
 
+	t.Run("re-registering a soft-deleted SiteURL restores the row and pings the remote (MM-68838)", func(t *testing.T) {
+		pluginID := "com.test.restore-" + model.NewId()
+		siteURL := "nats://restore-" + model.NewId()
+
+		// 1. Initial registration.
+		id1, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "restore test plugin",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     siteURL,
+		})
+		require.NoError(t, err)
+
+		// 2. Unregister soft-deletes the row.
+		require.NoError(t, th.App.UnregisterPluginRemoteForSharedChannels(pluginID, id1))
+
+		rcDeleted, err := th.App.Srv().Store().RemoteCluster().Get(id1, true)
+		require.NoError(t, err)
+		require.NotZero(t, rcDeleted.DeleteAt, "row should be soft-deleted after unregister")
+
+		// 3. Re-register the same SiteURL. The restore path must run.
+		id2, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "restore test plugin",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     siteURL,
+		})
+		require.NoError(t, err)
+		require.Equal(t, id1, id2, "restore path must reuse the existing remoteID")
+
+		// 4. The row must be restored (DeleteAt cleared). PingNow is called
+		// inside the restore branch; the actual ping fails in unit tests
+		// because no plugin process is loaded to answer OnSharedChannelsPing,
+		// so we cannot assert on LastPingAt here. The presence of the call
+		// is what fixes MM-68838 (offline-for-PingFreq window on restart).
+		rcRestored, err := th.App.Srv().Store().RemoteCluster().Get(id2, false)
+		require.NoError(t, err)
+		require.Zero(t, rcRestored.DeleteAt, "row should be restored after re-register")
+	})
+
 	t.Run("multi-remote registration returns distinct remoteIDs", func(t *testing.T) {
 		pluginID := "com.test.multi-" + model.NewId()
 
@@ -321,4 +387,118 @@ func TestUnregisterPluginForSharedChannelsBulk(t *testing.T) {
 	remotes, err := th.App.Srv().Store().RemoteCluster().GetAllByPluginID(pluginID)
 	require.NoError(t, err)
 	require.Empty(t, remotes)
+}
+
+// TestRegisterPluginForSharedChannelsPingIsDeferred guards the race fix.
+// A synchronous PingNow inside RegisterPluginForSharedChannels invoked the
+// plugin's OnSharedChannelsPing hook before the calling plugin could record
+// the returned RemoteId, so the very first ping always failed and the remote
+// stayed offline for ~PingFreq (1 minute). The fix is to defer the initial
+// ping to a goroutine. Both the new-row branch and the soft-delete-restore
+// branch must defer.
+func TestRegisterPluginForSharedChannelsPingIsDeferred(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := setupRemoteCluster(t).InitBasic(t)
+
+	tracker := &pingTrackingRCService{
+		RemoteClusterServiceIFace: th.Server.remoteClusterService,
+		pings:                     make(chan time.Time, 8),
+	}
+	original := th.Server.remoteClusterService
+	th.Server.remoteClusterService = tracker
+	t.Cleanup(func() { th.Server.remoteClusterService = original })
+
+	// Generous upper bound on real wall-time variance under load: the
+	// production delay is 5s; init() overrides to 100ms; we wait up to
+	// delay + 2s for the ping to actually arrive.
+	const arrivalGrace = 2 * time.Second
+	delay := pluginRemoteInitialPingDelay
+
+	// drain consumes any pending ping timestamps so a later sub-case does
+	// not see a stale one from an earlier sub-case.
+	drain := func(ch <-chan time.Time) {
+		for {
+			select {
+			case <-ch:
+			default:
+				return
+			}
+		}
+	}
+
+	assertDeferred := func(t *testing.T, registerStart time.Time) {
+		t.Helper()
+		// Phase 1: no ping in the first half of the delay (proves async).
+		var prematurePing bool
+		select {
+		case <-tracker.pings:
+			prematurePing = true
+		case <-time.After(delay / 2):
+		}
+		require.False(t, prematurePing, "PingNow fired synchronously inside RegisterPluginForSharedChannels; the deferral is broken")
+		// Phase 2: a ping arrives within delay + grace, and not before delay.
+		var pingAt time.Time
+		var pingArrived bool
+		select {
+		case pingAt = <-tracker.pings:
+			pingArrived = true
+		case <-time.After(delay + arrivalGrace):
+		}
+		require.True(t, pingArrived, "expected PingNow to fire within delay + grace, but it never did")
+		elapsed := pingAt.Sub(registerStart)
+		require.GreaterOrEqual(t, elapsed, delay,
+			"PingNow fired %s after Register returned, before the configured delay of %s", elapsed, delay)
+	}
+
+	t.Run("new-row branch defers the initial ping", func(t *testing.T) {
+		drain(tracker.pings)
+
+		start := time.Now()
+		_, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "deferred ping plugin",
+			PluginID:    "com.test.deferred-" + model.NewId(),
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     "nats://deferred-" + model.NewId(),
+		})
+		require.NoError(t, err)
+		assertDeferred(t, start)
+	})
+
+	t.Run("soft-delete restore branch defers the ping (MM-68838)", func(t *testing.T) {
+		drain(tracker.pings)
+
+		pluginID := "com.test.restore-defer-" + model.NewId()
+		siteURL := "nats://restore-defer-" + model.NewId()
+
+		// Initial register to create the row; consume its deferred ping.
+		id1, err := th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "restore defer plugin",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     siteURL,
+		})
+		require.NoError(t, err)
+		var initialPingArrived bool
+		select {
+		case <-tracker.pings:
+			initialPingArrived = true
+		case <-time.After(delay + arrivalGrace):
+		}
+		require.True(t, initialPingArrived, "initial register's deferred ping never arrived")
+
+		// Unregister soft-deletes the row.
+		require.NoError(t, th.App.UnregisterPluginRemoteForSharedChannels(pluginID, id1))
+		drain(tracker.pings)
+
+		// Re-register: the restore branch must also defer.
+		start := time.Now()
+		_, err = th.App.RegisterPluginForSharedChannels(th.Context, model.RegisterPluginOpts{
+			Displayname: "restore defer plugin",
+			PluginID:    pluginID,
+			CreatorID:   th.BasicUser.Id,
+			SiteURL:     siteURL,
+		})
+		require.NoError(t, err)
+		assertDeferred(t, start)
+	})
 }

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -856,6 +856,12 @@ func stripPort(hostport string) string {
 }
 
 func (s *Server) Start() error {
+	// Start inter-cluster services first so shared channels APIs are
+	// available when plugins activate during channels startup.
+	if err := s.startInterClusterServices(s.License()); err != nil {
+		mlog.Error("Error starting inter-cluster services", mlog.Err(err))
+	}
+
 	// Start channels.
 	// This needs to happen before because channels is dependent on the HTTP server.
 	if err := s.Channels().Start(); err != nil {
@@ -1111,10 +1117,6 @@ func (s *Server) Start() error {
 		if err := s.startLocalModeServer(); err != nil {
 			mlog.Fatal(err.Error())
 		}
-	}
-
-	if err := s.startInterClusterServices(s.License()); err != nil {
-		mlog.Error("Error starting inter-cluster services", mlog.Err(err))
 	}
 
 	return nil

--- a/server/channels/app/session_test.go
+++ b/server/channels/app/session_test.go
@@ -374,6 +374,7 @@ func TestGetRemoteClusterSession(t *testing.T) {
 	rc := model.RemoteCluster{
 		RemoteId:  remoteID,
 		Name:      "test",
+		SiteURL:   "https://test.example.com",
 		Token:     token,
 		CreatorId: model.NewId(),
 	}

--- a/server/channels/app/shared_channel.go
+++ b/server/channels/app/shared_channel.go
@@ -339,6 +339,7 @@ func (a *App) ReceiveSharedChannelAttachmentSyncMsg(rctx request.CTX, pluginID, 
 		Filename:  fi.Name,
 		FileSize:  fi.Size,
 		RemoteId:  rc.RemoteId,
+		ReqFileId: fi.Id,
 	}
 
 	us, appErr := a.CreateUploadSession(rctx, us)

--- a/server/channels/app/shared_channel.go
+++ b/server/channels/app/shared_channel.go
@@ -330,27 +330,80 @@ func (a *App) ReceiveSharedChannelAttachmentSyncMsg(rctx request.CTX, pluginID, 
 			map[string]any{"channelId": channelID}, "", http.StatusRequestEntityTooLarge)
 	}
 
-	// Create an upload session — this constructs the file path server-side
-	us := &model.UploadSession{
-		Id:        model.NewId(),
-		Type:      model.UploadTypeAttachment,
-		UserId:    fi.CreatorId,
-		ChannelId: channelID,
-		Filename:  fi.Name,
-		FileSize:  fi.Size,
-		RemoteId:  rc.RemoteId,
-		ReqFileId: fi.Id,
+	// Idempotency: if a FileInfo with the sender's id already exists for
+	// this channel and creator, this is a retry of a previously successful
+	// receive (e.g. caller re-delivered the same payload after a transient
+	// ack failure). Reuse the existing record rather than insert a duplicate
+	// (which would violate the FileInfo PK and force the caller to retry
+	// indefinitely). The bind/upsert tail still runs below so that a partial
+	// prior receive (FileInfo persisted but lazy-bind or attachment record
+	// never committed) self-heals on retry.
+	var saved *model.FileInfo
+	if fi.Id != "" {
+		if existing, getErr := a.Srv().Store().FileInfo().Get(fi.Id); getErr == nil {
+			if existing.ChannelId != channelID || existing.CreatorId != fi.CreatorId {
+				return nil, fmt.Errorf("file %s already exists under different channel/creator", fi.Id)
+			}
+			saved = existing
+		} else if !isNotFoundError(getErr) {
+			return nil, fmt.Errorf("error checking for existing file %s: %w", fi.Id, getErr)
+		}
 	}
 
-	us, appErr := a.CreateUploadSession(rctx, us)
-	if appErr != nil {
-		return nil, fmt.Errorf("error creating upload session: %w", appErr)
+	if saved == nil {
+		// Create an upload session, which constructs the file path server-side.
+		us := &model.UploadSession{
+			Id:        model.NewId(),
+			Type:      model.UploadTypeAttachment,
+			UserId:    fi.CreatorId,
+			ChannelId: channelID,
+			Filename:  fi.Name,
+			FileSize:  fi.Size,
+			RemoteId:  rc.RemoteId,
+			ReqFileId: fi.Id,
+		}
+
+		var appErr *model.AppError
+		us, appErr = a.CreateUploadSession(rctx, us)
+		if appErr != nil {
+			return nil, fmt.Errorf("error creating upload session: %w", appErr)
+		}
+
+		saved, appErr = a.UploadData(rctx, us, data)
+		if appErr != nil {
+			return nil, fmt.Errorf("error uploading attachment data: %w", appErr)
+		}
 	}
 
-	// Upload the file data through the standard upload path
-	saved, appErr := a.UploadData(rctx, us, data)
-	if appErr != nil {
-		return nil, fmt.Errorf("error uploading attachment data: %w", appErr)
+	// Bind the FileInfo to its post. AttachToPost is atomic against the
+	// post-receive path's parallel call for the same id, so whichever
+	// arrives second sees PostId already set and is a no-op. The
+	// post-receive path does not strip unmatched FileIds for remote-origin
+	// posts, so Post.FileIds does not need to be touched here.
+	//
+	// On a successful bind, publish a post_edited event so connected clients
+	// re-render the post with the now-resolvable attachment without needing
+	// a channel reload. The event is skipped when the post is not yet
+	// present (file-then-post ordering): the post-receive path will publish
+	// its own posted event with correct metadata once it arrives.
+	if fi.PostId != "" {
+		if attachErr := a.Srv().Store().FileInfo().AttachToPost(rctx, saved.Id, fi.PostId, channelID, saved.CreatorId); attachErr == nil {
+			if post, perr := a.Srv().Store().Post().GetSingle(rctx, fi.PostId, false); perr == nil {
+				preparedPost := a.PreparePostForClient(rctx, post, &model.PreparePostForClientOpts{})
+				message := model.NewWebSocketEvent(model.WebsocketEventPostEdited, "", channelID, "", nil, "")
+				if pubErr := a.publishWebsocketEventForPost(rctx, preparedPost, message); pubErr != nil {
+					rctx.Logger().Warn("ReceiveSharedChannelAttachmentSyncMsg: failed to publish post_edited event",
+						mlog.String("post_id", fi.PostId),
+						mlog.String("file_id", saved.Id),
+						mlog.Err(pubErr))
+				}
+			}
+		} else {
+			rctx.Logger().Debug("ReceiveSharedChannelAttachmentSyncMsg: AttachToPost did not bind",
+				mlog.String("post_id", fi.PostId),
+				mlog.String("file_id", saved.Id),
+				mlog.Err(attachErr))
+		}
 	}
 
 	// Save a SharedChannelAttachment record for cursor tracking

--- a/server/channels/app/shared_channel_test.go
+++ b/server/channels/app/shared_channel_test.go
@@ -1131,6 +1131,7 @@ func registerPluginRemoteForTest(t *testing.T, th *TestHelper, pluginID string, 
 		Displayname: "test-plugin-remote",
 		PluginID:    pluginID,
 		CreatorID:   th.BasicUser.Id,
+		SiteURL:     "plugin://" + pluginID,
 	})
 	require.NoError(t, err)
 
@@ -1148,7 +1149,7 @@ func registerPluginRemoteForTest(t *testing.T, th *TestHelper, pluginID string, 
 	err = th.App.InviteRemoteToChannel(channel.Id, remoteID, th.BasicUser.Id, false)
 	require.NoError(t, err)
 
-	rc, err := th.App.Srv().Store().RemoteCluster().GetByPluginID(pluginID)
+	rc, err := th.App.Srv().Store().RemoteCluster().Get(remoteID, false)
 	require.NoError(t, err)
 	return rc
 }

--- a/server/channels/app/shared_channel_test.go
+++ b/server/channels/app/shared_channel_test.go
@@ -5,14 +5,18 @@ package app
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"text/template"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -1371,6 +1375,375 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsg(t *testing.T) {
 		require.NoError(t, scaErr)
 		assert.Equal(t, saved.Id, sca.FileId)
 		assert.Equal(t, rc.RemoteId, sca.RemoteId)
+	})
+}
+
+// TestPluginAPIReceiveSharedChannelAttachmentSyncMsgOrderTolerance covers MM-68705:
+// the file-receive API must produce the same end state regardless of whether the
+// post or the file arrives first, and must be idempotent against re-delivery.
+func TestPluginAPIReceiveSharedChannelAttachmentSyncMsgOrderTolerance(t *testing.T) {
+	th := setupSharedChannels(t).InitBasic(t)
+
+	channel := th.CreateChannel(t, th.BasicTeam)
+	pluginID := "com.test.attachment-order-plugin"
+	rc := registerPluginRemoteForTest(t, th, pluginID, channel)
+
+	api := NewPluginAPI(th.App, th.Context, &model.Manifest{Id: pluginID})
+
+	// createRemoteUser builds a user owned by rc and inserts it directly so the
+	// test does not depend on a prior user-sync call ordering.
+	createRemoteUser := func(t *testing.T) *model.User {
+		t.Helper()
+		u := &model.User{
+			Email:    model.NewId() + "@remote.test",
+			Username: "remote-order-" + model.NewId()[:8],
+			Password: model.NewTestPassword(),
+			RemoteId: model.NewPointer(rc.RemoteId),
+		}
+		u, appErr := th.App.CreateUser(th.Context, u)
+		require.Nil(t, appErr)
+		return u
+	}
+
+	// syncPostWithFileIds sends a post via ReceiveSharedChannelSyncMsg with the
+	// given fileIDs preset on Post.FileIds. CreatePost on the receiving side
+	// will strip any fileID whose FileInfo does not yet exist.
+	syncPostWithFileIds := func(t *testing.T, postID, userID string, fileIDs []string) {
+		t.Helper()
+		msg := model.NewSyncMsg(channel.Id)
+		msg.Posts = []*model.Post{
+			{
+				Id:        postID,
+				ChannelId: channel.Id,
+				UserId:    userID,
+				Message:   "post with attachments",
+				FileIds:   fileIDs,
+				CreateAt:  model.GetMillis(),
+				RemoteId:  model.NewPointer(rc.RemoteId),
+			},
+		}
+		resp, err := api.ReceiveSharedChannelSyncMsg(rc.RemoteId, msg)
+		require.NoError(t, err)
+		assert.Empty(t, resp.PostErrors)
+	}
+
+	t.Run("post-then-file ordering binds correctly", func(t *testing.T) {
+		user := createRemoteUser(t)
+		postID := model.NewId()
+		fileID := model.NewId()
+
+		// Post arrives first carrying FileIds=[fileID]; FileInfo does not
+		// exist yet, but the remote-origin path preserves FileIds.
+		syncPostWithFileIds(t, postID, user.Id, []string{fileID})
+
+		preFile, appErr := th.App.GetSinglePost(th.Context, postID, false)
+		require.Nil(t, appErr)
+		assert.Contains(t, preFile.FileIds, fileID, "remote-origin posts must preserve unmatched FileIds")
+
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			PostId:    postID,
+			Name:      "attach.txt",
+			Size:      4,
+		}
+		saved, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+		require.NotNil(t, saved)
+
+		post, appErr := th.App.GetSinglePost(th.Context, postID, false)
+		require.Nil(t, appErr)
+		assert.Contains(t, post.FileIds, fileID)
+
+		storedFI, appErr := th.App.GetFileInfo(th.Context, fileID)
+		require.Nil(t, appErr)
+		assert.Equal(t, postID, storedFI.PostId)
+		assert.Equal(t, channel.Id, storedFI.ChannelId)
+	})
+
+	t.Run("file-then-post ordering binds correctly", func(t *testing.T) {
+		user := createRemoteUser(t)
+		postID := model.NewId()
+		fileID := model.NewId()
+
+		// File arrives first. The lazy-bind eagerly sets FileInfo.PostId
+		// even though the post is not yet present; the post-receive path
+		// preserves FileIds for remote-origin posts, so the post's later
+		// arrival converges without overwriting either side.
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			PostId:    postID,
+			Name:      "attach.txt",
+			Size:      4,
+		}
+		saved, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+		require.NotNil(t, saved)
+
+		syncPostWithFileIds(t, postID, user.Id, []string{fileID})
+
+		post, appErr := th.App.GetSinglePost(th.Context, postID, false)
+		require.Nil(t, appErr)
+		assert.Contains(t, post.FileIds, fileID)
+
+		storedFI, appErr := th.App.GetFileInfo(th.Context, fileID)
+		require.Nil(t, appErr)
+		assert.Equal(t, postID, storedFI.PostId)
+		assert.Equal(t, channel.Id, storedFI.ChannelId)
+	})
+
+	t.Run("repeated receive returns existing FileInfo without duplicate", func(t *testing.T) {
+		user := createRemoteUser(t)
+		fileID := model.NewId()
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			Name:      "retry.txt",
+			Size:      4,
+		}
+
+		first, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+		require.NotNil(t, first)
+
+		// Re-deliver with the same id, channel, and creator: must not error
+		// and must return the same FileInfo (no duplicate row, no new
+		// upload session).
+		second, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+		require.NotNil(t, second)
+		assert.Equal(t, first.Id, second.Id)
+		assert.Equal(t, first.Path, second.Path, "re-delivery must not produce a new server-side path")
+	})
+
+	t.Run("repeated receive with mismatched channel rejects", func(t *testing.T) {
+		user := createRemoteUser(t)
+		fileID := model.NewId()
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			Name:      "mismatch.txt",
+			Size:      4,
+		}
+
+		_, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+
+		// Share a second channel with the same remote and replay the same
+		// file id under the new channel; idempotency check must reject it.
+		otherChannel := th.CreateChannel(t, th.BasicTeam)
+		otherSC := &model.SharedChannel{
+			ChannelId:        otherChannel.Id,
+			TeamId:           otherChannel.TeamId,
+			Home:             true,
+			ShareName:        otherChannel.Name,
+			ShareDisplayName: otherChannel.DisplayName,
+			CreatorId:        th.BasicUser.Id,
+		}
+		_, shareErr := th.App.ShareChannel(th.Context, otherSC)
+		require.NoError(t, shareErr)
+		require.NoError(t, th.App.InviteRemoteToChannel(otherChannel.Id, rc.RemoteId, th.BasicUser.Id, false))
+
+		_, err = api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, otherChannel.Id, fi, bytes.NewReader([]byte("data")))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "different channel/creator")
+	})
+
+	t.Run("repeated receive with mismatched creator rejects", func(t *testing.T) {
+		userA := createRemoteUser(t)
+		userB := createRemoteUser(t)
+		fileID := model.NewId()
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: userA.Id,
+			Name:      "mismatch.txt",
+			Size:      4,
+		}
+
+		_, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+
+		fi.CreatorId = userB.Id
+		_, err = api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "different channel/creator")
+	})
+
+	t.Run("empty PostId is a lazy-bind no-op", func(t *testing.T) {
+		user := createRemoteUser(t)
+		fileID := model.NewId()
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			Name:      "free.txt",
+			Size:      4,
+		}
+
+		saved, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+		require.NotNil(t, saved)
+
+		storedFI, appErr := th.App.GetFileInfo(th.Context, fileID)
+		require.Nil(t, appErr)
+		assert.Empty(t, storedFI.PostId, "FileInfo must not be bound to any post when fi.PostId is empty")
+	})
+
+	t.Run("concurrent post and multi-file delivery converges", func(t *testing.T) {
+		// Plugin transports (e.g. NATS post stream + JetStream object store)
+		// deliver post-receive and file-receive on independent goroutines.
+		// A barrier-synchronised launch exercises the genuinely concurrent
+		// case: post.Save, attachFilesToPost, UploadData, and the lazy-bind
+		// can all interleave. The end state must still be: Post.FileIds
+		// contains every file id, and every FileInfo has PostId/ChannelId
+		// set. Run with -race to catch unsafe sharing.
+		const fanOut = 4
+		user := createRemoteUser(t)
+		postID := model.NewId()
+		fileIDs := make([]string, fanOut)
+		for i := range fileIDs {
+			fileIDs[i] = model.NewId()
+		}
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+		errs := make(chan error, fanOut+1)
+
+		wg.Go(func() {
+			<-start
+			msg := model.NewSyncMsg(channel.Id)
+			msg.Posts = []*model.Post{
+				{
+					Id:        postID,
+					ChannelId: channel.Id,
+					UserId:    user.Id,
+					Message:   "post with attachments",
+					FileIds:   fileIDs,
+					CreateAt:  model.GetMillis(),
+					RemoteId:  model.NewPointer(rc.RemoteId),
+				},
+			}
+			resp, syncErr := api.ReceiveSharedChannelSyncMsg(rc.RemoteId, msg)
+			if syncErr != nil {
+				errs <- syncErr
+				return
+			}
+			if len(resp.PostErrors) > 0 {
+				errs <- fmt.Errorf("post sync returned errors: %v", resp.PostErrors)
+			}
+		})
+
+		for _, fid := range fileIDs {
+			wg.Go(func() {
+				<-start
+				fi := &model.FileInfo{
+					Id:        fid,
+					CreatorId: user.Id,
+					PostId:    postID,
+					Name:      "concurrent.txt",
+					Size:      4,
+				}
+				if _, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data"))); err != nil {
+					errs <- err
+				}
+			})
+		}
+
+		close(start)
+		wg.Wait()
+		close(errs)
+		for err := range errs {
+			require.NoError(t, err)
+		}
+
+		post, appErr := th.App.GetSinglePost(th.Context, postID, false)
+		require.Nil(t, appErr)
+		for _, fid := range fileIDs {
+			assert.Contains(t, post.FileIds, fid, "Post.FileIds must contain every file id after concurrent delivery")
+			fi, appErr := th.App.GetFileInfo(th.Context, fid)
+			require.Nil(t, appErr)
+			assert.Equal(t, postID, fi.PostId, "FileInfo.PostId must reference the post")
+			assert.Equal(t, channel.Id, fi.ChannelId, "FileInfo.ChannelId must reference the channel")
+		}
+	})
+
+	t.Run("post-then-file ordering publishes post_edited so clients refresh", func(t *testing.T) {
+		// In post-then-file ordering, the initial posted event carries an
+		// empty metadata.files (the FileInfo did not exist yet). The
+		// file-receive path's lazy-bind must publish a post_edited event
+		// after the bind so connected clients re-render with the new
+		// attachment without a channel reload.
+		messages, closeWS := connectFakeWebSocket(t, th, th.BasicUser.Id, "",
+			[]model.WebsocketEventType{model.WebsocketEventPostEdited})
+		defer closeWS()
+
+		user := createRemoteUser(t)
+		postID := model.NewId()
+		fileID := model.NewId()
+
+		syncPostWithFileIds(t, postID, user.Id, []string{fileID})
+
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			PostId:    postID,
+			Name:      "ws.txt",
+			Size:      4,
+		}
+		_, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+
+		select {
+		case ev := <-messages:
+			require.Equal(t, model.WebsocketEventPostEdited, ev.EventType())
+			postJSON, ok := ev.GetData()["post"].(string)
+			require.True(t, ok, "post_edited payload must include serialised post")
+			var broadcastPost model.Post
+			require.NoError(t, json.Unmarshal([]byte(postJSON), &broadcastPost))
+			assert.Equal(t, postID, broadcastPost.Id)
+			require.NotNil(t, broadcastPost.Metadata, "broadcast post must include metadata")
+			fileIDsInBroadcast := make([]string, 0, len(broadcastPost.Metadata.Files))
+			for _, f := range broadcastPost.Metadata.Files {
+				fileIDsInBroadcast = append(fileIDsInBroadcast, f.Id)
+			}
+			assert.Contains(t, fileIDsInBroadcast, fileID,
+				"post_edited broadcast must surface the now-resolvable attachment to clients")
+		case <-time.After(5 * time.Second):
+			require.FailNow(t, "did not receive post_edited event within 5s after attachment lazy-bind")
+		}
+	})
+
+	t.Run("file-then-post ordering does not publish post_edited from lazy-bind", func(t *testing.T) {
+		// When the file arrives first, the post does not exist when the
+		// lazy-bind runs, so there is no post to broadcast. The eventual
+		// post arrival publishes a posted event with correct metadata; the
+		// lazy-bind must stay quiet to avoid a spurious post_edited for a
+		// post that has never been seen by any client.
+		messages, closeWS := connectFakeWebSocket(t, th, th.BasicUser.Id, "",
+			[]model.WebsocketEventType{model.WebsocketEventPostEdited})
+		defer closeWS()
+
+		user := createRemoteUser(t)
+		postID := model.NewId()
+		fileID := model.NewId()
+
+		fi := &model.FileInfo{
+			Id:        fileID,
+			CreatorId: user.Id,
+			PostId:    postID,
+			Name:      "ws.txt",
+			Size:      4,
+		}
+		_, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("data")))
+		require.NoError(t, err)
+
+		select {
+		case ev := <-messages:
+			require.FailNowf(t, "unexpected event",
+				"did not expect a post_edited event from lazy-bind when post is absent, got: %v", ev.EventType())
+		case <-time.After(500 * time.Millisecond):
+			// Expected: no event.
+		}
 	})
 }
 

--- a/server/channels/app/shared_channel_test.go
+++ b/server/channels/app/shared_channel_test.go
@@ -1341,7 +1341,11 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsg(t *testing.T) {
 		remoteUser, appErr := th.App.CreateUser(th.Context, remoteUser)
 		require.Nil(t, appErr)
 
+		// The sender-side file ID must be preserved on the receiving server so the
+		// post's FileIds (which reference the sender ID) resolve to the saved file.
+		senderFileID := model.NewId()
 		fi := &model.FileInfo{
+			Id:        senderFileID,
 			CreatorId: remoteUser.Id,
 			Name:      "hello.txt",
 			Size:      13,
@@ -1350,12 +1354,13 @@ func TestPluginAPIReceiveSharedChannelAttachmentSyncMsg(t *testing.T) {
 		saved, err := api.ReceiveSharedChannelAttachmentSyncMsg(rc.RemoteId, channel.Id, fi, bytes.NewReader([]byte("hello, world!")))
 		require.NoError(t, err)
 		require.NotNil(t, saved)
-		assert.NotEmpty(t, saved.Id)
+		assert.Equal(t, senderFileID, saved.Id, "saved FileInfo must keep the sender's file ID")
 		assert.Equal(t, rc.RemoteId, *saved.RemoteId)
 
 		// Verify the FileInfo was persisted with a server-constructed path
 		storedFI, appErr := th.App.GetFileInfo(th.Context, saved.Id)
 		require.Nil(t, appErr)
+		assert.Equal(t, senderFileID, storedFI.Id)
 		assert.Equal(t, "hello.txt", storedFI.Name)
 		assert.NotEmpty(t, storedFI.Path)
 		assert.Contains(t, storedFI.Path, "hello.txt")

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -11031,11 +11031,53 @@ func (s *RetryLayerRemoteClusterStore) GetAll(offset int, limit int, filter mode
 
 }
 
+func (s *RetryLayerRemoteClusterStore) GetAllByPluginID(pluginID string) ([]*model.RemoteCluster, error) {
+
+	tries := 0
+	for {
+		result, err := s.RemoteClusterStore.GetAllByPluginID(pluginID)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerRemoteClusterStore) GetByPluginID(pluginID string) (*model.RemoteCluster, error) {
 
 	tries := 0
 	for {
 		result, err := s.RemoteClusterStore.GetByPluginID(pluginID)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
+func (s *RetryLayerRemoteClusterStore) GetBySiteURL(siteURL string) (*model.RemoteCluster, error) {
+
+	tries := 0
+	for {
+		result, err := s.RemoteClusterStore.GetBySiteURL(siteURL)
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/sqlstore/remote_cluster_store.go
+++ b/server/channels/store/sqlstore/remote_cluster_store.go
@@ -54,16 +54,26 @@ func (s sqlRemoteClusterStore) Save(remoteCluster *model.RemoteCluster) (*model.
 		return nil, err
 	}
 
-	// check for pluginID collisions - on collision treat as idempotent
+	// For plugin remotes, check for SiteURL collisions and treat as idempotent.
+	// Non-plugin remotes skip this check and rely on the DB unique constraint
+	// so that AddRemoteCluster can report a proper conflict error.
+	// This reads from master to avoid race conditions on lagging replicas.
 	if remoteCluster.PluginID != "" {
-		rc, err := s.GetByPluginID(remoteCluster.PluginID)
-		if err == nil {
-			// if this plugin id already exists, just return it
-			return rc, nil
+		lookupQuery := s.getQueryBuilder().
+			Select(remoteClusterFields("")...).
+			From("RemoteClusters").
+			Where(sq.Eq{"SiteURL": remoteCluster.SiteURL})
+
+		lookupSQL, args, err := lookupQuery.ToSql()
+		if err != nil {
+			return nil, errors.Wrap(err, "remote_cluster_save_lookup_tosql")
 		}
-		if !errors.Is(err, sql.ErrNoRows) {
-			// anything other than NotFound is unexpected
-			return nil, errors.Wrapf(err, "failed to lookup RemoteCluster by pluginID %s", remoteCluster.PluginID)
+
+		var existing model.RemoteCluster
+		if err := s.GetMaster().Get(&existing, lookupSQL, args...); err == nil {
+			return &existing, nil
+		} else if !errors.Is(err, sql.ErrNoRows) {
+			return nil, errors.Wrapf(err, "failed to lookup RemoteCluster by SiteURL %s", remoteCluster.SiteURL)
 		}
 	}
 
@@ -183,6 +193,8 @@ func (s sqlRemoteClusterStore) Get(remoteId string, includeDeleted bool) (*model
 	return &rc, nil
 }
 
+// Deprecated: GetByPluginID returns a single remote for the plugin. Only correct
+// when the plugin has one registration. Use GetAllByPluginID instead.
 func (s sqlRemoteClusterStore) GetByPluginID(pluginID string) (*model.RemoteCluster, error) {
 	query := s.getQueryBuilder().
 		Select(remoteClusterFields("")...).
@@ -197,6 +209,43 @@ func (s sqlRemoteClusterStore) GetByPluginID(pluginID string) (*model.RemoteClus
 	var rc model.RemoteCluster
 	if err := s.GetReplica().Get(&rc, queryString, args...); err != nil {
 		return nil, errors.Wrap(err, "failed to find RemoteCluster by plugin_id")
+	}
+	return &rc, nil
+}
+
+func (s sqlRemoteClusterStore) GetAllByPluginID(pluginID string) ([]*model.RemoteCluster, error) {
+	query := s.getQueryBuilder().
+		Select(remoteClusterFields("")...).
+		From("RemoteClusters").
+		Where(sq.Eq{"PluginID": pluginID}).
+		Where(sq.Eq{"DeleteAt": 0})
+
+	queryString, args, err := query.ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "remote_cluster_get_all_by_pluginid_tosql")
+	}
+
+	var list []*model.RemoteCluster
+	if err := s.GetReplica().Select(&list, queryString, args...); err != nil {
+		return nil, errors.Wrap(err, "failed to find RemoteClusters by plugin_id")
+	}
+	return list, nil
+}
+
+func (s sqlRemoteClusterStore) GetBySiteURL(siteURL string) (*model.RemoteCluster, error) {
+	query := s.getQueryBuilder().
+		Select(remoteClusterFields("")...).
+		From("RemoteClusters").
+		Where(sq.Eq{"SiteURL": siteURL})
+
+	queryString, args, err := query.ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "remote_cluster_get_by_siteurl_tosql")
+	}
+
+	var rc model.RemoteCluster
+	if err := s.GetReplica().Get(&rc, queryString, args...); err != nil {
+		return nil, errors.Wrap(err, "failed to find RemoteCluster by SiteURL")
 	}
 	return &rc, nil
 }

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -572,7 +572,13 @@ type RemoteClusterStore interface {
 	Update(rc *model.RemoteCluster) (*model.RemoteCluster, error)
 	Delete(remoteClusterID string) (bool, error)
 	Get(remoteClusterID string, includeDeleted bool) (*model.RemoteCluster, error)
+	// Deprecated: GetByPluginID returns a single remote for the plugin. Only correct
+	// when the plugin has one registration. Use GetAllByPluginID instead.
 	GetByPluginID(pluginID string) (*model.RemoteCluster, error)
+	// GetAllByPluginID returns all remotes registered by the specified plugin.
+	GetAllByPluginID(pluginID string) ([]*model.RemoteCluster, error)
+	// GetBySiteURL returns the remote cluster with the given SiteURL, or an error if not found.
+	GetBySiteURL(siteURL string) (*model.RemoteCluster, error)
 	GetAll(offset, limit int, filter model.RemoteClusterQueryFilter) ([]*model.RemoteCluster, error)
 	UpdateTopics(remoteClusterID string, topics string) (*model.RemoteCluster, error)
 	SetLastPingAt(remoteClusterID string) error

--- a/server/channels/store/storetest/mocks/RemoteClusterStore.go
+++ b/server/channels/store/storetest/mocks/RemoteClusterStore.go
@@ -102,6 +102,36 @@ func (_m *RemoteClusterStore) GetAll(offset int, limit int, filter model.RemoteC
 	return r0, r1
 }
 
+// GetAllByPluginID provides a mock function with given fields: pluginID
+func (_m *RemoteClusterStore) GetAllByPluginID(pluginID string) ([]*model.RemoteCluster, error) {
+	ret := _m.Called(pluginID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllByPluginID")
+	}
+
+	var r0 []*model.RemoteCluster
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) ([]*model.RemoteCluster, error)); ok {
+		return rf(pluginID)
+	}
+	if rf, ok := ret.Get(0).(func(string) []*model.RemoteCluster); ok {
+		r0 = rf(pluginID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.RemoteCluster)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(pluginID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetByPluginID provides a mock function with given fields: pluginID
 func (_m *RemoteClusterStore) GetByPluginID(pluginID string) (*model.RemoteCluster, error) {
 	ret := _m.Called(pluginID)
@@ -125,6 +155,36 @@ func (_m *RemoteClusterStore) GetByPluginID(pluginID string) (*model.RemoteClust
 
 	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(pluginID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetBySiteURL provides a mock function with given fields: siteURL
+func (_m *RemoteClusterStore) GetBySiteURL(siteURL string) (*model.RemoteCluster, error) {
+	ret := _m.Called(siteURL)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetBySiteURL")
+	}
+
+	var r0 *model.RemoteCluster
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (*model.RemoteCluster, error)); ok {
+		return rf(siteURL)
+	}
+	if rf, ok := ret.Get(0).(func(string) *model.RemoteCluster); ok {
+		r0 = rf(siteURL)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.RemoteCluster)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(siteURL)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/remote_cluster_store.go
+++ b/server/channels/store/storetest/remote_cluster_store.go
@@ -22,6 +22,8 @@ func TestRemoteClusterStore(t *testing.T, rctx request.CTX, ss store.Store) {
 	t.Run("RemoteClusterDelete", func(t *testing.T) { testRemoteClusterDelete(t, rctx, ss) })
 	t.Run("RemoteClusterGet", func(t *testing.T) { testRemoteClusterGet(t, rctx, ss) })
 	t.Run("RemoteClusterGetByPluginID", func(t *testing.T) { testRemoteClusterGetByPluginID(t, rctx, ss) })
+	t.Run("RemoteClusterGetAllByPluginID", func(t *testing.T) { testRemoteClusterGetAllByPluginID(t, rctx, ss) })
+	t.Run("RemoteClusterGetBySiteURL", func(t *testing.T) { testRemoteClusterGetBySiteURL(t, rctx, ss) })
 	t.Run("RemoteClusterGetAll", func(t *testing.T) { testRemoteClusterGetAll(t, rctx, ss) })
 	t.Run("RemoteClusterGetByTopic", func(t *testing.T) { testRemoteClusterGetByTopic(t, rctx, ss) })
 	t.Run("RemoteClusterUpdateTopics", func(t *testing.T) { testRemoteClusterUpdateTopics(t, rctx, ss) })
@@ -68,34 +70,60 @@ func testRemoteClusterSave(t *testing.T, _ request.CTX, ss store.Store) {
 		require.Error(t, err)
 	})
 
-	t.Run("Save pluginID collision", func(t *testing.T) {
-		const testPluginID = "com.example.collision"
+	t.Run("Save plugin SiteURL collision is idempotent", func(t *testing.T) {
+		siteURL := makeSiteURL()
 
 		rc := &model.RemoteCluster{
 			Name:      "some_remote",
-			SiteURL:   makeSiteURL(),
+			SiteURL:   siteURL,
 			CreatorId: model.NewId(),
-			PluginID:  testPluginID,
+			PluginID:  model.NewId(),
 		}
 		_, err := ss.RemoteCluster().Save(rc)
 		require.NoError(t, err)
 
 		rc2 := &model.RemoteCluster{
 			Name:      "another_remote",
-			SiteURL:   makeSiteURL(),
+			SiteURL:   siteURL,
 			CreatorId: model.NewId(),
-			PluginID:  testPluginID,
+			PluginID:  model.NewId(),
 		}
 
 		rcSaved, err := ss.RemoteCluster().Save(rc2)
 		require.NoError(t, err)
 		require.NotNil(t, rcSaved)
 
-		// original remotecluster should be returned
+		// original remotecluster should be returned (idempotent save by SiteURL for plugins)
 		require.Equal(t, rc.Name, rcSaved.Name)
 		require.Equal(t, rc.SiteURL, rcSaved.SiteURL)
 		require.Greater(t, rc.CreateAt, int64(0))
-		require.Equal(t, rc.PluginID, rcSaved.PluginID)
+	})
+
+	t.Run("Save same pluginID different SiteURLs", func(t *testing.T) {
+		pluginID := model.NewId()
+
+		rc1 := &model.RemoteCluster{
+			Name:      "remote_1",
+			SiteURL:   makeSiteURL(),
+			CreatorId: model.NewId(),
+			PluginID:  pluginID,
+		}
+		saved1, err := ss.RemoteCluster().Save(rc1)
+		require.NoError(t, err)
+
+		rc2 := &model.RemoteCluster{
+			Name:      "remote_2",
+			SiteURL:   makeSiteURL(),
+			CreatorId: model.NewId(),
+			PluginID:  pluginID,
+		}
+		saved2, err := ss.RemoteCluster().Save(rc2)
+		require.NoError(t, err)
+
+		// Both should be saved with different RemoteIds
+		require.NotEqual(t, saved1.RemoteId, saved2.RemoteId)
+		require.Equal(t, pluginID, saved1.PluginID)
+		require.Equal(t, pluginID, saved2.PluginID)
 	})
 
 	t.Run("Save multiple with blank pluginID", func(t *testing.T) {
@@ -303,10 +331,10 @@ func testRemoteClusterGetAll(t *testing.T, _ request.CTX, ss store.Store) {
 		{Name: "some_online_remote", CreatorId: userId, SiteURL: makeSiteURL(), LastPingAt: now, Topics: " shared incident "},
 		{Name: "another_online_remote", CreatorId: model.NewId(), SiteURL: makeSiteURL(), LastPingAt: now, Topics: ""},
 		{Name: "another_offline_remote", CreatorId: model.NewId(), SiteURL: makeSiteURL(), LastPingAt: pingLongAgo, Topics: " shared "},
-		{Name: "brand_new_offline_remote", CreatorId: userId, SiteURL: "", LastPingAt: 0, Topics: " bogus shared stuff "},
+		{Name: "brand_new_offline_remote", CreatorId: userId, SiteURL: makeSiteURL(), LastPingAt: 0, Topics: " bogus shared stuff "},
 		{Name: "offline_plugin_remote", CreatorId: model.NewId(), SiteURL: makeSiteURL(), PluginID: model.NewId(), LastPingAt: 0, Topics: " pluginshare "},
 		{Name: "online_plugin_remote", CreatorId: model.NewId(), SiteURL: makeSiteURL(), PluginID: model.NewId(), LastPingAt: now, Topics: " pluginshare "},
-		{Name: "deleted_remote", CreatorId: model.NewId(), SiteURL: "", LastPingAt: 0, DeleteAt: 123},
+		{Name: "deleted_remote", CreatorId: model.NewId(), SiteURL: makeSiteURL(), LastPingAt: 0, DeleteAt: 123},
 	}
 
 	idsAll := make([]string, 0)
@@ -809,4 +837,99 @@ func testRemoteClusterUpdateTopics(t *testing.T, _ request.CTX, ss store.Store) 
 
 		require.Equal(t, tt.expected, rcUpdated.Topics)
 	}
+}
+
+func testRemoteClusterGetAllByPluginID(t *testing.T, _ request.CTX, ss store.Store) {
+	pluginID := "com.test.multi-remote-" + model.NewId()
+
+	t.Run("GetAllByPluginID returns multiple remotes", func(t *testing.T) {
+		rc1 := &model.RemoteCluster{
+			Name:      "remote_a",
+			SiteURL:   makeSiteURL(),
+			CreatorId: model.NewId(),
+			PluginID:  pluginID,
+		}
+		saved1, err := ss.RemoteCluster().Save(rc1)
+		require.NoError(t, err)
+
+		rc2 := &model.RemoteCluster{
+			Name:      "remote_b",
+			SiteURL:   makeSiteURL(),
+			CreatorId: model.NewId(),
+			PluginID:  pluginID,
+		}
+		saved2, err := ss.RemoteCluster().Save(rc2)
+		require.NoError(t, err)
+
+		results, err := ss.RemoteCluster().GetAllByPluginID(pluginID)
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		ids := getIds(results)
+		assert.Contains(t, ids, saved1.RemoteId)
+		assert.Contains(t, ids, saved2.RemoteId)
+	})
+
+	t.Run("GetAllByPluginID excludes deleted", func(t *testing.T) {
+		results, err := ss.RemoteCluster().GetAllByPluginID(pluginID)
+		require.NoError(t, err)
+		require.Len(t, results, 2)
+
+		// Delete one
+		_, err = ss.RemoteCluster().Delete(results[0].RemoteId)
+		require.NoError(t, err)
+
+		results, err = ss.RemoteCluster().GetAllByPluginID(pluginID)
+		require.NoError(t, err)
+		require.Len(t, results, 1)
+	})
+
+	t.Run("GetAllByPluginID not found", func(t *testing.T) {
+		results, err := ss.RemoteCluster().GetAllByPluginID("com.nonexistent.plugin")
+		require.NoError(t, err)
+		require.Empty(t, results)
+	})
+}
+
+func testRemoteClusterGetBySiteURL(t *testing.T, _ request.CTX, ss store.Store) {
+	t.Run("GetBySiteURL found", func(t *testing.T) {
+		siteURL := makeSiteURL()
+		rc := &model.RemoteCluster{
+			Name:      "siteurl_test",
+			SiteURL:   siteURL,
+			CreatorId: model.NewId(),
+			PluginID:  model.NewId(),
+		}
+		saved, err := ss.RemoteCluster().Save(rc)
+		require.NoError(t, err)
+
+		result, err := ss.RemoteCluster().GetBySiteURL(siteURL)
+		require.NoError(t, err)
+		require.Equal(t, saved.RemoteId, result.RemoteId)
+		require.Equal(t, siteURL, result.SiteURL)
+	})
+
+	t.Run("GetBySiteURL not found", func(t *testing.T) {
+		_, err := ss.RemoteCluster().GetBySiteURL("https://nonexistent.example.com")
+		require.Error(t, err)
+	})
+
+	t.Run("GetBySiteURL includes deleted", func(t *testing.T) {
+		siteURL := makeSiteURL()
+		rc := &model.RemoteCluster{
+			Name:      "deleted_siteurl_test",
+			SiteURL:   siteURL,
+			CreatorId: model.NewId(),
+		}
+		saved, err := ss.RemoteCluster().Save(rc)
+		require.NoError(t, err)
+
+		_, err = ss.RemoteCluster().Delete(saved.RemoteId)
+		require.NoError(t, err)
+
+		result, err := ss.RemoteCluster().GetBySiteURL(siteURL)
+		require.NoError(t, err)
+		require.Equal(t, saved.RemoteId, result.RemoteId)
+		require.NotZero(t, result.DeleteAt)
+	})
 }

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -8779,6 +8779,22 @@ func (s *TimerLayerRemoteClusterStore) GetAll(offset int, limit int, filter mode
 	return result, err
 }
 
+func (s *TimerLayerRemoteClusterStore) GetAllByPluginID(pluginID string) ([]*model.RemoteCluster, error) {
+	start := time.Now()
+
+	result, err := s.RemoteClusterStore.GetAllByPluginID(pluginID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RemoteClusterStore.GetAllByPluginID", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerRemoteClusterStore) GetByPluginID(pluginID string) (*model.RemoteCluster, error) {
 	start := time.Now()
 
@@ -8791,6 +8807,22 @@ func (s *TimerLayerRemoteClusterStore) GetByPluginID(pluginID string) (*model.Re
 			success = "true"
 		}
 		s.Root.Metrics.ObserveStoreMethodDuration("RemoteClusterStore.GetByPluginID", success, elapsed)
+	}
+	return result, err
+}
+
+func (s *TimerLayerRemoteClusterStore) GetBySiteURL(siteURL string) (*model.RemoteCluster, error) {
+	start := time.Now()
+
+	result, err := s.RemoteClusterStore.GetBySiteURL(siteURL)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RemoteClusterStore.GetBySiteURL", success, elapsed)
 	}
 	return result, err
 }

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10501,6 +10501,10 @@
     "translation": "ClusterName must be set."
   },
   {
+    "id": "model.cluster.is_valid.site_url.app_error",
+    "translation": "SiteURL must be set."
+  },
+  {
     "id": "model.cluster.is_valid.type.app_error",
     "translation": "Type must be set."
   },

--- a/server/public/model/file_info.go
+++ b/server/public/model/file_info.go
@@ -54,31 +54,31 @@ type GetFileInfosOptions struct {
 }
 
 type FileInfo struct {
-	Id        string `json:"id"`
-	CreatorId string `json:"user_id"`
-	PostId    string `json:"post_id,omitempty"`
+	Id        string `json:"id" xml:"Id"`
+	CreatorId string `json:"user_id" xml:"CreatorId"`
+	PostId    string `json:"post_id,omitempty" xml:"PostId,omitempty"`
 	// ChannelId is the denormalized value from the corresponding post. Note that this value is
 	// potentially distinct from the ChannelId provided when the file is first uploaded and
 	// used to organize the directories in the file store, since in theory that same file
 	// could be attached to a post from a different channel (or not attached to a post at all).
-	ChannelId       string  `json:"channel_id"`
-	CreateAt        int64   `json:"create_at"`
-	UpdateAt        int64   `json:"update_at"`
-	DeleteAt        int64   `json:"delete_at"`
-	Path            string  `json:"-"` // not sent back to the client
-	ThumbnailPath   string  `json:"-"` // not sent back to the client
-	PreviewPath     string  `json:"-"` // not sent back to the client
-	Name            string  `json:"name"`
-	Extension       string  `json:"extension"`
-	Size            int64   `json:"size"`
-	MimeType        string  `json:"mime_type"`
-	Width           int     `json:"width,omitempty"`
-	Height          int     `json:"height,omitempty"`
-	HasPreviewImage bool    `json:"has_preview_image,omitempty"`
-	MiniPreview     *[]byte `json:"mini_preview"` // pointer to distinguish NULL (no preview) from empty data
-	Content         string  `json:"-"`
-	RemoteId        *string `json:"remote_id"`
-	Archived        bool    `json:"archived"`
+	ChannelId       string  `json:"channel_id" xml:"ChannelId"`
+	CreateAt        int64   `json:"create_at" xml:"CreateAt"`
+	UpdateAt        int64   `json:"update_at" xml:"UpdateAt"`
+	DeleteAt        int64   `json:"delete_at" xml:"DeleteAt"`
+	Path            string  `json:"-" xml:"-"` // not sent back to the client
+	ThumbnailPath   string  `json:"-" xml:"-"` // not sent back to the client
+	PreviewPath     string  `json:"-" xml:"-"` // not sent back to the client
+	Name            string  `json:"name" xml:"Name"`
+	Extension       string  `json:"extension" xml:"Extension"`
+	Size            int64   `json:"size" xml:"Size"`
+	MimeType        string  `json:"mime_type" xml:"MimeType"`
+	Width           int     `json:"width,omitempty" xml:"Width,omitempty"`
+	Height          int     `json:"height,omitempty" xml:"Height,omitempty"`
+	HasPreviewImage bool    `json:"has_preview_image,omitempty" xml:"HasPreviewImage,omitempty"`
+	MiniPreview     *[]byte `json:"mini_preview" xml:"-"` // pointer to distinguish NULL (no preview) from empty data
+	Content         string  `json:"-" xml:"-"`
+	RemoteId        *string `json:"remote_id" xml:"RemoteId"`
+	Archived        bool    `json:"archived" xml:"Archived"`
 }
 
 func (fi *FileInfo) Auditable() map[string]any {

--- a/server/public/model/post.go
+++ b/server/public/model/post.go
@@ -112,39 +112,39 @@ const (
 )
 
 type Post struct {
-	Id         string `json:"id"`
-	CreateAt   int64  `json:"create_at"`
-	UpdateAt   int64  `json:"update_at"`
-	EditAt     int64  `json:"edit_at"`
-	DeleteAt   int64  `json:"delete_at"`
-	IsPinned   bool   `json:"is_pinned"`
-	UserId     string `json:"user_id"`
-	ChannelId  string `json:"channel_id"`
-	RootId     string `json:"root_id"`
-	OriginalId string `json:"original_id"`
+	Id         string `json:"id" xml:"Id"`
+	CreateAt   int64  `json:"create_at" xml:"CreateAt"`
+	UpdateAt   int64  `json:"update_at" xml:"UpdateAt"`
+	EditAt     int64  `json:"edit_at" xml:"EditAt"`
+	DeleteAt   int64  `json:"delete_at" xml:"DeleteAt"`
+	IsPinned   bool   `json:"is_pinned" xml:"IsPinned"`
+	UserId     string `json:"user_id" xml:"UserId"`
+	ChannelId  string `json:"channel_id" xml:"ChannelId"`
+	RootId     string `json:"root_id" xml:"RootId"`
+	OriginalId string `json:"original_id" xml:"OriginalId"`
 
-	Message string `json:"message"`
+	Message string `json:"message" xml:"Message"`
 	// MessageSource will contain the message as submitted by the user if Message has been modified
 	// by Mattermost for presentation (e.g if an image proxy is being used). It should be used to
 	// populate edit boxes if present.
-	MessageSource string `json:"message_source,omitempty"`
+	MessageSource string `json:"message_source,omitempty" xml:"MessageSource,omitempty"`
 
-	Type          string          `json:"type"`
-	propsMu       sync.RWMutex    `db:"-"`       // Unexported mutex used to guard Post.Props.
-	Props         StringInterface `json:"props"` // Deprecated: use GetProps()
-	Hashtags      string          `json:"hashtags"`
-	Filenames     StringArray     `json:"-"` // Deprecated, do not use this field any more
-	FileIds       StringArray     `json:"file_ids"`
-	PendingPostId string          `json:"pending_post_id"`
-	HasReactions  bool            `json:"has_reactions,omitempty"`
-	RemoteId      *string         `json:"remote_id,omitempty"`
+	Type          string          `json:"type" xml:"Type"`
+	propsMu       sync.RWMutex    `db:"-"`                   // Unexported mutex used to guard Post.Props.
+	Props         StringInterface `json:"props" xml:"Props"` // Deprecated: use GetProps()
+	Hashtags      string          `json:"hashtags" xml:"Hashtags"`
+	Filenames     StringArray     `json:"-" xml:"-"` // Deprecated, do not use this field any more
+	FileIds       StringArray     `json:"file_ids" xml:"FileIds>Id"`
+	PendingPostId string          `json:"pending_post_id" xml:"PendingPostId"`
+	HasReactions  bool            `json:"has_reactions,omitempty" xml:"HasReactions,omitempty"`
+	RemoteId      *string         `json:"remote_id,omitempty" xml:"RemoteId,omitempty"`
 
 	// Transient data populated before sending a post to the client
-	ReplyCount   int64         `json:"reply_count"`
-	LastReplyAt  int64         `json:"last_reply_at"`
-	Participants []*User       `json:"participants"`
-	IsFollowing  *bool         `json:"is_following,omitempty"` // for root posts in collapsed thread mode indicates if the current user is following this thread
-	Metadata     *PostMetadata `json:"metadata,omitempty"`
+	ReplyCount   int64         `json:"reply_count" xml:"ReplyCount"`
+	LastReplyAt  int64         `json:"last_reply_at" xml:"LastReplyAt"`
+	Participants []*User       `json:"participants" xml:"Participants>User"`
+	IsFollowing  *bool         `json:"is_following,omitempty" xml:"IsFollowing,omitempty"` // for root posts in collapsed thread mode indicates if the current user is following this thread
+	Metadata     *PostMetadata `json:"metadata,omitempty" xml:"-"`
 }
 
 func (o *Post) Auditable() map[string]any {

--- a/server/public/model/post_acknowledgement.go
+++ b/server/public/model/post_acknowledgement.go
@@ -6,11 +6,11 @@ package model
 import "net/http"
 
 type PostAcknowledgement struct {
-	UserId         string  `json:"user_id"`
-	PostId         string  `json:"post_id"`
-	AcknowledgedAt int64   `json:"acknowledged_at"`
-	ChannelId      string  `json:"channel_id"`
-	RemoteId       *string `json:"remote_id,omitempty"`
+	UserId         string  `json:"user_id" xml:"UserId"`
+	PostId         string  `json:"post_id" xml:"PostId"`
+	AcknowledgedAt int64   `json:"acknowledged_at" xml:"AcknowledgedAt"`
+	ChannelId      string  `json:"channel_id" xml:"ChannelId"`
+	RemoteId       *string `json:"remote_id,omitempty" xml:"RemoteId,omitempty"`
 }
 
 func (o *PostAcknowledgement) IsValid() *AppError {

--- a/server/public/model/reaction.go
+++ b/server/public/model/reaction.go
@@ -9,14 +9,14 @@ import (
 )
 
 type Reaction struct {
-	UserId    string  `json:"user_id"`
-	PostId    string  `json:"post_id"`
-	EmojiName string  `json:"emoji_name"`
-	CreateAt  int64   `json:"create_at"`
-	UpdateAt  int64   `json:"update_at"`
-	DeleteAt  int64   `json:"delete_at"`
-	RemoteId  *string `json:"remote_id"`
-	ChannelId string  `json:"channel_id"`
+	UserId    string  `json:"user_id" xml:"UserId"`
+	PostId    string  `json:"post_id" xml:"PostId"`
+	EmojiName string  `json:"emoji_name" xml:"EmojiName"`
+	CreateAt  int64   `json:"create_at" xml:"CreateAt"`
+	UpdateAt  int64   `json:"update_at" xml:"UpdateAt"`
+	DeleteAt  int64   `json:"delete_at" xml:"DeleteAt"`
+	RemoteId  *string `json:"remote_id" xml:"RemoteId"`
+	ChannelId string  `json:"channel_id" xml:"ChannelId"`
 }
 
 func (o *Reaction) IsValid() *AppError {

--- a/server/public/model/remote_cluster.go
+++ b/server/public/model/remote_cluster.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"net/http"
 	"net/url"
@@ -199,6 +200,35 @@ func IsValidRemoteName(s string) bool {
 		return false
 	}
 	return validRemoteNameChars.MatchString(s)
+}
+
+// CleanRemoteName converts an arbitrary string into a slug compatible with
+// IsValidRemoteName: lowercased, with spaces and other disallowed characters
+// replaced by hyphens. The result is truncated to RemoteNameMaxLength. If
+// the cleaned value is still invalid (e.g. empty input), a new ID is
+// substituted so the caller always receives a valid name.
+func CleanRemoteName(s string) string {
+	s = strings.ToLower(strings.ReplaceAll(s, " ", "-"))
+	s = strings.TrimSpace(s)
+
+	for _, c := range s {
+		char := fmt.Sprintf("%c", c)
+		if !validRemoteNameChars.MatchString(char) {
+			s = strings.ReplaceAll(s, char, "-")
+		}
+	}
+
+	s = strings.Trim(s, "-")
+
+	if len(s) > RemoteNameMaxLength {
+		s = strings.Trim(s[:RemoteNameMaxLength], "-")
+	}
+
+	if !IsValidRemoteName(s) {
+		s = NewId()
+	}
+
+	return s
 }
 
 func (rc *RemoteCluster) PreUpdate() {

--- a/server/public/model/remote_cluster.go
+++ b/server/public/model/remote_cluster.go
@@ -9,7 +9,6 @@ import (
 	"crypto/pbkdf2"
 	"crypto/rand"
 	"crypto/sha256"
-	"encoding/base32"
 	"encoding/json"
 	"errors"
 	"io"
@@ -27,7 +26,11 @@ const (
 	RemoteNameMaxLength      = 64
 
 	SiteURLPending = "pending_"
-	SiteURLPlugin  = "plugin_"
+
+	// Deprecated: SiteURLPlugin was used as a prefix for plugin-based remote SiteURLs.
+	// New registrations store the plugin-provided SiteURL directly. Use PluginID field
+	// to identify plugin-based remotes.
+	SiteURLPlugin = "plugin_"
 
 	BitflagOptionAutoShareDMs Bitmask = 1 << iota // Any new DM/GM is automatically shared
 	BitflagOptionAutoInvited                      // Remote is automatically invited to all shared channels
@@ -92,11 +95,7 @@ func (rc *RemoteCluster) Auditable() map[string]any {
 
 func (rc *RemoteCluster) PreSave() {
 	if rc.RemoteId == "" {
-		if rc.PluginID != "" {
-			rc.RemoteId = newIDFromBytes([]byte(rc.PluginID))
-		} else {
-			rc.RemoteId = NewId()
-		}
+		rc.RemoteId = NewId()
 	}
 
 	if rc.DisplayName == "" {
@@ -132,6 +131,10 @@ func (rc *RemoteCluster) IsValid() *AppError {
 
 	if !IsValidId(rc.CreatorId) {
 		return NewAppError("RemoteCluster.IsValid", "model.cluster.is_valid.id.app_error", nil, "creator_id="+rc.CreatorId, http.StatusBadRequest)
+	}
+
+	if rc.SiteURL == "" {
+		return NewAppError("RemoteCluster.IsValid", "model.cluster.is_valid.site_url.app_error", nil, "site_url is empty", http.StatusBadRequest)
 	}
 
 	if rc.DefaultTeamId != "" && !IsValidId(rc.DefaultTeamId) {
@@ -177,16 +180,6 @@ type RemoteClusterWithInvite struct {
 	RemoteCluster *RemoteCluster `json:"remote_cluster"`
 	Invite        string         `json:"invite"`
 	Password      string         `json:"password,omitempty"`
-}
-
-func newIDFromBytes(b []byte) string {
-	hash := sha256.New()
-	_, _ = hash.Write(b)
-	buf := hash.Sum(nil)
-
-	encoding := base32.NewEncoding("ybndrfg8ejkmcpqxot1uwisza345h769").WithPadding(base32.NoPadding)
-	id := encoding.EncodeToString(buf)
-	return id[:26]
 }
 
 func (rc *RemoteCluster) IsOptionFlagSet(flag Bitmask) bool {
@@ -235,10 +228,7 @@ func (rc *RemoteCluster) IsConfirmed() bool {
 }
 
 func (rc *RemoteCluster) IsPlugin() bool {
-	if rc.PluginID != "" || strings.HasPrefix(rc.SiteURL, SiteURLPlugin) {
-		return true // local plugins are automatically confirmed
-	}
-	return false
+	return rc.PluginID != ""
 }
 
 func (rc *RemoteCluster) GetSiteURL() string {

--- a/server/public/model/remote_cluster_test.go
+++ b/server/public/model/remote_cluster_test.go
@@ -24,6 +24,7 @@ func TestRemoteClusterIsValid(t *testing.T) {
 		{name: "Zero value", rc: &RemoteCluster{}, valid: false},
 		{name: "Missing cluster_name", rc: &RemoteCluster{RemoteId: id}, valid: false},
 		{name: "Missing host_name", rc: &RemoteCluster{RemoteId: id, Name: NewId()}, valid: false},
+		{name: "Missing site_url", rc: &RemoteCluster{RemoteId: id, Name: NewId(), CreatorId: creator, CreateAt: now}, valid: false},
 		{name: "Missing create_at", rc: &RemoteCluster{RemoteId: id, Name: NewId(), SiteURL: "example.com"}, valid: false},
 		{name: "Missing last_ping_at", rc: &RemoteCluster{RemoteId: id, Name: NewId(), SiteURL: "example.com", CreatorId: creator, CreateAt: now}, valid: true},
 		{name: "Missing creator", rc: &RemoteCluster{RemoteId: id, Name: NewId(), SiteURL: "example.com", CreateAt: now, LastPingAt: now}, valid: false},
@@ -240,24 +241,19 @@ func TestRemoteClusterToRemoteClusterInfo(t *testing.T) {
 	assert.Equal(t, rc.SiteURL, info.SiteURL)
 }
 
-func TestNewIDFromBytes(t *testing.T) {
-	tests := []struct {
-		name string
-		ss   string
-	}{
-		{name: "empty", ss: ""},
-		{name: "very short", ss: "x"},
-		{name: "normal", ss: "com.mattermost.msteams-sync"},
-		{name: "long", ss: "com.mattermost.msteams-synccom.mattermost.msteams-synccom.mattermost.msteams-synccom.mattermost.msteams-sync"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got1 := newIDFromBytes([]byte(tt.ss))
+func TestRemoteClusterIsPlugin(t *testing.T) {
+	t.Run("PluginID set returns true", func(t *testing.T) {
+		rc := &RemoteCluster{PluginID: "com.example.plugin", SiteURL: "https://example.com"}
+		assert.True(t, rc.IsPlugin())
+	})
 
-			assert.True(t, IsValidId(got1), "not a valid id")
+	t.Run("empty PluginID returns false", func(t *testing.T) {
+		rc := &RemoteCluster{SiteURL: "https://example.com"}
+		assert.False(t, rc.IsPlugin())
+	})
 
-			got2 := newIDFromBytes([]byte(tt.ss))
-			assert.Equal(t, got1, got2, "newIDFromBytes must generate same id for same inputs")
-		})
-	}
+	t.Run("plugin_ SiteURL prefix with empty PluginID returns false", func(t *testing.T) {
+		rc := &RemoteCluster{SiteURL: SiteURLPlugin + "com.example.plugin"}
+		assert.False(t, rc.IsPlugin(), "IsPlugin should only check PluginID, not SiteURL prefix")
+	})
 }

--- a/server/public/model/remote_cluster_test.go
+++ b/server/public/model/remote_cluster_test.go
@@ -6,6 +6,7 @@ package model
 import (
 	"crypto/rand"
 	"io"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -255,5 +256,46 @@ func TestRemoteClusterIsPlugin(t *testing.T) {
 	t.Run("plugin_ SiteURL prefix with empty PluginID returns false", func(t *testing.T) {
 		rc := &RemoteCluster{SiteURL: SiteURLPlugin + "com.example.plugin"}
 		assert.False(t, rc.IsPlugin(), "IsPlugin should only check PluginID, not SiteURL prefix")
+	})
+}
+
+func TestCleanRemoteName(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{name: "single space", in: "legacy plugin", want: "legacy-plugin"},
+		{name: "multiple spaces", in: "remote 1 plugin", want: "remote-1-plugin"},
+		{name: "uppercase", in: "Plugin A", want: "plugin-a"},
+		{name: "preserves dot, hyphen, underscore", in: "com.example_plugin-1", want: "com.example_plugin-1"},
+		{name: "trims separators", in: "  ---my remote---  ", want: "my-remote"},
+		{name: "punctuation collapses", in: "plugin@home!", want: "plugin-home"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CleanRemoteName(tc.in)
+			assert.Equal(t, tc.want, got)
+			assert.True(t, IsValidRemoteName(got), "CleanRemoteName must produce a valid name")
+		})
+	}
+
+	t.Run("empty input falls back to NewId", func(t *testing.T) {
+		got := CleanRemoteName("")
+		assert.True(t, IsValidRemoteName(got))
+		assert.Len(t, got, 26)
+	})
+
+	t.Run("only invalid characters falls back to NewId", func(t *testing.T) {
+		got := CleanRemoteName("@@@ !!! ???")
+		assert.True(t, IsValidRemoteName(got))
+		assert.Len(t, got, 26)
+	})
+
+	t.Run("over-length input is truncated", func(t *testing.T) {
+		in := strings.Repeat("a", RemoteNameMaxLength+10)
+		got := CleanRemoteName(in)
+		assert.True(t, IsValidRemoteName(got))
+		assert.LessOrEqual(t, len(got), RemoteNameMaxLength)
 	})
 }

--- a/server/public/model/shared_channel.go
+++ b/server/public/model/shared_channel.go
@@ -5,7 +5,9 @@ package model
 
 import (
 	"encoding/json"
+	"encoding/xml"
 	"net/http"
+	"sort"
 	"unicode/utf8"
 
 	"github.com/pkg/errors"
@@ -277,11 +279,11 @@ type SharedChannelRemoteFilterOpts struct {
 
 // MembershipChangeMsg represents a change in channel membership
 type MembershipChangeMsg struct {
-	ChannelId  string `json:"channel_id"`
-	UserId     string `json:"user_id"`
-	IsAdd      bool   `json:"is_add"`
-	RemoteId   string `json:"remote_id"`
-	ChangeTime int64  `json:"change_time"`
+	ChannelId  string `json:"channel_id" xml:"ChannelId"`
+	UserId     string `json:"user_id" xml:"UserId"`
+	IsAdd      bool   `json:"is_add" xml:"IsAdd"`
+	RemoteId   string `json:"remote_id" xml:"RemoteId"`
+	ChangeTime int64  `json:"change_time" xml:"ChangeTime"`
 }
 
 // SyncMsg represents a change in content (post add/edit/delete, reaction add/remove, users).
@@ -321,24 +323,223 @@ func (sm *SyncMsg) String() string {
 	return string(json)
 }
 
+// xmlSyncMsgFields contains the non-map fields of SyncMsg for XML serialization.
+type xmlSyncMsgFields struct {
+	Id                string                 `xml:"Id"`
+	ChannelId         string                 `xml:"ChannelId"`
+	Posts             []*Post                `xml:"Posts>Post,omitempty"`
+	Reactions         []*Reaction            `xml:"Reactions>Reaction,omitempty"`
+	Statuses          []*Status              `xml:"Statuses>Status,omitempty"`
+	MembershipChanges []*MembershipChangeMsg `xml:"MembershipChanges>MembershipChangeMsg,omitempty"`
+	Acknowledgements  []*PostAcknowledgement `xml:"Acknowledgements>PostAcknowledgement,omitempty"`
+}
+
+// xmlSyncMsgUser wraps a User with an ID attribute for XML map serialization.
+type xmlSyncMsgUser struct {
+	ID   string `xml:"id,attr"`
+	User *User  `xml:"User"`
+}
+
+// xmlSyncMsgMentionTransform represents a single mention transform entry.
+type xmlSyncMsgMentionTransform struct {
+	Key   string `xml:"key,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// MarshalXML encodes a SyncMsg to XML, handling the Users map and MentionTransforms map.
+func (sm *SyncMsg) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+
+	// Encode non-map fields via the helper struct.
+	fields := xmlSyncMsgFields{
+		Id:                sm.Id,
+		ChannelId:         sm.ChannelId,
+		Posts:             sm.Posts,
+		Reactions:         sm.Reactions,
+		Statuses:          sm.Statuses,
+		MembershipChanges: sm.MembershipChanges,
+		Acknowledgements:  sm.Acknowledgements,
+	}
+	if err := e.EncodeElement(fields, xml.StartElement{Name: xml.Name{Local: "Fields"}}); err != nil {
+		return err
+	}
+
+	// Encode Users map as <Users><UserEntry id="..."><User>...</User></UserEntry></Users>
+	if len(sm.Users) > 0 {
+		usersStart := xml.StartElement{Name: xml.Name{Local: "Users"}}
+		if err := e.EncodeToken(usersStart); err != nil {
+			return err
+		}
+
+		keys := make([]string, 0, len(sm.Users))
+		for k := range sm.Users {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			entry := xmlSyncMsgUser{ID: k, User: sm.Users[k]}
+			if err := e.EncodeElement(entry, xml.StartElement{Name: xml.Name{Local: "UserEntry"}}); err != nil {
+				return err
+			}
+		}
+
+		if err := e.EncodeToken(usersStart.End()); err != nil {
+			return err
+		}
+	}
+
+	// Encode MentionTransforms as <MentionTransforms><Transform key="..." value="..."/></MentionTransforms>
+	if len(sm.MentionTransforms) > 0 {
+		mtStart := xml.StartElement{Name: xml.Name{Local: "MentionTransforms"}}
+		if err := e.EncodeToken(mtStart); err != nil {
+			return err
+		}
+
+		keys := make([]string, 0, len(sm.MentionTransforms))
+		for k := range sm.MentionTransforms {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			entry := xmlSyncMsgMentionTransform{Key: k, Value: sm.MentionTransforms[k]}
+			if err := e.EncodeElement(entry, xml.StartElement{Name: xml.Name{Local: "Transform"}}); err != nil {
+				return err
+			}
+		}
+
+		if err := e.EncodeToken(mtStart.End()); err != nil {
+			return err
+		}
+	}
+
+	return e.EncodeToken(start.End())
+}
+
+// UnmarshalXML decodes a SyncMsg from XML, handling the Users map and MentionTransforms map.
+func (sm *SyncMsg) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	sm.Users = nil
+	sm.MentionTransforms = nil
+
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "Fields":
+				var fields xmlSyncMsgFields
+				if err := d.DecodeElement(&fields, &t); err != nil {
+					return err
+				}
+				sm.Id = fields.Id
+				sm.ChannelId = fields.ChannelId
+				sm.Posts = fields.Posts
+				sm.Reactions = fields.Reactions
+				sm.Statuses = fields.Statuses
+				sm.MembershipChanges = fields.MembershipChanges
+				sm.Acknowledgements = fields.Acknowledgements
+
+			case "Users":
+				sm.Users = make(map[string]*User)
+				if err := decodeXMLUsers(d, sm); err != nil {
+					return err
+				}
+
+			case "MentionTransforms":
+				sm.MentionTransforms = make(map[string]string)
+				if err := decodeXMLMentionTransforms(d, sm); err != nil {
+					return err
+				}
+
+			default:
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			}
+
+		case xml.EndElement:
+			return nil
+		}
+	}
+}
+
+func decodeXMLUsers(d *xml.Decoder, sm *SyncMsg) error {
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "UserEntry" {
+				var entry xmlSyncMsgUser
+				if err := d.DecodeElement(&entry, &t); err != nil {
+					return err
+				}
+				sm.Users[entry.ID] = entry.User
+			} else {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			}
+		case xml.EndElement:
+			return nil
+		}
+	}
+}
+
+func decodeXMLMentionTransforms(d *xml.Decoder, sm *SyncMsg) error {
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "Transform" {
+				var entry xmlSyncMsgMentionTransform
+				if err := d.DecodeElement(&entry, &t); err != nil {
+					return err
+				}
+				sm.MentionTransforms[entry.Key] = entry.Value
+			} else {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			}
+		case xml.EndElement:
+			return nil
+		}
+	}
+}
+
 // SyncResponse represents the response to a synchronization event
 type SyncResponse struct {
-	UsersLastUpdateAt int64    `json:"users_last_update_at"`
-	UserErrors        []string `json:"user_errors"`
-	UsersSyncd        []string `json:"users_syncd"`
+	UsersLastUpdateAt int64    `json:"users_last_update_at" xml:"UsersLastUpdateAt"`
+	UserErrors        []string `json:"user_errors" xml:"UserErrors>Error"`
+	UsersSyncd        []string `json:"users_syncd" xml:"UsersSyncd>UserId"`
 
-	PostsLastUpdateAt int64    `json:"posts_last_update_at"`
-	PostErrors        []string `json:"post_errors"`
+	PostsLastUpdateAt int64    `json:"posts_last_update_at" xml:"PostsLastUpdateAt"`
+	PostErrors        []string `json:"post_errors" xml:"PostErrors>Error"`
 
-	ReactionsLastUpdateAt int64    `json:"reactions_last_update_at"`
-	ReactionErrors        []string `json:"reaction_errors"`
+	ReactionsLastUpdateAt int64    `json:"reactions_last_update_at" xml:"ReactionsLastUpdateAt"`
+	ReactionErrors        []string `json:"reaction_errors" xml:"ReactionErrors>Error"`
 
-	AcknowledgementsLastUpdateAt int64    `json:"acknowledgements_last_update_at"`
-	AcknowledgementErrors        []string `json:"acknowledgement_errors"`
+	AcknowledgementsLastUpdateAt int64    `json:"acknowledgements_last_update_at" xml:"AcknowledgementsLastUpdateAt"`
+	AcknowledgementErrors        []string `json:"acknowledgement_errors" xml:"AcknowledgementErrors>Error"`
 
-	StatusErrors []string `json:"status_errors"` // user IDs for which the status sync failed
+	StatusErrors []string `json:"status_errors" xml:"StatusErrors>Error"` // user IDs for which the status sync failed
 
-	MembershipErrors []string `json:"membership_errors,omitempty"`
+	MembershipErrors []string `json:"membership_errors,omitempty" xml:"MembershipErrors>Error,omitempty"`
 }
 
 // RegisterPluginOpts is passed by plugins to the `RegisterPluginForSharedChannels` plugin API
@@ -349,6 +550,19 @@ type RegisterPluginOpts struct {
 	CreatorID    string // id of the user/bot registering
 	AutoShareDMs bool   // when true, all DMs are automatically shared to this remote
 	AutoInvited  bool   // when true, the plugin is automatically invited and sync'd with all shared channels.
+
+	// SiteURL identifies the remote endpoint for this secure connection. Stored directly as
+	// RemoteCluster.SiteURL. Must be unique across all remote clusters (enforced by the DB
+	// unique index on (SiteURL, RemoteTeamId)).
+	// When empty, defaults to "plugin_<PluginID>" for backward compatibility with single-remote
+	// plugins. When non-empty, the SiteURL must not already be in use by a different plugin or
+	// a server-to-server remote.
+	// Calling RegisterPluginForSharedChannels again with the same SiteURL returns the existing
+	// remoteID and preserves sync cursors (idempotent re-registration).
+	// A plugin registers multiple remotes by calling this method multiple times with different
+	// SiteURLs.
+	// Examples: "nats://nats:4222", "https://matrix.org"
+	SiteURL string
 }
 
 // GetOptionFlags returns a Bitmask of option flags as specified by the boolean options.

--- a/server/public/model/shared_channel_test.go
+++ b/server/public/model/shared_channel_test.go
@@ -4,6 +4,8 @@
 package model
 
 import (
+	"encoding/json"
+	"encoding/xml"
 	"strings"
 	"testing"
 
@@ -63,4 +65,455 @@ func TestSharedChannelPreUpdate(t *testing.T) {
 	o.PreUpdate()
 
 	require.GreaterOrEqual(t, o.UpdateAt, now)
+}
+
+func TestSyncMsgXMLRoundTrip(t *testing.T) {
+	remoteID := NewId()
+	msg := &SyncMsg{
+		Id:        NewId(),
+		ChannelId: NewId(),
+		Users: map[string]*User{
+			"user1": {
+				Id:       NewId(),
+				Username: "testuser1",
+				Email:    "test1@example.com",
+				Props:    StringMap{"key1": "val1"},
+				Timezone: StringMap{"useAutomaticTimezone": "true"},
+			},
+			"user2": {
+				Id:       NewId(),
+				Username: "testuser2",
+				Email:    "test2@example.com",
+			},
+		},
+		Posts: []*Post{
+			{
+				Id:        NewId(),
+				ChannelId: NewId(),
+				UserId:    NewId(),
+				Message:   "hello world",
+				Props:     StringInterface{"from_webhook": "true", "count": float64(42)},
+				RemoteId:  &remoteID,
+			},
+		},
+		Reactions: []*Reaction{
+			{
+				UserId:    NewId(),
+				PostId:    NewId(),
+				EmojiName: "thumbsup",
+				CreateAt:  1000,
+			},
+		},
+		Statuses: []*Status{
+			{
+				UserId: NewId(),
+				Status: StatusOnline,
+			},
+		},
+		MembershipChanges: []*MembershipChangeMsg{
+			{
+				ChannelId:  NewId(),
+				UserId:     NewId(),
+				IsAdd:      true,
+				RemoteId:   NewId(),
+				ChangeTime: 2000,
+			},
+		},
+		Acknowledgements: []*PostAcknowledgement{
+			{
+				UserId:         NewId(),
+				PostId:         NewId(),
+				AcknowledgedAt: 3000,
+				ChannelId:      NewId(),
+			},
+		},
+		MentionTransforms: map[string]string{
+			"@olduser": "@newuser",
+			"@admin":   "@remote_admin",
+		},
+	}
+
+	data, err := xml.MarshalIndent(msg, "", "  ")
+	require.NoError(t, err)
+
+	var decoded SyncMsg
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, msg.Id, decoded.Id)
+	assert.Equal(t, msg.ChannelId, decoded.ChannelId)
+	assert.Len(t, decoded.Users, 2)
+	assert.Equal(t, msg.Users["user1"].Username, decoded.Users["user1"].Username)
+	assert.Equal(t, msg.Users["user2"].Username, decoded.Users["user2"].Username)
+	assert.Len(t, decoded.Posts, 1)
+	assert.Equal(t, msg.Posts[0].Message, decoded.Posts[0].Message)
+	assert.Len(t, decoded.Reactions, 1)
+	assert.Equal(t, msg.Reactions[0].EmojiName, decoded.Reactions[0].EmojiName)
+	assert.Len(t, decoded.Statuses, 1)
+	assert.Equal(t, msg.Statuses[0].Status, decoded.Statuses[0].Status)
+	assert.Len(t, decoded.MembershipChanges, 1)
+	assert.Equal(t, msg.MembershipChanges[0].IsAdd, decoded.MembershipChanges[0].IsAdd)
+	assert.Len(t, decoded.Acknowledgements, 1)
+	assert.Equal(t, msg.Acknowledgements[0].AcknowledgedAt, decoded.Acknowledgements[0].AcknowledgedAt)
+	assert.Equal(t, msg.MentionTransforms, decoded.MentionTransforms)
+}
+
+func TestSyncMsgXMLUsersMap(t *testing.T) {
+	msg := &SyncMsg{
+		Id: NewId(),
+		Users: map[string]*User{
+			"alpha": {Id: "id-alpha", Username: "alpha"},
+			"beta":  {Id: "id-beta", Username: "beta"},
+			"gamma": {Id: "id-gamma", Username: "gamma"},
+		},
+	}
+
+	data, err := xml.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded SyncMsg
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	require.Len(t, decoded.Users, 3)
+	assert.Equal(t, "alpha", decoded.Users["alpha"].Username)
+	assert.Equal(t, "beta", decoded.Users["beta"].Username)
+	assert.Equal(t, "gamma", decoded.Users["gamma"].Username)
+}
+
+func TestSyncMsgXMLMentionTransforms(t *testing.T) {
+	msg := &SyncMsg{
+		Id: NewId(),
+		MentionTransforms: map[string]string{
+			"@user1": "@remote_user1",
+			"@user2": "@remote_user2",
+		},
+	}
+
+	data, err := xml.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded SyncMsg
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, msg.MentionTransforms, decoded.MentionTransforms)
+}
+
+func TestSyncMsgXMLEmptyMaps(t *testing.T) {
+	msg := &SyncMsg{
+		Id:        NewId(),
+		ChannelId: NewId(),
+	}
+
+	data, err := xml.Marshal(msg)
+	require.NoError(t, err)
+
+	var decoded SyncMsg
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, msg.Id, decoded.Id)
+	assert.Equal(t, msg.ChannelId, decoded.ChannelId)
+	assert.Nil(t, decoded.Users)
+	assert.Nil(t, decoded.MentionTransforms)
+}
+
+func TestPostXMLRoundTrip(t *testing.T) {
+	remoteID := NewId()
+	post := &Post{
+		Id:        NewId(),
+		CreateAt:  1000,
+		UpdateAt:  2000,
+		UserId:    NewId(),
+		ChannelId: NewId(),
+		Message:   "test message with <xml> special & chars",
+		Props: StringInterface{
+			"from_webhook": "true",
+			"count":        float64(42),
+			"nested":       map[string]any{"a": float64(1), "b": "two"},
+		},
+		FileIds:  StringArray{"file1", "file2"},
+		RemoteId: &remoteID,
+		Metadata: &PostMetadata{}, // should be excluded from XML
+	}
+
+	data, err := xml.MarshalIndent(post, "", "  ")
+	require.NoError(t, err)
+
+	var decoded Post
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, post.Id, decoded.Id)
+	assert.Equal(t, post.Message, decoded.Message)
+	assert.Equal(t, post.CreateAt, decoded.CreateAt)
+	assert.Equal(t, "true", decoded.Props["from_webhook"])
+	assert.Equal(t, float64(42), decoded.Props["count"])
+	assert.Equal(t, post.FileIds, decoded.FileIds)
+	assert.Equal(t, *post.RemoteId, *decoded.RemoteId)
+	assert.Nil(t, decoded.Metadata, "Metadata should be excluded from XML")
+}
+
+func TestUserXMLRoundTrip(t *testing.T) {
+	remoteID := NewId()
+	user := &User{
+		Id:          NewId(),
+		Username:    "testuser",
+		Email:       "test@example.com",
+		FirstName:   "Test",
+		LastName:    "User",
+		Props:       StringMap{"customkey": "customval"},
+		NotifyProps: StringMap{"push": "all", "desktop": "mention"},
+		Timezone:    StringMap{"useAutomaticTimezone": "true", "manualTimezone": "America/New_York"},
+		RemoteId:    &remoteID,
+	}
+
+	data, err := xml.MarshalIndent(user, "", "  ")
+	require.NoError(t, err)
+
+	var decoded User
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, user.Id, decoded.Id)
+	assert.Equal(t, user.Username, decoded.Username)
+	assert.Equal(t, user.Email, decoded.Email)
+	assert.Equal(t, user.Props, decoded.Props)
+	assert.Equal(t, user.NotifyProps, decoded.NotifyProps)
+	assert.Equal(t, user.Timezone, decoded.Timezone)
+	assert.Equal(t, *user.RemoteId, *decoded.RemoteId)
+}
+
+func TestReactionXMLRoundTrip(t *testing.T) {
+	remoteID := NewId()
+	reaction := &Reaction{
+		UserId:    NewId(),
+		PostId:    NewId(),
+		EmojiName: "thumbsup",
+		CreateAt:  1000,
+		UpdateAt:  2000,
+		RemoteId:  &remoteID,
+		ChannelId: NewId(),
+	}
+
+	data, err := xml.Marshal(reaction)
+	require.NoError(t, err)
+
+	var decoded Reaction
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, reaction.UserId, decoded.UserId)
+	assert.Equal(t, reaction.PostId, decoded.PostId)
+	assert.Equal(t, reaction.EmojiName, decoded.EmojiName)
+	assert.Equal(t, reaction.CreateAt, decoded.CreateAt)
+	assert.Equal(t, *reaction.RemoteId, *decoded.RemoteId)
+}
+
+func TestStatusXMLRoundTrip(t *testing.T) {
+	status := &Status{
+		UserId:         NewId(),
+		Status:         StatusOnline,
+		Manual:         true,
+		LastActivityAt: 5000,
+		DNDEndTime:     6000,
+		PrevStatus:     StatusAway, // should be excluded
+	}
+
+	data, err := xml.Marshal(status)
+	require.NoError(t, err)
+
+	var decoded Status
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, status.UserId, decoded.UserId)
+	assert.Equal(t, status.Status, decoded.Status)
+	assert.Equal(t, status.Manual, decoded.Manual)
+	assert.Equal(t, status.DNDEndTime, decoded.DNDEndTime)
+	assert.Empty(t, decoded.PrevStatus, "PrevStatus should be excluded from XML")
+}
+
+func TestPostAcknowledgementXMLRoundTrip(t *testing.T) {
+	remoteID := NewId()
+	ack := &PostAcknowledgement{
+		UserId:         NewId(),
+		PostId:         NewId(),
+		AcknowledgedAt: 3000,
+		ChannelId:      NewId(),
+		RemoteId:       &remoteID,
+	}
+
+	data, err := xml.Marshal(ack)
+	require.NoError(t, err)
+
+	var decoded PostAcknowledgement
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, ack.UserId, decoded.UserId)
+	assert.Equal(t, ack.PostId, decoded.PostId)
+	assert.Equal(t, ack.AcknowledgedAt, decoded.AcknowledgedAt)
+	assert.Equal(t, ack.ChannelId, decoded.ChannelId)
+	assert.Equal(t, *ack.RemoteId, *decoded.RemoteId)
+}
+
+func TestFileInfoXMLRoundTrip(t *testing.T) {
+	remoteID := NewId()
+	fi := &FileInfo{
+		Id:            NewId(),
+		CreatorId:     NewId(),
+		PostId:        NewId(),
+		ChannelId:     NewId(),
+		CreateAt:      1000,
+		UpdateAt:      2000,
+		Name:          "test.txt",
+		Extension:     "txt",
+		Size:          1024,
+		MimeType:      "text/plain",
+		RemoteId:      &remoteID,
+		Path:          "/data/test.txt",
+		ThumbnailPath: "/data/test_thumb.txt",
+		PreviewPath:   "/data/test_preview.txt",
+		Content:       "file content for search",
+	}
+
+	data, err := xml.Marshal(fi)
+	require.NoError(t, err)
+
+	var decoded FileInfo
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, fi.Id, decoded.Id)
+	assert.Equal(t, fi.CreatorId, decoded.CreatorId)
+	assert.Equal(t, fi.Name, decoded.Name)
+	assert.Equal(t, fi.Size, decoded.Size)
+	assert.Equal(t, *fi.RemoteId, *decoded.RemoteId)
+	assert.Empty(t, decoded.Path, "Path should be excluded from XML")
+	assert.Empty(t, decoded.ThumbnailPath, "ThumbnailPath should be excluded from XML")
+	assert.Empty(t, decoded.PreviewPath, "PreviewPath should be excluded from XML")
+	assert.Empty(t, decoded.Content, "Content should be excluded from XML")
+}
+
+func TestStringMapXMLRoundTrip(t *testing.T) {
+	m := StringMap{
+		"key1":  "value1",
+		"key2":  "value2",
+		"empty": "",
+	}
+
+	data, err := xml.Marshal(m)
+	require.NoError(t, err)
+
+	var decoded StringMap
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, m, decoded)
+}
+
+func TestStringInterfaceXMLRoundTrip(t *testing.T) {
+	m := StringInterface{
+		"string_val": "hello",
+		"number_val": float64(42),
+		"bool_val":   true,
+		"null_val":   nil,
+		"nested":     map[string]any{"a": float64(1), "b": "two"},
+	}
+
+	data, err := xml.Marshal(m)
+	require.NoError(t, err)
+
+	var decoded StringInterface
+	err = xml.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+
+	assert.Equal(t, "hello", decoded["string_val"])
+	assert.Equal(t, float64(42), decoded["number_val"])
+	assert.Equal(t, true, decoded["bool_val"])
+	assert.Nil(t, decoded["null_val"])
+	nested, ok := decoded["nested"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, float64(1), nested["a"])
+	assert.Equal(t, "two", nested["b"])
+}
+
+func TestXMLDoesNotAffectJSON(t *testing.T) {
+	remoteID := NewId()
+
+	t.Run("SyncMsg", func(t *testing.T) {
+		msg := &SyncMsg{
+			Id:        NewId(),
+			ChannelId: NewId(),
+			Users: map[string]*User{
+				"u1": {Id: NewId(), Username: "u1"},
+			},
+			Posts:             []*Post{{Id: NewId(), Message: "test"}},
+			MentionTransforms: map[string]string{"@a": "@b"},
+		}
+		data, err := json.Marshal(msg)
+		require.NoError(t, err)
+
+		var decoded SyncMsg
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, msg.Id, decoded.Id)
+		assert.Equal(t, msg.Users["u1"].Username, decoded.Users["u1"].Username)
+		assert.Equal(t, msg.MentionTransforms, decoded.MentionTransforms)
+	})
+
+	t.Run("Post", func(t *testing.T) {
+		post := &Post{
+			Id:       NewId(),
+			Message:  "test",
+			Props:    StringInterface{"key": "val"},
+			RemoteId: &remoteID,
+			Metadata: &PostMetadata{},
+		}
+		data, err := json.Marshal(post)
+		require.NoError(t, err)
+
+		var decoded Post
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, post.Id, decoded.Id)
+		assert.Equal(t, post.Props["key"], decoded.Props["key"])
+		assert.NotNil(t, decoded.Metadata, "Metadata should be present in JSON")
+	})
+
+	t.Run("User", func(t *testing.T) {
+		user := &User{
+			Id:       NewId(),
+			Username: "test",
+			Props:    StringMap{"k": "v"},
+			Timezone: StringMap{"tz": "utc"},
+		}
+		data, err := json.Marshal(user)
+		require.NoError(t, err)
+
+		var decoded User
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, user.Id, decoded.Id)
+		assert.Equal(t, user.Props, decoded.Props)
+		assert.Equal(t, user.Timezone, decoded.Timezone)
+	})
+
+	t.Run("SyncResponse", func(t *testing.T) {
+		sr := &SyncResponse{
+			UsersLastUpdateAt: 1000,
+			UserErrors:        []string{"err1"},
+			PostsLastUpdateAt: 2000,
+		}
+		data, err := json.Marshal(sr)
+		require.NoError(t, err)
+
+		var decoded SyncResponse
+		err = json.Unmarshal(data, &decoded)
+		require.NoError(t, err)
+		assert.Equal(t, sr.UsersLastUpdateAt, decoded.UsersLastUpdateAt)
+		assert.Equal(t, sr.UserErrors, decoded.UserErrors)
+	})
 }

--- a/server/public/model/status.go
+++ b/server/public/model/status.go
@@ -23,17 +23,17 @@ const (
 )
 
 type Status struct {
-	UserId         string `json:"user_id"`
-	Status         string `json:"status"`
-	Manual         bool   `json:"manual"`
-	LastActivityAt int64  `json:"last_activity_at"`
-	ActiveChannel  string `json:"active_channel,omitempty" db:"-"`
+	UserId         string `json:"user_id" xml:"UserId"`
+	Status         string `json:"status" xml:"Status"`
+	Manual         bool   `json:"manual" xml:"Manual"`
+	LastActivityAt int64  `json:"last_activity_at" xml:"LastActivityAt"`
+	ActiveChannel  string `json:"active_channel,omitempty" db:"-" xml:"ActiveChannel,omitempty"`
 
 	// DNDEndTime is the time that the user's DND status will expire. Unlike other timestamps in Mattermost, this value
 	// is in seconds instead of milliseconds.
-	DNDEndTime int64 `json:"dnd_end_time"`
+	DNDEndTime int64 `json:"dnd_end_time" xml:"DNDEndTime"`
 
-	PrevStatus string `json:"-"`
+	PrevStatus string `json:"-" xml:"-"`
 }
 
 func (s *Status) ToJSON() ([]byte, error) {

--- a/server/public/model/user.go
+++ b/server/public/model/user.go
@@ -84,41 +84,41 @@ type UserPasswordHasher interface {
 // This struct's serializer methods are auto-generated. If a new field is added/removed,
 // please run make gen-serialized.
 type User struct {
-	Id                     string      `json:"id"`
-	CreateAt               int64       `json:"create_at,omitempty"`
-	UpdateAt               int64       `json:"update_at,omitempty"`
-	DeleteAt               int64       `json:"delete_at"`
-	Username               string      `json:"username"`
-	Password               string      `json:"password,omitempty"`
-	AuthData               *string     `json:"auth_data,omitempty"`
-	AuthService            string      `json:"auth_service"`
-	Email                  string      `json:"email"`
-	EmailVerified          bool        `json:"email_verified,omitempty"`
-	Nickname               string      `json:"nickname"`
-	FirstName              string      `json:"first_name"`
-	LastName               string      `json:"last_name"`
-	Position               string      `json:"position"`
-	Roles                  string      `json:"roles"`
-	AllowMarketing         bool        `json:"allow_marketing,omitempty"`
-	Props                  StringMap   `json:"props,omitempty"`
-	NotifyProps            StringMap   `json:"notify_props,omitempty"`
-	LastPasswordUpdate     int64       `json:"last_password_update,omitempty"`
-	LastPictureUpdate      int64       `json:"last_picture_update,omitempty"`
-	FailedAttempts         int         `json:"failed_attempts,omitempty"`
-	Locale                 string      `json:"locale"`
-	Timezone               StringMap   `json:"timezone"`
-	MfaActive              bool        `json:"mfa_active,omitempty"`
-	MfaSecret              string      `json:"mfa_secret,omitempty"`
-	RemoteId               *string     `json:"remote_id,omitempty"`
-	LastActivityAt         int64       `json:"last_activity_at,omitempty"`
-	IsBot                  bool        `json:"is_bot,omitempty"`
-	BotDescription         string      `json:"bot_description,omitempty"`
-	BotLastIconUpdate      int64       `json:"bot_last_icon_update,omitempty"`
-	TermsOfServiceId       string      `json:"terms_of_service_id,omitempty"`
-	TermsOfServiceCreateAt int64       `json:"terms_of_service_create_at,omitempty"`
-	DisableWelcomeEmail    bool        `json:"disable_welcome_email"`
-	LastLogin              int64       `json:"last_login,omitempty"`
-	MfaUsedTimestamps      StringArray `json:"mfa_used_timestamps,omitempty"`
+	Id                     string      `json:"id" xml:"Id"`
+	CreateAt               int64       `json:"create_at,omitempty" xml:"CreateAt,omitempty"`
+	UpdateAt               int64       `json:"update_at,omitempty" xml:"UpdateAt,omitempty"`
+	DeleteAt               int64       `json:"delete_at" xml:"DeleteAt"`
+	Username               string      `json:"username" xml:"Username"`
+	Password               string      `json:"password,omitempty" xml:"-"`
+	AuthData               *string     `json:"auth_data,omitempty" xml:"-"`
+	AuthService            string      `json:"auth_service" xml:"AuthService"`
+	Email                  string      `json:"email" xml:"Email"`
+	EmailVerified          bool        `json:"email_verified,omitempty" xml:"EmailVerified,omitempty"`
+	Nickname               string      `json:"nickname" xml:"Nickname"`
+	FirstName              string      `json:"first_name" xml:"FirstName"`
+	LastName               string      `json:"last_name" xml:"LastName"`
+	Position               string      `json:"position" xml:"Position"`
+	Roles                  string      `json:"roles" xml:"Roles"`
+	AllowMarketing         bool        `json:"allow_marketing,omitempty" xml:"AllowMarketing,omitempty"`
+	Props                  StringMap   `json:"props,omitempty" xml:"Props,omitempty"`
+	NotifyProps            StringMap   `json:"notify_props,omitempty" xml:"NotifyProps,omitempty"`
+	LastPasswordUpdate     int64       `json:"last_password_update,omitempty" xml:"LastPasswordUpdate,omitempty"`
+	LastPictureUpdate      int64       `json:"last_picture_update,omitempty" xml:"LastPictureUpdate,omitempty"`
+	FailedAttempts         int         `json:"failed_attempts,omitempty" xml:"FailedAttempts,omitempty"`
+	Locale                 string      `json:"locale" xml:"Locale"`
+	Timezone               StringMap   `json:"timezone" xml:"Timezone"`
+	MfaActive              bool        `json:"mfa_active,omitempty" xml:"MfaActive,omitempty"`
+	MfaSecret              string      `json:"mfa_secret,omitempty" xml:"-"`
+	RemoteId               *string     `json:"remote_id,omitempty" xml:"RemoteId,omitempty"`
+	LastActivityAt         int64       `json:"last_activity_at,omitempty" xml:"LastActivityAt,omitempty"`
+	IsBot                  bool        `json:"is_bot,omitempty" xml:"IsBot,omitempty"`
+	BotDescription         string      `json:"bot_description,omitempty" xml:"BotDescription,omitempty"`
+	BotLastIconUpdate      int64       `json:"bot_last_icon_update,omitempty" xml:"BotLastIconUpdate,omitempty"`
+	TermsOfServiceId       string      `json:"terms_of_service_id,omitempty" xml:"TermsOfServiceId,omitempty"`
+	TermsOfServiceCreateAt int64       `json:"terms_of_service_create_at,omitempty" xml:"TermsOfServiceCreateAt,omitempty"`
+	DisableWelcomeEmail    bool        `json:"disable_welcome_email" xml:"DisableWelcomeEmail"`
+	LastLogin              int64       `json:"last_login,omitempty" xml:"LastLogin,omitempty"`
+	MfaUsedTimestamps      StringArray `json:"mfa_used_timestamps,omitempty" xml:"-"`
 }
 
 func (u *User) Auditable() map[string]any {

--- a/server/public/model/xml_helpers.go
+++ b/server/public/model/xml_helpers.go
@@ -1,0 +1,164 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+import (
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"sort"
+)
+
+// xmlStringMapEntry is the XML representation of a single StringMap entry.
+type xmlStringMapEntry struct {
+	Key   string `xml:"key,attr"`
+	Value string `xml:"value,attr"`
+}
+
+// MarshalXML encodes a StringMap as a sequence of <Entry key="..." value="..."/> elements.
+func (m StringMap) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if m == nil {
+		return e.EncodeElement(struct{}{}, start)
+	}
+
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+
+	// Sort keys for deterministic output.
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		entry := xmlStringMapEntry{Key: k, Value: m[k]}
+		if err := e.EncodeElement(entry, xml.StartElement{Name: xml.Name{Local: "Entry"}}); err != nil {
+			return err
+		}
+	}
+
+	return e.EncodeToken(start.End())
+}
+
+// UnmarshalXML decodes a sequence of <Entry key="..." value="..."/> elements into a StringMap.
+func (m *StringMap) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	*m = make(StringMap)
+
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "Entry" {
+				var entry xmlStringMapEntry
+				if err := d.DecodeElement(&entry, &t); err != nil {
+					return err
+				}
+				(*m)[entry.Key] = entry.Value
+			} else {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			}
+		case xml.EndElement:
+			return nil
+		}
+	}
+}
+
+// xmlStringInterfaceEntry is the XML representation of a single StringInterface entry.
+// Values are stored as strings. Non-string values are JSON-encoded.
+type xmlStringInterfaceEntry struct {
+	Key      string `xml:"key,attr"`
+	Value    string `xml:"value,attr"`
+	JSONType string `xml:"type,attr,omitempty"` // "json" when the value is JSON-encoded
+}
+
+// MarshalXML encodes a StringInterface as a sequence of <Entry> elements.
+// String values are stored directly. Other types are JSON-encoded with type="json".
+func (m StringInterface) MarshalXML(e *xml.Encoder, start xml.StartElement) error {
+	if m == nil {
+		return e.EncodeElement(struct{}{}, start)
+	}
+
+	if err := e.EncodeToken(start); err != nil {
+		return err
+	}
+
+	// Sort keys for deterministic output.
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	for _, k := range keys {
+		v := m[k]
+		entry := xmlStringInterfaceEntry{Key: k}
+
+		switch val := v.(type) {
+		case string:
+			entry.Value = val
+		case nil:
+			entry.JSONType = "json"
+			entry.Value = "null"
+		default:
+			b, err := json.Marshal(val)
+			if err != nil {
+				return fmt.Errorf("failed to marshal StringInterface value for key %q: %w", k, err)
+			}
+			entry.JSONType = "json"
+			entry.Value = string(b)
+		}
+
+		if err := e.EncodeElement(entry, xml.StartElement{Name: xml.Name{Local: "Entry"}}); err != nil {
+			return err
+		}
+	}
+
+	return e.EncodeToken(start.End())
+}
+
+// UnmarshalXML decodes a sequence of <Entry> elements into a StringInterface.
+// Entries with type="json" have their values JSON-decoded.
+func (m *StringInterface) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	*m = make(StringInterface)
+
+	for {
+		tok, err := d.Token()
+		if err != nil {
+			return err
+		}
+
+		switch t := tok.(type) {
+		case xml.StartElement:
+			if t.Name.Local == "Entry" {
+				var entry xmlStringInterfaceEntry
+				if err := d.DecodeElement(&entry, &t); err != nil {
+					return err
+				}
+				if entry.JSONType == "json" {
+					var v any
+					if err := json.Unmarshal([]byte(entry.Value), &v); err != nil {
+						return fmt.Errorf("failed to unmarshal StringInterface JSON value for key %q: %w", entry.Key, err)
+					}
+					(*m)[entry.Key] = v
+				} else {
+					(*m)[entry.Key] = entry.Value
+				}
+			} else {
+				if err := d.Skip(); err != nil {
+					return err
+				}
+			}
+		case xml.EndElement:
+			return nil
+		}
+	}
+}

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -1252,12 +1252,22 @@ type API interface {
 	// Minimum server version: 9.5
 	RegisterPluginForSharedChannels(opts model.RegisterPluginOpts) (remoteID string, err error)
 
-	// UnregisterPluginForSharedChannels unregisters the plugin as a `Remote` for SharedChannels.
-	// The plugin will no longer receive synchronization messages via the `OnSharedChannelsSyncMsg` hook.
+	// UnregisterPluginForSharedChannels unregisters all remotes for this plugin. The plugin will no
+	// longer receive synchronization messages via the `OnSharedChannelsSyncMsg` hook. Used in
+	// OnDeactivate for bulk cleanup.
 	//
 	// @tag SharedChannels
 	// Minimum server version: 9.5
 	UnregisterPluginForSharedChannels(pluginID string) error
+
+	// UnregisterPluginRemoteForSharedChannels unregisters a specific remote by its remoteID.
+	// The remote must belong to the calling plugin (ownership is validated server-side).
+	// The remote will no longer receive synchronization messages. Used for config change
+	// reconciliation when a connection is removed but others remain.
+	//
+	// @tag SharedChannels
+	// Minimum server version: 11.7
+	UnregisterPluginRemoteForSharedChannels(remoteID string) error
 
 	// ShareChannel marks a channel for sharing via shared channels. Note, this does not automatically
 	// invite any remote clusters to the channel - use `InviteRemote` to invite a remote , or this plugin,

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -1341,6 +1341,14 @@ type API interface {
 	// The remoteID identifies which of the plugin's registered remotes this attachment is from
 	// (the value returned by RegisterPluginForSharedChannels).
 	//
+	// The post-receive (ReceiveSharedChannelSyncMsg) and file-receive calls for the same
+	// post-and-attachment pair may be issued in either order or concurrently; the framework
+	// binds the file to its post regardless of arrival order. Repeated calls with the same
+	// (fi.Id, channelID, fi.CreatorId) return the existing FileInfo without producing
+	// duplicates, allowing transports with at-least-once delivery semantics to redeliver
+	// safely. Repeats whose fi.Id matches an existing record under a different channel or
+	// creator are rejected.
+	//
 	// @tag SharedChannels
 	// Minimum server version: 11.7
 	ReceiveSharedChannelAttachmentSyncMsg(remoteID, channelID string, fi *model.FileInfo, data io.Reader) (*model.FileInfo, error)

--- a/server/public/plugin/api_timer_layer_generated.go
+++ b/server/public/plugin/api_timer_layer_generated.go
@@ -1331,6 +1331,13 @@ func (api *apiTimerLayer) UnregisterPluginForSharedChannels(pluginID string) err
 	return _returnsA
 }
 
+func (api *apiTimerLayer) UnregisterPluginRemoteForSharedChannels(remoteID string) error {
+	startTime := timePkg.Now()
+	_returnsA := api.apiImpl.UnregisterPluginRemoteForSharedChannels(remoteID)
+	api.recordTime(startTime, "UnregisterPluginRemoteForSharedChannels", _returnsA == nil)
+	return _returnsA
+}
+
 func (api *apiTimerLayer) ShareChannel(sc *model.SharedChannel) (*model.SharedChannel, error) {
 	startTime := timePkg.Now()
 	_returnsA, _returnsB := api.apiImpl.ShareChannel(sc)

--- a/server/public/plugin/client_rpc.go
+++ b/server/public/plugin/client_rpc.go
@@ -1261,6 +1261,7 @@ func (s *apiRPCServer) ReceiveSharedChannelAttachmentSyncMsg(args *Z_ReceiveShar
 	defer dataReader.Close()
 
 	returns.A, returns.B = hook.ReceiveSharedChannelAttachmentSyncMsg(args.A, args.B, args.C, dataReader)
+	returns.B = encodableError(returns.B)
 	return nil
 }
 

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -6565,6 +6565,35 @@ func (s *apiRPCServer) UnregisterPluginForSharedChannels(args *Z_UnregisterPlugi
 	return nil
 }
 
+type Z_UnregisterPluginRemoteForSharedChannelsArgs struct {
+	A string
+}
+
+type Z_UnregisterPluginRemoteForSharedChannelsReturns struct {
+	A error
+}
+
+func (g *apiRPCClient) UnregisterPluginRemoteForSharedChannels(remoteID string) error {
+	_args := &Z_UnregisterPluginRemoteForSharedChannelsArgs{remoteID}
+	_returns := &Z_UnregisterPluginRemoteForSharedChannelsReturns{}
+	if err := g.client.Call("Plugin.UnregisterPluginRemoteForSharedChannels", _args, _returns); err != nil {
+		log.Printf("RPC call to UnregisterPluginRemoteForSharedChannels API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) UnregisterPluginRemoteForSharedChannels(args *Z_UnregisterPluginRemoteForSharedChannelsArgs, returns *Z_UnregisterPluginRemoteForSharedChannelsReturns) error {
+	if hook, ok := s.impl.(interface {
+		UnregisterPluginRemoteForSharedChannels(remoteID string) error
+	}); ok {
+		returns.A = hook.UnregisterPluginRemoteForSharedChannels(args.A)
+		returns.A = encodableError(returns.A)
+	} else {
+		return encodableError(fmt.Errorf("API UnregisterPluginRemoteForSharedChannels called but not implemented."))
+	}
+	return nil
+}
+
 type Z_ShareChannelArgs struct {
 	A *model.SharedChannel
 }

--- a/server/public/plugin/client_rpc_test.go
+++ b/server/public/plugin/client_rpc_test.go
@@ -1,0 +1,46 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package plugin
+
+import (
+	"bytes"
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestReceiveSharedChannelAttachmentSyncMsgReturns_GobRoundTrip pins the fix
+// for the gob-encoding bug in apiRPCServer.ReceiveSharedChannelAttachmentSyncMsg.
+// The hook may return errors wrapped with fmt.Errorf("...%w", err), producing
+// values of the unexported type *fmt.wrapError that gob refuses to encode.
+// The RPC server must run the error through encodableError before assigning
+// it to the returns struct. Without that, the RPC connection breaks and
+// every subsequent plugin to server call returns zero values.
+func TestReceiveSharedChannelAttachmentSyncMsgReturns_GobRoundTrip(t *testing.T) {
+	wrapped := fmt.Errorf("attachment sync failed: %w", errors.New("upstream boom"))
+
+	t.Run("raw wrapped error fails to gob-encode (reproduces the bug)", func(t *testing.T) {
+		returns := Z_ReceiveSharedChannelAttachmentSyncMsgReturns{B: wrapped}
+
+		var buf bytes.Buffer
+		err := gob.NewEncoder(&buf).Encode(&returns)
+		require.Error(t, err, "raw *fmt.wrapError must not be gob-encodable; if this assertion ever fails the bug guarded by encodableError no longer exists")
+		require.Contains(t, err.Error(), "fmt.wrapError")
+	})
+
+	t.Run("encodableError-wrapped error round-trips through gob", func(t *testing.T) {
+		returns := Z_ReceiveSharedChannelAttachmentSyncMsgReturns{B: encodableError(wrapped)}
+
+		var buf bytes.Buffer
+		require.NoError(t, gob.NewEncoder(&buf).Encode(&returns))
+
+		var decoded Z_ReceiveSharedChannelAttachmentSyncMsgReturns
+		require.NoError(t, gob.NewDecoder(&buf).Decode(&decoded))
+		require.Error(t, decoded.B)
+		require.Equal(t, wrapped.Error(), decoded.B.Error())
+	})
+}

--- a/server/public/plugin/plugintest/api.go
+++ b/server/public/plugin/plugintest/api.go
@@ -5493,6 +5493,24 @@ func (_m *API) UnregisterPluginForSharedChannels(pluginID string) error {
 	return r0
 }
 
+// UnregisterPluginRemoteForSharedChannels provides a mock function with given fields: remoteID
+func (_m *API) UnregisterPluginRemoteForSharedChannels(remoteID string) error {
+	ret := _m.Called(remoteID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UnregisterPluginRemoteForSharedChannels")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(remoteID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // UnshareChannel provides a mock function with given fields: channelID
 func (_m *API) UnshareChannel(channelID string) (bool, error) {
 	ret := _m.Called(channelID)

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/admin_channel_shared_indicator.test.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/admin_channel_shared_indicator.test.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {renderWithContext} from 'tests/react_testing_utils';
+
+import AdminChannelSharedIndicator from './admin_channel_shared_indicator';
+
+jest.mock('mattermost-redux/actions/shared_channels', () => ({
+    fetchChannelRemotes: jest.fn(() => ({type: 'MOCK_FETCH_CHANNEL_REMOTES'})),
+}));
+
+jest.mock('mattermost-redux/selectors/entities/shared_channels', () => ({
+    getRemoteNamesForChannel: jest.fn(() => [] as string[]),
+}));
+
+jest.mock('components/shared_channel_indicator', () => {
+    return jest.fn(() => <i data-testid='SharedChannelIcon'/>);
+});
+
+describe('admin_console/team_channel_settings/channel/list/AdminChannelSharedIndicator', () => {
+    beforeEach(() => {
+        jest.clearAllMocks();
+    });
+
+    test('fetches remotes on mount when remoteNames is empty', () => {
+        const {getRemoteNamesForChannel} = require('mattermost-redux/selectors/entities/shared_channels');
+        const {fetchChannelRemotes} = require('mattermost-redux/actions/shared_channels');
+        getRemoteNamesForChannel.mockReturnValue([]);
+
+        renderWithContext(<AdminChannelSharedIndicator channelId='channel-1'/>);
+
+        expect(fetchChannelRemotes).toHaveBeenCalledTimes(1);
+        expect(fetchChannelRemotes).toHaveBeenCalledWith('channel-1');
+    });
+
+    test('does not fetch remotes when remoteNames is already populated', () => {
+        const {getRemoteNamesForChannel} = require('mattermost-redux/selectors/entities/shared_channels');
+        const {fetchChannelRemotes} = require('mattermost-redux/actions/shared_channels');
+        getRemoteNamesForChannel.mockReturnValue(['Org A', 'Org B']);
+
+        renderWithContext(<AdminChannelSharedIndicator channelId='channel-1'/>);
+
+        expect(fetchChannelRemotes).not.toHaveBeenCalled();
+    });
+
+    test('passes remoteNames from the selector to SharedChannelIndicator', () => {
+        const {getRemoteNamesForChannel} = require('mattermost-redux/selectors/entities/shared_channels');
+        const SharedChannelIndicator = require('components/shared_channel_indicator');
+        getRemoteNamesForChannel.mockReturnValue(['Org A', 'Org B']);
+
+        renderWithContext(<AdminChannelSharedIndicator channelId='channel-1'/>);
+
+        const props = SharedChannelIndicator.mock.calls[0][0];
+        expect(props.remoteNames).toEqual(['Org A', 'Org B']);
+        expect(props.withTooltip).toBe(true);
+    });
+
+    test('forwards the className prop to SharedChannelIndicator', () => {
+        const SharedChannelIndicator = require('components/shared_channel_indicator');
+
+        renderWithContext(
+            <AdminChannelSharedIndicator
+                channelId='channel-1'
+                className='channel-icon'
+            />,
+        );
+
+        const props = SharedChannelIndicator.mock.calls[0][0];
+        expect(props.className).toBe('channel-icon');
+    });
+});

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/admin_channel_shared_indicator.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/admin_channel_shared_indicator.tsx
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useEffect} from 'react';
+import {shallowEqual, useDispatch, useSelector} from 'react-redux';
+
+import {fetchChannelRemotes} from 'mattermost-redux/actions/shared_channels';
+import {getRemoteNamesForChannel} from 'mattermost-redux/selectors/entities/shared_channels';
+
+import SharedChannelIndicator from 'components/shared_channel_indicator';
+
+import type {GlobalState} from 'types/store';
+
+type Props = {
+    channelId: string;
+    className?: string;
+};
+
+const AdminChannelSharedIndicator: React.FC<Props> = ({channelId, className}) => {
+    const dispatch = useDispatch();
+    const remoteNames = useSelector(
+        (state: GlobalState) => getRemoteNamesForChannel(state, channelId),
+        shallowEqual,
+    );
+
+    useEffect(() => {
+        if (channelId && remoteNames.length === 0) {
+            dispatch(fetchChannelRemotes(channelId));
+        }
+    }, [channelId, remoteNames.length, dispatch]);
+
+    return (
+        <SharedChannelIndicator
+            className={className}
+            withTooltip={true}
+            remoteNames={remoteNames}
+        />
+    );
+};
+
+export default AdminChannelSharedIndicator;

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/channel_list.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/channel_list.tsx
@@ -15,10 +15,11 @@ import type {Row, Column} from 'components/admin_console/data_grid/data_grid';
 import type {FilterOptions} from 'components/admin_console/filter/filter';
 import TeamFilterDropdown from 'components/admin_console/filter/team_filter_dropdown';
 import {PAGE_SIZE} from 'components/admin_console/team_channel_settings/abstract_list';
-import SharedChannelIndicator from 'components/shared_channel_indicator';
 
 import {getHistory} from 'utils/browser_history';
 import {getChannelIconComponent} from 'utils/channel_utils';
+
+import AdminChannelSharedIndicator from './admin_channel_shared_indicator';
 
 import './channel_list.scss';
 
@@ -195,9 +196,9 @@ export default class ChannelList extends React.PureComponent<ChannelListProps, C
             );
 
             const sharedChannelIcon = channel.shared ? (
-                <SharedChannelIndicator
+                <AdminChannelSharedIndicator
+                    channelId={channel.id}
                     className='channel-icon'
-                    withTooltip={true}
                 />
             ) : null;
 


### PR DESCRIPTION
#### Summary
Backports seven shared channels server-side fixes from master into `release-11.7`. These bring in plugin API improvements and stability fixes that the Cross Guard plugin depends on for receive-side shared channels work. 

Every cherry-pick applied cleanly with no manual conflict resolution.  The intention is to have these in a 11.7.x release for a specific customer.

Summary of changes: plugins using shared channels APIs can register multiple remotes, start cleanly, survive restarts, and reliably sync posts and attachments in either order; admins also see correct remote names in the console.  

Detailed breakdown:

1. MM-68339 — Multi-remote plugin registration & XML wire format Lets a single plugin register multiple shared-channel remote endpoints (previously capped at one per plugin) and adds XML serialization support for sync payloads. Foundational change so plugins can broker traffic with several external systems at once.
2. MM-68339 follow-up — Allow human-friendly plugin display names Fixes a regression from the above where plugin display names containing spaces (e.g. "legacy plugin") were rejected. Display name and internal slug are now separated, so admins see readable names.
3. MM-68622 — Plugins can use shared channels APIs at startup Previously, plugins calling shared-channel APIs during activation failed with "Shared Channels Service is disabled." The service now starts before plugins, so activation-time setup works as expected.
4. MM-68536 — System Console shows real remote names The admin Channels list was always showing the generic "Shared with trusted organizations" label. It now displays the actual remote organization names, matching the channel sidebar.
5. MM-68697 — Plugin-relayed attachments now visible Files synced via a plugin were saved to disk but invisible in the UI because the sender's file ID was overwritten. Attachments from plugin-brokered shared channels now appear correctly.
6. MM-68705 — Out-of-order attachment delivery handled Hardens the receive path so the post and its attachments can arrive in any order and duplicate deliveries are idempotent. Eliminates a class of "attachment missing" failures and retry loops when plugins ack unreliably.
7. MM-68708 — Test stability (no user-visible impact) Fixes a flaky test caused by feature-flag environment overrides. Internal only.
8. MM-68838 — Faster plugin reconnect & RPC crash fix. Two stability fixes: (a) when a plugin restarts, its remote is pinged immediately instead of waiting up to a minute, so the first post after restart goes through; (b) fixes a plugin/server RPC crash where a wrapped error caused the connection to drop and downstream plugin calls to panic.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68339
https://mattermost.atlassian.net/browse/MM-68536
https://mattermost.atlassian.net/browse/MM-68622
https://mattermost.atlassian.net/browse/MM-68697
https://mattermost.atlassian.net/browse/MM-68705
https://mattermost.atlassian.net/browse/MM-68708
https://mattermost.atlassian.net/browse/MM-68838

```release-note
NONE
```
