### PR TITLE
fix: align preview-toggle shortcut with advertised Cmd+Alt+P (#36392)

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_key_handler.tsx
@@ -275,7 +275,7 @@ const useKeyHandler = (
                 e.stopPropagation();
                 e.preventDefault();
                 toggleAdvanceTextEditor();
-            } else if (Keyboard.isKeyPressed(e, KeyCodes.P) && draft.message.length && !UserAgent.isMac() && showFormattingBar) {
+            } else if (Keyboard.isKeyPressed(e, KeyCodes.P) && draft.message.length) {
                 e.stopPropagation();
                 e.preventDefault();
                 toggleShowPreview();

--- a/webapp/channels/src/components/textbox/textbox.tsx
+++ b/webapp/channels/src/components/textbox/textbox.tsx
@@ -300,7 +300,7 @@ export default class Textbox extends React.PureComponent<Props> {
                 className={classNames('textarea-wrapper', {'textarea-wrapper-preview': this.props.preview, 'textarea-wrapper-preview--disabled': Boolean(this.props.preview && this.props.disabled)})}
             >
                 <div
-                    tabIndex={this.props.tabIndex}
+                    tabIndex={this.props.tabIndex ?? -1}
                     ref={this.preview}
                     className={classNames('form-control custom-textarea textbox-preview-area', {'textarea--has-labels': this.props.hasLabels})}
                     onKeyPress={this.handleKeyPress}


### PR DESCRIPTION
The tooltip on the Show/Hide Preview eye icon advertises Cmd+Alt+P (Ctrl+Alt+P on non-Mac), but on macOS the handler was gated to non-Mac only and required the formatting toolbar to be visible, so Cmd+Alt+P never reached the preview toggle. Additionally, the preview <div> rendered with tabIndex={undefined} when no tabIndex prop was supplied, making it unfocusable, so the auto-focus after entering preview silently failed and subsequent keystrokes fell through to the browser instead of the React handler — preventing users from switching back out of preview mode via the same shortcut.

- use_key_handler.tsx: drop the !UserAgent.isMac() && showFormattingBar clauses from the Cmd+Alt+P branch so the shortcut works on every platform and regardless of formatting-bar visibility, matching what the tooltip advertises.
- textbox.tsx: default the preview div's tabIndex to -1 when no prop is supplied so it is reliably focusable, restoring the round-trip toggle.

#### Summary
The Show/Hide Preview eye icon's tooltip advertises `⌘+⌥+P` on macOS and `Ctrl+Alt+P` elsewhere, but two bugs prevented the advertised shortcut from working end-to-end:

1. In the keydown handler, the `Cmd+Alt+P` branch was gated by `!UserAgent.isMac() && showFormattingBar`, so macOS users never reached it and even non-Mac users only got it when the formatting toolbar was visible. macOS was instead being served by an unrelated `Cmd+Shift+P` branch (which the tooltip never advertised, and which collides with Safari's "Open Private Window").
2. The preview `<div>` rendered with `tabIndex={this.props.tabIndex}` where no `tabIndex` prop is passed up the tree, so it was unfocusable. The autofocus call after entering preview silently failed, focus stayed on `<body>`, and the next keystroke went to the browser instead of the React handler — so the shortcut couldn't toggle back to compose.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/36392

#### Screenshots
N/A — keyboard shortcut behavior change, no UI differences.

#### Release Note
```release-note
Fixed a bug where the advertised ⌘+⌥+P (Ctrl+Alt+P) shortcut did not toggle the message preview on macOS, and could not be used to switch back from preview to compose mode.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes are isolated to the advanced text editor's key handler and the textbox preview rendering, with existing test coverage (211 lines in textbox.test.tsx). However, the focus management change to the preview div (tabIndex default value) affects keyboard interaction behavior in a widely-used component (58 imports across the codebase). While the individual changes are minimal (±1 line each), focus and keyboard shortcut behavior can have unexpected side effects on related features.

**QA Recommendation:** Focus manual QA on keyboard navigation and focus management: (1) verify Cmd+Alt+P (macOS) / Ctrl+Alt+P (other platforms) reliably toggles preview mode and compose mode on all supported browsers and platforms, (2) test that the preview div properly receives and maintains focus when toggled, and (3) confirm that keyboard shortcuts work regardless of whether the formatting toolbar is visible. Automated testing of these specific scenarios is recommended given the breadth of textbox usage.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36735?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->