### PR TITLE
fix: correct typo 'Seperate' to 'Separate' in team access allowed domains text

### DIFF
--- a/webapp/channels/src/components/team_settings/team_access_tab/allowed_domains_select.tsx
+++ b/webapp/channels/src/components/team_settings/team_access_tab/allowed_domains_select.tsx
@@ -71,7 +71,7 @@ const AllowedDomainsSelect = ({allowedDomains, setAllowedDomains, setHasChanges,
                 onChange={handleOnChangeDomains}
                 handleNewSelection={updateAllowedDomains}
                 isClearable={false}
-                description={formatMessage({id: 'general_tab.AllowedDomainsTip', defaultMessage: 'Seperate multiple domains with a space, comma, tab or enter.'})}
+                description={formatMessage({id: 'general_tab.AllowedDomainsTip', defaultMessage: 'Separate multiple domains with a space, comma, tab or enter.'})}
             />
             }
         </>

--- a/webapp/channels/src/components/team_settings/team_access_tab/team_access_tab.test.tsx
+++ b/webapp/channels/src/components/team_settings/team_access_tab/team_access_tab.test.tsx
@@ -81,14 +81,14 @@ describe('components/TeamSettings', () => {
     test('should not show allowed domains input if allowed domains is empty', () => {
         const props = {...defaultProps, team: TestHelper.getTeamMock({allowed_domains: ''})};
         renderWithContext(<AccessTab {...props}/>);
-        const allowedDomainsInput = screen.queryByText('Seperate multiple domains with a space, comma, tab or enter.');
+        const allowedDomainsInput = screen.queryByText('Separate multiple domains with a space, comma, tab or enter.');
         expect(allowedDomainsInput).toBeNull();
     });
 
     test('should show allowed domains input if allowed domains is not empty', () => {
         const props = {...defaultProps, team: TestHelper.getTeamMock({allowed_domains: 'test.com'})};
         renderWithContext(<AccessTab {...props}/>);
-        const allowedDomainsInput = screen.getByText('Seperate multiple domains with a space, comma, tab or enter.');
+        const allowedDomainsInput = screen.getByText('Separate multiple domains with a space, comma, tab or enter.');
         expect(allowedDomainsInput).toBeInTheDocument();
         const allowedDomainsInputValue = screen.getByText('test.com');
         expect(allowedDomainsInputValue).toBeInTheDocument();


### PR DESCRIPTION
This is an independent contribution made without access to proprietary information or internal code review.

#### Summary
Corrects the misspelling of "Seperate" to "Separate" in the team access tab allowed domains description text and its corresponding test assertions.

**Root Cause:** Typo in `defaultMessage` prop and test string matchers.

**Fix:**
- `allowed_domains_select.tsx`: `Seperate` → `Separate` in `defaultMessage`
- `team_access_tab.test.tsx`: `Seperate` → `Separate` in two test assertions (lines 84, 91)

**Testing:** Existing tests pass with the corrected string. No functional changes.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is a purely textual change affecting only a UI description message with zero functional or logic modifications. The component and tests remain isolated to the AllowedDomainsSelect feature with no impact on shared utilities, base classes, or cross-module dependencies.

**QA Recommendation:** Minimal manual QA required—verify the corrected "Separate" text displays properly in the team access settings UI. Automated test coverage is complete with all assertions updated accordingly.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36645?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->