### PR TITLE
MM-68929: Use pending config in admin Test Connection buttons

### DIFF
--- a/webapp/channels/src/actions/admin_actions.jsx
+++ b/webapp/channels/src/actions/admin_actions.jsx
@@ -366,8 +366,8 @@ export async function elasticsearchTest(config, success, error) {
     }
 }
 
-export async function testS3Connection(success, error) {
-    const {data, error: err} = await dispatch(AdminActions.testS3Connection());
+export async function testS3Connection(success, error, config) {
+    const {data, error: err} = await dispatch(AdminActions.testS3Connection(config));
     if (data && success) {
         success(data);
     } else if (err && error) {
@@ -453,8 +453,8 @@ export async function invalidateAllEmailInvites(success, error) {
     }
 }
 
-export async function testSmtp(success, error) {
-    const {data, error: err} = await dispatch(AdminActions.testEmail());
+export async function testSmtp(success, error, config) {
+    const {data, error: err} = await dispatch(AdminActions.testEmail(config));
     if (data && success) {
         success(data);
     } else if (err && error) {

--- a/webapp/channels/src/actions/admin_actions.test.js
+++ b/webapp/channels/src/actions/admin_actions.test.js
@@ -1,15 +1,21 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import nock from 'nock';
 import React from 'react';
+
+import {Client4} from 'mattermost-redux/client';
 
 import * as Actions from 'actions/admin_actions.jsx';
 import configureStore from 'store';
+
+Client4.setUrl('http://localhost:8065');
 
 describe('Actions.Admin', () => {
     let store;
     beforeEach(async () => {
         store = await configureStore();
+        nock.cleanAll();
     });
 
     test('Register a plugin adds the plugin to the state', async () => {
@@ -66,5 +72,37 @@ describe('Actions.Admin', () => {
                     pluginId: 'plugin-id',
                     component: React.Component,
                 }}});
+    });
+
+    test('testS3Connection forwards the provided config to the server', async () => {
+        const config = {FileSettings: {AmazonS3AccessKeyId: 'pending-key', AmazonS3SecretAccessKey: 'pending-secret'}};
+        const success = jest.fn();
+        const error = jest.fn();
+
+        const scope = nock(Client4.getBaseRoute()).
+            post('/file/s3_test', config).
+            reply(200, {status: 'OK'});
+
+        await Actions.testS3Connection(success, error, config);
+
+        expect(scope.isDone()).toBe(true);
+        expect(success).toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
+    });
+
+    test('testSmtp forwards the provided config to the server', async () => {
+        const config = {EmailSettings: {SMTPServer: 'smtp.pending.example', SMTPUsername: 'pending-user'}};
+        const success = jest.fn();
+        const error = jest.fn();
+
+        const scope = nock(Client4.getBaseRoute()).
+            post('/email/test', config).
+            reply(200, {status: 'OK'});
+
+        await Actions.testSmtp(success, error, config);
+
+        expect(scope.isDone()).toBe(true);
+        expect(success).toHaveBeenCalled();
+        expect(error).not.toHaveBeenCalled();
     });
 });

--- a/webapp/channels/src/actions/admin_actions.test.js
+++ b/webapp/channels/src/actions/admin_actions.test.js
@@ -105,4 +105,36 @@ describe('Actions.Admin', () => {
         expect(success).toHaveBeenCalled();
         expect(error).not.toHaveBeenCalled();
     });
+
+    test('testS3Connection invokes the error callback when the server returns an error', async () => {
+        const config = {FileSettings: {AmazonS3AccessKeyId: 'bad-key'}};
+        const success = jest.fn();
+        const error = jest.fn();
+
+        const scope = nock(Client4.getBaseRoute()).
+            post('/file/s3_test', config).
+            reply(500, {id: 'api.file.test_connection_s3.app_error', message: 'Connection failed'});
+
+        await Actions.testS3Connection(success, error, config);
+
+        expect(scope.isDone()).toBe(true);
+        expect(error).toHaveBeenCalled();
+        expect(success).not.toHaveBeenCalled();
+    });
+
+    test('testSmtp invokes the error callback when the server returns an error', async () => {
+        const config = {EmailSettings: {SMTPServer: 'invalid.smtp'}};
+        const success = jest.fn();
+        const error = jest.fn();
+
+        const scope = nock(Client4.getBaseRoute()).
+            post('/email/test', config).
+            reply(400, {id: 'api.admin.test_email.app_error', message: 'Invalid SMTP config'});
+
+        await Actions.testSmtp(success, error, config);
+
+        expect(scope.isDone()).toBe(true);
+        expect(error).toHaveBeenCalled();
+        expect(success).not.toHaveBeenCalled();
+    });
 });

--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -1331,6 +1331,8 @@ const AdminDefinition: AdminDefinitionType = {
                             loading: defineMessage({id: 'admin.s3.testing', defaultMessage: 'Testing...'}),
                             error_message: defineMessage({id: 'admin.s3.s3Fail', defaultMessage: 'Connection unsuccessful: {error}'}), // eslint-disable-line formatjs/enforce-placeholders -- error provided at runtime
                             success_message: defineMessage({id: 'admin.s3.s3Success', defaultMessage: 'Connection was successful'}),
+                            sourceConfig: true,
+                            skipSaveNeeded: true,
                             isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.ENVIRONMENT.FILE_STORAGE)),
                         },
                     ],
@@ -1526,6 +1528,8 @@ const AdminDefinition: AdminDefinitionType = {
                             loading: defineMessage({id: 'admin.s3.testing', defaultMessage: 'Testing...'}),
                             error_message: defineMessage({id: 'admin.s3.s3Fail', defaultMessage: 'Connection unsuccessful: {error}'}), // eslint-disable-line formatjs/enforce-placeholders -- error provided at runtime
                             success_message: defineMessage({id: 'admin.s3.s3Success', defaultMessage: 'Connection was successful'}),
+                            sourceConfig: true,
+                            skipSaveNeeded: true,
                             isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.ENVIRONMENT.FILE_STORAGE)),
                             isHidden: it.any(it.stateEquals('FileSettings.ExportDriverName', 'NONE'), it.stateEquals('FileSettings.DedicatedExportStore', false)),
                         },
@@ -1691,6 +1695,8 @@ const AdminDefinition: AdminDefinitionType = {
                             loading: defineMessage({id: 'admin.environment.smtp.testing', defaultMessage: 'Testing...'}),
                             error_message: defineMessage({id: 'admin.environment.smtp.smtpFail', defaultMessage: 'Connection unsuccessful: {error}'}), // eslint-disable-line formatjs/enforce-placeholders -- placeholders provided
                             success_message: defineMessage({id: 'admin.environment.smtp.smtpSuccess', defaultMessage: 'No errors were reported while sending an email. Please check your inbox to make sure.'}),
+                            sourceConfig: true,
+                            skipSaveNeeded: true,
                             isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.ENVIRONMENT.SMTP)),
                         },
                         {

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.test.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.test.tsx
@@ -605,6 +605,123 @@ describe('components/admin_console/SchemaAdminSettings', () => {
         expect(radioButtons.length).toBeGreaterThan(0);
     });
 
+    test('button with sourceConfig forwards the pending in-form config to the action', async () => {
+        const action = jest.fn();
+        const buttonSchema = {
+            id: 'TestButtonConfig',
+            name: 'test_button_config',
+            name_default: 'Test Button Config',
+            settings: [
+                {
+                    key: 'FileSettings.AmazonS3AccessKeyId',
+                    label: 'access-key-label',
+                    label_default: 'Access Key',
+                    type: 'text',
+                    default: '',
+                },
+                {
+                    key: 'TestS3',
+                    label: 'test-s3-button',
+                    label_default: 'Test Connection',
+                    type: 'button',
+                    action,
+                    sourceConfig: true,
+                    skipSaveNeeded: true,
+                    error_message: 'admin.test.fail',
+                    error_message_default: 'fail: {error}',
+                },
+            ],
+        } as unknown as AdminDefinitionSubSectionSchema;
+
+        const initialConfig = {
+            FileSettings: {
+                AmazonS3AccessKeyId: 'saved-key',
+            },
+        } as Partial<AdminConfig>;
+
+        renderWithContext(
+            <SchemaAdminSettings
+                {...DefaultProps}
+                config={initialConfig}
+                environmentConfig={{}}
+                schema={buttonSchema}
+                patchConfig={jest.fn()}
+            />,
+        );
+
+        const input = screen.getByRole('textbox', {name: /access-key-label/i});
+        await userEvent.clear(input);
+        await userEvent.type(input, 'pending-key');
+
+        const button = screen.getByRole('button', {name: /test-s3-button/i});
+        await userEvent.click(button);
+
+        await waitFor(() => {
+            expect(action).toHaveBeenCalledTimes(1);
+        });
+
+        const sourceData = action.mock.calls[0][2];
+        expect(typeof sourceData).toBe('object');
+        expect(sourceData?.FileSettings?.AmazonS3AccessKeyId).toBe('pending-key');
+    });
+
+    test('button without sourceConfig forwards the sourceUrlKey state value as a string', async () => {
+        const action = jest.fn();
+        const buttonSchema = {
+            id: 'TestButtonUrl',
+            name: 'test_button_url',
+            name_default: 'Test Button Url',
+            settings: [
+                {
+                    key: 'ServiceSettings.SiteURL',
+                    label: 'site-url-label',
+                    label_default: 'Site URL',
+                    type: 'text',
+                    default: '',
+                },
+                {
+                    key: 'TestSiteURL',
+                    label: 'test-site-button',
+                    label_default: 'Test Live URL',
+                    type: 'button',
+                    action,
+                    skipSaveNeeded: true,
+                    error_message: 'admin.test.fail',
+                    error_message_default: 'fail: {error}',
+                },
+            ],
+        } as unknown as AdminDefinitionSubSectionSchema;
+
+        const initialConfig = {
+            ServiceSettings: {
+                SiteURL: 'http://saved.example',
+            },
+        } as Partial<AdminConfig>;
+
+        renderWithContext(
+            <SchemaAdminSettings
+                {...DefaultProps}
+                config={initialConfig}
+                environmentConfig={{}}
+                schema={buttonSchema}
+                patchConfig={jest.fn()}
+            />,
+        );
+
+        const input = screen.getByRole('textbox', {name: /site-url-label/i});
+        await userEvent.clear(input);
+        await userEvent.type(input, 'http://pending.example');
+
+        const button = screen.getByRole('button', {name: /test-site-button/i});
+        await userEvent.click(button);
+
+        await waitFor(() => {
+            expect(action).toHaveBeenCalledTimes(1);
+        });
+
+        expect(action.mock.calls[0][2]).toBe('http://pending.example');
+    });
+
     test('should call patchConfig on form submission', async () => {
         const mockPatchConfig = jest.fn(() => Promise.resolve({data: true}));
 

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -409,12 +409,16 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
                 }
             };
 
-            let sourceUrlKey = 'ServiceSettings.SiteURL';
-            if (setting.sourceUrlKey) {
-                sourceUrlKey = setting.sourceUrlKey;
+            let sourceData: string | Partial<AdminConfig>;
+            if (setting.sourceConfig) {
+                const cloned = JSON.parse(JSON.stringify(this.props.config));
+                sourceData = getConfigFromState(cloned, this.state, this.props.schema, this.isDisabled);
+            } else {
+                const sourceUrlKey = setting.sourceUrlKey || 'ServiceSettings.SiteURL';
+                sourceData = this.state[sourceUrlKey];
             }
 
-            setting.action(successCallback, error, this.state[sourceUrlKey]);
+            setting.action(successCallback, error, sourceData);
         };
 
         const helpText = renderSettingHelpText(setting, this.props.schema, this.isDisabled(setting));

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -410,7 +410,7 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
             };
 
             let sourceData: string | Partial<AdminConfig>;
-            if (setting.sourceConfig) {
+            if (setting.sourceConfig && this.props.schema) {
                 const cloned = JSON.parse(JSON.stringify(this.props.config));
                 sourceData = getConfigFromState(cloned, this.state, this.props.schema, this.isDisabled);
             } else {

--- a/webapp/channels/src/components/admin_console/types.ts
+++ b/webapp/channels/src/components/admin_console/types.ts
@@ -127,11 +127,12 @@ type AdminDefinitionSettingLanguage = AdminDefinitionSettingBase & {
 
 export type AdminDefinitionSettingButton = AdminDefinitionSettingBase & {
     type: 'button';
-    action: (success: (data?: any) => void, error: (error: {message: string; detailed_error?: string}) => void, siteUrl: string) => void;
+    action: (success: (data?: any) => void, error: (error: {message: string; detailed_error?: string}) => void, sourceData: string | Partial<AdminConfig>) => void;
     loading?: string | MessageDescriptor;
     error_message: string | MessageDescriptor;
     success_message?: string | MessageDescriptor;
     sourceUrlKey?: string;
+    sourceConfig?: boolean;
     skipSaveNeeded?: boolean;
 }
 


### PR DESCRIPTION
#### Summary
The Test Connection buttons for S3 file storage, S3 export storage, and SMTP went through `admin_actions` wrappers that dropped the optional config argument, so the server fell back to the persisted config. Admins editing credentials in the form and clicking **Test Connection** were validating the saved config, not their pending changes.

This PR adds an opt-in `sourceConfig` flag on `AdminDefinitionSettingButton`. When set, `schema_admin_settings` builds the pending config via `getConfigFromState` (the same helper Save uses) and forwards it to the action. The `testS3Connection` and `testSmtp` wrappers in `admin_actions.jsx` now forward that config to the underlying redux actions (which already accept it, as does `Client4` and the server handler). The three affected buttons (file storage S3, export storage S3, SMTP) opt in with `sourceConfig: true` and `skipSaveNeeded: true` so admins can test pending values without saving first.

QA steps:
1. System Console -> Environment -> File Storage. Change the S3 credentials so they differ from what's saved. Click **Test Connection** without saving.
   - Expected: the test runs against the pending values in the form. Wrong credentials should fail; correct credentials should succeed.
2. Repeat for System Console -> Environment -> Export Storage (when a dedicated export S3 store is configured).
3. Repeat for System Console -> Site Configuration -> Notifications -> SMTP (Test Connection button).
4. Sanity-check unaffected buttons still work: the SAML "Get SAML Metadata from IdP" button and the "Test Live URL" button under Web Server.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68929

#### Screenshots
N/A — behavior change only; no UI changes.

#### Release Note
```release-note
Fixed admin console Test Connection buttons (S3 file storage, S3 export storage, SMTP) so they validate pending in-form values instead of the saved config.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change alters the `AdminDefinitionSettingButton` action signature and adds a new `sourceConfig` branch in schema handling, which introduces a new code path for button actions; tests cover the affected flows but other admin buttons relying on the previous site-url-string behavior could be impacted if they opt in incorrectly.  
**QA Recommendation:** Manually verify the three Test Connection buttons (S3 file storage, S3 export storage, SMTP) use pending in-form values, and perform a brief smoke test of other admin console buttons to confirm fallback behavior and existing workflows remain unchanged.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36675?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->