### PR TITLE
fix: add missing aria-label to app bar component for screen readers

### DIFF
--- a/webapp/channels/src/components/app_bar/app_bar_plugin_component.tsx
+++ b/webapp/channels/src/components/app_bar/app_bar_plugin_component.tsx
@@ -66,6 +66,7 @@ const AppBarPluginComponent = ({
         <div
             role='button'
             tabIndex={0}
+            aria-label={tooltipText}
             className='app-bar__icon-inner'
         >
             <img
@@ -84,6 +85,7 @@ const AppBarPluginComponent = ({
             <div
                 role='button'
                 tabIndex={0}
+                aria-label={tooltipText}
                 className={classNames('app-bar__old-icon app-bar__icon-inner app-bar__icon-inner--centered', {'app-bar__old-icon--active': isButtonActive})}
             >
                 {icon}


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
This PR resolves a critical WCAG 2.1 accessibility violation where the App Bar plugin custom icon components lack accessible names, causing screen readers to announce them as empty "buttons" during keyboard navigation.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/36604

#### Screenshots
<img width="1151" height="502" alt="image" src="https://github.com/user-attachments/assets/61587628-b6d6-4f56-b5ab-502ce49a6b94" />


#### Release Note
```release-note
NONE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes are purely additive (adding aria-label attributes to two button divs) with no modifications to component logic, event handlers, or rendering behavior. The `tooltipText` variable is already safely defined and used elsewhere in the component (line 106), eliminating risk of undefined values or regressions.

**QA Recommendation:** Manual QA is optional. The existing snapshot tests will capture the changes, and standard component regression testing combined with a quick accessibility verification (screen reader announcement of plugin icon buttons) is sufficient.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36605?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->