### PR TITLE
Tighten CI workflows

### DIFF
--- a/.github/workflows/server-ci-artifacts.yml
+++ b/.github/workflows/server-ci-artifacts.yml
@@ -14,7 +14,7 @@ jobs:
   ## We only need the condition on the first job
   ## This will run only when a pull request is created with server changes
   update-initial-status:
-    if: github.repository_owner == 'mattermost' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if: github.repository_owner == 'mattermost' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-22.04
     steps:
       - uses: mattermost/actions/delivery/update-commit-status@f324ac89b05cc3511cb06e60642ac2fb829f0a63

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -348,6 +348,7 @@ jobs:
           make build-cmd
           make package
       - name: Persist dist artifacts
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: server-dist-artifact


### PR DESCRIPTION
## Summary

Align the `server-dist-artifact` upload condition with `server-build-artifact`.

## Jira ticket
https://mattermost.atlassian.net/browse/MM-68928

## Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** These are purely CI/CD workflow configuration changes that add conditional gates to artifact uploads. The risk of regression is minimal since they only affect when artifacts are persisted and published, not any production code or core logic. The changes intentionally restrict artifact uploads to direct pushes and same-repository PRs, preventing external fork builds from publishing artifacts.

**QA Recommendation:** Manual QA is not necessary for these workflow changes. Automated CI/CD testing and sanity checks (e.g., verifying that master branch builds still publish artifacts) are sufficient. Monitor the next few releases to confirm artifacts are published correctly for master/release branch pushes and internal PRs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36672?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->