### PR TITLE
Bump Go to 1.25.10 in release-11.7

### DIFF
--- a/server/build/Dockerfile.buildenv
+++ b/server/build/Dockerfile.buildenv
@@ -1,4 +1,4 @@
-FROM mattermost/golang-bullseye:1.25.9@sha256:eb35cc5421737a4a85c7000aa85ed153a26b979d573b961c28f013d47726d4ed
+FROM mattermost/golang-bullseye:1.25.10@sha256:fcfc43854984deade99baafaf8dbce7b5a21408dcf8638d1e05e29d1501b632c
 ARG NODE_VERSION=20.11.1
 
 RUN apt-get update && apt-get install -y make git apt-transport-https ca-certificates curl software-properties-common build-essential zip xmlsec1 jq pgloader gnupg

--- a/server/build/Dockerfile.buildenv-fips
+++ b/server/build/Dockerfile.buildenv-fips
@@ -1,4 +1,4 @@
-FROM cgr.dev/mattermost.com/go-msft-fips:1.25.9-dev@sha256:e85eab899d8700962a60ad05b887de5fc8463a879b38d5d2c30b0d1384446189
+FROM cgr.dev/mattermost.com/go-msft-fips:1.25.10-dev@sha256:eeaf85f1dd83cdd7415d055fba1c119e1f2bf6066de788999ae963243db80b88
 ARG NODE_VERSION=20.11.1
 
 RUN apk add curl ca-certificates mailcap unrtf wv poppler-utils tzdata gpg xmlsec


### PR DESCRIPTION
## Summary

Bumps Go from 1.25.9 to 1.25.10 via Dockerfile. (This multi-step process is annoying: exploring an alternative for the future in #36715.)

## Release Note
```release-note
NONE
```