### PR TITLE
chore(ci): allow build-server-image to build and push from release branches

### DIFF
--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - release-*
     paths:
       - server/build/Dockerfile.buildenv
       - server/build/Dockerfile.buildenv-fips
@@ -57,7 +58,7 @@ jobs:
           echo "GO_VERSION=${GO_VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: buildenv/push
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-')
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           provenance: false
@@ -103,7 +104,7 @@ jobs:
           echo "GO_VERSION=${GO_VERSION}" >> "${GITHUB_OUTPUT}"
 
       - name: buildenv/push
-        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-')
         uses: docker/build-push-action@d08e5c354a6adb9ed34480a06d141179aa583294 # v7.0.0
         with:
           provenance: false


### PR DESCRIPTION
#### Summary

Updates the `BuildEnv Docker Image` workflow to trigger on pushes to `release-*` branches in addition to `master`, and allows the push steps in both `build-image` and `build-image-fips` jobs to run from those branches. This makes it possible to bump the Go version in an older release branch and have the corresponding build server image pushed automatically.

This also means that, in theory, different branches could have different definitions of what constitutes a particular Go version. That doesn't happen in practice, so we'll accept that risk for now -- but revisit this as we make incremental changes.

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to a single GitHub Actions workflow configuration file with no modifications to shared utilities, base classes, or application code. The workflow extension is additive in nature (adding `release-*` branch triggers alongside existing `master` support) with minimal risk of breaking existing behavior.

**QA Recommendation:** Manual QA can be minimal given the isolated nature of the change. Verification should focus on confirming that the workflow triggers correctly on release-* branches and that the push steps execute as expected when the workflow runs on those branches. No application-level testing is required.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36716?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->