### PR TITLE
MM-68946 - make sure put /access_control_policies masks the return expression

### DIFF
--- a/server/channels/api4/access_control_test.go
+++ b/server/channels/api4/access_control_test.go
@@ -1690,12 +1690,7 @@ func TestResponseMaskingOnPolicyEndpoints(t *testing.T) {
 	t.Run("getAccessControlPolicy response is masked", func(t *testing.T) {
 		// GET is the canonical read path — masking here means the raw CEL in the
 		// policy response cannot leak values the caller couldn't already see in the
-		// visual AST. The create / search / setActive paths share the same
-		// MaskPolicyExpressions call so they're covered by inspection. Unit-testing
-		// them through the HTTP handler is impractical because
-		// validatePolicyExpressionValues rejects unknown-field references before
-		// MaskPolicyExpressions ever runs, and we can't seed a real shared_only
-		// CPA field without plugin context. End-to-end paths are covered by E2E.
+		// visual AST.
 		mockACS := &mocks.AccessControlServiceInterface{}
 		th.App.Srv().Channels().AccessControl = mockACS
 		stored := newPolicy(th.BasicChannel.Id)
@@ -1708,6 +1703,47 @@ func TestResponseMaskingOnPolicyEndpoints(t *testing.T) {
 		require.NotEmpty(t, result.Rules)
 		require.Equal(t, expectedMaskedExpr, result.Rules[0].Expression,
 			"get response must mask the raw CEL exactly")
+	})
+
+	t.Run("createAccessControlPolicy PUT response is masked", func(t *testing.T) {
+		// "true" expression bypasses validatePolicyExpressionValues (no real CPA field
+		// needed). SavePolicy mock returns a name-normalised policy so MaskPolicyExpressions
+		// can apply masking before the response is written.
+		mockACS := &mocks.AccessControlServiceInterface{}
+		th.App.Srv().Channels().AccessControl = mockACS
+
+		savedPolicy := &model.AccessControlPolicy{
+			ID:      model.NewId(),
+			Type:    model.AccessControlPolicyTypeParent,
+			Version: model.AccessControlPolicyVersionV0_3,
+			Rules: []model.AccessControlPolicyRule{
+				{Actions: []string{"membership"}, Expression: sensitiveExpr},
+			},
+		}
+		mockACS.On("GetPolicy", mock.Anything, mock.Anything).
+			Return(nil, model.NewAppError("GetPolicy", "app.pap.get_policy.app_error", nil, "not found", http.StatusNotFound)).Times(1)
+		mockACS.On("SavePolicy", mock.Anything, mock.Anything).Return(savedPolicy, nil).Once()
+		mockACS.On("ExpressionToVisualAST", mock.Anything, sensitiveExpr).Return(unknownFieldAST, nil).Once()
+
+		submitted := &model.AccessControlPolicy{
+			Type:    model.AccessControlPolicyTypeParent,
+			Version: model.AccessControlPolicyVersionV0_3,
+			Rules: []model.AccessControlPolicyRule{
+				{Actions: []string{"membership"}, Expression: "true"},
+			},
+		}
+
+		r, err := th.SystemAdminClient.DoAPIPutJSON(context.Background(), "/access_control_policies", submitted)
+		require.NoError(t, err)
+		defer r.Body.Close()
+		require.Equal(t, http.StatusOK, r.StatusCode)
+
+		var result model.AccessControlPolicy
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&result))
+		require.NotEmpty(t, result.Rules)
+		require.Equal(t, expectedMaskedExpr, result.Rules[0].Expression)
+
+		mockACS.AssertExpectations(t)
 	})
 }
 


### PR DESCRIPTION
#### Summary
When modifying a policy with masked expressions, the put reply was returning the expressions without mask.

Enteprise PR: 
https://github.com/mattermost/enterprise/pull/2170

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-68946

#### Screenshots

https://github.com/user-attachments/assets/35281614-6354-40da-bea8-7362e8f0346c




#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Minimal. This PR adds only test coverage to verify that the existing `MaskPolicyExpressions` masking logic is properly applied in PUT /access_control_policies responses. No production code was modified—the masking functionality was already implemented in the handler.

**QA Recommendation:** Minimal manual QA required. Automated test coverage is comprehensive. A quick smoke test of PUT /access_control_policies in an ABAC-enabled environment would suffice to confirm the endpoint continues functioning properly.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36705?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->