### PR TITLE
Automated cherry pick of #36685

### DIFF
--- a/webapp/channels/src/components/post_view/post_attachment_container/post_attachment_container.test.tsx
+++ b/webapp/channels/src/components/post_view/post_attachment_container/post_attachment_container.test.tsx
@@ -59,6 +59,20 @@ describe('PostAttachmentContainer', () => {
         expect(screen.getByText('some children')).toBeInTheDocument();
     });
 
+    test('should render non-clickable attachment when click action is prevented', () => {
+        const {container} = renderWithContext(
+            <PostAttachmentContainer
+                {...baseProps}
+                preventClickAction={true}
+            />,
+            initialState,
+        );
+
+        expect(screen.queryByRole('button')).not.toBeInTheDocument();
+        const attachment = container.querySelector('.attachment');
+        expect(attachment).toHaveClass('attachment--permalink', 'attachment--prevent-click');
+    });
+
     test('should handle clicks on elements with non-string className without throwing error', () => {
         renderWithContext(
             <PostAttachmentContainer {...baseProps}/>, initialState,

--- a/webapp/channels/src/components/post_view/post_attachment_container/post_attachment_container.tsx
+++ b/webapp/channels/src/components/post_view/post_attachment_container/post_attachment_container.tsx
@@ -50,6 +50,7 @@ const getElementClassName = (element: EventTarget | null): string => {
 const PostAttachmentContainer = (props: Props) => {
     const {children, className, link, preventClickAction} = props;
     const history = useHistory();
+    const attachmentClassName = `attachment attachment--${className}${preventClickAction ? ' attachment--prevent-click' : ''}`;
 
     const params = getTeamAndPostIdFromLink(link);
 
@@ -90,7 +91,7 @@ const PostAttachmentContainer = (props: Props) => {
     }, [className, crtEnabled, dispatch, history, link, params, post, shouldFocusPostWithoutRedirect, currentUserId]);
     return (
         <div
-            className={`attachment attachment--${className}`}
+            className={attachmentClassName}
             role={preventClickAction ? undefined : 'button'}
             onClick={preventClickAction ? undefined : handleOnClick}
         >

--- a/webapp/channels/src/components/properties_card_view/propertyValueRenderer/post_preview_property_renderer/post_preview_property_renderer.test.tsx
+++ b/webapp/channels/src/components/properties_card_view/propertyValueRenderer/post_preview_property_renderer/post_preview_property_renderer.test.tsx
@@ -98,7 +98,7 @@ describe('PostPreviewPropertyRenderer', () => {
     };
 
     it('should render PostMessagePreview when all data is available', async () => {
-        const {getByTestId, getByText} = renderWithContext(
+        const {container, getByTestId, getByText} = renderWithContext(
             <PostPreviewPropertyRenderer {...defaultProps}/>,
             baseState,
         );
@@ -109,6 +109,10 @@ describe('PostPreviewPropertyRenderer', () => {
 
         expect(getByText('Test post message')).toBeVisible();
         expect(getByText('Originally posted in ~Test Channel')).toBeVisible();
+
+        const previewAttachment = container.querySelector('.attachment');
+        expect(previewAttachment).toHaveClass('attachment--permalink', 'attachment--prevent-click');
+        expect(previewAttachment).not.toHaveAttribute('role');
     });
 
     it('should return null when post is not found', async () => {

--- a/webapp/channels/src/sass/layout/_webhooks.scss
+++ b/webapp/channels/src/sass/layout/_webhooks.scss
@@ -101,6 +101,11 @@
             }
         }
 
+        &.attachment--prevent-click,
+        &.attachment--prevent-click:hover {
+            cursor: default;
+        }
+
         .attachment__content {
             border-width: 1px;
             border-style: solid;


### PR DESCRIPTION
Cherry pick of #36685 on release-11.8.

/cc  @cursor[bot]

```release-note
NONE
```