### PR TITLE
[MM-68999] Add SchemaVersion to PropertyGroup for group-specific field schema versioning

### DIFF
--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -272,7 +272,7 @@ func NewServer(options ...Option) (*Server, error) {
 
 	// Register builtin property groups before creating hooks that reference them
 	if err = s.propertyService.RegisterBuiltinGroups([]*model.PropertyGroup{
-		{Name: model.AccessControlPropertyGroupName, Version: model.PropertyGroupVersionV2},
+		{Name: model.AccessControlPropertyGroupName, Version: model.PropertyGroupVersionV2, SchemaVersion: model.AccessControlPropertyGroupSchemaVersion},
 		{Name: model.ContentFlaggingGroupName, Version: model.PropertyGroupVersionV1},
 	}); err != nil {
 		return nil, errors.Wrap(err, "failed to register builtin property groups")

--- a/server/channels/db/migrations/postgres/000193_add_property_groups_schema_version.down.sql
+++ b/server/channels/db/migrations/postgres/000193_add_property_groups_schema_version.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE PropertyGroups DROP COLUMN IF EXISTS SchemaVersion;

--- a/server/channels/db/migrations/postgres/000193_add_property_groups_schema_version.up.sql
+++ b/server/channels/db/migrations/postgres/000193_add_property_groups_schema_version.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE PropertyGroups ADD COLUMN IF NOT EXISTS SchemaVersion integer DEFAULT 1 NOT NULL;

--- a/server/channels/store/sqlstore/property_group_store.go
+++ b/server/channels/store/sqlstore/property_group_store.go
@@ -11,7 +11,7 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 )
 
-var propertyGroupColumns = []string{"ID", "Name", "Version"}
+var propertyGroupColumns = []string{"ID", "Name", "Version", "SchemaVersion"}
 
 type SqlPropertyGroupStore struct {
 	*SqlStore
@@ -34,8 +34,8 @@ func (s *SqlPropertyGroupStore) Register(group *model.PropertyGroup) (*model.Pro
 
 	builder := s.getQueryBuilder().
 		Insert("PropertyGroups").
-		Columns("ID", "Name", "Version").
-		Values(group.ID, group.Name, group.Version)
+		Columns("ID", "Name", "Version", "SchemaVersion").
+		Values(group.ID, group.Name, group.Version, group.SchemaVersion)
 
 	builder = builder.SuffixExpr(sq.Expr("ON CONFLICT (Name) DO NOTHING"))
 

--- a/server/channels/store/storetest/property_group_store.go
+++ b/server/channels/store/storetest/property_group_store.go
@@ -15,6 +15,7 @@ import (
 func TestPropertyGroupStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
 	t.Run("RegisterAndGetPropertyGroup", func(t *testing.T) { testRegisterAndGetPropertyGroup(t, rctx, ss) })
 	t.Run("IncrementVersion", func(t *testing.T) { testIncrementVersion(t, rctx, ss) })
+	t.Run("SchemaVersionPersistence", func(t *testing.T) { testSchemaVersionPersistence(t, rctx, ss) })
 }
 
 func testRegisterAndGetPropertyGroup(t *testing.T, _ request.CTX, ss store.Store) {
@@ -118,6 +119,57 @@ func testRegisterAndGetPropertyGroup(t *testing.T, _ request.CTX, ss store.Store
 	t.Run("should return error for non-existent ID", func(t *testing.T) {
 		_, err := ss.PropertyGroup().GetByID(model.NewId())
 		require.Error(t, err)
+	})
+}
+
+func testSchemaVersionPersistence(t *testing.T, _ request.CTX, ss store.Store) {
+	t.Run("explicit SchemaVersion is persisted and returned", func(t *testing.T) {
+		group, err := ss.PropertyGroup().Register(&model.PropertyGroup{
+			Name:          "schema_version_explicit_test",
+			Version:       model.PropertyGroupVersionV1,
+			SchemaVersion: 5,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 5, group.SchemaVersion)
+
+		fetched, err := ss.PropertyGroup().Get("schema_version_explicit_test")
+		require.NoError(t, err)
+		require.Equal(t, 5, fetched.SchemaVersion)
+	})
+
+	t.Run("SchemaVersion defaults to 1 when not set", func(t *testing.T) {
+		group, err := ss.PropertyGroup().Register(&model.PropertyGroup{
+			Name:    "schema_version_default_test",
+			Version: model.PropertyGroupVersionV1,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 1, group.SchemaVersion)
+
+		fetched, err := ss.PropertyGroup().Get("schema_version_default_test")
+		require.NoError(t, err)
+		require.Equal(t, 1, fetched.SchemaVersion)
+	})
+
+	t.Run("SchemaVersion is not updated on re-registration", func(t *testing.T) {
+		original, err := ss.PropertyGroup().Register(&model.PropertyGroup{
+			Name:          "schema_version_immutable_test",
+			Version:       model.PropertyGroupVersionV1,
+			SchemaVersion: 2,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, original.SchemaVersion)
+
+		reregistered, err := ss.PropertyGroup().Register(&model.PropertyGroup{
+			Name:          "schema_version_immutable_test",
+			Version:       model.PropertyGroupVersionV1,
+			SchemaVersion: 99,
+		})
+		require.NoError(t, err)
+		require.Equal(t, 2, reregistered.SchemaVersion)
+
+		fetched, err := ss.PropertyGroup().Get("schema_version_immutable_test")
+		require.NoError(t, err)
+		require.Equal(t, 2, fetched.SchemaVersion)
 	})
 }
 

--- a/server/public/model/property_group.go
+++ b/server/public/model/property_group.go
@@ -32,10 +32,17 @@ const (
 	PropertyGroupVersionV2 = 2
 )
 
+// AccessControlPropertyGroupSchemaVersion is the current schema version for
+// the access_control group's field definitions. Increment this constant
+// whenever the shape of access_control fields (attrs, types, options) changes
+// in a way that consumers need to detect.
+const AccessControlPropertyGroupSchemaVersion = 1
+
 type PropertyGroup struct {
-	ID      string `json:"id"`
-	Name    string `json:"name"`
-	Version int    `json:"version"`
+	ID            string `json:"id"`
+	Name          string `json:"name"`
+	Version       int    `json:"version"`
+	SchemaVersion int    `json:"schema_version"`
 }
 
 func (pg *PropertyGroup) IsPSAv1() bool {

--- a/server/public/model/property_group.go
+++ b/server/public/model/property_group.go
@@ -61,6 +61,10 @@ func (pg *PropertyGroup) PreSave() {
 	if pg.Version == 0 {
 		pg.Version = PropertyGroupVersionV1
 	}
+
+	if pg.SchemaVersion <= 0 {
+		pg.SchemaVersion = 1
+	}
 }
 
 func (pg *PropertyGroup) IsValid() *AppError {

--- a/server/public/model/property_group_test.go
+++ b/server/public/model/property_group_test.go
@@ -129,4 +129,22 @@ func TestPropertyGroupPreSave(t *testing.T) {
 		pg.PreSave()
 		assert.Equal(t, PropertyGroupVersionV2, pg.Version)
 	})
+
+	t.Run("defaults schema_version to 1 when zero", func(t *testing.T) {
+		pg := &PropertyGroup{Name: "test_group"}
+		pg.PreSave()
+		assert.Equal(t, 1, pg.SchemaVersion)
+	})
+
+	t.Run("defaults schema_version to 1 when negative", func(t *testing.T) {
+		pg := &PropertyGroup{Name: "test_group", SchemaVersion: -5}
+		pg.PreSave()
+		assert.Equal(t, 1, pg.SchemaVersion)
+	})
+
+	t.Run("does not overwrite existing schema_version", func(t *testing.T) {
+		pg := &PropertyGroup{Name: "test_group", SchemaVersion: 3}
+		pg.PreSave()
+		assert.Equal(t, 3, pg.SchemaVersion)
+	})
 }


### PR DESCRIPTION
## Summary

Property groups (like `access_control`) contain a set of fields that define things like user attributes, visibility rules, and access control settings. Until now, there was no way to tell whether those field definitions had changed — only a global compatibility version for the whole property system existed.

This adds a `SchemaVersion` field to property groups so that when the fields within a group change (new fields added, types changed, options restructured), that change can be signaled with a version bump. Consumers can read `schema_version` from the group and know whether they need to handle a newer or older shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Ticket Link

https://mattermost.atlassian.net/browse/MM-68999

## Changes

- `PropertyGroup` gains a `schema_version` field (integer, returned in API responses)
- A new constant `AccessControlPropertyGroupSchemaVersion` tracks the current version for the `access_control` group, starting at 1
- DB migration 000193 adds the column with a default of 1, so all existing groups are initialized to 1
- `PreSave()` now defaults `SchemaVersion` to 1 for any value `<= 0`, so callers registering builtin groups don't need to set it explicitly — the `content_flagging` group (and any future groups) get a valid schema version automatically
- Store-level tests covering explicit `SchemaVersion` persistence, the default-to-1 path, and immutability on re-registration
- Unit tests for the `PreSave` defaulting behavior (zero and negative values)

## Release Notes

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes add a new `SchemaVersion` field across the PropertyGroup model, store layer, and database, affecting data persistence and retrieval paths. However, the migration includes a safe `DEFAULT 1` constraint and existing tests do not validate SchemaVersion behavior, leaving potential edge cases uncovered. Notably, the `PreSave()` method does not initialize SchemaVersion to a default value (unlike the Version field), which could lead to inconsistent state if groups are created in-memory without explicitly setting this field.

**QA Recommendation:** Beyond automated test execution, recommend manual verification that: (1) PropertyGroups registered via the API endpoint return the `schema_version` field correctly in responses, (2) accessing existing PropertyGroups after migration returns `schema_version: 1` as expected, and (3) the access_control group is properly registered with `AccessControlPropertyGroupSchemaVersion`. Additionally, validate behavior in access control workflows where PropertyGroup is referenced.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36747?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->