### PR TITLE
Fix config-change-checker to use merge-base for per-file diffs

### DIFF
--- a/.github/scripts/check_config_changes_ci.py
+++ b/.github/scripts/check_config_changes_ci.py
@@ -127,6 +127,25 @@ def file_at(ref: str, path: str) -> str:
         ).stdout
     except subprocess.CalledProcessError:
         return ""
+
+
+def _compute_merge_base() -> str:
+    """Resolve the merge-base of BASE_SHA and HEAD_SHA.
+
+    Per-checker comparisons must use this rather than BASE_SHA. BASE_SHA is the
+    tip of the target branch at PR-event time; if that branch advances on a
+    watched file after the PR diverges, comparing branch-tip vs target-tip
+    would attribute those upstream edits to this PR (false add/remove).
+    `git diff A...B` already does this implicitly; the per-file snapshots must
+    match.
+    """
+    return subprocess.run(
+        ["git", "merge-base", BASE_SHA, HEAD_SHA],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+MERGE_BASE = _compute_merge_base()
  
  
 # ── Checker 1 — config.go ──────────────────────────────────────────────────────
@@ -184,7 +203,7 @@ def check_config(patches: dict[str, str]) -> CheckResult:
     if _CONFIG_PATH not in patches:
         return result
  
-    base_fields = _scan_struct_fields(file_at(BASE_SHA, _CONFIG_PATH))
+    base_fields = _scan_struct_fields(file_at(MERGE_BASE, _CONFIG_PATH))
     head_fields = _scan_struct_fields(file_at(HEAD_SHA, _CONFIG_PATH))
  
     added   = head_fields - base_fields
@@ -271,7 +290,7 @@ def check_api(patches: dict[str, str]) -> CheckResult:
     removed_eps: set[tuple[str, str, str]] = set()
  
     for fname, patch in api4_patches.items():
-        base_eps = _parse_endpoints(file_at(BASE_SHA, fname))
+        base_eps = _parse_endpoints(file_at(MERGE_BASE, fname))
         head_eps = _parse_endpoints(file_at(HEAD_SHA, fname))
         added_eps   |= head_eps - base_eps
         removed_eps |= base_eps - head_eps
@@ -308,7 +327,7 @@ def check_audit_events(patches: dict[str, str]) -> CheckResult:
     if _AUDIT_EVENT_PATH not in patches:
         return result
  
-    base_events = _parse_audit_events(file_at(BASE_SHA, _AUDIT_EVENT_PATH))
+    base_events = _parse_audit_events(file_at(MERGE_BASE, _AUDIT_EVENT_PATH))
     head_events = _parse_audit_events(file_at(HEAD_SHA, _AUDIT_EVENT_PATH))
  
     result.additions = sorted(f"`{e}`" for e in head_events - base_events)
@@ -343,7 +362,7 @@ def check_go_version(patches: dict[str, str]) -> CheckResult:
     if _DOCKERFILE_PATH not in patches:
         return result
  
-    old_ver = _parse_go_version(file_at(BASE_SHA, _DOCKERFILE_PATH))
+    old_ver = _parse_go_version(file_at(MERGE_BASE, _DOCKERFILE_PATH))
     new_ver = _parse_go_version(file_at(HEAD_SHA, _DOCKERFILE_PATH))
  
     if old_ver and new_ver and old_ver != new_ver:


### PR DESCRIPTION
#### Summary

Per-checker comparisons used `file_at(BASE_SHA, ...)` for the "before" snapshot. `BASE_SHA` is the target-branch tip at PR-event time, so commits landing on `master` after the PR diverges (touching a watched file) get attributed to the PR as additions/removals.

The patch-collection step already uses `git diff BASE...HEAD` (merge-base relative). Switched the per-file snapshots to read from the merge-base too, so the "before" view matches what the PR actually started from. Applies to all four checkers (`config.go`, `api4/`, `audit_events.go`, `Dockerfile.buildenv`).

#### Release Note

```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is a targeted bug-fix to a CI tooling script that corrects false positives in change detection. The change aligns per-file snapshot comparisons with the existing patch-collection logic by using merge-base instead of the target branch tip, eliminating incorrect attribution of upstream commits to PRs. The modification is minimal (adding a 16-line helper function and one constant, with 4 reference updates across four checkers) and isolated to a single CI script with no shared dependencies or side effects.

**QA Recommendation:** Minimal manual QA required. Verify that when the target branch receives commits touching watched files (config.go, api4/, audit_events.go, Dockerfile.buildenv) after a PR diverges, those changes are **not** incorrectly flagged as PR additions/removals in the PR description. Standard automated CI testing of the script's core checkers is sufficient for release validation.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36670?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->