### PR TITLE
Automated cherry pick of #36637

### DIFF
--- a/e2e-tests/cypress/cypress.config.ts
+++ b/e2e-tests/cypress/cypress.config.ts
@@ -27,9 +27,9 @@ export default defineConfig({
     viewportWidth: 1300,
     allowCypressEnv: false,
     expose: {
-        adminEmail: 'sysadmin@sample.mattermost.com',
-        adminUsername: 'sysadmin',
-        adminPassword: 'Sys@dmin-sample1',
+        adminEmail: process.env.CYPRESS_adminEmail || 'sysadmin@sample.mattermost.com',
+        adminUsername: process.env.CYPRESS_adminUsername || 'sysadmin',
+        adminPassword: process.env.CYPRESS_adminPassword || 'Sys@dmin-sample1',
         allowedUntrustedInternalConnections: 'localhost',
         cwsURL: 'http://localhost:8076',
         cwsAPIURL: 'http://localhost:8076',

--- a/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_image_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_image_spec.js
@@ -16,11 +16,16 @@ describe('Verify Accessibility Support in Different Images', () => {
     let otherUser;
 
     before(() => {
-        cy.apiInitSetup().then(({offTopicUrl, user}) => {
-            otherUser = user;
+        cy.apiInitSetup().then(({team, offTopicUrl, user}) => {
+            cy.apiCreateUser({prefix: 'other'}).then(({user: user1}) => {
+                otherUser = user1;
+                return cy.apiAddUserToTeam(team.id, otherUser.id);
+            }).then(() => {
+                cy.apiLogin(user);
 
-            // Visit the Off Topic channel
-            cy.visit(offTopicUrl);
+                // Visit the Off Topic channel
+                cy.visit(offTopicUrl);
+            });
         });
     });
 

--- a/e2e-tests/cypress/tests/support/index.js
+++ b/e2e-tests/cypress/tests/support/index.js
@@ -254,6 +254,7 @@ function sysadminSetup(user) {
 
 function resetUserPreference(userId) {
     cy.apiSaveTeammateNameDisplayPreference('username');
+    cy.apiSaveMessageDisplayPreference('clean');
     cy.apiSaveLinkPreviewsPreference('true');
     cy.apiSaveCollapsePreviewsPreference('false');
     cy.apiSaveClockDisplayModeTo24HourPreference(false);

--- a/e2e-tests/playwright/specs/functional/system_console/system_users/column_sort.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/system_users/column_sort.spec.ts
@@ -53,7 +53,7 @@ test.describe('System Console - Users table sorting', () => {
             }
             expect(emails.length).toBeGreaterThan(3);
 
-            const sorted = [...emails].sort((a, b) => a.localeCompare(b));
+            const sorted = [...emails].sort((a, b) => a.localeCompare(b, undefined, {ignorePunctuation: true}));
             if (sortDirection === 'descending') {
                 sorted.reverse();
             }
@@ -81,7 +81,7 @@ test.describe('System Console - Users table sorting', () => {
             }
             expect(emails.length).toBeGreaterThan(3);
 
-            const sorted = [...emails].sort((a, b) => a.localeCompare(b));
+            const sorted = [...emails].sort((a, b) => a.localeCompare(b, undefined, {ignorePunctuation: true}));
             if (reversedDirection === 'descending') {
                 sorted.reverse();
             }


### PR DESCRIPTION
Cherry pick of #36637 on release-11.8.

/cc  @lieut-data

```release-note
NONE
```