### PR TITLE
Stop logging email subject when sending mail

### DIFF
--- a/server/platform/shared/mail/mail.go
+++ b/server/platform/shared/mail/mail.go
@@ -291,7 +291,7 @@ func sendMailUsingConfigAdvanced(mail mailData, config *SMTPConfig) error {
 const SendGridXSMTPAPIHeader = "X-SMTPAPI"
 
 func sendMail(c smtpClient, mail mailData, date time.Time, config *SMTPConfig) error {
-	mlog.Info("sending mail", mlog.String("to", mail.smtpTo), mlog.String("subject", mail.subject))
+	mlog.Info("sending mail", mlog.String("to", mail.smtpTo))
 
 	htmlMessage := mail.htmlBody
 	text, _, err := docconv.ConvertHTML(strings.NewReader(htmlMessage), true)


### PR DESCRIPTION
#### Summary
The `sending mail` Info log in `server/platform/shared/mail/mail.go` includes the email subject. For notification mails like DMs and mentions, the subject contains the sender's name and channel context (e.g. `[Team] New Direct Message from Alice on May 22, 2026`) — PII visible to anyone with access to server logs.

This drops the `subject` field from the log line. The `to` address is preserved so the log still confirms an outbound notification fired, which is useful when debugging delivery. Kept at Info rather than dropping to Debug so admins don't lose visibility into mail being sent at default log levels.

#### Ticket Link
None

#### Release Note
```release-note
Stopped logging the email subject in the "sending mail" server log, which could expose PII such as sender names from DM and mention notifications.
```
