### PR TITLE
Exclude webhook posts from thread participation check

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.test.ts
@@ -1116,6 +1116,34 @@ describe('Selectors.Posts', () => {
             expect(isPostCommentMention(modifiedThreadState, 'e')).toEqual(true);
         });
 
+        it('Should return false as thread reply is from webhook with current user id', () => {
+            const modifiedWebhookThreadState = {
+                ...modifiedState,
+                entities: {
+                    ...modifiedState.entities,
+                    posts: {
+                        ...modifiedState.entities.posts,
+                        posts: {
+                            ...modifiedState.entities.posts.posts,
+                            a: {
+                                ...modifiedState.entities.posts.posts.a,
+                                user_id: 'b',
+                            },
+                            c: {
+                                ...modifiedState.entities.posts.posts.c,
+                                user_id: user1.id,
+                                props: {
+                                    from_webhook: 'true',
+                                },
+                            },
+                        },
+                    },
+                },
+            };
+
+            expect(isPostCommentMention(modifiedWebhookThreadState, 'e')).toEqual(false);
+        });
+
         it('Should return false as user commented in the thread but notify_props is for root only', () => {
             const modifiedCurrentUserForNotifyProps = {
                 ...testState.entities.users.profiles[user1.id],

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.ts
@@ -587,7 +587,7 @@ export const makeIsPostCommentMention = (): ((state: GlobalState, postId: Post['
                         continue;
                     }
 
-                    if (p.user_id === currentUser.id) {
+                    if (p.user_id === currentUser.id && !isFromWebhook(p)) {
                         threadRepliedToByCurrentUser = true;
                     }
                 }

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/posts.ts
@@ -34,6 +34,7 @@ import {
     comparePosts,
     isPostPendingOrFailed,
     isPostCommentMention,
+    isFromWebhook,
 } from 'mattermost-redux/utils/post_utils';
 import {isGuest} from 'mattermost-redux/utils/user_utils';
 


### PR DESCRIPTION
#### Summary

Threads started by a webhook will no longer be highlighted for the user who owns the webhook as we're now checking if the post is created by a webhook.

This change updates `makeIsPostCommentMention` to skip webhook posts when setting `threadRepliedToByCurrentUser`, using the existing `isFromWebhook` helper. This aligns with how webhook posts are treated elsewhere in the codebase (e.g. `isPostCommentMention`, post list separators, thread viewer).

A regression test was added to verify that a webhook thread reply with the current user's ID does not trigger a comment mention when the user has not actually participated in the thread.

#### Release Note
```release-note
 - Threads started by a webhook will no longer be highlighted for the user who owns the webhook
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Low risk of breaking existing functionality since the change introduces a bug fix that aligns with established webhook-handling patterns already used in similar selectors (`isPostCommentMention`, `post_list.ts`, `threads.ts`). However, users with integrated webhooks posting to threads may see changes in notification behavior, as the fix prevents webhook posts from incorrectly counting toward thread participation for comment-mention notifications.

**QA Recommendation:** Focused manual testing recommended on webhook-triggered thread replies to verify comment-mention notifications behave correctly. Given the regression test coverage and pattern consistency with existing code, full manual QA can be minimized to webhook-specific scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36673?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->