### PR TITLE
Hide Download Apps link when running in Desktop app

### DIFF
--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.test.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.test.tsx
@@ -3,9 +3,9 @@
 
 import React from 'react';
 
+import * as UserAgent from '@mattermost/shared/utils/user_agent';
 import type {UserProfile} from '@mattermost/types/users';
 import type {DeepPartial} from '@mattermost/types/utilities';
-import * as UserAgent from '@mattermost/shared/utils/user_agent';
 
 import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.test.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.test.tsx
@@ -5,6 +5,7 @@ import React from 'react';
 
 import type {UserProfile} from '@mattermost/types/users';
 import type {DeepPartial} from '@mattermost/types/utilities';
+import * as UserAgent from '@mattermost/shared/utils/user_agent';
 
 import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';
@@ -14,6 +15,11 @@ import type {GlobalState} from 'types/store';
 import ProductMenuList from './product_menu_list';
 import type {Props as ProductMenuListProps} from './product_menu_list';
 
+const isDesktopAppMock = jest.mocked(UserAgent.isDesktopApp);
+
+jest.mock('@mattermost/shared/utils/user_agent', () => ({
+    isDesktopApp: jest.fn(() => false),
+}));
 jest.mock('components/widgets/menu/menu_items/menu_cloud_trial', () => () => null);
 jest.mock('components/widgets/menu/menu_items/menu_item_cloud_limit', () => () => null);
 jest.mock('components/permissions_gates/system_permission_gate', () => ({children}: {children: React.ReactNode}) => <>{children}</>);
@@ -237,5 +243,18 @@ describe('components/global/product_switcher_menu', () => {
             await userEvent.click(screen.getByText('Integrations'));
             expect(container).toMatchSnapshot();
         });
+    });
+
+    test('shows Download Apps link when appDownloadLink configured and not in desktop app', () => {
+        isDesktopAppMock.mockReturnValue(false);
+        const {container} = renderWithContext(<ProductMenuList {...defaultProps}/>, adminState);
+        expect(container.querySelector('#nativeAppLink')).not.toBeNull();
+    });
+
+    test('hides Download Apps link when in desktop app', () => {
+        isDesktopAppMock.mockReturnValue(true);
+        const {container} = renderWithContext(<ProductMenuList {...defaultProps}/>, adminState);
+        expect(container.querySelector('#nativeAppLink')).toBeNull();
+        isDesktopAppMock.mockReturnValue(false);
     });
 });

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.tsx
@@ -13,6 +13,7 @@ import {
     ViewGridPlusOutlineIcon,
     WebhookIncomingIcon,
 } from '@mattermost/compass-icons/components';
+import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
 import type {UserProfile} from '@mattermost/types/users';
 
 import {Permissions} from 'mattermost-redux/constants';
@@ -26,8 +27,6 @@ import MarketplaceModal from 'components/plugin_marketplace/marketplace_modal';
 import UserGroupsModal from 'components/user_groups_modal';
 import Menu from 'components/widgets/menu/menu';
 import RestrictedIndicator from 'components/widgets/menu/menu_items/restricted_indicator';
-
-import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
 
 import {FREEMIUM_TO_ENTERPRISE_TRIAL_LENGTH_DAYS} from 'utils/cloud_utils';
 import {LicenseSkus, ModalIdentifiers, MattermostFeatures} from 'utils/constants';

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.tsx
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/product_menu_list/product_menu_list.tsx
@@ -27,6 +27,8 @@ import UserGroupsModal from 'components/user_groups_modal';
 import Menu from 'components/widgets/menu/menu';
 import RestrictedIndicator from 'components/widgets/menu/menu_items/restricted_indicator';
 
+import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
+
 import {FREEMIUM_TO_ENTERPRISE_TRIAL_LENGTH_DAYS} from 'utils/cloud_utils';
 import {LicenseSkus, ModalIdentifiers, MattermostFeatures} from 'utils/constants';
 import {makeUrlSafe} from 'utils/url';
@@ -208,7 +210,7 @@ const ProductMenuList = (props: Props): JSX.Element | null => {
                 </TeamPermissionGate>
                 <Menu.ItemExternalLink
                     id='nativeAppLink'
-                    show={appDownloadLink}
+                    show={Boolean(appDownloadLink) && !isDesktopApp()}
                     url={makeUrlSafe(appDownloadLink)}
                     text={formatMessage({id: 'navbar_dropdown.nativeApps', defaultMessage: 'Download Apps'})}
                     icon={<DownloadOutlineIcon size={18}/>}

--- a/webapp/channels/src/components/mobile_sidebar_right/mobile_sidebar_right_items/mobile_sidebar_right_items.test.tsx
+++ b/webapp/channels/src/components/mobile_sidebar_right/mobile_sidebar_right_items/mobile_sidebar_right_items.test.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 
+import * as UserAgent from '@mattermost/shared/utils/user_agent';
 import {Permissions} from 'mattermost-redux/constants';
 
 import type {MockIntl} from 'tests/helpers/intl-test-helper';
@@ -10,6 +11,12 @@ import {renderWithContext, screen} from 'tests/react_testing_utils';
 
 import {MobileSidebarRightItems} from './mobile_sidebar_right_items';
 import type {Props} from './mobile_sidebar_right_items';
+
+const isDesktopAppMock = jest.mocked(UserAgent.isDesktopApp);
+
+jest.mock('@mattermost/shared/utils/user_agent', () => ({
+    isDesktopApp: jest.fn(() => false),
+}));
 
 describe('MobileSidebarRightItems', () => {
     const defaultProps: Props = {
@@ -160,14 +167,28 @@ describe('MobileSidebarRightItems', () => {
         expect(screen.getByText('Help')).toBeInTheDocument();
     });
 
-    test('should show report link when provided', () => {
+    test('should show Download Apps link when appDownloadLink is set and not in desktop app', () => {
+        isDesktopAppMock.mockReturnValue(false);
         renderWithContext(
             <MobileSidebarRightItems
                 {...defaultProps}
-                reportAProblemLink='https://report.example.com'
+                appDownloadLink='https://downloads.example.com'
             />,
             defaultState,
         );
-        expect(screen.getByText('Report a Problem')).toBeInTheDocument();
+        expect(screen.getByText('Download Apps')).toBeInTheDocument();
+    });
+
+    test('should hide Download Apps link when in desktop app', () => {
+        isDesktopAppMock.mockReturnValue(true);
+        renderWithContext(
+            <MobileSidebarRightItems
+                {...defaultProps}
+                appDownloadLink='https://downloads.example.com'
+            />,
+            defaultState,
+        );
+        expect(screen.queryByText('Download Apps')).not.toBeInTheDocument();
+        isDesktopAppMock.mockReturnValue(false);
     });
 });

--- a/webapp/channels/src/components/mobile_sidebar_right/mobile_sidebar_right_items/mobile_sidebar_right_items.test.tsx
+++ b/webapp/channels/src/components/mobile_sidebar_right/mobile_sidebar_right_items/mobile_sidebar_right_items.test.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 
 import * as UserAgent from '@mattermost/shared/utils/user_agent';
+
 import {Permissions} from 'mattermost-redux/constants';
 
 import type {MockIntl} from 'tests/helpers/intl-test-helper';

--- a/webapp/channels/src/components/mobile_sidebar_right/mobile_sidebar_right_items/mobile_sidebar_right_items.tsx
+++ b/webapp/channels/src/components/mobile_sidebar_right/mobile_sidebar_right_items/mobile_sidebar_right_items.tsx
@@ -27,6 +27,8 @@ import UserAccountOnlineMenuItem from 'components/user_account_menu/user_account
 import UserSettingsModal from 'components/user_settings/modal';
 import Menu from 'components/widgets/menu/menu';
 
+import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
+
 import {ModalIdentifiers, UserStatuses} from 'utils/constants';
 import {makeUrlSafe} from 'utils/url';
 
@@ -407,7 +409,7 @@ export class MobileSidebarRightItems extends React.PureComponent<Props> {
                     />
                     <Menu.ItemExternalLink
                         id='nativeAppLink'
-                        show={this.props.appDownloadLink}
+                        show={Boolean(this.props.appDownloadLink) && !isDesktopApp()}
                         url={safeAppDownloadLink}
                         text={formatMessage({id: 'navbar_dropdown.nativeApps', defaultMessage: 'Download Apps'})}
                         icon={

--- a/webapp/channels/src/components/mobile_sidebar_right/mobile_sidebar_right_items/mobile_sidebar_right_items.tsx
+++ b/webapp/channels/src/components/mobile_sidebar_right/mobile_sidebar_right_items/mobile_sidebar_right_items.tsx
@@ -5,6 +5,8 @@ import React from 'react';
 import {injectIntl} from 'react-intl';
 import type {WrappedComponentProps} from 'react-intl';
 
+import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
+
 import {Permissions} from 'mattermost-redux/constants';
 
 import {emitUserLoggedOutEvent} from 'actions/global_actions';
@@ -26,8 +28,6 @@ import UserAccountOfflineMenuItem from 'components/user_account_menu/user_accoun
 import UserAccountOnlineMenuItem from 'components/user_account_menu/user_account_online_menuitem';
 import UserSettingsModal from 'components/user_settings/modal';
 import Menu from 'components/widgets/menu/menu';
-
-import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
 
 import {ModalIdentifiers, UserStatuses} from 'utils/constants';
 import {makeUrlSafe} from 'utils/url';

--- a/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_completed.test.tsx
+++ b/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_completed.test.tsx
@@ -3,9 +3,17 @@
 
 import React from 'react';
 
+import * as UserAgent from '@mattermost/shared/utils/user_agent';
+
 import {renderWithContext, userEvent} from 'tests/react_testing_utils';
 
 import Completed from './onboarding_tasklist_completed';
+
+const isDesktopAppMock = jest.mocked(UserAgent.isDesktopApp);
+
+jest.mock('@mattermost/shared/utils/user_agent', () => ({
+    isDesktopApp: jest.fn(() => false),
+}));
 
 jest.mock('mattermost-redux/actions/admin', () => ({
     ...jest.requireActual('mattermost-redux/actions/admin'),
@@ -66,5 +74,18 @@ describe('components/onboarding_tasklist/onboarding_tasklist_completed.tsx', () 
         // calls the dissmiss function on click
         await userEvent.click(noThanksLink[0]);
         expect(dismissMockFn).toHaveBeenCalledTimes(1);
+    });
+
+    test('displays download apps link when not in desktop app', () => {
+        isDesktopAppMock.mockReturnValue(false);
+        const {container} = renderWithContext(<Completed {...props}/>, initialState);
+        expect(container.querySelectorAll('.download-apps')).toHaveLength(1);
+    });
+
+    test('hides download apps link when in desktop app', () => {
+        isDesktopAppMock.mockReturnValue(true);
+        const {container} = renderWithContext(<Completed {...props}/>, initialState);
+        expect(container.querySelectorAll('.download-apps')).toHaveLength(0);
+        isDesktopAppMock.mockReturnValue(false);
     });
 });

--- a/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
+++ b/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
@@ -15,6 +15,8 @@ import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import ExternalLink from 'components/external_link';
 import StartTrialBtn from 'components/learn_more_trial_modal/start_trial_btn';
 
+import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
+
 import completedImg from 'images/completed.svg';
 import {AboutLinks, LicenseLinks} from 'utils/constants';
 
@@ -212,24 +214,26 @@ const Completed = (props: Props): JSX.Element => {
                             />
                         </button>
                     )}
-                    <div className='download-apps'>
-                        <span>
-                            <FormattedMessage
-                                id='onboardingTask.checklist.downloads'
-                                defaultMessage='Now that you’re all set up, <link>download our apps.</link>'
-                                values={{
-                                    link: (msg: React.ReactNode) => (
-                                        <ExternalLink
-                                            location='onboarding_tasklist_completed'
-                                            href='https://mattermost.com/download#desktop'
-                                        >
-                                            {msg}
-                                        </ExternalLink>
-                                    ),
-                                }}
-                            />
-                        </span>
-                    </div>
+                    {!isDesktopApp() && (
+                        <div className='download-apps'>
+                            <span>
+                                <FormattedMessage
+                                    id='onboardingTask.checklist.downloads'
+                                    defaultMessage='Now that you’re all set up, <link>download our apps.</link>'
+                                    values={{
+                                        link: (msg: React.ReactNode) => (
+                                            <ExternalLink
+                                                location='onboarding_tasklist_completed'
+                                                href='https://mattermost.com/download#desktop'
+                                            >
+                                                {msg}
+                                            </ExternalLink>
+                                        ),
+                                    }}
+                                />
+                            </span>
+                        </div>
+                    )}
                     {showStartTrialBtn && <div className='disclaimer'>
                         <span>
                             <FormattedMessage

--- a/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
+++ b/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
@@ -7,6 +7,7 @@ import {useSelector, useDispatch} from 'react-redux';
 import {CSSTransition} from 'react-transition-group';
 import styled from 'styled-components';
 
+import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
 import type {GlobalState} from '@mattermost/types/store';
 
 import {getPrevTrialLicense} from 'mattermost-redux/actions/admin';
@@ -14,8 +15,6 @@ import {getLicense} from 'mattermost-redux/selectors/entities/general';
 
 import ExternalLink from 'components/external_link';
 import StartTrialBtn from 'components/learn_more_trial_modal/start_trial_btn';
-
-import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
 
 import completedImg from 'images/completed.svg';
 import {AboutLinks, LicenseLinks} from 'utils/constants';

--- a/webapp/channels/src/components/onboarding_tasks/onboarding_tasks_manager.test.tsx
+++ b/webapp/channels/src/components/onboarding_tasks/onboarding_tasks_manager.test.tsx
@@ -3,9 +3,17 @@
 
 import React from 'react';
 
+import * as UserAgent from '@mattermost/shared/utils/user_agent';
+
 import {renderWithContext, screen} from 'tests/react_testing_utils';
 
 import {useTasksList} from './onboarding_tasks_manager';
+
+const isDesktopAppMock = jest.mocked(UserAgent.isDesktopApp);
+
+jest.mock('@mattermost/shared/utils/user_agent', () => ({
+    isDesktopApp: jest.fn(() => false),
+}));
 
 const WrapperComponent = (): JSX.Element => {
     const taskList = useTasksList();
@@ -86,5 +94,17 @@ describe('onboarding tasks manager', () => {
 
         // verify visit_system_console and start_trial were removed
         expect(screen.queryByText('invite_people')).not.toBeInTheDocument();
+    });
+
+    it('Removes download_app task when running in desktop app', () => {
+        isDesktopAppMock.mockReturnValue(true);
+        renderWithContext(
+            <WrapperComponent/>,
+            initialState,
+        );
+
+        expect(screen.getAllByRole('listitem')).toHaveLength(5);
+        expect(screen.queryByText('download_app')).not.toBeInTheDocument();
+        isDesktopAppMock.mockReturnValue(false);
     });
 });

--- a/webapp/channels/src/components/onboarding_tasks/onboarding_tasks_manager.tsx
+++ b/webapp/channels/src/components/onboarding_tasks/onboarding_tasks_manager.tsx
@@ -6,6 +6,8 @@ import {useIntl} from 'react-intl';
 import {useDispatch, useSelector} from 'react-redux';
 import {matchPath, useLocation} from 'react-router-dom';
 
+import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
+
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
@@ -38,8 +40,6 @@ import {
     TutorialTourName,
 } from 'components/tours';
 import {ELEMENT_ID_FOR_USER_ACCOUNT_MENU_BUTTON} from 'components/user_account_menu/user_account_menu';
-
-import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
 
 import {ModalIdentifiers} from 'utils/constants';
 

--- a/webapp/channels/src/components/onboarding_tasks/onboarding_tasks_manager.tsx
+++ b/webapp/channels/src/components/onboarding_tasks/onboarding_tasks_manager.tsx
@@ -39,6 +39,8 @@ import {
 } from 'components/tours';
 import {ELEMENT_ID_FOR_USER_ACCOUNT_MENU_BUTTON} from 'components/user_account_menu/user_account_menu';
 
+import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
+
 import {ModalIdentifiers} from 'utils/constants';
 
 import type {GlobalState} from 'types/store';
@@ -136,6 +138,10 @@ export const useTasksList = () => {
     // invite other users is hidden for guest users
     if (isGuestUser) {
         delete list.INVITE_PEOPLE;
+    }
+
+    if (isDesktopApp()) {
+        delete list.DOWNLOAD_APP;
     }
 
     return Object.values(list);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

The product menu and mobile account menu entries for downloading apps will be hidden when `isDesktopApp()` is true based on user agent detection. Onboarding checklist no longer surfaces the desktop/mobile download task, and the onboarding completion footer no longer shows the download-apps call to action inside the Desktop app.

Unit tests were added for menu visibility and onboarding behavior with a mocked `@mattermost/shared/utils/user_agent` module.

QA: Open the Channels product menu from the Desktop application and verify "Download Apps" is absent while it still appears when the webapp is opened from a conventional browser.

#### Release Note

```release-note
Hid redundant "Download Apps" links and onboarding download reminders when Mattermost runs inside the Desktop app.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1493fe67-4b7f-4d05-9cd2-f68c4ec71df9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1493fe67-4b7f-4d05-9cd2-f68c4ec71df9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated UI visibility modifications applied to 4 component files with corresponding test cases added for both desktop and non-desktop scenarios. The conditional logic is straightforward (adding `!isDesktopApp()` checks), affects only download-related UI elements, and does not modify shared utilities or critical business logic.

**QA Recommendation:** Manual QA verification in actual Desktop app environment is recommended to confirm user agent detection correctly identifies the Desktop application context and Download Apps links are properly hidden. Automated test coverage is comprehensive; minimal manual testing needed beyond visual validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36614?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->