### PR TITLE
fix: correct typo 'recieve' to 'receive' in registry.ts JSDoc

### DIFF
--- a/webapp/channels/src/plugins/registry.ts
+++ b/webapp/channels/src/plugins/registry.ts
@@ -1018,7 +1018,7 @@ export default class PluginRegistry {
      * Note that this is a low-level interface primarily meant for internal use, and is not subject
      * to semver guarantees. It may change in the future.
      * Accepts the following:
-     * - func - A function that recieve the admin console config definitions and return a new
+     * - func - A function that receive the admin console config definitions and return a new
      *          version of it, which is used for build the admin console.
      * Each plugin can register at most one admin console plugin function, with newer registrations
      * replacing older ones.


### PR DESCRIPTION
This is an independent contribution made by an individual developer. This work is not associated with any hackathon, competition, or coordinated PR campaign.

#### Summary
Corrects a typo in the JSDoc comment for the `registerAdminConsolePlugin` function in `registry.ts`. The word "recieve" was misspelled and has been corrected to "receive".

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Zero risk of regression. This is a documentation-only change to a JSDoc comment with no modification to executable code, logic, or behavior.

**QA Recommendation:** No manual QA required. Automated testing is not applicable for documentation fixes.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36655?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->