### PR TITLE
MM-68845: Tighten authorization on /share-channel autocomplete

### DIFF
--- a/server/channels/app/slashcommands/command_share.go
+++ b/server/channels/app/slashcommands/command_share.go
@@ -63,6 +63,10 @@ func (sp *ShareProvider) GetCommand(a *app.App, T i18n.TranslateFunc) *model.Com
 }
 
 func (sp *ShareProvider) GetAutoCompleteListItems(rctx request.CTX, a *app.App, commandArgs *model.CommandArgs, arg *model.AutocompleteArg, parsed, toBeParsed string) ([]model.AutocompleteListItem, error) {
+	if !a.HasPermissionTo(commandArgs.UserId, model.PermissionManageSharedChannels) {
+		return []model.AutocompleteListItem{}, nil
+	}
+
 	switch {
 	case strings.Contains(parsed, " share "):
 

--- a/server/channels/app/slashcommands/command_share_test.go
+++ b/server/channels/app/slashcommands/command_share_test.go
@@ -127,10 +127,6 @@ func TestShareProviderDoCommand(t *testing.T) {
 	})
 }
 
-// TestShareProviderGetAutoCompleteListItemsPermission verifies that ShareProvider's dynamic
-// autocomplete for `/share-channel invite --connectionID` and `/share-channel uninvite --connectionID`
-// requires the manage_shared_channels permission and does not leak remote cluster metadata
-// (RemoteId / DisplayName / SiteURL) to unprivileged callers.
 func TestShareProviderGetAutoCompleteListItemsPermission(t *testing.T) {
 	connectionIDArg := func() *model.AutocompleteArg {
 		return &model.AutocompleteArg{Name: "connectionID"}
@@ -153,19 +149,17 @@ func TestShareProviderGetAutoCompleteListItemsPermission(t *testing.T) {
 		return rc
 	}
 
-	// assertNoRemoteLeak enforces that none of the seeded remote cluster's identifying
-	// fields appear in any returned autocomplete item.
-	assertNoRemoteLeak := func(t *testing.T, items []model.AutocompleteListItem, rc *model.RemoteCluster) {
+	assertNoRemoteData := func(t *testing.T, items []model.AutocompleteListItem, rc *model.RemoteCluster) {
 		t.Helper()
 		for i, item := range items {
-			assert.NotContains(t, item.Item, rc.RemoteId, "item[%d].Item leaked RemoteId", i)
-			assert.NotContains(t, item.HelpText, rc.RemoteId, "item[%d].HelpText leaked RemoteId", i)
-			assert.NotContains(t, item.HelpText, rc.DisplayName, "item[%d].HelpText leaked DisplayName", i)
-			assert.NotContains(t, item.HelpText, rc.SiteURL, "item[%d].HelpText leaked SiteURL", i)
+			assert.NotContains(t, item.Item, rc.RemoteId, "item[%d].Item contained RemoteId", i)
+			assert.NotContains(t, item.HelpText, rc.RemoteId, "item[%d].HelpText contained RemoteId", i)
+			assert.NotContains(t, item.HelpText, rc.DisplayName, "item[%d].HelpText contained DisplayName", i)
+			assert.NotContains(t, item.HelpText, rc.SiteURL, "item[%d].HelpText contained SiteURL", i)
 		}
 	}
 
-	t.Run("invite without manage_shared_channels permission must not leak remote cluster data", func(t *testing.T) {
+	t.Run("invite without manage_shared_channels permission returns no remote cluster data", func(t *testing.T) {
 		th := setupForSharedChannels(t).initBasic(t)
 
 		require.False(t, th.App.HasPermissionTo(th.BasicUser.Id, model.PermissionManageSharedChannels),
@@ -186,15 +180,13 @@ func TestShareProviderGetAutoCompleteListItemsPermission(t *testing.T) {
 
 		items, err := commandProvider.GetAutoCompleteListItems(th.Context, th.App, args, connectionIDArg(), "/share-channel invite ", "")
 
-		// Acceptable secure behavior: either an empty list (preferred per ticket mitigation),
-		// or a non-nil error with an empty list. Either way, no remote cluster data may leak.
 		if err == nil {
 			assert.Empty(t, items, "expected empty autocomplete list when caller lacks manage_shared_channels")
 		}
-		assertNoRemoteLeak(t, items, rc)
+		assertNoRemoteData(t, items, rc)
 	})
 
-	t.Run("uninvite without manage_shared_channels permission must not leak remote cluster data", func(t *testing.T) {
+	t.Run("uninvite without manage_shared_channels permission returns no remote cluster data", func(t *testing.T) {
 		th := setupForSharedChannels(t).initBasic(t)
 
 		require.False(t, th.App.HasPermissionTo(th.BasicUser.Id, model.PermissionManageSharedChannels),
@@ -218,7 +210,7 @@ func TestShareProviderGetAutoCompleteListItemsPermission(t *testing.T) {
 		if err == nil {
 			assert.Empty(t, items, "expected empty autocomplete list when caller lacks manage_shared_channels")
 		}
-		assertNoRemoteLeak(t, items, rc)
+		assertNoRemoteData(t, items, rc)
 	})
 
 	t.Run("invite with manage_shared_channels permission returns remote cluster data", func(t *testing.T) {
@@ -284,15 +276,6 @@ func TestShareProviderGetAutoCompleteListItemsPermission(t *testing.T) {
 	})
 }
 
-// TestShareProviderGetAutoCompleteListItemsAdjacentRoles encodes secure behavior for
-// privilege variants the original ticket did not spell out:
-//   - A guest user (system_guest role) must NEVER receive remote cluster metadata via the
-//     /share-channel invite|uninvite autocomplete, because system_guest does not grant
-//     manage_shared_channels.
-//   - A system admin must STILL receive remote cluster metadata, because system_admin
-//     inherits manage_shared_channels via AllPermissions. This guards against a future
-//     refactor over-restricting the autocomplete (e.g. swapping HasPermissionTo for a
-//     team/channel-scoped check that would not match how DoCommand is gated).
 func TestShareProviderGetAutoCompleteListItemsAdjacentRoles(t *testing.T) {
 	connectionIDArg := func() *model.AutocompleteArg {
 		return &model.AutocompleteArg{Name: "connectionID"}
@@ -315,17 +298,17 @@ func TestShareProviderGetAutoCompleteListItemsAdjacentRoles(t *testing.T) {
 		return rc
 	}
 
-	assertNoRemoteLeak := func(t *testing.T, items []model.AutocompleteListItem, rc *model.RemoteCluster) {
+	assertNoRemoteData := func(t *testing.T, items []model.AutocompleteListItem, rc *model.RemoteCluster) {
 		t.Helper()
 		for i, item := range items {
-			assert.NotContains(t, item.Item, rc.RemoteId, "item[%d].Item leaked RemoteId", i)
-			assert.NotContains(t, item.HelpText, rc.RemoteId, "item[%d].HelpText leaked RemoteId", i)
-			assert.NotContains(t, item.HelpText, rc.DisplayName, "item[%d].HelpText leaked DisplayName", i)
-			assert.NotContains(t, item.HelpText, rc.SiteURL, "item[%d].HelpText leaked SiteURL", i)
+			assert.NotContains(t, item.Item, rc.RemoteId, "item[%d].Item contained RemoteId", i)
+			assert.NotContains(t, item.HelpText, rc.RemoteId, "item[%d].HelpText contained RemoteId", i)
+			assert.NotContains(t, item.HelpText, rc.DisplayName, "item[%d].HelpText contained DisplayName", i)
+			assert.NotContains(t, item.HelpText, rc.SiteURL, "item[%d].HelpText contained SiteURL", i)
 		}
 	}
 
-	t.Run("guest user must not receive remote cluster data on invite autocomplete", func(t *testing.T) {
+	t.Run("guest user receives no remote cluster data on invite autocomplete", func(t *testing.T) {
 		th := setupForSharedChannels(t).initBasic(t)
 
 		guest := th.createGuest(t)
@@ -349,10 +332,10 @@ func TestShareProviderGetAutoCompleteListItemsAdjacentRoles(t *testing.T) {
 		if err == nil {
 			assert.Empty(t, items, "expected empty autocomplete list for guest on invite")
 		}
-		assertNoRemoteLeak(t, items, rc)
+		assertNoRemoteData(t, items, rc)
 	})
 
-	t.Run("guest user must not receive remote cluster data on uninvite autocomplete", func(t *testing.T) {
+	t.Run("guest user receives no remote cluster data on uninvite autocomplete", func(t *testing.T) {
 		th := setupForSharedChannels(t).initBasic(t)
 
 		guest := th.createGuest(t)
@@ -376,10 +359,10 @@ func TestShareProviderGetAutoCompleteListItemsAdjacentRoles(t *testing.T) {
 		if err == nil {
 			assert.Empty(t, items, "expected empty autocomplete list for guest on uninvite")
 		}
-		assertNoRemoteLeak(t, items, rc)
+		assertNoRemoteData(t, items, rc)
 	})
 
-	t.Run("system admin still receives remote cluster data on invite via inherited permission", func(t *testing.T) {
+	t.Run("system admin receives remote cluster data on invite", func(t *testing.T) {
 		th := setupForSharedChannels(t).initBasic(t)
 
 		require.True(t, th.App.HasPermissionTo(th.SystemAdminUser.Id, model.PermissionManageSharedChannels),
@@ -412,7 +395,7 @@ func TestShareProviderGetAutoCompleteListItemsAdjacentRoles(t *testing.T) {
 		require.True(t, found, "expected seeded RemoteId %q to appear for system admin", rc.RemoteId)
 	})
 
-	t.Run("system admin still receives remote cluster data on uninvite via inherited permission", func(t *testing.T) {
+	t.Run("system admin receives remote cluster data on uninvite", func(t *testing.T) {
 		th := setupForSharedChannels(t).initBasic(t)
 
 		require.True(t, th.App.HasPermissionTo(th.SystemAdminUser.Id, model.PermissionManageSharedChannels),

--- a/server/channels/app/slashcommands/command_share_test.go
+++ b/server/channels/app/slashcommands/command_share_test.go
@@ -126,3 +126,322 @@ func TestShareProviderDoCommand(t *testing.T) {
 		require.Contains(t, response.Text, args.T("api.command_share.invite_remote_to_channel.error"))
 	})
 }
+
+// TestShareProviderGetAutoCompleteListItemsPermission verifies that ShareProvider's dynamic
+// autocomplete for `/share-channel invite --connectionID` and `/share-channel uninvite --connectionID`
+// requires the manage_shared_channels permission and does not leak remote cluster metadata
+// (RemoteId / DisplayName / SiteURL) to unprivileged callers.
+func TestShareProviderGetAutoCompleteListItemsPermission(t *testing.T) {
+	connectionIDArg := func() *model.AutocompleteArg {
+		return &model.AutocompleteArg{Name: "connectionID"}
+	}
+
+	seedRemote := func(t *testing.T, th *TestHelper) *model.RemoteCluster {
+		t.Helper()
+		rc, err := th.App.AddRemoteCluster(&model.RemoteCluster{
+			RemoteId:    model.NewId(),
+			Name:        "remote-" + model.NewId(),
+			DisplayName: "Remote Display Name Sentinel",
+			SiteURL:     "https://remote-sentinel.example.com",
+			Token:       model.NewId(),
+			Topics:      "topic",
+			CreateAt:    model.GetMillis(),
+			LastPingAt:  model.GetMillis(),
+			CreatorId:   model.NewId(),
+		})
+		require.Nil(t, err)
+		return rc
+	}
+
+	// assertNoRemoteLeak enforces that none of the seeded remote cluster's identifying
+	// fields appear in any returned autocomplete item.
+	assertNoRemoteLeak := func(t *testing.T, items []model.AutocompleteListItem, rc *model.RemoteCluster) {
+		t.Helper()
+		for i, item := range items {
+			assert.NotContains(t, item.Item, rc.RemoteId, "item[%d].Item leaked RemoteId", i)
+			assert.NotContains(t, item.HelpText, rc.RemoteId, "item[%d].HelpText leaked RemoteId", i)
+			assert.NotContains(t, item.HelpText, rc.DisplayName, "item[%d].HelpText leaked DisplayName", i)
+			assert.NotContains(t, item.HelpText, rc.SiteURL, "item[%d].HelpText leaked SiteURL", i)
+		}
+	}
+
+	t.Run("invite without manage_shared_channels permission must not leak remote cluster data", func(t *testing.T) {
+		th := setupForSharedChannels(t).initBasic(t)
+
+		require.False(t, th.App.HasPermissionTo(th.BasicUser.Id, model.PermissionManageSharedChannels),
+			"precondition: BasicUser must not have manage_shared_channels for this subtest")
+
+		rc := seedRemote(t, th)
+
+		commandProvider := ShareProvider{}
+		channel := th.CreateChannel(t, th.BasicTeam, WithShared(false))
+
+		args := &model.CommandArgs{
+			T:         func(s string, args ...any) string { return s },
+			ChannelId: channel.Id,
+			UserId:    th.BasicUser.Id,
+			TeamId:    th.BasicTeam.Id,
+			Command:   "/share-channel invite --connectionID",
+		}
+
+		items, err := commandProvider.GetAutoCompleteListItems(th.Context, th.App, args, connectionIDArg(), "/share-channel invite ", "")
+
+		// Acceptable secure behavior: either an empty list (preferred per ticket mitigation),
+		// or a non-nil error with an empty list. Either way, no remote cluster data may leak.
+		if err == nil {
+			assert.Empty(t, items, "expected empty autocomplete list when caller lacks manage_shared_channels")
+		}
+		assertNoRemoteLeak(t, items, rc)
+	})
+
+	t.Run("uninvite without manage_shared_channels permission must not leak remote cluster data", func(t *testing.T) {
+		th := setupForSharedChannels(t).initBasic(t)
+
+		require.False(t, th.App.HasPermissionTo(th.BasicUser.Id, model.PermissionManageSharedChannels),
+			"precondition: BasicUser must not have manage_shared_channels for this subtest")
+
+		rc := seedRemote(t, th)
+
+		commandProvider := ShareProvider{}
+		channel := th.CreateChannel(t, th.BasicTeam, WithShared(false))
+
+		args := &model.CommandArgs{
+			T:         func(s string, args ...any) string { return s },
+			ChannelId: channel.Id,
+			UserId:    th.BasicUser.Id,
+			TeamId:    th.BasicTeam.Id,
+			Command:   "/share-channel uninvite --connectionID",
+		}
+
+		items, err := commandProvider.GetAutoCompleteListItems(th.Context, th.App, args, connectionIDArg(), "/share-channel uninvite ", "")
+
+		if err == nil {
+			assert.Empty(t, items, "expected empty autocomplete list when caller lacks manage_shared_channels")
+		}
+		assertNoRemoteLeak(t, items, rc)
+	})
+
+	t.Run("invite with manage_shared_channels permission returns remote cluster data", func(t *testing.T) {
+		th := setupForSharedChannels(t).initBasic(t)
+		th.addPermissionToRole(t, model.PermissionManageSharedChannels.Id, th.BasicUser.Roles)
+
+		rc := seedRemote(t, th)
+
+		commandProvider := ShareProvider{}
+		channel := th.CreateChannel(t, th.BasicTeam, WithShared(false))
+
+		args := &model.CommandArgs{
+			T:         func(s string, args ...any) string { return s },
+			ChannelId: channel.Id,
+			UserId:    th.BasicUser.Id,
+			TeamId:    th.BasicTeam.Id,
+			Command:   "/share-channel invite --connectionID",
+		}
+
+		items, err := commandProvider.GetAutoCompleteListItems(th.Context, th.App, args, connectionIDArg(), "/share-channel invite ", "")
+		require.NoError(t, err)
+		require.NotEmpty(t, items, "expected at least one autocomplete item when caller has manage_shared_channels")
+
+		found := false
+		for _, item := range items {
+			if item.Item == rc.RemoteId {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "expected seeded RemoteId %q to appear in autocomplete items when caller has manage_shared_channels", rc.RemoteId)
+	})
+
+	t.Run("uninvite with manage_shared_channels permission returns remote cluster data", func(t *testing.T) {
+		th := setupForSharedChannels(t).initBasic(t)
+		th.addPermissionToRole(t, model.PermissionManageSharedChannels.Id, th.BasicUser.Roles)
+
+		rc := seedRemote(t, th)
+
+		commandProvider := ShareProvider{}
+		channel := th.CreateChannel(t, th.BasicTeam, WithShared(false))
+
+		args := &model.CommandArgs{
+			T:         func(s string, args ...any) string { return s },
+			ChannelId: channel.Id,
+			UserId:    th.BasicUser.Id,
+			TeamId:    th.BasicTeam.Id,
+			Command:   "/share-channel uninvite --connectionID",
+		}
+
+		items, err := commandProvider.GetAutoCompleteListItems(th.Context, th.App, args, connectionIDArg(), "/share-channel uninvite ", "")
+		require.NoError(t, err)
+		require.NotEmpty(t, items, "expected at least one autocomplete item when caller has manage_shared_channels")
+
+		found := false
+		for _, item := range items {
+			if item.Item == rc.RemoteId {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "expected seeded RemoteId %q to appear in autocomplete items when caller has manage_shared_channels", rc.RemoteId)
+	})
+}
+
+// TestShareProviderGetAutoCompleteListItemsAdjacentRoles encodes secure behavior for
+// privilege variants the original ticket did not spell out:
+//   - A guest user (system_guest role) must NEVER receive remote cluster metadata via the
+//     /share-channel invite|uninvite autocomplete, because system_guest does not grant
+//     manage_shared_channels.
+//   - A system admin must STILL receive remote cluster metadata, because system_admin
+//     inherits manage_shared_channels via AllPermissions. This guards against a future
+//     refactor over-restricting the autocomplete (e.g. swapping HasPermissionTo for a
+//     team/channel-scoped check that would not match how DoCommand is gated).
+func TestShareProviderGetAutoCompleteListItemsAdjacentRoles(t *testing.T) {
+	connectionIDArg := func() *model.AutocompleteArg {
+		return &model.AutocompleteArg{Name: "connectionID"}
+	}
+
+	seedRemote := func(t *testing.T, th *TestHelper) *model.RemoteCluster {
+		t.Helper()
+		rc, err := th.App.AddRemoteCluster(&model.RemoteCluster{
+			RemoteId:    model.NewId(),
+			Name:        "remote-" + model.NewId(),
+			DisplayName: "Adjacent Sentinel Display",
+			SiteURL:     "https://adjacent-sentinel.example.com",
+			Token:       model.NewId(),
+			Topics:      "topic",
+			CreateAt:    model.GetMillis(),
+			LastPingAt:  model.GetMillis(),
+			CreatorId:   model.NewId(),
+		})
+		require.Nil(t, err)
+		return rc
+	}
+
+	assertNoRemoteLeak := func(t *testing.T, items []model.AutocompleteListItem, rc *model.RemoteCluster) {
+		t.Helper()
+		for i, item := range items {
+			assert.NotContains(t, item.Item, rc.RemoteId, "item[%d].Item leaked RemoteId", i)
+			assert.NotContains(t, item.HelpText, rc.RemoteId, "item[%d].HelpText leaked RemoteId", i)
+			assert.NotContains(t, item.HelpText, rc.DisplayName, "item[%d].HelpText leaked DisplayName", i)
+			assert.NotContains(t, item.HelpText, rc.SiteURL, "item[%d].HelpText leaked SiteURL", i)
+		}
+	}
+
+	t.Run("guest user must not receive remote cluster data on invite autocomplete", func(t *testing.T) {
+		th := setupForSharedChannels(t).initBasic(t)
+
+		guest := th.createGuest(t)
+		require.False(t, th.App.HasPermissionTo(guest.Id, model.PermissionManageSharedChannels),
+			"precondition: a freshly-created guest must not have manage_shared_channels")
+
+		rc := seedRemote(t, th)
+
+		commandProvider := ShareProvider{}
+		channel := th.CreateChannel(t, th.BasicTeam, WithShared(false))
+
+		args := &model.CommandArgs{
+			T:         func(s string, args ...any) string { return s },
+			ChannelId: channel.Id,
+			UserId:    guest.Id,
+			TeamId:    th.BasicTeam.Id,
+			Command:   "/share-channel invite --connectionID",
+		}
+
+		items, err := commandProvider.GetAutoCompleteListItems(th.Context, th.App, args, connectionIDArg(), "/share-channel invite ", "")
+		if err == nil {
+			assert.Empty(t, items, "expected empty autocomplete list for guest on invite")
+		}
+		assertNoRemoteLeak(t, items, rc)
+	})
+
+	t.Run("guest user must not receive remote cluster data on uninvite autocomplete", func(t *testing.T) {
+		th := setupForSharedChannels(t).initBasic(t)
+
+		guest := th.createGuest(t)
+		require.False(t, th.App.HasPermissionTo(guest.Id, model.PermissionManageSharedChannels),
+			"precondition: a freshly-created guest must not have manage_shared_channels")
+
+		rc := seedRemote(t, th)
+
+		commandProvider := ShareProvider{}
+		channel := th.CreateChannel(t, th.BasicTeam, WithShared(false))
+
+		args := &model.CommandArgs{
+			T:         func(s string, args ...any) string { return s },
+			ChannelId: channel.Id,
+			UserId:    guest.Id,
+			TeamId:    th.BasicTeam.Id,
+			Command:   "/share-channel uninvite --connectionID",
+		}
+
+		items, err := commandProvider.GetAutoCompleteListItems(th.Context, th.App, args, connectionIDArg(), "/share-channel uninvite ", "")
+		if err == nil {
+			assert.Empty(t, items, "expected empty autocomplete list for guest on uninvite")
+		}
+		assertNoRemoteLeak(t, items, rc)
+	})
+
+	t.Run("system admin still receives remote cluster data on invite via inherited permission", func(t *testing.T) {
+		th := setupForSharedChannels(t).initBasic(t)
+
+		require.True(t, th.App.HasPermissionTo(th.SystemAdminUser.Id, model.PermissionManageSharedChannels),
+			"precondition: SystemAdminUser must have manage_shared_channels via inherited permissions")
+
+		rc := seedRemote(t, th)
+
+		commandProvider := ShareProvider{}
+		channel := th.CreateChannel(t, th.BasicTeam, WithShared(false))
+
+		args := &model.CommandArgs{
+			T:         func(s string, args ...any) string { return s },
+			ChannelId: channel.Id,
+			UserId:    th.SystemAdminUser.Id,
+			TeamId:    th.BasicTeam.Id,
+			Command:   "/share-channel invite --connectionID",
+		}
+
+		items, err := commandProvider.GetAutoCompleteListItems(th.Context, th.App, args, connectionIDArg(), "/share-channel invite ", "")
+		require.NoError(t, err)
+		require.NotEmpty(t, items, "expected at least one autocomplete item for system admin")
+
+		found := false
+		for _, item := range items {
+			if item.Item == rc.RemoteId {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "expected seeded RemoteId %q to appear for system admin", rc.RemoteId)
+	})
+
+	t.Run("system admin still receives remote cluster data on uninvite via inherited permission", func(t *testing.T) {
+		th := setupForSharedChannels(t).initBasic(t)
+
+		require.True(t, th.App.HasPermissionTo(th.SystemAdminUser.Id, model.PermissionManageSharedChannels),
+			"precondition: SystemAdminUser must have manage_shared_channels via inherited permissions")
+
+		rc := seedRemote(t, th)
+
+		commandProvider := ShareProvider{}
+		channel := th.CreateChannel(t, th.BasicTeam, WithShared(false))
+
+		args := &model.CommandArgs{
+			T:         func(s string, args ...any) string { return s },
+			ChannelId: channel.Id,
+			UserId:    th.SystemAdminUser.Id,
+			TeamId:    th.BasicTeam.Id,
+			Command:   "/share-channel uninvite --connectionID",
+		}
+
+		items, err := commandProvider.GetAutoCompleteListItems(th.Context, th.App, args, connectionIDArg(), "/share-channel uninvite ", "")
+		require.NoError(t, err)
+		require.NotEmpty(t, items, "expected at least one autocomplete item for system admin")
+
+		found := false
+		for _, item := range items {
+			if item.Item == rc.RemoteId {
+				found = true
+				break
+			}
+		}
+		require.True(t, found, "expected seeded RemoteId %q to appear for system admin", rc.RemoteId)
+	})
+}


### PR DESCRIPTION
#### Summary
Adds a permission check to the dynamic autocomplete suggestions for the `/share-channel` slash command, matching the existing gate on `/secure-connection` autocomplete and on `/share-channel` command execution. Includes regression tests covering callers with and without the permission, plus guest and system-admin variants.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68845

#### Screenshots
N/A — backend-only change.

#### Release Note
```release-note
None
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change adds an authorization check to /share-channel autocomplete, limiting suggestions to users with manage_shared_channels; this may prevent previously-available autocomplete for unprivileged users but aligns with existing runtime command authorization and similar autocomplete gates, lowering unexpected side effects.  
**QA Recommendation:** Run focused manual QA verifying autocomplete behavior across roles (guest, basic user, users with manage_shared_channels, system admin) to confirm unprivileged callers see no remote cluster metadata and privileged callers retain expected suggestions.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36662?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->