### PR TITLE
Used short mode of data spillage report card in threads view to fix spacing issue

### DIFF
--- a/webapp/channels/src/components/post_view/data_spillage_report/data_spillage_report.test.tsx
+++ b/webapp/channels/src/components/post_view/data_spillage_report/data_spillage_report.test.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {act} from '@testing-library/react';
+import {createMemoryHistory} from 'history';
 import React from 'react';
 
 import type {Post} from '@mattermost/types/posts';
@@ -429,6 +430,32 @@ describe('components/post_view/data_spillage_report/DataSpillageReport', () => {
         expect(screen.queryByTestId('data-spillage-action')).toBeVisible();
         expect(screen.queryByTestId('data-spillage-action-remove-message')).toBeVisible();
         expect(screen.queryByTestId('data-spillage-action-keep-message')).toBeVisible();
+    });
+
+    it('should render in short mode in the global threads view even when isRHS is true', async () => {
+        const history = createMemoryHistory({initialEntries: ['/myteam/threads/abcdefghijklmnopqrstuvwxyz']});
+
+        renderWithContext(
+            <DataSpillageReport
+                post={post}
+                isRHS={true}
+            />,
+            baseState,
+            {history},
+        );
+
+        await act(async () => {});
+
+        const card = screen.getByTestId('data-spillage-report');
+        expect(card).toHaveClass('mode_short');
+        expect(card).not.toHaveClass('mode_full');
+
+        // short mode renders only the short field set
+        expect(screen.queryAllByTestId('property-card-row')).toHaveLength(4);
+
+        // action rows are gated on mode === 'full', so they must not render here
+        expect(screen.queryByTestId('data-spillage-action')).not.toBeInTheDocument();
+        expect(screen.queryByTestId('data-spillage-action-download-report')).not.toBeInTheDocument();
     });
 
     describe.each([

--- a/webapp/channels/src/components/post_view/data_spillage_report/data_spillage_report.tsx
+++ b/webapp/channels/src/components/post_view/data_spillage_report/data_spillage_report.tsx
@@ -3,6 +3,7 @@
 
 import React, {useMemo} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
+import {matchPath, useLocation} from 'react-router-dom';
 
 import {ContentFlaggingStatus} from '@mattermost/types/content_flagging';
 import type {Post} from '@mattermost/types/posts';
@@ -60,6 +61,9 @@ type Props = {
 
 export function DataSpillageReport({post, isRHS}: Props) {
     const {formatMessage} = useIntl();
+    const {pathname} = useLocation();
+
+    const inGlobalThreadsView = matchPath(pathname, {path: '/:team/threads/:threadIdentifier?'}) != null;
 
     const reportedPostId = post.props.reported_post_id as string;
 
@@ -108,7 +112,7 @@ export function DataSpillageReport({post, isRHS}: Props) {
         user: (<AtMention mentionName={reportingUser?.username || ''}/>),
     });
 
-    const mode = isRHS ? 'full' : 'short';
+    const mode = (isRHS && !inGlobalThreadsView) ? 'full' : 'short';
 
     const metadata = useMemo<PropertiesCardViewMetadata>(() => {
         const fieldMetadata: PropertiesCardViewMetadata = {


### PR DESCRIPTION
#### Summary
Used short mode of data spillage report card in threads view to fix spacing issue.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-68964

#### Screenshots
<img width="634" height="414" alt="Screenshot 2026-05-22 at 6 57 43 PM" src="https://github.com/user-attachments/assets/d1f75da2-ac77-4a50-8012-582caea6dd22" />

#### Release Note
```release-note
Fixed missing spacing in data spillage report card UI when opened in Threads view.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is highly localized to the `DataSpillageReport` component with minimal complexity added (detecting thread view context and selecting a display mode). Existing test coverage is supplemented with a new test case specifically verifying the new behavior, reducing regression risk.

**QA Recommendation:** Light manual testing recommended. Focus on verifying the data spillage report card displays correctly in threads view without spacing issues, and confirm the full mode still renders properly in other contexts (RHS, normal view).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36709?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->