### PR TITLE
ci: allow Go version bumps in a single PR via mattermost-build-server-dev

### DIFF
--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -21,6 +21,10 @@ on:
         required: false
         default: false
         type: boolean
+      build-image:
+        description: "The build image to use (Docker Hub ref normally, ghcr.io ref for in-flight Go bumps)"
+        required: true
+        type: string
 
 jobs:
   test:
@@ -42,11 +46,10 @@ jobs:
       - name: Setup BUILD_IMAGE
         id: build
         run: |
+          echo "BUILD_IMAGE=${{ inputs.build-image }}" >> "${GITHUB_OUTPUT}"
           if [[ ${{ inputs.fips-enabled }} == 'true' ]]; then
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}-fips" >> "${GITHUB_OUTPUT}"
           else
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}" >> "${GITHUB_OUTPUT}"
           fi
 

--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -22,7 +22,7 @@ on:
         default: false
         type: boolean
       build-image:
-        description: "The build image to use (Docker Hub ref normally, ghcr.io ref for in-flight Go bumps)"
+        description: "The build image to use (e.g. mattermost-build-server-dev for in-flight Go bumps)"
         required: true
         type: string
 

--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -45,8 +45,10 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Setup BUILD_IMAGE
         id: build
+        env:
+          BUILD_IMAGE: ${{ inputs.build-image }}
         run: |
-          echo "BUILD_IMAGE=${{ inputs.build-image }}" >> "${GITHUB_OUTPUT}"
+          echo "BUILD_IMAGE=${BUILD_IMAGE}" >> "${GITHUB_OUTPUT}"
           if [[ ${{ inputs.fips-enabled }} == 'true' ]]; then
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}-fips" >> "${GITHUB_OUTPUT}"
           else

--- a/.github/workflows/server-ci-nightly-race.yml
+++ b/.github/workflows/server-ci-nightly-race.yml
@@ -46,6 +46,7 @@ jobs:
       logsartifact: race-detector-server-test-logs
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: false
+      build-image: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
       fullyparallel: false
       race-enabled: true
       runner: ubuntu-22.04

--- a/.github/workflows/server-ci-weekly.yml
+++ b/.github/workflows/server-ci-weekly.yml
@@ -47,6 +47,7 @@ jobs:
       logsartifact: postgres-binary-server-test-logs
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: false
+      build-image: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
       # Unsharded run on a single 8-core runner: fullyparallel=true causes
       # resource exhaustion (too many server instances, WebSocket hubs, and
       # DB connections) and crashes the hosted runner. See #35995.
@@ -64,6 +65,7 @@ jobs:
       logsartifact: postgres-server-fips-test-logs
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: true
+      build-image: mattermost/mattermost-build-server-fips:${{ needs.go.outputs.version }}
       # Unsharded run on a single 8-core runner: see note on test-postgres-binary.
       fullyparallel: false
 
@@ -79,3 +81,4 @@ jobs:
       logsartifact: mmctl-fips-test-logs
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: true
+      build-image: mattermost/mattermost-build-server-fips:${{ needs.go.outputs.version }}

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -68,18 +68,23 @@ jobs:
         env:
           GO_VERSION: ${{ steps.calculate.outputs.GO_VERSION }}
           COMMIT_SHA: ${{ github.sha }}
+          CAN_PUSH: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
         run: |
           if docker manifest inspect "mattermost/mattermost-build-server:${GO_VERSION}" > /dev/null 2>&1; then
             echo "image=mattermost/mattermost-build-server:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
-          else
+          elif [[ "${CAN_PUSH}" == "true" ]]; then
             echo "image=ghcr.io/mattermost/mattermost-build-server:${COMMIT_SHA}" >> "${GITHUB_OUTPUT}"
             echo "BUILDENV_NEEDED=true" >> "${GITHUB_ENV}"
+          else
+            echo "image=mattermost/mattermost-build-server:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
           fi
           if docker manifest inspect "mattermost/mattermost-build-server-fips:${GO_VERSION}" > /dev/null 2>&1; then
             echo "image-fips=mattermost/mattermost-build-server-fips:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
-          else
+          elif [[ "${CAN_PUSH}" == "true" ]]; then
             echo "image-fips=ghcr.io/mattermost/mattermost-build-server-fips:${COMMIT_SHA}" >> "${GITHUB_OUTPUT}"
             echo "BUILDENV_FIPS_NEEDED=true" >> "${GITHUB_ENV}"
+          else
+            echo "image-fips=mattermost/mattermost-build-server-fips:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Login to ghcr.io

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -17,8 +17,6 @@ on:
       - ".github/workflows/server-test-template.yml"
       - ".github/workflows/server-test-merge-template.yml"
       - ".github/workflows/mmctl-test-template.yml"
-      - "!server/build/Dockerfile.buildenv"
-      - "!server/build/Dockerfile.buildenv-fips"
       - "tools/mattermost-govet/**"
       - "!server/**/*.md"
       - "!server/NOTICE.txt"
@@ -32,9 +30,17 @@ jobs:
   go:
     name: Compute Go Version
     runs-on: ubuntu-22.04
+    permissions:
+      id-token: write    # for chainguard (FIPS base image pull)
+      contents: read
+      packages: write    # for ghcr.io push
     outputs:
       version: ${{ steps.calculate.outputs.GO_VERSION }}
       gomod-changed: ${{ steps.changed-files.outputs.any_changed }}
+      image: ${{ steps.resolve.outputs.image }}
+      image-fips: ${{ steps.resolve.outputs.image-fips }}
+    env:
+      CHAINCTL_IDENTITY: ee399b4c72dd4e58e3d617f78fc47b74733c9557/922f2d48307d6f5f
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -48,11 +54,70 @@ jobs:
         with:
           files: |
             **/go.mod
+      - name: buildenv/docker-login
+        # Private FIPS image on Docker Hub requires auth to inspect. Skip on fork PRs where secrets
+        # are unavailable; the FIPS build steps below are also skipped for forks.
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Resolve image references
+        id: resolve
+        run: |
+          if docker manifest inspect "mattermost/mattermost-build-server:${{ steps.calculate.outputs.GO_VERSION }}" > /dev/null 2>&1; then
+            echo "image=mattermost/mattermost-build-server:${{ steps.calculate.outputs.GO_VERSION }}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "image=ghcr.io/mattermost/mattermost-build-server:${{ github.sha }}" >> "${GITHUB_OUTPUT}"
+            echo "BUILDENV_NEEDED=true" >> "${GITHUB_ENV}"
+          fi
+          if docker manifest inspect "mattermost/mattermost-build-server-fips:${{ steps.calculate.outputs.GO_VERSION }}" > /dev/null 2>&1; then
+            echo "image-fips=mattermost/mattermost-build-server-fips:${{ steps.calculate.outputs.GO_VERSION }}" >> "${GITHUB_OUTPUT}"
+          else
+            echo "image-fips=ghcr.io/mattermost/mattermost-build-server-fips:${{ github.sha }}" >> "${GITHUB_OUTPUT}"
+            echo "BUILDENV_FIPS_NEEDED=true" >> "${GITHUB_ENV}"
+          fi
+
+      - name: Login to ghcr.io
+        if: env.BUILDENV_NEEDED == 'true' || env.BUILDENV_FIPS_NEEDED == 'true'
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Setup Chainctl
+        if: env.BUILDENV_FIPS_NEEDED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: chainguard-dev/setup-chainctl@c125f765e82b09a42af3185f3214465314d75c5d # v0.5.0
+        with:
+          identity: ${{ env.CHAINCTL_IDENTITY }}
+
+      - name: Build and push buildenv to ghcr.io
+        if: env.BUILDENV_NEEDED == 'true'
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          provenance: false
+          file: server/build/Dockerfile.buildenv
+          push: true
+          tags: ${{ steps.resolve.outputs.image }}
+          labels: org.opencontainers.image.source=https://github.com/mattermost/mattermost
+
+      - name: Build and push buildenv-fips to ghcr.io
+        if: env.BUILDENV_FIPS_NEEDED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
+        with:
+          provenance: false
+          file: server/build/Dockerfile.buildenv-fips
+          push: true
+          tags: ${{ steps.resolve.outputs.image-fips }}
+          labels: org.opencontainers.image.source=https://github.com/mattermost/mattermost
+
   check-mocks:
     name: Check mocks
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: ${{ needs.go.outputs.image }}
     defaults:
       run:
         working-directory: server
@@ -69,7 +134,7 @@ jobs:
     name: Check go mod tidy
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: ${{ needs.go.outputs.image }}
     defaults:
       run:
         working-directory: server
@@ -86,7 +151,7 @@ jobs:
     name: Check go fix
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: ${{ needs.go.outputs.image }}
     defaults:
       run:
         working-directory: server
@@ -103,7 +168,7 @@ jobs:
     name: check-style
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: ${{ needs.go.outputs.image }}
     defaults:
       run:
         working-directory: server
@@ -118,7 +183,7 @@ jobs:
     name: Check serialization methods for hot structs
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: ${{ needs.go.outputs.image }}
     defaults:
       run:
         working-directory: server
@@ -135,7 +200,7 @@ jobs:
     name: Vet API
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: ${{ needs.go.outputs.image }}
     defaults:
       run:
         working-directory: server
@@ -150,7 +215,7 @@ jobs:
     name: Check migration files
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: ${{ needs.go.outputs.image }}
     defaults:
       run:
         working-directory: server
@@ -165,7 +230,7 @@ jobs:
     name: Generate email templates
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: ${{ needs.go.outputs.image }}
     defaults:
       run:
         working-directory: server
@@ -182,7 +247,7 @@ jobs:
     name: Check store layers
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: ${{ needs.go.outputs.image }}
     defaults:
       run:
         working-directory: server
@@ -199,7 +264,7 @@ jobs:
     name: Check mmctl docs
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: ${{ needs.go.outputs.image }}
     defaults:
       run:
         working-directory: server
@@ -236,6 +301,7 @@ jobs:
       enablecoverage: ${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.base.ref, 'release-') }}
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: false
+      build-image: ${{ needs.go.outputs.image }}
       shard-index: ${{ matrix.shard }}
       shard-total: 4
   # -- Merge test results (handles both single-run and future sharded runs) --
@@ -262,6 +328,7 @@ jobs:
       logsartifact: elasticsearch-v8-server-test-logs
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: false
+      build-image: ${{ needs.go.outputs.image }}
       elasticsearch-version: "8.9.0"
       test-target: "test-server-elasticsearch"
 
@@ -277,6 +344,7 @@ jobs:
       logsartifact: opensearch-v2-server-test-logs
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: false
+      build-image: ${{ needs.go.outputs.image }}
       opensearch-version: "2.19.0"
       test-target: "test-server-opensearch"
 
@@ -299,6 +367,7 @@ jobs:
       logsartifact: "postgres-server-fips-test-logs-shard-${{ matrix.shard }}"
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: true
+      build-image: ${{ needs.go.outputs.image-fips }}
       shard-index: ${{ matrix.shard }}
       shard-total: 4
   merge-postgres-fips-test-results:
@@ -322,6 +391,7 @@ jobs:
       logsartifact: mmctl-test-logs
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: false
+      build-image: ${{ needs.go.outputs.image }}
   test-mmctl-fips:
     if: contains(github.head_ref, 'fips') || needs.go.outputs.gomod-changed == 'true'
     name: Run mmctl tests (FIPS)
@@ -335,12 +405,13 @@ jobs:
       logsartifact: mmctl-fips-test-logs
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: true
+      build-image: ${{ needs.go.outputs.image-fips }}
 
   build-mattermost-server:
     name: Build mattermost server app
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
+    container: ${{ needs.go.outputs.image }}
     defaults:
       run:
         working-directory: server

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -33,7 +33,6 @@ jobs:
     permissions:
       id-token: write    # for chainguard (FIPS base image pull)
       contents: read
-      packages: write    # for ghcr.io push
     outputs:
       version: ${{ steps.calculate.outputs.GO_VERSION }}
       gomod-changed: ${{ steps.changed-files.outputs.any_changed }}
@@ -73,7 +72,7 @@ jobs:
           if docker manifest inspect "mattermost/mattermost-build-server:${GO_VERSION}" > /dev/null 2>&1; then
             echo "image=mattermost/mattermost-build-server:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
           elif [[ "${CAN_PUSH}" == "true" ]]; then
-            echo "image=ghcr.io/mattermost/mattermost-build-server:${COMMIT_SHA}" >> "${GITHUB_OUTPUT}"
+            echo "image=mattermost/mattermost-build-server-dev:${COMMIT_SHA}" >> "${GITHUB_OUTPUT}"
             echo "BUILDENV_NEEDED=true" >> "${GITHUB_ENV}"
           else
             echo "image=mattermost/mattermost-build-server:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
@@ -81,27 +80,19 @@ jobs:
           if docker manifest inspect "mattermost/mattermost-build-server-fips:${GO_VERSION}" > /dev/null 2>&1; then
             echo "image-fips=mattermost/mattermost-build-server-fips:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
           elif [[ "${CAN_PUSH}" == "true" ]]; then
-            echo "image-fips=ghcr.io/mattermost/mattermost-build-server-fips:${COMMIT_SHA}" >> "${GITHUB_OUTPUT}"
+            echo "image-fips=mattermost/mattermost-build-server-fips-dev:${COMMIT_SHA}" >> "${GITHUB_OUTPUT}"
             echo "BUILDENV_FIPS_NEEDED=true" >> "${GITHUB_ENV}"
           else
             echo "image-fips=mattermost/mattermost-build-server-fips:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
           fi
 
-      - name: Login to ghcr.io
-        if: env.BUILDENV_NEEDED == 'true' || env.BUILDENV_FIPS_NEEDED == 'true'
-        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Setup Chainctl
-        if: env.BUILDENV_FIPS_NEEDED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: env.BUILDENV_FIPS_NEEDED == 'true'
         uses: chainguard-dev/setup-chainctl@c125f765e82b09a42af3185f3214465314d75c5d # v0.5.0
         with:
           identity: ${{ env.CHAINCTL_IDENTITY }}
 
-      - name: Build and push buildenv to ghcr.io
+      - name: Build and push buildenv to Docker Hub
         if: env.BUILDENV_NEEDED == 'true'
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
@@ -109,23 +100,25 @@ jobs:
           file: server/build/Dockerfile.buildenv
           push: true
           tags: ${{ steps.resolve.outputs.image }}
-          labels: org.opencontainers.image.source=https://github.com/mattermost/mattermost
 
-      - name: Build and push buildenv-fips to ghcr.io
-        if: env.BUILDENV_FIPS_NEEDED == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+      - name: Build and push buildenv-fips to Docker Hub
+        if: env.BUILDENV_FIPS_NEEDED == 'true'
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           provenance: false
           file: server/build/Dockerfile.buildenv-fips
           push: true
           tags: ${{ steps.resolve.outputs.image-fips }}
-          labels: org.opencontainers.image.source=https://github.com/mattermost/mattermost
 
   check-mocks:
     name: Check mocks
     needs: go
     runs-on: ubuntu-22.04
-    container: ${{ needs.go.outputs.image }}
+    container:
+      image: ${{ needs.go.outputs.image }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     defaults:
       run:
         working-directory: server
@@ -142,7 +135,11 @@ jobs:
     name: Check go mod tidy
     needs: go
     runs-on: ubuntu-22.04
-    container: ${{ needs.go.outputs.image }}
+    container:
+      image: ${{ needs.go.outputs.image }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     defaults:
       run:
         working-directory: server
@@ -159,7 +156,11 @@ jobs:
     name: Check go fix
     needs: go
     runs-on: ubuntu-22.04
-    container: ${{ needs.go.outputs.image }}
+    container:
+      image: ${{ needs.go.outputs.image }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     defaults:
       run:
         working-directory: server
@@ -176,7 +177,11 @@ jobs:
     name: check-style
     needs: go
     runs-on: ubuntu-22.04
-    container: ${{ needs.go.outputs.image }}
+    container:
+      image: ${{ needs.go.outputs.image }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     defaults:
       run:
         working-directory: server
@@ -191,7 +196,11 @@ jobs:
     name: Check serialization methods for hot structs
     needs: go
     runs-on: ubuntu-22.04
-    container: ${{ needs.go.outputs.image }}
+    container:
+      image: ${{ needs.go.outputs.image }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     defaults:
       run:
         working-directory: server
@@ -208,7 +217,11 @@ jobs:
     name: Vet API
     needs: go
     runs-on: ubuntu-22.04
-    container: ${{ needs.go.outputs.image }}
+    container:
+      image: ${{ needs.go.outputs.image }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     defaults:
       run:
         working-directory: server
@@ -223,7 +236,11 @@ jobs:
     name: Check migration files
     needs: go
     runs-on: ubuntu-22.04
-    container: ${{ needs.go.outputs.image }}
+    container:
+      image: ${{ needs.go.outputs.image }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     defaults:
       run:
         working-directory: server
@@ -238,7 +255,11 @@ jobs:
     name: Generate email templates
     needs: go
     runs-on: ubuntu-22.04
-    container: ${{ needs.go.outputs.image }}
+    container:
+      image: ${{ needs.go.outputs.image }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     defaults:
       run:
         working-directory: server
@@ -255,7 +276,11 @@ jobs:
     name: Check store layers
     needs: go
     runs-on: ubuntu-22.04
-    container: ${{ needs.go.outputs.image }}
+    container:
+      image: ${{ needs.go.outputs.image }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     defaults:
       run:
         working-directory: server
@@ -272,7 +297,11 @@ jobs:
     name: Check mmctl docs
     needs: go
     runs-on: ubuntu-22.04
-    container: ${{ needs.go.outputs.image }}
+    container:
+      image: ${{ needs.go.outputs.image }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     defaults:
       run:
         working-directory: server
@@ -419,7 +448,11 @@ jobs:
     name: Build mattermost server app
     needs: go
     runs-on: ubuntu-22.04
-    container: ${{ needs.go.outputs.image }}
+    container:
+      image: ${{ needs.go.outputs.image }}
+      credentials:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
     defaults:
       run:
         working-directory: server

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -65,15 +65,17 @@ jobs:
 
       - name: Resolve image references
         id: resolve
+        env:
+          GO_VERSION: ${{ steps.calculate.outputs.GO_VERSION }}
         run: |
-          if docker manifest inspect "mattermost/mattermost-build-server:${{ steps.calculate.outputs.GO_VERSION }}" > /dev/null 2>&1; then
-            echo "image=mattermost/mattermost-build-server:${{ steps.calculate.outputs.GO_VERSION }}" >> "${GITHUB_OUTPUT}"
+          if docker manifest inspect "mattermost/mattermost-build-server:${GO_VERSION}" > /dev/null 2>&1; then
+            echo "image=mattermost/mattermost-build-server:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
           else
             echo "image=ghcr.io/mattermost/mattermost-build-server:${{ github.sha }}" >> "${GITHUB_OUTPUT}"
             echo "BUILDENV_NEEDED=true" >> "${GITHUB_ENV}"
           fi
-          if docker manifest inspect "mattermost/mattermost-build-server-fips:${{ steps.calculate.outputs.GO_VERSION }}" > /dev/null 2>&1; then
-            echo "image-fips=mattermost/mattermost-build-server-fips:${{ steps.calculate.outputs.GO_VERSION }}" >> "${GITHUB_OUTPUT}"
+          if docker manifest inspect "mattermost/mattermost-build-server-fips:${GO_VERSION}" > /dev/null 2>&1; then
+            echo "image-fips=mattermost/mattermost-build-server-fips:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
           else
             echo "image-fips=ghcr.io/mattermost/mattermost-build-server-fips:${{ github.sha }}" >> "${GITHUB_OUTPUT}"
             echo "BUILDENV_FIPS_NEEDED=true" >> "${GITHUB_ENV}"

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -67,17 +67,18 @@ jobs:
         id: resolve
         env:
           GO_VERSION: ${{ steps.calculate.outputs.GO_VERSION }}
+          COMMIT_SHA: ${{ github.sha }}
         run: |
           if docker manifest inspect "mattermost/mattermost-build-server:${GO_VERSION}" > /dev/null 2>&1; then
             echo "image=mattermost/mattermost-build-server:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
           else
-            echo "image=ghcr.io/mattermost/mattermost-build-server:${{ github.sha }}" >> "${GITHUB_OUTPUT}"
+            echo "image=ghcr.io/mattermost/mattermost-build-server:${COMMIT_SHA}" >> "${GITHUB_OUTPUT}"
             echo "BUILDENV_NEEDED=true" >> "${GITHUB_ENV}"
           fi
           if docker manifest inspect "mattermost/mattermost-build-server-fips:${GO_VERSION}" > /dev/null 2>&1; then
             echo "image-fips=mattermost/mattermost-build-server-fips:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
           else
-            echo "image-fips=ghcr.io/mattermost/mattermost-build-server-fips:${{ github.sha }}" >> "${GITHUB_OUTPUT}"
+            echo "image-fips=ghcr.io/mattermost/mattermost-build-server-fips:${COMMIT_SHA}" >> "${GITHUB_OUTPUT}"
             echo "BUILDENV_FIPS_NEEDED=true" >> "${GITHUB_ENV}"
           fi
 

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -113,8 +113,10 @@ jobs:
 
       - name: Setup BUILD_IMAGE
         id: build
+        env:
+          BUILD_IMAGE: ${{ inputs.build-image }}
         run: |
-          echo "BUILD_IMAGE=${{ inputs.build-image }}" >> "${GITHUB_OUTPUT}"
+          echo "BUILD_IMAGE=${BUILD_IMAGE}" >> "${GITHUB_OUTPUT}"
           if [[ ${{ inputs.fips-enabled }} == 'true' ]]; then
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}-fips" >> "${GITHUB_OUTPUT}"
           else

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -65,7 +65,7 @@ on:
         type: boolean
         default: false
       build-image:
-        description: "The build image to use (Docker Hub ref normally, ghcr.io ref for in-flight Go bumps)"
+        description: "The build image to use (e.g. mattermost-build-server-dev for in-flight Go bumps)"
         required: true
         type: string
 

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -64,6 +64,10 @@ on:
         required: false
         type: boolean
         default: false
+      build-image:
+        description: "The build image to use (Docker Hub ref normally, ghcr.io ref for in-flight Go bumps)"
+        required: true
+        type: string
 
 permissions:
   contents: read
@@ -110,11 +114,10 @@ jobs:
       - name: Setup BUILD_IMAGE
         id: build
         run: |
+          echo "BUILD_IMAGE=${{ inputs.build-image }}" >> "${GITHUB_OUTPUT}"
           if [[ ${{ inputs.fips-enabled }} == 'true' ]]; then
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}-fips" >> "${GITHUB_OUTPUT}"
           else
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}" >> "${GITHUB_OUTPUT}"
           fi
 


### PR DESCRIPTION
#### Summary

Previously, bumping the Go version required two sequential PRs: one to update `Dockerfile.buildenv` (then wait for master CI to build and push the new image to Docker Hub), then a second PR to bump `.go-version` and `go.mod`. The second PR couldn't run CI until the image existed on Docker Hub.

This collapses that into a single PR by introducing two new private Docker Hub images as a dev staging area:
- `mattermost/mattermost-build-server-dev:<commit-sha>`
- `mattermost/mattermost-build-server-fips-dev:<commit-sha>`

The `go` job now checks whether the versioned buildenv images exist on Docker Hub. If they do (the 99% case), it uses them unchanged and nothing else changes. If not (a Go bump PR), it builds the images from the Dockerfiles and pushes them to the private `-dev` variants tagged with the commit SHA. All downstream jobs then pull from there using the existing Docker Hub credentials.

On merge to master, the existing `build-server-image.yml` workflow publishes the canonical versioned images to the standard Docker Hub repos as before.

Key design decisions:
- Both `-dev` images are **private** on Docker Hub, so the FIPS image is never exposed publicly.
- Fork PRs (`CAN_PUSH=false`) fall back gracefully to the official Docker Hub ref — forks can't perform Go bumps anyway.
- All `container:` jobs now explicitly supply Docker Hub credentials, which are redundant but harmless for public images and necessary for the private `-dev` variants.
- `build-image` is now a required input to `server-test-template` and `mmctl-test-template`, with all callers passing the resolved image explicitly.

**Prerequisite**: the two new private Docker Hub repos must be created and the existing `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` credentials given write access to them.

#### Release Note

```release-note
NONE
```