### PR TITLE
Fix flaky E2E tests (Cypress + Playwright)

### DIFF
--- a/e2e-tests/cypress/cypress.config.ts
+++ b/e2e-tests/cypress/cypress.config.ts
@@ -27,9 +27,9 @@ export default defineConfig({
     viewportWidth: 1300,
     allowCypressEnv: false,
     expose: {
-        adminEmail: 'sysadmin@sample.mattermost.com',
-        adminUsername: 'sysadmin',
-        adminPassword: 'Sys@dmin-sample1',
+        adminEmail: process.env.CYPRESS_adminEmail || 'sysadmin@sample.mattermost.com',
+        adminUsername: process.env.CYPRESS_adminUsername || 'sysadmin',
+        adminPassword: process.env.CYPRESS_adminPassword || 'Sys@dmin-sample1',
         allowedUntrustedInternalConnections: 'localhost',
         cwsURL: 'http://localhost:8076',
         cwsAPIURL: 'http://localhost:8076',

--- a/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_image_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_image_spec.js
@@ -16,11 +16,16 @@ describe('Verify Accessibility Support in Different Images', () => {
     let otherUser;
 
     before(() => {
-        cy.apiInitSetup().then(({offTopicUrl, user}) => {
-            otherUser = user;
+        cy.apiInitSetup().then(({team, offTopicUrl, user}) => {
+            cy.apiCreateUser({prefix: 'other'}).then(({user: user1}) => {
+                otherUser = user1;
+                return cy.apiAddUserToTeam(team.id, otherUser.id);
+            }).then(() => {
+                cy.apiLogin(user);
 
-            // Visit the Off Topic channel
-            cy.visit(offTopicUrl);
+                // Visit the Off Topic channel
+                cy.visit(offTopicUrl);
+            });
         });
     });
 

--- a/e2e-tests/cypress/tests/support/index.js
+++ b/e2e-tests/cypress/tests/support/index.js
@@ -254,6 +254,7 @@ function sysadminSetup(user) {
 
 function resetUserPreference(userId) {
     cy.apiSaveTeammateNameDisplayPreference('username');
+    cy.apiSaveMessageDisplayPreference('clean');
     cy.apiSaveLinkPreviewsPreference('true');
     cy.apiSaveCollapsePreviewsPreference('false');
     cy.apiSaveClockDisplayModeTo24HourPreference(false);

--- a/e2e-tests/playwright/specs/functional/system_console/system_users/column_sort.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/system_users/column_sort.spec.ts
@@ -53,7 +53,7 @@ test.describe('System Console - Users table sorting', () => {
             }
             expect(emails.length).toBeGreaterThan(3);
 
-            const sorted = [...emails].sort((a, b) => a.localeCompare(b));
+            const sorted = [...emails].sort((a, b) => a.localeCompare(b, undefined, {ignorePunctuation: true}));
             if (sortDirection === 'descending') {
                 sorted.reverse();
             }
@@ -81,7 +81,7 @@ test.describe('System Console - Users table sorting', () => {
             }
             expect(emails.length).toBeGreaterThan(3);
 
-            const sorted = [...emails].sort((a, b) => a.localeCompare(b));
+            const sorted = [...emails].sort((a, b) => a.localeCompare(b, undefined, {ignorePunctuation: true}));
             if (reversedDirection === 'descending') {
                 sorted.reverse();
             }


### PR DESCRIPTION
#### Summary

Three fixes for flaky E2E tests:

**Cypress: restore `CYPRESS_*` env var overrides**
`allowCypressEnv: false` (introduced in the Cypress v15.13 upgrade, PR #36091) disables Cypress's automatic `CYPRESS_*` environment variable handling, which broke the `CYPRESS_adminUsername` / `CYPRESS_adminPassword` override mechanism used by local and CI runners. Rather than reverting that setting, the fix explicitly reads `process.env.CYPRESS_adminEmail`, `process.env.CYPRESS_adminUsername`, and `process.env.CYPRESS_adminPassword` with default fallbacks in the `expose` block, restoring the override capability while keeping `allowCypressEnv: false`.

**Cypress: fix MM-T1508 accessibility image test flakiness**
The test was failing intermittently because the admin user could carry a stale compact-display-mode preference from a previous spec, causing post avatars to render with `pointer-events: none` and blocking the `.status-wrapper` click. Two fixes:
- `resetUserPreference()` now resets `message_display` to `'clean'` so compact mode doesn't leak across spec files.
- `accessibility_image_spec` `before()` now runs as a fresh user with default preferences rather than the shared admin account.

**Playwright: fix MM-T5523-1 email sort test flakiness**
The sort-verification logic used `localeCompare()` without a locale, which on a CI runner with a `C` system locale uses byte order (placing `-` before digits). PostgreSQL's `en_US.UTF-8` collation ignores hyphens at the primary sort level, so emails like `dm-peer-restricted…` sorted to different positions in JS vs the DB. Fixed by passing `{ ignorePunctuation: true }` to make JS collation closer to Postgres behavior in practice.

#### Ticket Link

<!-- no Jira tickets for these flakiness fixes -->

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes touch shared test infrastructure (Cypress configuration and shared utility function `resetUserPreference`) that could affect multiple test suites if environment variable overrides or preference resets fail. However, fallback defaults and additive-only modifications mitigate direct regression risk.

**QA Recommendation:** Verify that Cypress tests execute correctly with environment variable overrides in CI/CD pipelines and that user preference resets don't cause unintended side effects in dependent tests. Standard E2E test execution should sufficiently validate these changes given their test-only scope.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36637?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->