### PR TITLE
Add Docker Hub auth to Cloud Agent start hook

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -17,7 +17,7 @@ The Docker build context is `.cursor/` only. The Dockerfile intentionally does n
 ## Runtime Hooks
 
 - `cloud-agent-install.sh` runs after Cursor checks out the repo. It refreshes nvm, installs agent-browser browsers, verifies Cursor's multi-repo `mattermost/enterprise` checkout, runs `server` Go dependency hydration, installs webapp dependencies, and runs Playwright `npm ci`.
-- `cloud-agent-start.sh` materializes `.cursor/cursor.md` as `.cursor/AGENTS.md`, fixes current-session Docker socket access, then starts Docker and waits until `docker info` and `docker compose version` succeed.
+- `cloud-agent-start.sh` materializes `.cursor/cursor.md` as `.cursor/AGENTS.md`, fixes current-session Docker socket access, starts Docker, waits until `docker info` and `docker compose version` succeed, then logs in to Docker Hub when credentials are configured.
 
 The environment declares `github.com/mattermost/enterprise` in `repositoryDependencies` so Cursor can provide it as part of the multi-repo workspace. Cursor currently clones the repositories as siblings, such as `/agent/repos/mattermost` and `/agent/repos/enterprise`, which matches `server/Makefile`'s default `../../enterprise` path. The install hook does not clone, pull, or symlink enterprise.
 
@@ -33,4 +33,7 @@ Set these environment variables to `true` to shorten startup for narrow tasks:
 
 ## Expected Secrets
 
-- AWS uploads use the standard AWS CLI environment variables provided to the Cloud Agent: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_S3_BUCKET_NAME`. The image only supplies the `aws` binary.
+Configure these in the [Cursor Cloud Agents dashboard](https://cursor.com/dashboard/cloud-agents) as environment-scoped secrets for the Mattermost Cloud Agent environment.
+
+- AWS uploads use the standard AWS CLI environment variables: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `AWS_S3_BUCKET_NAME`. The image only supplies the `aws` binary.
+- Docker Hub pulls use the same variable names as CI: `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN`. The start hook runs `docker login` after `dockerd` is ready. Mark `DOCKERHUB_TOKEN` as **redacted** in the dashboard. When both are set, agents can pull the full default `make start-docker` image set without hitting anonymous rate limits.

--- a/.cursor/cursor.md
+++ b/.cursor/cursor.md
@@ -58,7 +58,8 @@ The Mattermost server is expected at `http://localhost:8065`. The webapp dev ser
   ```
 
 - When the server starts and `MM_LICENSE` is present in the environment, the server applies that license automatically. If `MM_LICENSE` is not set, starting the server automatically applies an Entry license, which provides nearly all functionality needed for development.
-- `ENABLED_DOCKER_SERVICES='postgres redis'` avoids optional local-dev services such as Prometheus, Grafana, Loki, Minio, Azurite, and OpenLDAP. This is useful in Cloud when Docker Hub rate limits block the default `make start-docker` dependency set.
+- When `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` are configured as Cloud Agent secrets, `cloud-agent-start.sh` logs in to Docker Hub and the full default `make start-docker` dependency set can be used without trimming services.
+- `ENABLED_DOCKER_SERVICES='postgres redis'` avoids optional local-dev services such as Prometheus, Grafana, Loki, Minio, Azurite, and OpenLDAP. Use this fallback when Docker Hub credentials are unavailable and anonymous pulls hit rate limits.
 - If the first-user signup UI is flaky but the server is already healthy, seed local state with `mmctl` and then log in through the browser:
 
   ```bash

--- a/.cursor/scripts/cloud-agent-start.sh
+++ b/.cursor/scripts/cloud-agent-start.sh
@@ -34,6 +34,21 @@ ensure_docker_socket_access() {
   fi
 }
 
+docker_login_if_configured() {
+  if [ -z "${DOCKERHUB_USERNAME:-}" ] || [ -z "${DOCKERHUB_TOKEN:-}" ]; then
+    log "Docker Hub credentials not configured; anonymous pulls may hit rate limits."
+    return 0
+  fi
+
+  log "Logging in to Docker Hub as ${DOCKERHUB_USERNAME}."
+  if echo "${DOCKERHUB_TOKEN}" | docker login -u "${DOCKERHUB_USERNAME}" --password-stdin >/tmp/docker-login.log 2>&1; then
+    log "Docker Hub login succeeded."
+  else
+    log "Docker Hub login failed; see /tmp/docker-login.log."
+    tail -n 20 /tmp/docker-login.log >&2 || true
+  fi
+}
+
 if [ -f /proc/sys/kernel/apparmor_restrict_unprivileged_userns ]; then
   sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0 >/dev/null 2>&1 || \
     log "Could not relax AppArmor user namespace restriction; openldap-based tests may need a larger host profile."
@@ -44,6 +59,7 @@ ensure_docker_socket_access
 if docker info >/dev/null 2>&1; then
   log "Docker is already running."
   docker compose version
+  docker_login_if_configured
   exit 0
 fi
 
@@ -64,6 +80,7 @@ for _ in {1..60}; do
     log "Docker is ready."
     docker version
     docker compose version
+    docker_login_if_configured
     exit 0
   fi
 


### PR DESCRIPTION
#### Summary
Cloud Agents hit Docker Hub anonymous pull rate limits when running `make start-docker` because DinD pulls were unauthenticated. This adds optional Docker Hub login to `.cursor/scripts/cloud-agent-start.sh` after `dockerd` is ready, using `DOCKERHUB_USERNAME` and `DOCKERHUB_TOKEN` injected as Cursor dashboard secrets (same names as CI).

When credentials are configured, agents can use the full default dependency set. When they are absent, startup continues with a warning and the existing `ENABLED_DOCKER_SERVICES='postgres redis'` fallback still applies.

#### Release Note
```release-note
NONE
```


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes are isolated to a Cloud Agent development startup script and are purely additive with graceful error handling—missing credentials don't break execution, and Docker login failure logs but continues. The function has defensive coding that returns 0 on credential absence or authentication failure, maintaining backward compatibility; the only behavioral change without credentials is an additional log message.

**QA Recommendation:** Minimal manual QA required. Verify that the script executes successfully in two scenarios: (1) without `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` set (should log warning and continue), and (2) with valid Docker Hub credentials configured (should authenticate and succeed). Since this is a development environment hook with no production impact, automated testing of the startup script in both credential states would be sufficient.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36632?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->