### PR TITLE
Automated cherry pick of #36684

### DIFF
--- a/webapp/channels/src/components/admin_console/access_control/editors/cel_editor/editor.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/editors/cel_editor/editor.tsx
@@ -25,6 +25,7 @@ const MONACO_EDITOR_OPTIONS: monaco.editor.IStandaloneEditorConstructionOptions 
     extraEditorClassName: 'policyEditor',
     language: POLICY_LANGUAGE,
     automaticLayout: true,
+    fixedOverflowWidgets: true,
     minimap: {enabled: false},
     lineNumbers: 'off',
     scrollBeyondLastLine: false,

--- a/webapp/platform/shared/src/components/tooltip/with_tooltip.tsx
+++ b/webapp/platform/shared/src/components/tooltip/with_tooltip.tsx
@@ -16,6 +16,7 @@ import {
     useTransitionStyles,
     FloatingArrow,
     flip,
+    shift,
     useMergeRefs,
 } from '@floating-ui/react';
 import classNames from 'classnames';
@@ -126,6 +127,7 @@ export function WithTooltip({
             flip({
                 fallbackPlacements: placements.fallback,
             }),
+            shift({padding: OverlayArrow.OFFSET}),
             arrow({
                 element: arrowRef,
             }),


### PR DESCRIPTION
Cherry pick of #36684 on release-11.8.

/cc  @cursor[bot]

```release-note
NONE
```