### PR TITLE
refactor: lessen/eliminate npm cache-restore failures and improve cache/restore for each E2E test runners

### DIFF
--- a/.github/e2e-tests-workflows.md
+++ b/.github/e2e-tests-workflows.md
@@ -16,22 +16,116 @@ All pipelines follow the **smoke-then-full** pattern: smoke tests run first, ful
 
 ```
 .github/workflows/
-├── e2e-tests-ci.yml                    # PR orchestrator
-├── e2e-tests-on-merge.yml              # Merge orchestrator (master/release branches)
-├── e2e-tests-on-release.yml            # Release cut orchestrator
-├── e2e-tests-cypress.yml               # Shared wrapper: cypress smoke -> full
-├── e2e-tests-playwright.yml            # Shared wrapper: playwright smoke -> full
-├── e2e-tests-cypress-template.yml      # Template: actual cypress test execution
-└── e2e-tests-playwright-template.yml   # Template: actual playwright test execution
+├── e2e-tests-ci.yml                       # PR orchestrator
+├── e2e-tests-on-merge.yml                 # Merge orchestrator (master/release branches)
+├── e2e-tests-on-release.yml               # Release cut orchestrator
+├── e2e-tests-cypress.yml                  # Shared wrapper: routes to v1 or v2 template
+├── e2e-tests-playwright.yml               # Shared wrapper: routes to v1 or v2 template
+├── e2e-tests-cypress-template-v2.yml      # Active: cypress + test-system-io dispatch
+├── e2e-tests-playwright-template-v2.yml   # Active: playwright + test-system-io dispatch
+├── e2e-tests-cypress-template.yml         # Deprecated v1 (legacy in-job execution)
+└── e2e-tests-playwright-template.yml      # Deprecated v1 (legacy in-job execution)
 ```
+
+> **v1 templates are deprecated.** They remain available behind a feature flag during cutover but receive no further changes. New work targets the v2 templates exclusively. The wrappers route by `vars.E2E_USE_TEST_IO_DISPATCH` — `'true'` selects v2, anything else falls back to v1.
 
 ### Call hierarchy
 
 ```
 e2e-tests-ci.yml ─────────────────┐
-e2e-tests-on-merge.yml ───────────┤──► e2e-tests-cypress.yml ──► e2e-tests-cypress-template.yml
-e2e-tests-on-release.yml ─────────┘    e2e-tests-playwright.yml ──► e2e-tests-playwright-template.yml
+e2e-tests-on-merge.yml ───────────┤──► e2e-tests-cypress.yml ─────┐
+e2e-tests-on-release.yml ─────────┘    e2e-tests-playwright.yml ──┤
+                                                                  │
+                                       ┌──────────────────────────┘
+                                       │  routes on E2E_USE_TEST_IO_DISPATCH
+                                       ▼
+                  v2 (active) ──► e2e-tests-{cypress,playwright}-template-v2.yml
+                  v1 (legacy) ──► e2e-tests-{cypress,playwright}-template.yml
 ```
+
+---
+
+## Workflow Architecture (v2)
+
+v2 splits the template into five jobs — `prepare-run`, `prep-deps`, `dispatch-begin`, `workers` (matrix), and `report` — and pushes spec-level execution to [Test System IO](https://github.com/mattermost/mattermost-test-system-io) so workers stay thin and identical.
+
+```
+┌──────────────────────────────────────────────────────────────────────────┐
+│  Template v2: e2e-tests-{cypress,playwright}-template-v2.yml              │
+│                                                                            │
+│   ┌───────────────────┐                ┌──────────────────────────────┐   │
+│   │ prepare-run       │                │ prep-deps                    │   │
+│   │ (1 runner)        │    parallel    │ (1 runner)                   │   │
+│   │                   │ ◄────────────► │                              │   │
+│   │ • build workers   │                │ Cypress:                     │   │
+│   │   matrix [1..N]   │                │   • cypress/node_modules     │   │
+│   │ • compute commit  │                │   • ~/.cache/Cypress (binary)│   │
+│   │   status context  │                │                              │   │
+│   │ • emit composite  │                │ Playwright:                  │   │
+│   │   identity        │                │   • webapp/platform/{client, │   │
+│   │                   │                │       types}/{lib,node_mod}  │   │
+│   │                   │                │   • playwright/node_modules  │   │
+│   │                   │                │   • playwright/lib/dist      │   │
+│   │                   │                │   • ~/.cache/ms-playwright   │   │
+│   │                   │                │     (chromium only)          │   │
+│   │                   │                │                              │   │
+│   │                   │                │   → saved to actions/cache   │   │
+│   └─────────┬─────────┘                └───────────────┬──────────────┘   │
+│             │                                          │                  │
+│             │                                          ▼                  │
+│             │                          ┌──────────────────────────────┐  │
+│             │                          │ dispatch-begin               │  │
+│             │                          │ • register run with          │  │
+│             │                          │   Test System IO             │  │
+│             │                          │ • runs immediately before    │  │
+│             │                          │   workers to minimise the    │  │
+│             │                          │   inactivity-timeout window  │  │
+│             │                          └───────────────┬──────────────┘  │
+│             │                                          │                  │
+│             └────────────────────┬─────────────────────┘                  │
+│                                  ▼                                        │
+│   ┌─────────────────────────────────────────────────────────────────┐    │
+│   │ workers  (matrix, fail-fast: false)                             │    │
+│   │   Cypress full: N=40       |   Playwright full: N=10            │    │
+│   │                                                                 │    │
+│   │   each worker, in parallel:                                     │    │
+│   │     1. sparse-checkout actions + full checkout-repo             │    │
+│   │     2. setup-node                                                │    │
+│   │     3. restore caches  ◄─── actions/cache (from prep-deps)      │    │
+│   │        (fail-on-cache-miss: true)                               │    │
+│   │     4. cloud-init + start-server  (docker compose stack)        │    │
+│   │     5. prepare-cypress | prepare-playwright (run setup project) │    │
+│   │     6. dispatch-run  ──────────────────────────────────┐        │    │
+│   │        (pulls specs from Test System IO, runs locally,  │       │    │
+│   │         posts result, loops until queue is empty)       │       │    │
+│   │     7. cloud-teardown                                   │       │    │
+│   └────────────────────┬────────────────────────────────────┼───────┘    │
+│                        │                                    │            │
+│                        ▼                                    │            │
+│   ┌─────────────────────────────────────────────────┐       │            │
+│   │ report                                           │       │            │
+│   │ • pull aggregated results from Test System IO    │  ◄────┘            │
+│   │ • post commit status                             │                    │
+│   │ • send webhook notification                      │                    │
+│   └─────────────────────────────────────────────────┘                    │
+└────────────────────────────────────────────────────────────────────────┬─┘
+                                                                          │
+                                              ┌───────────────────────────▼───┐
+                                              │ Test System IO (external)     │
+                                              │ • spec-level dispatch         │
+                                              │ • result aggregation          │
+                                              │ • retry orchestration         │
+                                              └───────────────────────────────┘
+```
+
+### Key properties
+
+- **Spec-level vs. job-level parallelism.** The matrix sizes the runner pool; Test System IO does the spec assignment. Slow specs don't block a worker — fast workers keep pulling the next spec from the queue.
+- **Cache-only workers.** `prep-deps` installs once per workflow run and saves to `actions/cache`. Every worker restores with `fail-on-cache-miss: true` and runs zero `npm ci`. Eliminates the 40-way `EEXIST/ENOENT` race in npm's shared cacache writer.
+- **dispatch-begin runs late.** It depends on `prep-deps` so the gap between Test System IO run registration and the first worker calling `dispatch-run` is just per-worker setup (~3–5 min). Registering earlier risks the run timing out before any worker checks in, bulk-failing every spec.
+- **Playwright slim slice.** Playwright only consumes `@mattermost/client` and `@mattermost/types` from webapp, so prep-deps caches just those two packages' built `lib/` and `node_modules` (~10–30 MB) instead of the full `webapp/node_modules` tree (~1–2 GB).
+- **Browser/binary caches.** Cypress caches `~/.cache/Cypress` (cypress binary lives outside node_modules); playwright caches `~/.cache/ms-playwright` (chromium only). Both keyed on the framework's lockfile so they invalidate on version bumps.
+- **No retry plumbing in the template.** Test System IO handles per-spec retries; the workflow only sees aggregated results.
 
 ---
 

--- a/.github/workflows/e2e-tests-check.yml
+++ b/.github/workflows/e2e-tests-check.yml
@@ -25,6 +25,12 @@ jobs:
           cache-dependency-path: |
             e2e-tests/cypress/package-lock.json
             e2e-tests/playwright/package-lock.json
+            webapp/package-lock.json
+      - name: ci/npm-cache-verify
+        # Heal any partial/dangling entries left in the restored ~/.npm cache
+        # before running `npm ci`. Avoids the intermittent EEXIST/ENOENT
+        # failures in npm's cacache writer.
+        run: npm cache verify
 
       # Cypress check
       - name: ci/cypress/npm-install

--- a/.github/workflows/e2e-tests-cypress-template-v2.yml
+++ b/.github/workflows/e2e-tests-cypress-template-v2.yml
@@ -135,7 +135,7 @@ env:
   SERVER_IMAGE: "${{ inputs.server_image_repo }}/${{ inputs.server_edition == 'fips' && 'mattermost-enterprise-fips-edition' || inputs.server_edition == 'team' && 'mattermost-team-edition' || 'mattermost-enterprise-edition' }}:${{ inputs.server_image_tag }}"
 
 jobs:
-  dispatch-begin:
+  prepare-run:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -193,13 +193,62 @@ jobs:
         run: |
           echo "workers=$(jq -nc --argjson n ${{ inputs.workers }} '[range(1; $n+1)]')" >> $GITHUB_OUTPUT
           echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
+
+  # Install cypress node_modules once, then workers restore from cache.
+  prep-deps:
+    name: prep-deps
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - name: ci/checkout-repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 1
+      - name: ci/setup-node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: ".nvmrc"
+      - name: ci/cache-cypress-deps
+        # node_modules + the cypress binary (downloaded to ~/.cache/Cypress by
+        # cypress's postinstall, not into node_modules). Both must be cached;
+        # otherwise workers see "cypress npm package installed but binary missing".
+        id: cache-cypress
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            e2e-tests/cypress/node_modules
+            ~/.cache/Cypress
+          key: e2e-cypress-deps-${{ runner.os }}-${{ hashFiles('e2e-tests/cypress/package-lock.json') }}
+      - name: ci/install-cypress-deps
+        if: steps.cache-cypress.outputs.cache-hit != 'true'
+        working-directory: e2e-tests/cypress
+        run: npm ci
+
+  # Register the Test System IO run AFTER prep-deps so workers reach
+  # dispatch-run within Test System IO's inactivity window.
+  dispatch-begin:
+    runs-on: ubuntu-24.04
+    needs: [prepare-run, prep-deps]
+    permissions:
+      contents: read
+      id-token: write
+      statuses: write
+    steps:
+      - name: ci/checkout-repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 1
       - name: ci/dispatch-begin
         uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-dispatch-begin@main
         with:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
           framework: cypress
           repo-dir: ${{ github.workspace }}
-          composite-identity: ${{ steps.composite-identity.outputs.composite-identity-json }}
+          composite-identity: ${{ needs.prepare-run.outputs.composite-identity-json }}
           total-reports-expected: ${{ inputs.workers }}
           retest-on-fail: ${{ inputs.retest_on_fail }}
           cypress-stage: ${{ inputs.cypress_stage }}
@@ -217,16 +266,16 @@ jobs:
     name: dispatch-run-${{ matrix.worker_index }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: dispatch-begin
+    needs: [prepare-run, dispatch-begin]
     permissions:
       contents: read
       id-token: write
     strategy:
       fail-fast: false
       matrix:
-        worker_index: ${{ fromJSON(needs.dispatch-begin.outputs.workers-matrix) }}
+        worker_index: ${{ fromJSON(needs.prepare-run.outputs.workers-matrix) }}
     env:
-      COMPOSITE_IDENTITY: ${{ needs.dispatch-begin.outputs.composite-identity-json }}
+      COMPOSITE_IDENTITY: ${{ needs.prepare-run.outputs.composite-identity-json }}
       SERVER: "${{ inputs.server }}"
       MM_LICENSE: "${{ secrets.MM_LICENSE }}"
       ENABLED_DOCKER_SERVICES: "${{ inputs.enabled_docker_services }}"
@@ -260,29 +309,26 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: "e2e-tests/cypress/package-lock.json"
-      - name: ci/get-webapp-node-modules
-        working-directory: webapp
-        run: make node_modules
+      - name: ci/restore-cypress-deps
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            e2e-tests/cypress/node_modules
+            ~/.cache/Cypress
+          key: e2e-cypress-deps-${{ runner.os }}-${{ hashFiles('e2e-tests/cypress/package-lock.json') }}
+          fail-on-cache-miss: true
       - name: ci/cloud-init
         working-directory: e2e-tests
         run: make cloud-init
       - name: ci/start-server
         working-directory: e2e-tests
         run: make start-server
-      # `npm ci` in the host context replaces the container-built native
-      # binaries with host-built ones, since the dispatch adapter spawns
-      # `npx cypress run` on the host.
-      - name: ci/prepare-cypress
-        working-directory: e2e-tests/cypress
-        run: npm ci
       - name: ci/dispatch-run
         uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-dispatch-run@main
         with:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
           framework: cypress
-          composite-identity: ${{ needs.dispatch-begin.outputs.composite-identity-json }}
+          composite-identity: ${{ needs.prepare-run.outputs.composite-identity-json }}
           repo-dir: ${{ github.workspace }}
           artifacts-root: ${{ github.workspace }}/worker-artifacts
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -306,7 +352,7 @@ jobs:
 
   report:
     runs-on: ubuntu-24.04
-    needs: [dispatch-begin, workers]
+    needs: [prepare-run, dispatch-begin, workers]
     if: always()
     permissions:
       contents: read
@@ -324,7 +370,7 @@ jobs:
         uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-summary@main
         with:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
-          composite-identity: ${{ needs.dispatch-begin.outputs.composite-identity-json }}
+          composite-identity: ${{ needs.prepare-run.outputs.composite-identity-json }}
           framework: cypress
           report-type: ${{ inputs.report_type }}
           image-tag: ${{ inputs.server_image_tag }}

--- a/.github/workflows/e2e-tests-playwright-template-v2.yml
+++ b/.github/workflows/e2e-tests-playwright-template-v2.yml
@@ -101,7 +101,7 @@ env:
   SERVER_IMAGE: "${{ inputs.server_image_repo }}/${{ inputs.server_edition == 'fips' && 'mattermost-enterprise-fips-edition' || inputs.server_edition == 'team' && 'mattermost-team-edition' || 'mattermost-enterprise-edition' }}:${{ inputs.server_image_tag }}"
 
 jobs:
-  dispatch-begin:
+  prepare-run:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -158,13 +158,104 @@ jobs:
         run: |
           echo "workers=$(jq -nc --argjson n ${{ inputs.workers }} '[range(1; $n+1)]')" >> $GITHUB_OUTPUT
           echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
+
+  # Build @mattermost/client + @mattermost/types and install playwright deps once,
+  # then workers restore from cache. Playwright only consumes those two packages
+  # from webapp, so we cache just their built lib/ instead of all of webapp/node_modules.
+  prep-deps:
+    name: prep-deps
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    permissions:
+      contents: read
+    steps:
+      - name: ci/checkout-repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 1
+      - name: ci/setup-node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: ".nvmrc"
+      - name: ci/cache-platform-pkgs
+        # `webapp/node_modules/@mattermost/{client,types}` are the workspace
+        # symlinks Node walks up to find when platform/client requires
+        # @mattermost/types. Without them, module resolution fails inside
+        # the slim slice.
+        id: cache-platform-pkgs
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            webapp/node_modules/@mattermost/client
+            webapp/node_modules/@mattermost/types
+            webapp/platform/client/lib
+            webapp/platform/client/node_modules
+            webapp/platform/types/lib
+            webapp/platform/types/node_modules
+          key: e2e-platform-pkgs-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json', 'webapp/platform/client/src/**', 'webapp/platform/client/tsconfig*.json', 'webapp/platform/types/src/**', 'webapp/platform/types/tsconfig*.json') }}
+      - name: ci/build-platform-pkgs
+        # Full webapp install is needed for tsc + workspace linking; the
+        # postinstall builds platform/{client,types}/lib. We only cache those.
+        if: steps.cache-platform-pkgs.outputs.cache-hit != 'true'
+        working-directory: webapp
+        run: make node_modules
+      - name: ci/cache-playwright-deps
+        # Caches node_modules + the rolled-up @mattermost/playwright-lib dist
+        # so workers don't re-run rollup on every job.
+        id: cache-playwright
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            e2e-tests/playwright/node_modules
+            e2e-tests/playwright/lib/dist
+            e2e-tests/playwright/lib/node_modules
+          key: e2e-playwright-deps-${{ runner.os }}-${{ hashFiles('e2e-tests/playwright/package-lock.json', 'e2e-tests/playwright/lib/src/**', 'e2e-tests/playwright/lib/package.json', 'e2e-tests/playwright/lib/rollup.config.js', 'e2e-tests/playwright/lib/tsconfig.json') }}
+      - name: ci/install-playwright-deps
+        # `npm ci` creates symlinks at node_modules/@mattermost/{client,types}
+        # → webapp/platform/{client,types}; targets must already be built.
+        # The postinstall then builds lib/dist via rollup. Skip browser
+        # download here — chromium is cached separately below.
+        if: steps.cache-playwright.outputs.cache-hit != 'true'
+        working-directory: e2e-tests/playwright
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+        run: npm ci
+      - name: ci/cache-playwright-browsers
+        # Cache chromium binary (~150MB) keyed on the playwright lockfile so a
+        # version bump invalidates. Restored by workers; no docker image needed.
+        id: cache-pw-browsers
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('e2e-tests/playwright/package-lock.json') }}
+      - name: ci/install-playwright-chromium
+        if: steps.cache-pw-browsers.outputs.cache-hit != 'true'
+        working-directory: e2e-tests/playwright
+        run: npx playwright install chromium
+
+  # Register the Test System IO run AFTER prep-deps so workers reach
+  # dispatch-run within Test System IO's inactivity window.
+  dispatch-begin:
+    runs-on: ubuntu-24.04
+    needs: [prepare-run, prep-deps]
+    permissions:
+      contents: read
+      id-token: write
+      statuses: write
+    steps:
+      - name: ci/checkout-repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 1
       - name: ci/dispatch-begin
         uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-dispatch-begin@main
         with:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
           framework: playwright
           repo-dir: ${{ github.workspace }}
-          composite-identity: ${{ steps.composite-identity.outputs.composite-identity-json }}
+          composite-identity: ${{ needs.prepare-run.outputs.composite-identity-json }}
           total-reports-expected: ${{ inputs.workers }}
           retest-on-fail: ${{ inputs.retest_on_fail }}
           playwright-project: ${{ inputs.playwright_project }}
@@ -177,16 +268,16 @@ jobs:
     name: dispatch-run-${{ matrix.worker_index }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: dispatch-begin
+    needs: [prepare-run, dispatch-begin]
     permissions:
       contents: read
       id-token: write
     strategy:
       fail-fast: false
       matrix:
-        worker_index: ${{ fromJSON(needs.dispatch-begin.outputs.workers-matrix) }}
+        worker_index: ${{ fromJSON(needs.prepare-run.outputs.workers-matrix) }}
     env:
-      COMPOSITE_IDENTITY: ${{ needs.dispatch-begin.outputs.composite-identity-json }}
+      COMPOSITE_IDENTITY: ${{ needs.prepare-run.outputs.composite-identity-json }}
       SERVER: "${{ inputs.server }}"
       MM_LICENSE: "${{ secrets.MM_LICENSE }}"
       ENABLED_DOCKER_SERVICES: "${{ inputs.enabled_docker_services }}"
@@ -214,31 +305,53 @@ jobs:
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: "e2e-tests/playwright/package-lock.json"
-      - name: ci/get-webapp-node-modules
-        working-directory: webapp
-        run: make node_modules
+      - name: ci/restore-platform-pkgs
+        # Built lib/ for @mattermost/client and @mattermost/types, plus the
+        # webapp workspace symlinks under webapp/node_modules/@mattermost/.
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            webapp/node_modules/@mattermost/client
+            webapp/node_modules/@mattermost/types
+            webapp/platform/client/lib
+            webapp/platform/client/node_modules
+            webapp/platform/types/lib
+            webapp/platform/types/node_modules
+          key: e2e-platform-pkgs-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json', 'webapp/platform/client/src/**', 'webapp/platform/client/tsconfig*.json', 'webapp/platform/types/src/**', 'webapp/platform/types/tsconfig*.json') }}
+          fail-on-cache-miss: true
+      - name: ci/restore-playwright-deps
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            e2e-tests/playwright/node_modules
+            e2e-tests/playwright/lib/dist
+            e2e-tests/playwright/lib/node_modules
+          key: e2e-playwright-deps-${{ runner.os }}-${{ hashFiles('e2e-tests/playwright/package-lock.json', 'e2e-tests/playwright/lib/src/**', 'e2e-tests/playwright/lib/package.json', 'e2e-tests/playwright/lib/rollup.config.js', 'e2e-tests/playwright/lib/tsconfig.json') }}
+          fail-on-cache-miss: true
+      - name: ci/restore-playwright-browsers
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('e2e-tests/playwright/package-lock.json') }}
+          fail-on-cache-miss: true
       - name: ci/cloud-init
         working-directory: e2e-tests
         run: make cloud-init
       - name: ci/start-server
         working-directory: e2e-tests
         run: make start-server
-      # Build once + run the `setup` project so per-spec dispatches can
-      # pass --no-deps and skip plugin-load + server-deployment checks.
+      # Run the `setup` project so per-spec dispatches can pass --no-deps
+      # and skip plugin-load + server-deployment checks. node_modules,
+      # lib/dist, and chromium are all restored from cache.
       - name: ci/prepare-playwright
         working-directory: e2e-tests/playwright
-        run: |
-          npm ci
-          npm run build
-          npx playwright test --project=setup
+        run: npx playwright test --project=setup
       - name: ci/dispatch-run
         uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-dispatch-run@main
         with:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
           framework: playwright
-          composite-identity: ${{ needs.dispatch-begin.outputs.composite-identity-json }}
+          composite-identity: ${{ needs.prepare-run.outputs.composite-identity-json }}
           repo-dir: ${{ github.workspace }}
           artifacts-root: ${{ github.workspace }}/worker-artifacts
           github-token: ${{ secrets.GITHUB_TOKEN }}
@@ -263,7 +376,7 @@ jobs:
 
   report:
     runs-on: ubuntu-24.04
-    needs: [dispatch-begin, workers]
+    needs: [prepare-run, dispatch-begin, workers]
     if: always()
     permissions:
       contents: read
@@ -281,7 +394,7 @@ jobs:
         uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-summary@main
         with:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
-          composite-identity: ${{ needs.dispatch-begin.outputs.composite-identity-json }}
+          composite-identity: ${{ needs.prepare-run.outputs.composite-identity-json }}
           framework: playwright
           report-type: ${{ inputs.report_type }}
           image-tag: ${{ inputs.server_image_tag }}

--- a/.github/workflows/e2e-tests-playwright-template.yml
+++ b/.github/workflows/e2e-tests-playwright-template.yml
@@ -179,7 +179,14 @@ jobs:
         with:
           node-version-file: ".nvmrc"
           cache: npm
-          cache-dependency-path: "e2e-tests/playwright/package-lock.json"
+          cache-dependency-path: |
+            e2e-tests/playwright/package-lock.json
+            webapp/package-lock.json
+      - name: ci/npm-cache-verify
+        # Heal any partial/dangling entries left in the restored ~/.npm cache
+        # before running `npm ci`. Avoids the intermittent EEXIST/ENOENT
+        # failures in npm's cacache writer.
+        run: npm cache verify
       - name: ci/get-webapp-node-modules
         working-directory: webapp
         run: make node_modules


### PR DESCRIPTION
#### Summary

Restructures the v2 cypress + playwright E2E templates so workers restore `node_modules` from `actions/cache` instead of running `npm ci`. This eliminates the intermittent `EEXIST/ENOENT` failures inside npm's cacache writer that occasionally aborted `npm ci` on a runner. The failure is per-process (each runner has its own `~/.npm`), but the workers matrix multiplied the per-workflow failure odds enough to make it routine. Removing `npm ci` from workers entirely closes the failure mode and cuts ~5 min of duplicated install work off every worker. The deprecated v1 templates and `e2e-tests-check.yml` get a conservative cache-key + `npm cache verify` patch as a fallback fix.

**What broke runs before this PR**

1. **`EEXIST/ENOENT` in npm's cacache writer** https://github.com/mattermost/mattermost/actions/runs/25950859885/job/76288315281 — npm's parallel download/extract workers occasionally collide on the same content-hash path, failing the whole `npm ci`. Each runner hits this independently, so every worker in the matrix was an extra chance for the workflow to fail; any single failure was enough to break the run. Workers now restore `node_modules/` directly from `actions/cache` and never run `npm ci`. Only `prep-deps` does, on a single runner, on cache miss only — so most runs make zero `npm ci` calls per workflow.

__What changed per template__

__`e2e-tests-cypress-template-v2.yml`__

- Split the old `dispatch-begin` job into `prepare-run` (matrix + identity only) and a new `dispatch-begin` (registers with Test System IO).
- Added `prep-deps` job that installs cypress deps once and caches them.
- Workers drop `make node_modules` (webapp was unused on the cypress path) and `npm ci` (replaced with `actions/cache/restore --fail-on-cache-miss`).
- Cache includes both `e2e-tests/cypress/node_modules` and `~/.cache/Cypress` (cypress binary lives outside `node_modules`).

__`e2e-tests-playwright-template-v2.yml`__

- Same `prepare-run` / `prep-deps` / `dispatch-begin` / `workers` topology.
- Playwright only consumes `@mattermost/client` and `@mattermost/types` from webapp, so `prep-deps` caches only:
  - `webapp/node_modules/@mattermost/{client,types}` (workspace symlinks — required for Node module resolution from `webapp/platform/client/lib/`)
  - `webapp/platform/{client,types}/{lib,node_modules}` (built outputs)
  - `e2e-tests/playwright/{node_modules,lib/dist,lib/node_modules}` (deps + rollup output)
  - `~/.cache/ms-playwright` (chromium only)
- `prep-deps`' `npm ci` uses `PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD=1`; chromium is installed via an explicit `npx playwright install chromium` step (skips the bundled firefox download).
- Workers drop `make node_modules`, `npm ci`, `npm run build`, and `npx playwright install` — just cache restores and `npx playwright test --project=setup`.

__Per-worker overhead, before vs. after__

| Step | Before (cache miss) | After (cache hit) |
|---|---|---|
| `make node_modules` | 3–5 min | — |
| `npm ci` (cypress/playwright) | 1–2 min | — |
| `npm run postinstall` (playwright lib/dist) | 5–30 s | — |
| Chromium download | 15–30 s | — |
| Cache restores (node_modules + binaries) | — | ~20–30 s |
| **Worker time before `dispatch-run`** | **5–7 min** | **3–5 min** (cloud-init + start-server dominate) |

`npm` operations per workflow run drop from ~80 (40 workers × 2 installs) to 1–2 in `prep-deps`.

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** These workflow changes restructure test infrastructure across multiple E2E template files and introduce cache-based dependency restoration. While the changes include protective measures (npm cache verify steps and explicit job dependencies), they consolidate npm operations into a centralized prep-deps job, creating a single point of failure if cache restoration fails or corrupts; however, the risk is mitigated by GitHub Actions' inherent fallback behavior.

**QA Recommendation:** Automated E2E test execution should catch most issues (workflow execution itself proves the changes work). Recommend one manual verification run of both Cypress and Playwright test workflows on a non-critical branch to confirm cache restoration, job sequencing, and test execution complete successfully. Focus verification on cache hit scenarios (second run) and intentional cache misses to validate fallback paths.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36599?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->