### PR TITLE
[MM-69000] Return error when plugins use deprecated custom_profile_attributes group name

### DIFF
--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -1712,9 +1712,8 @@ func (api *PluginAPI) SearchPropertyValues(groupID string, opts model.PropertyVa
 func (api *PluginAPI) RegisterPropertyGroup(name string) (*model.PropertyGroup, error) {
 	if name == model.DeprecatedCPAPropertyGroupName {
 		return nil, fmt.Errorf(
-			"the group name %q has been renamed to %q; use %q instead",
+			"%q is a version 1 PSA group that has been deprecated; use the version 2 PSA group %q instead",
 			model.DeprecatedCPAPropertyGroupName,
-			model.AccessControlPropertyGroupName,
 			model.AccessControlPropertyGroupName,
 		)
 	}
@@ -1729,21 +1728,18 @@ func (api *PluginAPI) RegisterPropertyGroup(name string) (*model.PropertyGroup, 
 }
 
 func (api *PluginAPI) GetPropertyGroup(name string) (*model.PropertyGroup, error) {
-	name = migrateDeprecatedPropertyGroupName(name)
+	if name == model.DeprecatedCPAPropertyGroupName {
+		return nil, fmt.Errorf(
+			"%q is a version 1 PSA group that has been deprecated; use the version 2 PSA group %q instead",
+			model.DeprecatedCPAPropertyGroupName,
+			model.AccessControlPropertyGroupName,
+		)
+	}
 	group, appErr := api.app.GetPropertyGroup(api.psaPluginContext(), name)
 	if appErr != nil {
 		return nil, appErr
 	}
 	return group, nil
-}
-
-// migrateDeprecatedPropertyGroupName maps the deprecated "custom_profile_attributes"
-// group name to the current "access_control" name for backward compatibility.
-func migrateDeprecatedPropertyGroupName(name string) string {
-	if name == model.DeprecatedCPAPropertyGroupName {
-		return model.AccessControlPropertyGroupName
-	}
-	return name
 }
 
 func (api *PluginAPI) GetPropertyFieldByName(groupID, targetID, name string) (*model.PropertyField, error) {

--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -3876,7 +3876,7 @@ func TestPluginAPIPropertyGroupDeprecatedName(t *testing.T) {
 		// Register using the deprecated name must fail
 		_, err := api.RegisterPropertyGroup(model.DeprecatedCPAPropertyGroupName)
 		require.Error(t, err)
-		assert.Contains(t, err.Error(), "renamed")
+		assert.Contains(t, err.Error(), "deprecated")
 
 		// Register using the canonical name should still work
 		group, err := api.RegisterPropertyGroup(model.AccessControlPropertyGroupName)
@@ -3885,24 +3885,21 @@ func TestPluginAPIPropertyGroupDeprecatedName(t *testing.T) {
 		assert.Equal(t, model.AccessControlPropertyGroupName, group.Name)
 	})
 
-	t.Run("GetPropertyGroup maps deprecated name to canonical name", func(t *testing.T) {
+	t.Run("GetPropertyGroup rejects deprecated name", func(t *testing.T) {
 		th := Setup(t).InitBasic(t)
 
 		api := th.SetupPluginAPI()
 
-		// The access_control group is registered at server startup, so
-		// we can look it up directly.
+		// Looking up by the deprecated name must fail with an actionable error
+		_, err := api.GetPropertyGroup(model.DeprecatedCPAPropertyGroupName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "deprecated")
+
+		// Looking up by the canonical name should still work
 		canonical, err := api.GetPropertyGroup(model.AccessControlPropertyGroupName)
 		require.NoError(t, err)
 		require.NotNil(t, canonical)
-
-		// Looking up by the deprecated name should return the same group
-		deprecated, err := api.GetPropertyGroup(model.DeprecatedCPAPropertyGroupName)
-		require.NoError(t, err)
-		require.NotNil(t, deprecated)
-
-		assert.Equal(t, canonical.ID, deprecated.ID)
-		assert.Equal(t, model.AccessControlPropertyGroupName, deprecated.Name)
+		assert.Equal(t, model.AccessControlPropertyGroupName, canonical.Name)
 	})
 
 	t.Run("other group names are not affected by the mapping", func(t *testing.T) {


### PR DESCRIPTION
## Summary

Mattermost has two generations of its property system:

The first generation used a group called `custom_profile_attributes`. That group has since been replaced by a second-generation group called `access_control`, which is more capable and is where active development happens.

To smooth the transition, the plugin API was quietly remapping any call that used the old name to the new one behind the scenes. This PR removes that silent remapping and returns a clear error instead:

> `"custom_profile_attributes"` is a version 1 PSA group that has been deprecated; use the version 2 PSA group `"access_control"` instead

This gives plugin developers an explicit, actionable signal rather than letting them unknowingly rely on an incomplete compatibility shim that could result in cryptic errors and subtle breakage. The same explicit error was already in place for `RegisterPropertyGroup`; this change brings `GetPropertyGroup` in line with it and cleans up the now-unused helper function that performed the remapping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
## Ticket Link

https://mattermost.atlassian.net/browse/MM-69000

## Release Notes

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** This is an intentional breaking change to the plugin API that removes backward-compatible remapping of the deprecated `custom_profile_attributes` group name. Any plugins relying on this silent remapping will fail at runtime with an explicit error, potentially affecting third-party and community plugins that haven't migrated to the canonical `access_control` group name.

**QA Recommendation:** Coordinate with plugin developers and the Mattermost Marketplace to identify and flag plugins using the deprecated group name. Manual testing should focus on verifying the new error messages are actionable and that the canonical group name continues to function correctly across property group operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36748?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->