### PR TITLE
chore: update reusable workflows to specific commit sha

### DIFF
--- a/.github/workflows/e2e-tests-cypress-template-v2.yml
+++ b/.github/workflows/e2e-tests-cypress-template-v2.yml
@@ -194,7 +194,7 @@ jobs:
           echo "workers=$(jq -nc --argjson n ${{ inputs.workers }} '[range(1; $n+1)]')" >> $GITHUB_OUTPUT
           echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
       - name: ci/dispatch-begin
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-dispatch-begin@main
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-dispatch-begin@a2ea7f005484c28fedf51e16645f6d3bd683fd63 # 2026-05-16
         with:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
           framework: cypress
@@ -278,7 +278,7 @@ jobs:
         working-directory: e2e-tests/cypress
         run: npm ci
       - name: ci/dispatch-run
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-dispatch-run@main
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-dispatch-run@a2ea7f005484c28fedf51e16645f6d3bd683fd63 # 2026-05-16
         with:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
           framework: cypress
@@ -321,7 +321,7 @@ jobs:
       - name: ci/run-summary
         id: summary
         continue-on-error: true
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-summary@main
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-summary@a2ea7f005484c28fedf51e16645f6d3bd683fd63 # 2026-05-16
         with:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
           composite-identity: ${{ needs.dispatch-begin.outputs.composite-identity-json }}

--- a/.github/workflows/e2e-tests-playwright-template-v2.yml
+++ b/.github/workflows/e2e-tests-playwright-template-v2.yml
@@ -159,7 +159,7 @@ jobs:
           echo "workers=$(jq -nc --argjson n ${{ inputs.workers }} '[range(1; $n+1)]')" >> $GITHUB_OUTPUT
           echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
       - name: ci/dispatch-begin
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-dispatch-begin@main
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-dispatch-begin@a2ea7f005484c28fedf51e16645f6d3bd683fd63 # 2026-05-16
         with:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
           framework: playwright
@@ -234,7 +234,7 @@ jobs:
           npm run build
           npx playwright test --project=setup
       - name: ci/dispatch-run
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-dispatch-run@main
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-dispatch-run@a2ea7f005484c28fedf51e16645f6d3bd683fd63 # 2026-05-16
         with:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
           framework: playwright
@@ -278,7 +278,7 @@ jobs:
       - name: ci/run-summary
         id: summary
         continue-on-error: true
-        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-summary@main
+        uses: mattermost/mattermost-test-system-io/.github/actions/test-system-io-summary@a2ea7f005484c28fedf51e16645f6d3bd683fd63 # 2026-05-16
         with:
           use-staging: ${{ vars.E2E_USE_STAGING_TEST_IO_URL != 'false' }}
           composite-identity: ${{ needs.dispatch-begin.outputs.composite-identity-json }}

--- a/.github/workflows/pr-test-analysis-override.yml
+++ b/.github/workflows/pr-test-analysis-override.yml
@@ -21,8 +21,7 @@ jobs:
       github.event.issue.pull_request &&
       startsWith(github.event.comment.body, '/test-analysis-override') &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.comment.author_association)
-    # Pin to a commit SHA once the reusable workflow is stable. Using @main during initial rollout.
-    uses: mattermost/mattermost-test-automation-toolkit/.github/workflows/pr-test-analysis-override.yml@main
+    uses: mattermost/mattermost-test-automation-toolkit/.github/workflows/pr-test-analysis-override.yml@93d73f4f101e10dc03c7ed6b76b35eb5ff5babb7 # 2026-05-16
     with:
       pr_number: ${{ github.event.issue.number }}
       target_repo: mattermost/mattermost

--- a/.github/workflows/pr-test-analysis.yml
+++ b/.github/workflows/pr-test-analysis.yml
@@ -36,8 +36,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.draft == false &&
        github.event.pull_request.head.repo.full_name == 'mattermost/mattermost')
-    # Pin to a commit SHA once the reusable workflow is stable. Using @main during initial rollout.
-    uses: mattermost/mattermost-test-automation-toolkit/.github/workflows/pr-test-analysis.yml@main
+    uses: mattermost/mattermost-test-automation-toolkit/.github/workflows/pr-test-analysis.yml@93d73f4f101e10dc03c7ed6b76b35eb5ff5babb7 # 2026-05-16
     with:
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       target_repo: mattermost/mattermost


### PR DESCRIPTION
#### Summary
Pinned commit SHAs used for PR Test Analysis and Test System IO.

#### Ticket Link
none

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to CI/CD workflow configuration files with no modification to business logic or production code. Action references are simply pinned to specific commits while preserving all existing workflow logic and job structure, creating negligible risk of regressions.

**QA Recommendation:** Minimal manual QA required. Verify that E2E test workflows (Cypress and Playwright) and PR test analysis pipelines execute successfully on the next code changes, confirming the pinned action versions function as expected. No regression testing of application features is necessary.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36600?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->