### PR TITLE
MM-66162: harden GET /sharedchannels/{id}/remotes error path and add WS guard

### DIFF
--- a/server/channels/api4/shared_channel.go
+++ b/server/channels/api4/shared_channel.go
@@ -274,7 +274,7 @@ func getSharedChannelRemotes(c *Context, w http.ResponseWriter, r *http.Request)
 		if errors.Is(err, model.ErrChannelNotShared) {
 			remoteStatuses = []*model.SharedChannelRemoteStatus{}
 		} else {
-			c.Err = model.NewAppError("getSharedChannelRemotes", "api.command_share.fetch_remote_status.error", nil, "", http.StatusInternalServerError).Wrap(err)
+			c.Err = model.NewAppError("getSharedChannelRemotes", "api.command_share.fetch_remote_status.error", map[string]any{"Error": err.Error()}, "", http.StatusInternalServerError).Wrap(err)
 			return
 		}
 	}

--- a/server/channels/api4/shared_channel_remotes_test.go
+++ b/server/channels/api4/shared_channel_remotes_test.go
@@ -85,6 +85,7 @@ func TestGetSharedChannelRemotes(t *testing.T) {
 	url := fmt.Sprintf("/sharedchannels/%s/remotes", channel1.Id)
 	resp, err := th.Client.DoAPIGet(context.Background(), url, "")
 	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 
 	var result []*model.RemoteClusterInfo
 	err = json.NewDecoder(resp.Body).Decode(&result)
@@ -135,6 +136,49 @@ func TestGetSharedChannelRemotes_ReturnsEmptyForNonSharedChannel(t *testing.T) {
 	channel := th.CreateChannelWithClientAndTeam(t, th.Client, model.ChannelTypeOpen, th.BasicTeam.Id)
 
 	// Request remotes for non-shared channel - should return empty array, not error
+	url := fmt.Sprintf("/sharedchannels/%s/remotes", channel.Id)
+	resp, err := th.Client.DoAPIGet(context.Background(), url, "")
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+
+	var result []*model.RemoteClusterInfo
+	err = json.NewDecoder(resp.Body).Decode(&result)
+	require.NoError(t, err)
+
+	require.NotNil(t, result)
+	require.Empty(t, result)
+}
+
+func TestGetSharedChannelRemotes_ReturnsEmptyForStaleSharedChannelState(t *testing.T) {
+	th := setupForSharedChannels(t).InitBasic(t)
+
+	channel := th.CreateChannelWithClientAndTeam(t, th.Client, model.ChannelTypeOpen, th.BasicTeam.Id)
+	require.NoError(t, th.App.Srv().Store().Channel().SetShared(channel.Id, true))
+
+	remote, appErr := th.App.AddRemoteCluster(&model.RemoteCluster{
+		Name:        "stale-remote",
+		DisplayName: "Stale Remote",
+		SiteURL:     "http://stale.example.com",
+		CreatorId:   th.BasicUser.Id,
+		Token:       model.NewId(),
+		LastPingAt:  model.GetMillis(),
+	})
+	require.Nil(t, appErr)
+
+	// Simulate stale DB state: the channel/remote rows remain, but the SharedChannels row is missing.
+	_, err := th.App.Srv().Store().SharedChannel().SaveRemote(&model.SharedChannelRemote{
+		ChannelId:         channel.Id,
+		RemoteId:          remote.RemoteId,
+		CreatorId:         th.BasicUser.Id,
+		IsInviteAccepted:  true,
+		IsInviteConfirmed: true,
+	})
+	require.NoError(t, err)
+
+	hasRemote, err := th.App.Srv().Store().SharedChannel().HasRemote(channel.Id, remote.RemoteId)
+	require.NoError(t, err)
+	require.True(t, hasRemote)
+
 	url := fmt.Sprintf("/sharedchannels/%s/remotes", channel.Id)
 	resp, err := th.Client.DoAPIGet(context.Background(), url, "")
 	require.NoError(t, err)

--- a/webapp/channels/src/actions/websocket_actions.test.jsx
+++ b/webapp/channels/src/actions/websocket_actions.test.jsx
@@ -14,6 +14,7 @@ import {
     getPostThreads,
     receivedNewPost,
 } from 'mattermost-redux/actions/posts';
+import {fetchChannelRemotes} from 'mattermost-redux/actions/shared_channels';
 import {batchFetchStatusesProfilesGroupsFromPosts} from 'mattermost-redux/actions/status_profile_polling';
 import {getUser} from 'mattermost-redux/actions/users';
 import {getCustomProfileAttributes} from 'mattermost-redux/selectors/entities/general';
@@ -1833,9 +1834,6 @@ describe('handleChannelConvertedEvent', () => {
 
 describe('handleSharedChannelRemoteUpdatedEvent', () => {
     const channelId = 'shared-remote-channel';
-
-    // eslint-disable-next-line global-require
-    const {fetchChannelRemotes} = require('mattermost-redux/actions/shared_channels');
 
     beforeEach(() => {
         store.dispatch.mockClear();

--- a/webapp/channels/src/actions/websocket_actions.test.jsx
+++ b/webapp/channels/src/actions/websocket_actions.test.jsx
@@ -1869,6 +1869,11 @@ describe('handleSharedChannelRemoteUpdatedEvent', () => {
         handleEvent(msg);
 
         expect(fetchChannelRemotes).toHaveBeenCalledWith(channelId, true);
+        expect(store.dispatch).toHaveBeenCalledWith({
+            type: 'MOCK_FETCH_CHANNEL_REMOTES',
+            channelId,
+            forceRefresh: true,
+        });
     });
 
     test('skips fetch when local channel is not shared (regression: MM-66162)', () => {

--- a/webapp/channels/src/actions/websocket_actions.test.jsx
+++ b/webapp/channels/src/actions/websocket_actions.test.jsx
@@ -124,6 +124,14 @@ jest.mock('components/common/hooks/useAccessControlAttributes', () => ({
     invalidateAccessControlAttributesCache: jest.fn(),
 }));
 
+jest.mock('mattermost-redux/actions/shared_channels', () => ({
+    fetchChannelRemotes: jest.fn((channelId, forceRefresh) => ({
+        type: 'MOCK_FETCH_CHANNEL_REMOTES',
+        channelId,
+        forceRefresh,
+    })),
+}));
+
 let mockState = {
     entities: {
         apps: {
@@ -1820,5 +1828,86 @@ describe('handleChannelConvertedEvent', () => {
                 name: 'test-channel',
             },
         });
+    });
+});
+
+describe('handleSharedChannelRemoteUpdatedEvent', () => {
+    const channelId = 'shared-remote-channel';
+
+    // eslint-disable-next-line global-require
+    const {fetchChannelRemotes} = require('mattermost-redux/actions/shared_channels');
+
+    beforeEach(() => {
+        store.dispatch.mockClear();
+        fetchChannelRemotes.mockClear();
+        mockState = {
+            ...mockState,
+            entities: {
+                ...mockState.entities,
+                channels: {
+                    ...mockState.entities.channels,
+                    channels: {
+                        ...mockState.entities.channels.channels,
+                        [channelId]: {
+                            id: channelId,
+                            team_id: 'currentTeamId',
+                            type: Constants.OPEN_CHANNEL,
+                            name: 'shared-channel',
+                            shared: true,
+                        },
+                    },
+                },
+            },
+        };
+    });
+
+    test('dispatches fetchChannelRemotes when local channel is shared', () => {
+        const msg = {
+            event: WebSocketEvents.SharedChannelRemoteUpdated,
+            data: {channel_id: channelId},
+            broadcast: {channel_id: channelId},
+        };
+
+        handleEvent(msg);
+
+        expect(fetchChannelRemotes).toHaveBeenCalledWith(channelId, true);
+    });
+
+    test('skips fetch when local channel is not shared (regression: MM-66162)', () => {
+        mockState.entities.channels.channels[channelId].shared = false;
+
+        const msg = {
+            event: WebSocketEvents.SharedChannelRemoteUpdated,
+            data: {channel_id: channelId},
+            broadcast: {channel_id: channelId},
+        };
+
+        handleEvent(msg);
+
+        expect(fetchChannelRemotes).not.toHaveBeenCalled();
+    });
+
+    test('skips fetch when channel is absent from local state', () => {
+        const msg = {
+            event: WebSocketEvents.SharedChannelRemoteUpdated,
+            data: {channel_id: 'unknown-channel'},
+            broadcast: {channel_id: 'unknown-channel'},
+        };
+
+        handleEvent(msg);
+
+        expect(fetchChannelRemotes).not.toHaveBeenCalled();
+    });
+
+    test('skips fetch when channel_id is missing from both data and broadcast', () => {
+        const msg = {
+            event: WebSocketEvents.SharedChannelRemoteUpdated,
+            data: {},
+            broadcast: {},
+        };
+
+        handleEvent(msg);
+
+        expect(fetchChannelRemotes).not.toHaveBeenCalled();
     });
 });

--- a/webapp/channels/src/actions/websocket_actions.ts
+++ b/webapp/channels/src/actions/websocket_actions.ts
@@ -779,11 +779,23 @@ export function handleEvent(msg: WebSocketMessage) {
     });
 }
 
+// The server publishes shared_channel_remote_updated from the onInvite callback after a remote
+// (cluster or plugin) accepts a channel invitation. The channel is already shared at that point,
+// and the channel_updated event that set shared=true ran earlier in the share flow, so the local
+// channel should already reflect shared=true when this arrives. If it doesn't, the event isn't
+// meaningful for us and we skip the fetch.
 function handleSharedChannelRemoteUpdatedEvent(msg: WebSocketMessages.SharedChannelRemoteUpdated) {
     const channelId = msg.data.channel_id || msg.broadcast.channel_id;
-    if (channelId) {
-        dispatch(fetchChannelRemotes(channelId, true));
+    if (!channelId) {
+        return;
     }
+
+    const channel = getChannel(getState(), channelId);
+    if (!channel?.shared) {
+        return;
+    }
+
+    dispatch(fetchChannelRemotes(channelId, true));
 }
 
 // handleChannelConvertedEvent handles updating of channel which is converted between public and private


### PR DESCRIPTION
#### Summary
Two small follow-ups on top of the existing fix (PR #35448, `errors.Is(model.ErrChannelNotShared)` branch in `getSharedChannelRemotes`) that turned the 500 into a 200 with an empty list.

The HTTP 500 error returned was fixed in an earlier PR.

**Server (`server/channels/api4/shared_channel.go`)** - the 500 path on the same handler builds its `AppError` with `nil` params, so the i18n template `"Could not fetch status for secure connections: {{.Error}}."` rendered as `<no value>` in logs and response bodies when a genuinely unexpected error occurred (this is exactly what we see in the original ticket's log: `"Could not fetch status for secure connections: <no value>."`). Pass `map[string]any{"Error": err.Error()}` so the underlying error surfaces, matching the pattern already used by the slash command caller in
`channels/app/slashcommands/command_share.go:281`.

**Webapp (`webapp/channels/src/actions/websocket_actions.ts`)** - `handleSharedChannelRemoteUpdatedEvent` dispatched `fetchChannelRemotes` unconditionally on every `shared_channel_remote_updated` WS event, even for channels the local state already knows are not shared. The server publishes this event from the `onInvite` callback at `platform/services/sharedchannel/channelinvite.go:209`, which runs after a remote (cluster or plugin) accepts a channel invitation. By that point the channel has already been flipped to `shared: true` and the `channel_updated` event that did so has already gone out, so the local channel should reflect `shared: true` when this event arrives. If it doesn't, the event is not actionable for us and we skip the fetch. Comment in the handler explains the timing.

Adds jest coverage for the four cases of the new guard (shared, not shared, unknown channel, missing `channel_id`).

Existing regression coverage for the original 500 is already in `TestGetSharedChannelRemotes_ReturnsEmptyForNonSharedChannel` (and the stale-state variant added by #36694), so no new Go test is needed for the status code contract.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-66162

#### Screenshots
<!-- Include screenshots or GIFs for UI changes. -->

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes are localized and defensive—adding error details in a handler and a WebSocket guard; covered by Jest tests for the guard and existing Go tests for the 500→200 regression, so regression risk is low and confined to the shared-channels flow.  
**QA Recommendation:** Minimal manual QA—smoke-test shared-channel invites, remote-status updates, and verify no unnecessary fetches for non-shared channels.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36696?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->