### PR TITLE
MM-68248: Handle missing OpenSearch indexes gracefully before reindex

### DIFF
--- a/server/enterprise/elasticsearch/opensearch/opensearch.go
+++ b/server/enterprise/elasticsearch/opensearch/opensearch.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"slices"
@@ -39,6 +40,14 @@ const opensearchMaxVersion = 2
 var (
 	purgeIndexListAllowedIndexes = []string{common.IndexBaseChannels}
 )
+
+// isIndexNotFound reports whether err is a 404 index_not_found_exception from
+// OpenSearch. This happens when an index has never been created (e.g. no
+// reindex has run yet) and should be treated as an empty result, not an error.
+func isIndexNotFound(err error) bool {
+	var osErr *opensearch.StructError
+	return errors.As(err, &osErr) && osErr.Status == http.StatusNotFound
+}
 
 type OpensearchInterfaceImpl struct {
 	client      *opensearchapi.Client
@@ -840,6 +849,9 @@ func (os *OpensearchInterfaceImpl) DeleteChannelPosts(rctx request.CTX, channelI
 	if err != nil {
 		return model.NewAppError("Opensearch.DeleteChannelPosts", "ent.elasticsearch.delete_channel_posts.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
+	if len(postIndexes) == 0 {
+		return nil
+	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*os.Platform.Config().ElasticsearchSettings.RequestTimeoutSeconds)*time.Second)
 	defer cancel()
@@ -880,6 +892,9 @@ func (os *OpensearchInterfaceImpl) UpdatePostsChannelTypeByChannelId(rctx reques
 	postIndexes, err := os.getPostIndexNames()
 	if err != nil {
 		return model.NewAppError("Opensearch.UpdatePostsChannelTypeByChannelId", "ent.elasticsearch.update_posts_channel_type.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
+	}
+	if len(postIndexes) == 0 {
+		return nil
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*os.Platform.Config().ElasticsearchSettings.RequestTimeoutSeconds)*time.Second)
@@ -942,6 +957,9 @@ func (os *OpensearchInterfaceImpl) BackfillPostsChannelType(rctx request.CTX, ch
 	postIndexes, err := os.getPostIndexNames()
 	if err != nil {
 		return model.NewAppError("Opensearch.BackfillPostsChannelType", "ent.elasticsearch.backfill_posts_channel_type.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
+	}
+	if len(postIndexes) == 0 {
+		return nil
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Hour)
@@ -1013,6 +1031,9 @@ func (os *OpensearchInterfaceImpl) DeleteUserPosts(rctx request.CTX, userID stri
 	postIndexes, err := os.getPostIndexNames()
 	if err != nil {
 		return model.NewAppError("Opensearch.DeleteUserPosts", "ent.elasticsearch.delete_user_posts.error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	if len(postIndexes) == 0 {
+		return nil
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(*os.Platform.Config().ElasticsearchSettings.RequestTimeoutSeconds)*time.Second)
@@ -2127,6 +2148,9 @@ func (os *OpensearchInterfaceImpl) SearchFiles(channels model.ChannelList, searc
 		},
 	})
 	if err != nil {
+		if isIndexNotFound(err) {
+			return []string{}, nil
+		}
 		errorStr := "err=" + err.Error()
 		if *os.Platform.Config().ElasticsearchSettings.Trace == "error" {
 			errorStr = "Query=" + getJSONOrErrorStr(query) + ", " + errorStr
@@ -2210,6 +2234,9 @@ func (os *OpensearchInterfaceImpl) DeleteUserFiles(rctx request.CTX, userID stri
 		Body:    bytes.NewReader(queryBuf),
 	})
 	if err != nil {
+		if isIndexNotFound(err) {
+			return nil
+		}
 		return model.NewAppError("Opensearch.DeleteUserFiles", "ent.elasticsearch.delete_user_files.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	rctx.Logger().Info("User files deleted", mlog.String("user_id", userID), mlog.Int("deleted", response.Deleted))
@@ -2246,6 +2273,9 @@ func (os *OpensearchInterfaceImpl) DeletePostFiles(rctx request.CTX, postID stri
 		Body:    bytes.NewReader(queryBuf),
 	})
 	if err != nil {
+		if isIndexNotFound(err) {
+			return nil
+		}
 		return model.NewAppError("Opensearch.DeletePostFiles", "ent.elasticsearch.delete_post_files.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	rctx.Logger().Info("Post files deleted", mlog.String("post_id", postID), mlog.Int("deleted", response.Deleted))
@@ -2293,6 +2323,9 @@ func (os *OpensearchInterfaceImpl) DeleteFilesBatch(rctx request.CTX, endTime, l
 		},
 	})
 	if err != nil {
+		if isIndexNotFound(err) {
+			return nil
+		}
 		return model.NewAppError("Opensearch.DeleteUserPosts", "ent.elasticsearch.delete_user_posts.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	rctx.Logger().Info("Files batch deleted", mlog.Int("end_time", endTime), mlog.Int("limit", limit), mlog.Int("deleted", response.Deleted))

--- a/server/enterprise/elasticsearch/opensearch/opensearch.go
+++ b/server/enterprise/elasticsearch/opensearch/opensearch.go
@@ -2310,7 +2310,7 @@ func (os *OpensearchInterfaceImpl) DeleteFilesBatch(rctx request.CTX, endTime, l
 		Query: query,
 	})
 	if err != nil {
-		return model.NewAppError("Opensearch.DeleteUserFiles", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		return model.NewAppError("Opensearch.DeleteFilesBatch", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	response, err := os.client.Document.DeleteByQuery(ctx, opensearchapi.DocumentDeleteByQueryReq{
 		Indices: []string{*os.Platform.Config().ElasticsearchSettings.IndexPrefix + common.IndexBaseFiles},
@@ -2326,7 +2326,7 @@ func (os *OpensearchInterfaceImpl) DeleteFilesBatch(rctx request.CTX, endTime, l
 		if isIndexNotFound(err) {
 			return nil
 		}
-		return model.NewAppError("Opensearch.DeleteUserPosts", "ent.elasticsearch.delete_user_posts.error", nil, "", http.StatusInternalServerError).Wrap(err)
+		return model.NewAppError("Opensearch.DeleteFilesBatch", "ent.elasticsearch.delete_files_batch.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	rctx.Logger().Info("Files batch deleted", mlog.Int("end_time", endTime), mlog.Int("limit", limit), mlog.Int("deleted", response.Deleted))
 

--- a/server/enterprise/elasticsearch/opensearch/opensearch.go
+++ b/server/enterprise/elasticsearch/opensearch/opensearch.go
@@ -46,7 +46,7 @@ var (
 // reindex has run yet) and should be treated as an empty result, not an error.
 func isIndexNotFound(err error) bool {
 	var osErr *opensearch.StructError
-	return errors.As(err, &osErr) && osErr.Status == http.StatusNotFound
+	return errors.As(err, &osErr) && osErr.Status == http.StatusNotFound && osErr.Err.Type == "index_not_found_exception"
 }
 
 type OpensearchInterfaceImpl struct {

--- a/server/enterprise/elasticsearch/opensearch/opensearch_test.go
+++ b/server/enterprise/elasticsearch/opensearch/opensearch_test.go
@@ -212,6 +212,59 @@ func (s *OpensearchInterfaceTestSuite) TestSyncBulkIndexChannels() {
 	})
 }
 
+// TestNoIndexesGracefulHandling verifies that write and search operations
+// return nil/empty (not an error) when no indexes exist yet. This covers the
+// state before any reindex has run: the index templates are present but the
+// actual indexes have never been created.
+func (s *OpensearchInterfaceTestSuite) TestNoIndexesGracefulHandling() {
+	// SetupTest already calls PurgeIndexes, so there are no indexes at this point.
+	impl := s.CommonTestSuite.ESImpl
+	rctx := s.th.Context
+
+	s.Run("BackfillPostsChannelType", func() {
+		appErr := impl.BackfillPostsChannelType(rctx, []string{"channel1", "channel2"}, "O")
+		s.Nil(appErr)
+	})
+
+	s.Run("DeleteChannelPosts", func() {
+		appErr := impl.DeleteChannelPosts(rctx, s.th.BasicChannel.Id)
+		s.Nil(appErr)
+	})
+
+	s.Run("DeleteUserPosts", func() {
+		appErr := impl.DeleteUserPosts(rctx, s.th.BasicUser.Id)
+		s.Nil(appErr)
+	})
+
+	s.Run("UpdatePostsChannelTypeByChannelId", func() {
+		appErr := impl.UpdatePostsChannelTypeByChannelId(rctx, s.th.BasicChannel.Id, "O")
+		s.Nil(appErr)
+	})
+
+	s.Run("SearchFiles", func() {
+		channels := model.ChannelList{s.th.BasicChannel}
+		params := model.ParseSearchParams("test", 0)
+		fileIDs, appErr := impl.SearchFiles(channels, params, 0, 20)
+		s.Nil(appErr)
+		s.Empty(fileIDs)
+	})
+
+	s.Run("DeletePostFiles", func() {
+		appErr := impl.DeletePostFiles(rctx, s.th.BasicPost.Id)
+		s.Nil(appErr)
+	})
+
+	s.Run("DeleteUserFiles", func() {
+		appErr := impl.DeleteUserFiles(rctx, s.th.BasicUser.Id)
+		s.Nil(appErr)
+	})
+
+	s.Run("DeleteFilesBatch", func() {
+		appErr := impl.DeleteFilesBatch(rctx, model.GetMillis(), 1000)
+		s.Nil(appErr)
+	})
+}
+
 func (s *OpensearchInterfaceTestSuite) TestTemplateCreationClientError() {
 	s.Run("Should handle error with CausedBy information from opensearch", func() {
 		// Invalid template request that will trigger an error with caused_by

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9999,6 +9999,10 @@
     "translation": "Failed to delete file"
   },
   {
+    "id": "ent.elasticsearch.delete_files_batch.error",
+    "translation": "Failed to delete files batch"
+  },
+  {
     "id": "ent.elasticsearch.delete_post.error",
     "translation": "Failed to delete the post"
   },


### PR DESCRIPTION
#### Summary

Guards OpenSearch write and search operations against the state where indexes have not been created yet (i.e. before any reindex has run). Indexes are created on first document write, not at startup — so any operation that targets a missing index will fail until content is indexed.

Two failure modes fixed:

- **`_update_by_query` / `_delete_by_query` with no post indexes** — OpenSearch v3 rejects these at the root endpoint with 405. `DeleteChannelPosts`, `UpdatePostsChannelTypeByChannelId`, `BackfillPostsChannelType`, and `DeleteUserPosts` now return early when `getPostIndexNames()` returns empty.
- **`index_not_found_exception` on exact index names** — OpenSearch returns 404 when querying or mutating an exact index name that doesn't exist. `SearchFiles`, `DeleteUserFiles`, `DeletePostFiles`, and `DeleteFilesBatch` now treat 404 as empty/nil rather than an error.

Also fixes a copy-paste bug where `DeleteFilesBatch` used the wrong operation name (`Opensearch.DeleteUserPosts`) in its `AppError`.

Test coverage added in `TestNoIndexesGracefulHandling` confirming all eight affected operations are no-ops when no indexes exist.

#### Ticket Link

Relates-to: https://mattermost.atlassian.net/browse/MM-68248

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change modifies error handling for OpenSearch index-not-found and empty-index cases across eight search/delete/update operations in the opensearch module; it's well-scoped and covered by a new test but alters behavior in core deletion/search flows which could surface regressions if non-404 errors are misclassified or if other callers rely on previous errors.  
**QA Recommendation:** Run targeted manual QA for channel/user deletion, post backfills, and file search/delete flows in both "no-index" (pre-write) and normal (post-index) states to ensure 404s are treated as no-ops while other errors still surface; broader regression testing of deletion/search workflows is recommended but can be limited given the added automated test coverage.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36712?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->