### PR TITLE
Add auth token to flaky test webhook

### DIFF
--- a/.github/workflows/server-ci-report.yml
+++ b/.github/workflows/server-ci-report.yml
@@ -131,9 +131,11 @@ jobs:
           && steps.report.outputs.failed == '0'
           && github.event.workflow_run.event == 'pull_request'
           && env.WEBHOOK_URL_FLAKY_TEST != ''
+          && env.WEBHOOK_AUTH_TOKEN_FLAKY_TEST != ''
         continue-on-error: true
         env:
           WEBHOOK_URL_FLAKY_TEST: ${{ secrets.WEBHOOK_URL_FLAKY_TEST }}
+          WEBHOOK_AUTH_TOKEN_FLAKY_TEST: ${{ secrets.WEBHOOK_AUTH_TOKEN_FLAKY_TEST }}
           FLAKY_SUMMARY: ${{ steps.report.outputs.flaky_summary }}
           PR_NUMBER: ${{ steps.incoming-pr.outputs.NUMBER }}
           REPO: ${{ github.repository }}
@@ -148,5 +150,6 @@ jobs:
             --connect-timeout 5 \
             --max-time 30 \
             -H "Content-Type: application/json" \
+            -H "Authorization: Bearer $WEBHOOK_AUTH_TOKEN_FLAKY_TEST" \
             -d "$PAYLOAD" \
             "$WEBHOOK_URL_FLAKY_TEST"


### PR DESCRIPTION
#### Summary
Adds a bearer authorization header to the flaky-test webhook request using the `WEBHOOK_AUTH_TOKEN_FLAKY_TEST` secret. The webhook step now requires both the URL and auth token secrets to be present before sending the flaky summary payload.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to a single CI/CD workflow step that conditionally sends test failure reports to an external webhook. The modification only adds an Authorization bearer token header to the curl request when both the webhook URL and auth token secrets are present, with no impact on application code or user-facing features.

**QA Recommendation:** No manual QA needed for this infrastructure change. Verify the external webhook endpoint accepts the new Authorization header format through existing integration tests.

---

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36636?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->