### PR TITLE
chore(ci): upgrade Go to 1.26.3 in build container Dockerfiles

### DIFF
--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -1,4 +1,4 @@
-FROM mattermost/golang-bullseye:1.26.2@sha256:fc2cc64f035c74f14b0e5921971bcda4b6dbd281430d3cbfb0bf539ebb1bacd5
+FROM mattermost/golang-bullseye:1.26.3@sha256:3ae112b7dc291665c5582b9d768fc2adb4cdc3afbbd3fc82e03a10cd711e1a60
 ARG NODE_VERSION=20.11.1
 
 RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq pgloader gnupg

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -1,4 +1,4 @@
-FROM cgr.dev/mattermost.com/go-msft-fips:1.26.2-dev@sha256:cdd5bd448fcf61654893846572f006aff7349aa21027de590fc2bd020f8126f1
+FROM cgr.dev/mattermost.com/go-msft-fips:1.26.3-dev@sha256:48ab99fede7fb33e132a0636072971e1ec4a69520865bfa1e4b517ee9cfdef34
 ARG NODE_VERSION=20.11.1
 
 RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg xmlsec


### PR DESCRIPTION
#### Summary

Upgrades the Go version from 1.26.2 to 1.26.3 in both build container Dockerfiles:
- `server/build/Dockerfile.buildenv` — `mattermost/golang-bullseye:1.26.3`
- `server/build/Dockerfile.buildenv-fips` — `cgr.dev/mattermost.com/go-msft-fips:1.26.3-dev`

Once merged, `build-server-image.yml` will publish the updated Docker image.

#### Release Note

```release-note
Go runtime updated from 1.26.2 to 1.26.3.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Go patch version upgrade (1.26.2 → 1.26.3) in build containers is low-risk, containing only bug fixes and security patches. Changes are isolated to build environment with no modifications to application code paths.

**QA Recommendation:** Minimal manual QA required. Automated build and test pipeline validation is sufficient. Recommend running standard build verification to confirm images generate expected artifacts.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36648?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->