### PR TITLE
Fix BuildAccessControlSubject call missing channelID argument

### DIFF
--- a/server/channels/app/channel_join_request.go
+++ b/server/channels/app/channel_join_request.go
@@ -334,7 +334,7 @@ func (a *App) evaluateChannelMembership(rctx request.CTX, user *model.User, chan
 		return false, nil
 	}
 
-	subject, appErr := a.BuildAccessControlSubject(rctx, user.Id, user.Roles)
+	subject, appErr := a.BuildAccessControlSubject(rctx, user.Id, user.Roles, channel.Id)
 	if appErr != nil {
 		return false, appErr
 	}


### PR DESCRIPTION
#### Summary

Fixes a build error introduced when `BuildAccessControlSubject` was updated to require a `channelID` argument: the call site in `evaluateChannelMembership` (`channels/app/channel_join_request.go`) was not updated to pass the fourth argument. This PR passes `channel.Id` at that call site.

#### Ticket Link

Fixes broken `master` build.

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change fixes a compilation error from an incomplete refactoring where `BuildAccessControlSubject` was changed to require a `channelID` argument, but this call site in `evaluateChannelMembership` was not updated. This is a straightforward bug fix with minimal regression risk since the previous code would not compile.

**QA Recommendation:** Minimal manual QA required given the isolated nature of the change. Recommend verifying channel join request flows with policy enforcement to ensure the channel-scoped role resolution works correctly. Existing automated tests for `RequestJoinChannel` and access control evaluation provide good coverage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36681?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->