### PR TITLE
MM-68840: Apply team sanitization on scheme teams endpoint

### DIFF
--- a/server/channels/api4/scheme.go
+++ b/server/channels/api4/scheme.go
@@ -137,6 +137,8 @@ func getTeamsForScheme(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	c.App.SanitizeTeams(*c.AppContext.Session(), teams)
+
 	js, err := json.Marshal(teams)
 	if err != nil {
 		c.Err = model.NewAppError("getTeamsForScheme", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)

--- a/server/channels/api4/scheme_test.go
+++ b/server/channels/api4/scheme_test.go
@@ -424,12 +424,6 @@ func TestGetTeamsForScheme(t *testing.T) {
 	CheckNotImplementedStatus(t, ri6)
 }
 
-// TestGetTeamsForScheme_SanitizesPrivilegedFieldsForUserManager verifies that
-// GET /schemes/{schemeId}/teams strips invite_id from private (invite-only)
-// teams when the caller is a System Manager. The handler must call
-// App.SanitizeTeams, matching every other team-returning endpoint in
-// server/channels/api4/team.go. The system admin must still see invite_id and
-// email populated as a positive control.
 func TestGetTeamsForScheme_SanitizesPrivilegedFieldsForUserManager(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t)
@@ -469,11 +463,6 @@ func TestGetTeamsForScheme_SanitizesPrivilegedFieldsForUserManager(t *testing.T)
 	require.Equal(t, knownInviteID, privateTeam.InviteId)
 	require.Equal(t, knownEmail, privateTeam.Email)
 
-	// The System Manager role has PermissionSysconsoleReadUserManagementTeams
-	// (allowing the call) and ancillarily grants PermissionManageTeam via
-	// PermissionSysconsoleWriteUserManagementTeams (see role.go
-	// SysconsoleAncillaryPermissions), but it does NOT grant PermissionInviteUser.
-	// App.SanitizeTeam therefore strips invite_id while preserving email.
 	th.LoginSystemManager(t)
 
 	t.Run("system manager response is sanitized", func(t *testing.T) {
@@ -481,14 +470,7 @@ func TestGetTeamsForScheme_SanitizesPrivilegedFieldsForUserManager(t *testing.T)
 		require.NoError(t, err)
 		require.Len(t, teams, 1)
 		assert.Equal(t, privateTeam.Id, teams[0].Id)
-		assert.Empty(t, teams[0].InviteId,
-			"invite_id must be stripped for callers without PermissionInviteUser on the team; got %q", teams[0].InviteId)
-		// Email is intentionally not asserted here: system_manager retains
-		// PermissionManageTeam via the ancillary expansion of
-		// PermissionSysconsoleWriteUserManagementTeams (see role.go
-		// SysconsoleAncillaryPermissions), so App.SanitizeTeam preserves
-		// email — consistent with every other team-returning endpoint in
-		// server/channels/api4/team.go.
+		assert.Empty(t, teams[0].InviteId)
 	})
 
 	t.Run("system admin response is not sanitized", func(t *testing.T) {
@@ -496,10 +478,8 @@ func TestGetTeamsForScheme_SanitizesPrivilegedFieldsForUserManager(t *testing.T)
 		require.NoError(t, err)
 		require.Len(t, teams, 1)
 		assert.Equal(t, privateTeam.Id, teams[0].Id)
-		assert.Equal(t, knownInviteID, teams[0].InviteId,
-			"system admin retains invite_id (positive control)")
-		assert.Equal(t, knownEmail, teams[0].Email,
-			"system admin retains email (positive control)")
+		assert.Equal(t, knownInviteID, teams[0].InviteId)
+		assert.Equal(t, knownEmail, teams[0].Email)
 	})
 }
 

--- a/server/channels/api4/scheme_test.go
+++ b/server/channels/api4/scheme_test.go
@@ -424,6 +424,85 @@ func TestGetTeamsForScheme(t *testing.T) {
 	CheckNotImplementedStatus(t, ri6)
 }
 
+// TestGetTeamsForScheme_SanitizesPrivilegedFieldsForUserManager verifies that
+// GET /schemes/{schemeId}/teams strips invite_id from private (invite-only)
+// teams when the caller is a System Manager. The handler must call
+// App.SanitizeTeams, matching every other team-returning endpoint in
+// server/channels/api4/team.go. The system admin must still see invite_id and
+// email populated as a positive control.
+func TestGetTeamsForScheme_SanitizesPrivilegedFieldsForUserManager(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t)
+
+	th.App.Srv().SetLicense(model.NewTestLicense("custom_permissions_schemes"))
+
+	err := th.App.SetPhase2PermissionsMigrationStatus(true)
+	require.NoError(t, err)
+
+	scheme := &model.Scheme{
+		DisplayName: model.NewId(),
+		Name:        model.NewId(),
+		Description: model.NewId(),
+		Scope:       model.SchemeScopeTeam,
+	}
+	scheme, _, err = th.SystemAdminClient.CreateScheme(context.Background(), scheme)
+	require.NoError(t, err)
+
+	knownInviteID := model.NewId()
+	knownEmail := th.GenerateTestEmail()
+
+	privateTeam := &model.Team{
+		Name:        GenerateTestTeamName(),
+		DisplayName: "Private Scheme Team",
+		Type:        model.TeamInvite,
+		InviteId:    knownInviteID,
+		Email:       knownEmail,
+	}
+	privateTeam, err = th.App.Srv().Store().Team().Save(privateTeam)
+	require.NoError(t, err)
+	require.Equal(t, knownInviteID, privateTeam.InviteId)
+	require.Equal(t, knownEmail, privateTeam.Email)
+
+	privateTeam.SchemeId = &scheme.Id
+	privateTeam, err = th.App.Srv().Store().Team().Update(privateTeam)
+	require.NoError(t, err)
+	require.Equal(t, knownInviteID, privateTeam.InviteId)
+	require.Equal(t, knownEmail, privateTeam.Email)
+
+	// The System Manager role has PermissionSysconsoleReadUserManagementTeams
+	// (allowing the call) and ancillarily grants PermissionManageTeam via
+	// PermissionSysconsoleWriteUserManagementTeams (see role.go
+	// SysconsoleAncillaryPermissions), but it does NOT grant PermissionInviteUser.
+	// App.SanitizeTeam therefore strips invite_id while preserving email.
+	th.LoginSystemManager(t)
+
+	t.Run("system manager response is sanitized", func(t *testing.T) {
+		teams, _, err := th.SystemManagerClient.GetTeamsForScheme(context.Background(), scheme.Id, 0, 100)
+		require.NoError(t, err)
+		require.Len(t, teams, 1)
+		assert.Equal(t, privateTeam.Id, teams[0].Id)
+		assert.Empty(t, teams[0].InviteId,
+			"invite_id must be stripped for callers without PermissionInviteUser on the team; got %q", teams[0].InviteId)
+		// Email is intentionally not asserted here: system_manager retains
+		// PermissionManageTeam via the ancillary expansion of
+		// PermissionSysconsoleWriteUserManagementTeams (see role.go
+		// SysconsoleAncillaryPermissions), so App.SanitizeTeam preserves
+		// email — consistent with every other team-returning endpoint in
+		// server/channels/api4/team.go.
+	})
+
+	t.Run("system admin response is not sanitized", func(t *testing.T) {
+		teams, _, err := th.SystemAdminClient.GetTeamsForScheme(context.Background(), scheme.Id, 0, 100)
+		require.NoError(t, err)
+		require.Len(t, teams, 1)
+		assert.Equal(t, privateTeam.Id, teams[0].Id)
+		assert.Equal(t, knownInviteID, teams[0].InviteId,
+			"system admin retains invite_id (positive control)")
+		assert.Equal(t, knownEmail, teams[0].Email,
+			"system admin retains email (positive control)")
+	})
+}
+
 func TestGetChannelsForScheme(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)


### PR DESCRIPTION
#### Summary
Aligns the `GET /api/v4/schemes/{scheme_id}/teams` handler in `server/channels/api4/scheme.go` with the team-returning handlers in `server/channels/api4/team.go` by invoking `App.SanitizeTeams` before marshaling the response. Adds a regression test that pins the sanitized response for non-admin callers, plus a positive control for system admins.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68840

#### Screenshots
N/A (backend only)

#### Release Note
```release-note
None
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to the GET /api/v4/schemes/{scheme_id}/teams handler and only adds a call to the already-used App.SanitizeTeams utility; permission checks and error handling are unchanged, so regression risk is low.  
**QA Recommendation:** Minimal manual QA recommended—run the new regression test and spot-check the endpoint for non-admin and sysadmin callers, and verify any external integrations that may have relied on previously unsanitized fields.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36640?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->