### PR TITLE
[MM-69026] Add zoom and pan to the image file preview

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/files_and_attachments/file_preview_image_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/files_and_attachments/file_preview_image_spec.js
@@ -140,10 +140,12 @@ describe('Upload Files - Image', () => {
         // # Click zoom-in
         cy.get('@filePreviewModal').find('.modal-zoom-btn .icon-plus').click();
 
-        // * Image is scaled up (transform contains scale > 1)
+        // * Image is scaled up — match only scale values strictly greater than 1
+        //   (e.g. scale(1.25), scale(2)), so a transform of scale(1) or no
+        //   scale at all would fail this assertion.
         cy.get('@filePreviewModal').find('[data-testid="imagePreview"]').
             should('have.attr', 'style').
-            and('match', /scale\((?!1\))[0-9.]+\)/);
+            and('match', /scale\((?:1\.\d+|[2-9]\d*(?:\.\d+)?)\)/);
 
         // # Press '0' to reset
         cy.get('body').type('0');

--- a/e2e-tests/cypress/tests/integration/channels/files_and_attachments/file_preview_image_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/files_and_attachments/file_preview_image_spec.js
@@ -104,6 +104,59 @@ describe('Upload Files - Image', () => {
 
         testImage(properties);
     });
+
+    it('MM-69026 - Image preview supports zoom controls and keyboard shortcut', () => {
+        // Use a unique filename so we can find the thumbnail unambiguously after
+        // earlier tests in this spec have already uploaded PNG.png/JPG.jpg/etc.
+        const fileName = 'mm-69026-zoom.png';
+        const properties = {
+            filePath: 'mm_file_testing/Images/PNG.png',
+            fileName,
+            originalWidth: 400,
+            originalHeight: 479,
+            mimeType: 'image/png',
+        };
+
+        // # Post any message
+        cy.postMessage(fileName);
+
+        // # Post an image in center channel
+        attachFile(properties);
+
+        // # Wait until file upload is complete then submit
+        waitUntilUploadComplete();
+        cy.uiGetPostTextBox().clear().type('{enter}');
+        cy.wait(TIMEOUTS.FIVE_SEC);
+
+        // # Open file preview
+        cy.uiGetFileThumbnail(fileName).click();
+
+        // * Verify preview modal opened
+        cy.uiGetFilePreviewModal().as('filePreviewModal');
+
+        // * Zoom controls are visible for images
+        cy.get('@filePreviewModal').find('.file-preview-modal__zoom-bar .modal-zoom-btn').should('have.length.at.least', 1);
+
+        // # Click zoom-in
+        cy.get('@filePreviewModal').find('.modal-zoom-btn .icon-plus').click();
+
+        // * Image is scaled up (transform contains scale > 1)
+        cy.get('@filePreviewModal').find('[data-testid="imagePreview"]').
+            should('have.attr', 'style').
+            and('match', /scale\((?!1\))[0-9.]+\)/);
+
+        // # Press '0' to reset
+        cy.get('body').type('0');
+
+        // * Image transform clears (no scale applied at default 1.0)
+        cy.get('@filePreviewModal').find('[data-testid="imagePreview"]').then(($img) => {
+            const style = $img.attr('style') || '';
+            expect(style).to.not.match(/scale\([0-9.]+\)/);
+        });
+
+        // # Close modal
+        cy.uiCloseFilePreviewModal();
+    });
 });
 
 function testImage(properties) {

--- a/webapp/channels/src/components/file_preview_modal/__snapshots__/file_preview_modal.test.tsx.snap
+++ b/webapp/channels/src/components/file_preview_modal/__snapshots__/file_preview_modal.test.tsx.snap
@@ -130,6 +130,9 @@ exports[`components/FilePreviewModal should match snapshot, loaded 1`] = `
             <div>
               File Preview Modal Header
             </div>
+            <div>
+              Popover Bar
+            </div>
           </div>
           <div
             class="file-preview-modal__content"
@@ -158,6 +161,9 @@ exports[`components/FilePreviewModal should match snapshot, loaded and showing f
           <div>
             <div>
               File Preview Modal Header
+            </div>
+            <div>
+              Popover Bar
             </div>
           </div>
           <div
@@ -275,6 +281,9 @@ exports[`components/FilePreviewModal should match snapshot, loaded with footer 1
             <div>
               File Preview Modal Header
             </div>
+            <div>
+              Popover Bar
+            </div>
           </div>
           <div
             class="file-preview-modal__content"
@@ -303,6 +312,9 @@ exports[`components/FilePreviewModal should match snapshot, loaded with image 1`
           <div>
             <div>
               File Preview Modal Header
+            </div>
+            <div>
+              Popover Bar
             </div>
           </div>
           <div

--- a/webapp/channels/src/components/file_preview_modal/__snapshots__/image_preview.test.tsx.snap
+++ b/webapp/channels/src/components/file_preview_modal/__snapshots__/image_preview.test.tsx.snap
@@ -10,6 +10,7 @@ exports[`components/view_image/ImagePreview should match snapshot, with preview 
       alt="preview url image"
       class="image_preview__image"
       data-testid="imagePreview"
+      draggable="false"
       loading="lazy"
       src="/api/v4/files/file_id_1/preview"
     />
@@ -19,9 +20,15 @@ exports[`components/view_image/ImagePreview should match snapshot, with preview 
 
 exports[`components/view_image/ImagePreview should match snapshot, with preview, cannot download 1`] = `
 <div>
-  <img
-    src="/api/v4/files/file_id_1/preview"
-  />
+  <span
+    class="image_preview"
+  >
+    <img
+      class="image_preview__image"
+      draggable="false"
+      src="/api/v4/files/file_id_1/preview"
+    />
+  </span>
 </div>
 `;
 
@@ -35,6 +42,7 @@ exports[`components/view_image/ImagePreview should match snapshot, without previ
       alt="preview url image"
       class="image_preview__image"
       data-testid="imagePreview"
+      draggable="false"
       loading="lazy"
       src="/api/v4/files/file_id?download=1"
     />
@@ -44,8 +52,14 @@ exports[`components/view_image/ImagePreview should match snapshot, without previ
 
 exports[`components/view_image/ImagePreview should match snapshot, without preview, cannot download 1`] = `
 <div>
-  <img
-    src="/api/v4/files/file_id?download=1"
-  />
+  <span
+    class="image_preview"
+  >
+    <img
+      class="image_preview__image"
+      draggable="false"
+      src="/api/v4/files/file_id?download=1"
+    />
+  </span>
 </div>
 `;

--- a/webapp/channels/src/components/file_preview_modal/file_preview_modal.scss
+++ b/webapp/channels/src/components/file_preview_modal/file_preview_modal.scss
@@ -19,6 +19,7 @@
 
     &__content {
         display: flex;
+        overflow: hidden; // clip transformed image previews so panning can't escape behind the header
         height: calc(100vh - 72px);
         align-items: center;
         justify-content: center;

--- a/webapp/channels/src/components/file_preview_modal/file_preview_modal.test.tsx
+++ b/webapp/channels/src/components/file_preview_modal/file_preview_modal.test.tsx
@@ -444,3 +444,299 @@ describe('computeZoomAtCursor', () => {
         expect(computeZoomAtCursor(0, t, 10, 10, 2)).toBe(t);
     });
 });
+
+describe('FilePreviewModal static helpers', () => {
+    test('getDefaultScaleForFile returns the image default for image extensions', () => {
+        const png = TestHelper.getFileInfoMock({extension: 'png'});
+        expect(FilePreviewModal.getDefaultScaleForFile(png)).toBe(1.0);
+    });
+
+    test('getDefaultScaleForFile returns the image default for SVG', () => {
+        const svg = TestHelper.getFileInfoMock({extension: 'svg'});
+        expect(FilePreviewModal.getDefaultScaleForFile(svg)).toBe(1.0);
+    });
+
+    test('getDefaultScaleForFile returns the (PDF) default for other file types', () => {
+        const pdf = TestHelper.getFileInfoMock({extension: 'pdf'});
+        expect(FilePreviewModal.getDefaultScaleForFile(pdf)).toBe(1.75);
+    });
+
+    test('getMaxScaleForFile caps images at 2.0 and other files at 3.0', () => {
+        expect(FilePreviewModal.getMaxScaleForFile(TestHelper.getFileInfoMock({extension: 'png'}))).toBe(2.0);
+        expect(FilePreviewModal.getMaxScaleForFile(TestHelper.getFileInfoMock({extension: 'svg'}))).toBe(2.0);
+        expect(FilePreviewModal.getMaxScaleForFile(TestHelper.getFileInfoMock({extension: 'pdf'}))).toBe(3.0);
+    });
+
+    test('getFileIdentity distinguishes FileInfo by id and LinkInfo by link', () => {
+        const fileInfo = TestHelper.getFileInfoMock({id: 'abc-123', extension: 'png'});
+        const linkInfo = {link: 'https://example.com/x.png', extension: 'png', name: 'x.png'};
+        expect(FilePreviewModal.getFileIdentity(fileInfo)).toBe('f:abc-123');
+        expect(FilePreviewModal.getFileIdentity(linkInfo as any)).toBe('l:https://example.com/x.png');
+    });
+
+    test('getFileIdentity namespaces file ids vs links so a literal collision never compares equal', () => {
+        const fileInfo = TestHelper.getFileInfoMock({id: 'shared-value', extension: 'png'});
+        const linkInfo = {link: 'shared-value', extension: 'png', name: 'x.png'};
+        expect(FilePreviewModal.getFileIdentity(fileInfo)).not.toBe(FilePreviewModal.getFileIdentity(linkInfo as any));
+    });
+});
+
+describe('FilePreviewModal instance behavior', () => {
+    const imageProps = {
+        fileInfos: [TestHelper.getFileInfoMock({id: 'img_1', extension: 'png'})],
+        startIndex: 0,
+        canDownloadFiles: true,
+        enablePublicLink: true,
+        isMobileView: false,
+        post: TestHelper.getPostMock(),
+        onExited: jest.fn(),
+    };
+
+    const mountModal = (props = imageProps) => {
+        const ref = React.createRef<FilePreviewModal>();
+        const utils = render(
+            <FilePreviewModal
+                ref={ref}
+                {...props}
+            />,
+        );
+        return {ref, ...utils};
+    };
+
+    describe('handleKeyDown', () => {
+        test('"+" zooms in and "-" zooms back out for an image', () => {
+            const {ref} = mountModal();
+            act(() => {
+                ref.current?.setState({showZoomControls: true, loaded: {0: true}});
+            });
+
+            act(() => {
+                document.dispatchEvent(new KeyboardEvent('keydown', {key: '+'}));
+            });
+            expect(ref.current?.state.scale[0]).toBeCloseTo(1.25);
+
+            act(() => {
+                document.dispatchEvent(new KeyboardEvent('keydown', {key: '-'}));
+            });
+            expect(ref.current?.state.scale[0]).toBeCloseTo(1.0);
+        });
+
+        test('"0" resets a previously zoomed image to default scale', () => {
+            const {ref} = mountModal();
+            act(() => {
+                ref.current?.setState({showZoomControls: true, loaded: {0: true}, scale: {0: 1.5}});
+            });
+
+            act(() => {
+                document.dispatchEvent(new KeyboardEvent('keydown', {key: '0'}));
+            });
+            expect(ref.current?.state.scale[0]).toBe(1.0);
+        });
+
+        test('ignores zoom keys when a Ctrl/Cmd modifier is held', () => {
+            const {ref} = mountModal();
+            act(() => {
+                ref.current?.setState({showZoomControls: true, loaded: {0: true}});
+            });
+
+            act(() => {
+                document.dispatchEvent(new KeyboardEvent('keydown', {key: '+', ctrlKey: true}));
+                document.dispatchEvent(new KeyboardEvent('keydown', {key: '+', metaKey: true}));
+            });
+            expect(ref.current?.state.scale[0]).toBe(1.0);
+        });
+
+        test('ignores zoom keys when an input element has focus', () => {
+            const {ref} = mountModal();
+            act(() => {
+                ref.current?.setState({showZoomControls: true, loaded: {0: true}});
+            });
+
+            const input = document.createElement('input');
+            document.body.appendChild(input);
+            input.focus();
+
+            act(() => {
+                input.dispatchEvent(new KeyboardEvent('keydown', {key: '+', bubbles: true}));
+            });
+            expect(ref.current?.state.scale[0]).toBe(1.0);
+
+            document.body.removeChild(input);
+        });
+    });
+
+    describe('handleImageMouseDown drag gate', () => {
+        // The drag handler requires DOM-level event listeners to set up; we
+        // assert behavior via the resulting React state rather than the
+        // private dragState field.
+        test('does not start a drag when the image is at default scale', () => {
+            const {ref} = mountModal();
+            act(() => {
+                ref.current?.setState({showZoomControls: true, loaded: {0: true}});
+            });
+
+            const mockEvent = {button: 0, clientX: 0, clientY: 0, preventDefault: jest.fn()} as any;
+            act(() => {
+                ref.current?.handleImageMouseDown(mockEvent);
+            });
+            expect(ref.current?.state.isDragging).toBe(false);
+        });
+
+        test('starts a drag when the image is zoomed past default scale', () => {
+            const {ref} = mountModal();
+            act(() => {
+                ref.current?.setState({showZoomControls: true, loaded: {0: true}, scale: {0: 1.5}});
+            });
+
+            const mockEvent = {button: 0, clientX: 0, clientY: 0, preventDefault: jest.fn()} as any;
+            act(() => {
+                ref.current?.handleImageMouseDown(mockEvent);
+            });
+            expect(ref.current?.state.isDragging).toBe(true);
+
+            // Cleanup: simulate mouseup so the document listeners don't leak
+            // between tests.
+            act(() => {
+                document.dispatchEvent(new MouseEvent('mouseup'));
+            });
+        });
+
+        test('ignores non-left-button mousedowns', () => {
+            const {ref} = mountModal();
+            act(() => {
+                ref.current?.setState({showZoomControls: true, loaded: {0: true}, scale: {0: 1.5}});
+            });
+
+            const mockEvent = {button: 2, clientX: 0, clientY: 0, preventDefault: jest.fn()} as any;
+            act(() => {
+                ref.current?.handleImageMouseDown(mockEvent);
+            });
+            expect(ref.current?.state.isDragging).toBe(false);
+        });
+    });
+
+    describe('handleImageWheel scale clamping', () => {
+        // Use a stable rect for getBoundingClientRect across these tests so the
+        // cursor-offset math is predictable.
+        const wheelEventOn = (target: HTMLElement, deltaY: number) => {
+            const evt = new WheelEvent('wheel', {deltaY, clientX: 100, clientY: 100, cancelable: true});
+            Object.defineProperty(evt, 'currentTarget', {value: target, configurable: true});
+            return evt;
+        };
+
+        test('clamps zoom-in at MAX_SCALE_IMAGE (2.0)', () => {
+            const {ref} = mountModal();
+            act(() => {
+                ref.current?.setState({showZoomControls: true, loaded: {0: true}, scale: {0: 1.9}});
+            });
+            const dummy = document.createElement('div');
+            jest.spyOn(dummy, 'getBoundingClientRect').mockReturnValue({left: 0, top: 0, width: 200, height: 200, right: 200, bottom: 200, x: 0, y: 0, toJSON: () => ({})});
+
+            act(() => {
+                ref.current?.handleImageWheel(wheelEventOn(dummy, -100));
+
+                // A second zoom-in should not push past the cap.
+                ref.current?.handleImageWheel(wheelEventOn(dummy, -100));
+            });
+            expect(ref.current?.state.scale[0]).toBeLessThanOrEqual(2.0);
+            expect(ref.current?.state.scale[0]).toBeCloseTo(2.0);
+        });
+
+        test('clamps zoom-out at MIN_SCALE (0.25)', () => {
+            const {ref} = mountModal();
+            act(() => {
+                ref.current?.setState({showZoomControls: true, loaded: {0: true}, scale: {0: 0.3}});
+            });
+            const dummy = document.createElement('div');
+            jest.spyOn(dummy, 'getBoundingClientRect').mockReturnValue({left: 0, top: 0, width: 200, height: 200, right: 200, bottom: 200, x: 0, y: 0, toJSON: () => ({})});
+
+            act(() => {
+                ref.current?.handleImageWheel(wheelEventOn(dummy, 100));
+                ref.current?.handleImageWheel(wheelEventOn(dummy, 100));
+            });
+            expect(ref.current?.state.scale[0]).toBeGreaterThanOrEqual(0.25);
+            expect(ref.current?.state.scale[0]).toBeCloseTo(0.25);
+        });
+
+        test('no-op when deltaY is exactly zero', () => {
+            const {ref} = mountModal();
+            act(() => {
+                ref.current?.setState({showZoomControls: true, loaded: {0: true}, scale: {0: 1.0}});
+            });
+            const dummy = document.createElement('div');
+            jest.spyOn(dummy, 'getBoundingClientRect').mockReturnValue({left: 0, top: 0, width: 200, height: 200, right: 200, bottom: 200, x: 0, y: 0, toJSON: () => ({})});
+
+            act(() => {
+                ref.current?.handleImageWheel(wheelEventOn(dummy, 0));
+            });
+            expect(ref.current?.state.scale[0]).toBe(1.0);
+        });
+    });
+
+    describe('getDerivedStateFromProps identity reconciliation', () => {
+        test('resets scale/translate at an index where the file identity changed (same length)', () => {
+            const initial = {
+                ...imageProps,
+                fileInfos: [
+                    TestHelper.getFileInfoMock({id: 'a', extension: 'png'}),
+                    TestHelper.getFileInfoMock({id: 'b', extension: 'png'}),
+                ],
+            };
+            const {ref, rerender} = mountModal(initial);
+
+            // Simulate the user zooming both images.
+            act(() => {
+                ref.current?.setState({
+                    scale: {0: 1.5, 1: 1.75},
+                    translate: {0: {x: 10, y: 10}, 1: {x: 20, y: 20}},
+                });
+            });
+
+            // Swap the file at index 1 for a different one; index 0 keeps its identity.
+            const swapped = {
+                ...initial,
+                fileInfos: [
+                    initial.fileInfos[0],
+                    TestHelper.getFileInfoMock({id: 'c', extension: 'png'}),
+                ],
+            };
+            rerender(
+                <FilePreviewModal
+                    ref={ref}
+                    {...swapped}
+                />,
+            );
+
+            // Index 0 (unchanged identity) keeps its zoom; index 1 (new identity) resets.
+            expect(ref.current?.state.scale[0]).toBe(1.5);
+            expect(ref.current?.state.translate[0]).toEqual({x: 10, y: 10});
+            expect(ref.current?.state.scale[1]).toBe(1.0);
+            expect(ref.current?.state.translate[1]).toEqual({x: 0, y: 0});
+        });
+
+        test('seeds default scale/translate for brand-new indexes when the list grows', () => {
+            const {ref, rerender} = mountModal();
+            act(() => {
+                ref.current?.setState({scale: {0: 1.5}, translate: {0: {x: 5, y: 5}}});
+            });
+
+            const grown = {
+                ...imageProps,
+                fileInfos: [
+                    imageProps.fileInfos[0],
+                    TestHelper.getFileInfoMock({id: 'new', extension: 'pdf'}),
+                ],
+            };
+            rerender(
+                <FilePreviewModal
+                    ref={ref}
+                    {...grown}
+                />,
+            );
+
+            expect(ref.current?.state.scale[0]).toBe(1.5);
+            expect(ref.current?.state.scale[1]).toBe(1.75); // pdf default
+            expect(ref.current?.state.translate[1]).toEqual({x: 0, y: 0});
+        });
+    });
+});

--- a/webapp/channels/src/components/file_preview_modal/file_preview_modal.test.tsx
+++ b/webapp/channels/src/components/file_preview_modal/file_preview_modal.test.tsx
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import FilePreviewModal from 'components/file_preview_modal/file_preview_modal';
+import FilePreviewModal, {computeZoomAtCursor} from 'components/file_preview_modal/file_preview_modal';
 
 import {act, render} from 'tests/react_testing_utils';
 import Constants from 'utils/constants';
@@ -399,5 +399,48 @@ describe('components/FilePreviewModal', () => {
         const props = {...baseProps, pluginFilePreviewComponents};
         const {container} = renderModal(props);
         expect(container).toMatchSnapshot();
+    });
+});
+
+describe('computeZoomAtCursor', () => {
+    test('cursor at center yields zero translate when starting from zero', () => {
+        const result = computeZoomAtCursor(1, {x: 0, y: 0}, 0, 0, 2);
+        expect(result).toEqual({x: 0, y: 0});
+    });
+
+    test('zooming in at an off-center cursor shifts translate opposite to the cursor', () => {
+        // Cursor 100px right of center, zooming 1 -> 2. The pixel under the cursor
+        // must remain under the cursor, so translate must move by -100px on x.
+        const result = computeZoomAtCursor(1, {x: 0, y: 0}, 100, 50, 2);
+        expect(result).toEqual({x: -100, y: -50});
+    });
+
+    test('zooming back to the same scale is a no-op on translate', () => {
+        const start = {x: 30, y: -40};
+        const result = computeZoomAtCursor(2, start, 75, 25, 2);
+        expect(result).toEqual(start);
+    });
+
+    test('preserves the pixel under the cursor across a zoom step', () => {
+        // The image pixel under the cursor (in local image-center coords) is
+        //   p = (cursor - translate) / scale
+        // After the new scale + new translate, applying the same transform to p
+        // should land back at the cursor position.
+        const oldScale = 1.5;
+        const oldT = {x: 20, y: -10};
+        const cursor = {x: 60, y: 80};
+        const newScale = 2.25;
+        const px = (cursor.x - oldT.x) / oldScale;
+        const py = (cursor.y - oldT.y) / oldScale;
+
+        const newT = computeZoomAtCursor(oldScale, oldT, cursor.x, cursor.y, newScale);
+
+        expect(newT.x + newScale * px).toBeCloseTo(cursor.x);
+        expect(newT.y + newScale * py).toBeCloseTo(cursor.y);
+    });
+
+    test('returns the input translate when oldScale is zero (guard)', () => {
+        const t = {x: 5, y: 7};
+        expect(computeZoomAtCursor(0, t, 10, 10, 2)).toBe(t);
     });
 });

--- a/webapp/channels/src/components/file_preview_modal/file_preview_modal.test.tsx
+++ b/webapp/channels/src/components/file_preview_modal/file_preview_modal.test.tsx
@@ -435,8 +435,8 @@ describe('computeZoomAtCursor', () => {
 
         const newT = computeZoomAtCursor(oldScale, oldT, cursor.x, cursor.y, newScale);
 
-        expect(newT.x + newScale * px).toBeCloseTo(cursor.x);
-        expect(newT.y + newScale * py).toBeCloseTo(cursor.y);
+        expect(newT.x + (newScale * px)).toBeCloseTo(cursor.x);
+        expect(newT.y + (newScale * py)).toBeCloseTo(cursor.y);
     });
 
     test('returns the input translate when oldScale is zero (guard)', () => {

--- a/webapp/channels/src/components/file_preview_modal/file_preview_modal.tsx
+++ b/webapp/channels/src/components/file_preview_modal/file_preview_modal.tsx
@@ -62,6 +62,8 @@ export type Props = {
     startIndex: number;
 }
 
+type Translate = {x: number; y: number};
+
 type State = {
     show: boolean;
     imageIndex: number;
@@ -72,7 +74,29 @@ type State = {
     showCloseBtn: boolean;
     showZoomControls: boolean;
     scale: Record<number, number>;
+    translate: Record<number, Translate>;
+    isDragging: boolean;
     content: string;
+}
+
+// Pure helper for cursor-aware zoom math. Given current scale + translate,
+// the cursor position relative to the wrapper's center, and the new scale,
+// returns the new translate so the image pixel under the cursor stays fixed.
+export function computeZoomAtCursor(
+    oldScale: number,
+    oldTranslate: Translate,
+    cursorOffsetX: number,
+    cursorOffsetY: number,
+    newScale: number,
+): Translate {
+    if (oldScale === 0) {
+        return oldTranslate;
+    }
+    const ratio = newScale / oldScale;
+    return {
+        x: cursorOffsetX * (1 - ratio) + oldTranslate.x * ratio,
+        y: cursorOffsetY * (1 - ratio) + oldTranslate.y * ratio,
+    };
 }
 
 export default class FilePreviewModal extends React.PureComponent<Props, State> {
@@ -94,9 +118,25 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
             progress: Utils.fillRecord(0, this.props.fileInfos.length),
             showCloseBtn: false,
             showZoomControls: false,
-            scale: Utils.fillRecord(ZoomSettings.DEFAULT_SCALE, this.props.fileInfos.length),
+            scale: this.props.fileInfos.reduce<Record<number, number>>((acc, fileInfo, index) => {
+                acc[index] = FilePreviewModal.getDefaultScaleForFile(fileInfo);
+                return acc;
+            }, {}),
+            translate: this.props.fileInfos.reduce<Record<number, Translate>>((acc, _fileInfo, index) => {
+                acc[index] = {x: 0, y: 0};
+                return acc;
+            }, {}),
+            isDragging: false,
             content: '',
         };
+    }
+
+    static getDefaultScaleForFile(fileInfo: FileInfo | LinkInfo): number {
+        const fileType = Utils.getFileType(fileInfo.extension || '');
+        if (fileType === FileTypes.IMAGE || fileType === FileTypes.SVG) {
+            return ZoomSettings.DEFAULT_SCALE_IMAGE;
+        }
+        return ZoomSettings.DEFAULT_SCALE;
     }
 
     handleNext = () => {
@@ -123,20 +163,61 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
         }
     };
 
+    // Zoom keyboard shortcuts. Bound on keydown so they fire on press (not release)
+    // and feel snappy when held. Modifier keys are required to be absent so we
+    // don't shadow text-editing shortcuts in any focused input.
+    handleKeyDown = (e: KeyboardEvent) => {
+        if (!this.state.show || !this.state.showZoomControls || e.ctrlKey || e.metaKey || e.altKey) {
+            return;
+        }
+        // Don't hijack '+'/'='/'-'/'0' while the user is typing in an input.
+        const target = e.target as HTMLElement | null;
+        if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
+            return;
+        }
+        switch (e.key) {
+        case '+':
+        case '=':
+            e.preventDefault();
+            this.handleZoomIn();
+            break;
+        case '-':
+            e.preventDefault();
+            this.handleZoomOut();
+            break;
+        case '0':
+            e.preventDefault();
+            this.handleZoomReset();
+            break;
+        }
+    };
+
     componentDidMount() {
         document.addEventListener('keyup', this.handleKeyPress);
+        document.addEventListener('keydown', this.handleKeyDown);
 
         this.showImage(this.props.startIndex);
     }
 
     componentWillUnmount() {
         document.removeEventListener('keyup', this.handleKeyPress);
+        document.removeEventListener('keydown', this.handleKeyDown);
+        document.removeEventListener('mousemove', this.handleDocumentMouseMove);
+        document.removeEventListener('mouseup', this.handleDocumentMouseUp);
+        window.removeEventListener('blur', this.endDrag);
     }
 
     static getDerivedStateFromProps(props: Props, state: State) {
         const updatedState: Partial<State> = {};
-        if (props.fileInfos[state.imageIndex] && props.fileInfos[state.imageIndex].extension === FileTypes.PDF) {
-            updatedState.showZoomControls = true;
+        const currentFile = props.fileInfos[state.imageIndex];
+        if (currentFile) {
+            const extension = currentFile.extension;
+            const fileType = Utils.getFileType(extension || '');
+            updatedState.showZoomControls = (
+                extension === FileTypes.PDF ||
+                fileType === FileTypes.IMAGE ||
+                fileType === FileTypes.SVG
+            );
         } else {
             updatedState.showZoomControls = false;
         }
@@ -248,12 +329,22 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
         this.setState({showCloseBtn: false});
     };
 
-    setScale = (index: number, scale: number) => {
+    // Apply a scale update for the current image. Auto-snaps translate to the
+    // origin when the new scale equals the file's default (so the image is
+    // re-centered when fully zoomed out via the reset/zoom buttons).
+    setScale = (index: number, scale: number, translate?: Translate) => {
+        const fileInfo = this.props.fileInfos[index];
+        const defaultScale = FilePreviewModal.getDefaultScaleForFile(fileInfo);
         this.setState((prevState) => {
+            const snappedTranslate = scale === defaultScale ? {x: 0, y: 0} : (translate ?? prevState.translate[index] ?? {x: 0, y: 0});
             return {
                 scale: {
                     ...prevState.scale,
                     [index]: scale,
+                },
+                translate: {
+                    ...prevState.translate,
+                    [index]: snappedTranslate,
                 },
             };
         });
@@ -272,7 +363,103 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
     };
 
     handleZoomReset = () => {
-        this.setScale(this.state.imageIndex, ZoomSettings.DEFAULT_SCALE);
+        const fileInfo = this.props.fileInfos[this.state.imageIndex];
+        this.setScale(this.state.imageIndex, FilePreviewModal.getDefaultScaleForFile(fileInfo));
+    };
+
+    // Native (non-passive) wheel handler so preventDefault actually suppresses
+    // the page-scroll default. Bound by ImagePreview via addEventListener.
+    handleImageWheel = (e: WheelEvent) => {
+        if (!this.state.showZoomControls || e.deltaY === 0) {
+            return;
+        }
+        e.preventDefault();
+
+        const target = e.currentTarget as HTMLElement | null;
+        if (!target) {
+            return;
+        }
+        const rect = target.getBoundingClientRect();
+        const cursorOffsetX = e.clientX - rect.left - rect.width / 2;
+        const cursorOffsetY = e.clientY - rect.top - rect.height / 2;
+
+        // Trackpad pinch / smooth wheel emit many small deltaY events. Scale
+        // the step by deltaY magnitude (capped at 1) so trackpad zoom doesn't
+        // sprint past max scale in a few frames.
+        const direction = e.deltaY < 0 ? 1 : -1;
+        const stepMagnitude = Math.min(Math.abs(e.deltaY) / 100, 1) * ZoomSettings.SCALE_DELTA;
+
+        this.setState((prev) => {
+            const idx = prev.imageIndex;
+            const fileInfo = this.props.fileInfos[idx];
+            const defaultScale = FilePreviewModal.getDefaultScaleForFile(fileInfo);
+            const oldScale = prev.scale[idx] ?? defaultScale;
+            const newScale = direction > 0 ?
+                Math.min(oldScale + stepMagnitude, ZoomSettings.MAX_SCALE) :
+                Math.max(oldScale - stepMagnitude, ZoomSettings.MIN_SCALE);
+            if (newScale === oldScale) {
+                return null;
+            }
+            const oldTranslate = prev.translate[idx] ?? {x: 0, y: 0};
+            const newTranslate = newScale === defaultScale ?
+                {x: 0, y: 0} :
+                computeZoomAtCursor(oldScale, oldTranslate, cursorOffsetX, cursorOffsetY, newScale);
+            return {
+                scale: {...prev.scale, [idx]: newScale},
+                translate: {...prev.translate, [idx]: newTranslate},
+            };
+        });
+    };
+
+    // Drag state lives outside React state — only the resulting translate needs
+    // to render, not the in-flight drag metadata.
+    private dragState: {startX: number; startY: number; startTx: number; startTy: number; index: number} | null = null;
+
+    handleImageMouseDown = (e: React.MouseEvent<HTMLElement>) => {
+        if (e.button !== 0 || !this.state.showZoomControls) {
+            return;
+        }
+        const idx = this.state.imageIndex;
+        const current = this.state.translate[idx] ?? {x: 0, y: 0};
+        this.dragState = {
+            startX: e.clientX,
+            startY: e.clientY,
+            startTx: current.x,
+            startTy: current.y,
+            index: idx,
+        };
+        document.addEventListener('mousemove', this.handleDocumentMouseMove);
+        document.addEventListener('mouseup', this.handleDocumentMouseUp);
+        window.addEventListener('blur', this.endDrag);
+        this.setState({isDragging: true});
+        e.preventDefault(); // suppress text selection / link drag-ghost
+    };
+
+    private handleDocumentMouseMove = (e: MouseEvent) => {
+        if (!this.dragState) {
+            return;
+        }
+        const {startX, startY, startTx, startTy, index} = this.dragState;
+        const newTx = startTx + (e.clientX - startX);
+        const newTy = startTy + (e.clientY - startY);
+        this.setState((prev) => ({
+            translate: {...prev.translate, [index]: {x: newTx, y: newTy}},
+        }));
+    };
+
+    private handleDocumentMouseUp = () => {
+        this.endDrag();
+    };
+
+    private endDrag = () => {
+        if (!this.dragState) {
+            return;
+        }
+        this.dragState = null;
+        document.removeEventListener('mousemove', this.handleDocumentMouseMove);
+        document.removeEventListener('mouseup', this.handleDocumentMouseUp);
+        window.removeEventListener('blur', this.endDrag);
+        this.setState({isDragging: false});
     };
 
     handleModalClose = () => {
@@ -335,10 +522,29 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
         if (!isFileInfo(fileInfo) || !fileInfo.archived) {
             if (this.state.loaded[this.state.imageIndex]) {
                 if (fileType === FileTypes.IMAGE || fileType === FileTypes.SVG) {
+                    const currentScale = this.state.scale[this.state.imageIndex];
+                    const currentTranslate = this.state.translate[this.state.imageIndex] ?? {x: 0, y: 0};
+                    const defaultScale = FilePreviewModal.getDefaultScaleForFile(fileInfo);
                     content = (
                         <ImagePreview
                             fileInfo={fileInfo as FileInfo}
                             canDownloadFiles={this.props.canDownloadFiles}
+                            scale={currentScale}
+                            translate={currentTranslate}
+                            onWheel={this.handleImageWheel}
+                            onMouseDown={this.handleImageMouseDown}
+                            isZoomed={currentScale !== defaultScale}
+                            isDragging={this.state.isDragging}
+                        />
+                    );
+                    zoomBar = (
+                        <PopoverBar
+                            scale={this.state.scale[this.state.imageIndex]}
+                            defaultScale={ZoomSettings.DEFAULT_SCALE_IMAGE}
+                            showZoomControls={this.state.showZoomControls}
+                            handleZoomIn={this.handleZoomIn}
+                            handleZoomOut={this.handleZoomOut}
+                            handleZoomReset={this.handleZoomReset}
                         />
                     );
                 } else if (fileType === FileTypes.VIDEO || fileType === FileTypes.AUDIO) {

--- a/webapp/channels/src/components/file_preview_modal/file_preview_modal.tsx
+++ b/webapp/channels/src/components/file_preview_modal/file_preview_modal.tsx
@@ -70,6 +70,7 @@ type State = {
     imageHeight: number | string;
     loaded: Record<number, boolean>;
     prevFileInfosCount: number;
+    prevFileIds: string[];
     progress: Record<number, number>;
     showCloseBtn: boolean;
     showZoomControls: boolean;
@@ -115,6 +116,7 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
             imageHeight: '100%',
             loaded: Utils.fillRecord(false, this.props.fileInfos.length),
             prevFileInfosCount: 0,
+            prevFileIds: this.props.fileInfos.map(FilePreviewModal.getFileIdentity),
             progress: Utils.fillRecord(0, this.props.fileInfos.length),
             showCloseBtn: false,
             showZoomControls: false,
@@ -129,6 +131,17 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
             isDragging: false,
             content: '',
         };
+    }
+
+    // Stable identity for a file used to detect same-length swaps in the
+    // fileInfos prop (a websocket post update could replace one attachment
+    // without changing the array length). FileInfo has an `id`, LinkInfo
+    // has a `link`; fall back to extension to keep this total.
+    static getFileIdentity(fileInfo: FileInfo | LinkInfo): string {
+        if (isFileInfo(fileInfo)) {
+            return `f:${fileInfo.id}`;
+        }
+        return `l:${fileInfo.link ?? fileInfo.extension ?? ''}`;
     }
 
     static getDefaultScaleForFile(fileInfo: FileInfo | LinkInfo): number {
@@ -233,21 +246,32 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
         } else {
             updatedState.showZoomControls = false;
         }
-        if (props.fileInfos.length !== state.prevFileInfosCount) {
+
+        // Detect any change to the file list — either the length, or a
+        // same-index identity swap (e.g. a websocket post update replacing
+        // attachment N without changing array length).
+        const nextFileIds = props.fileInfos.map(FilePreviewModal.getFileIdentity);
+        const lengthChanged = props.fileInfos.length !== state.prevFileInfosCount;
+        const identitiesChanged = !lengthChanged && nextFileIds.some((id, i) => id !== state.prevFileIds[i]);
+        if (lengthChanged || identitiesChanged) {
             updatedState.loaded = Utils.fillRecord(false, props.fileInfos.length);
             updatedState.progress = Utils.fillRecord(0, props.fileInfos.length);
             updatedState.prevFileInfosCount = props.fileInfos.length;
+            updatedState.prevFileIds = nextFileIds;
 
-            // Reconcile scale/translate with the new file list: preserve any
-            // existing per-index entries, seed brand-new indexes with the
-            // file's default, and drop entries past the new length so a
-            // missing entry can never read as `undefined` (which would flip
-            // isZoomed and leak through clamp comparisons).
+            // Reconcile scale/translate per index: preserve entries whose
+            // file identity is unchanged; reset to the new file's default
+            // when the identity at that index changed (or is brand new).
             const nextScale: Record<number, number> = {};
             const nextTranslate: Record<number, Translate> = {};
             for (let i = 0; i < props.fileInfos.length; i++) {
-                nextScale[i] = state.scale[i] ?? FilePreviewModal.getDefaultScaleForFile(props.fileInfos[i]);
-                nextTranslate[i] = state.translate[i] ?? {x: 0, y: 0};
+                const idUnchanged = state.prevFileIds[i] === nextFileIds[i];
+                nextScale[i] = idUnchanged && state.scale[i] !== undefined ?
+                    state.scale[i] :
+                    FilePreviewModal.getDefaultScaleForFile(props.fileInfos[i]);
+                nextTranslate[i] = idUnchanged && state.translate[i] !== undefined ?
+                    state.translate[i] :
+                    {x: 0, y: 0};
             }
             updatedState.scale = nextScale;
             updatedState.translate = nextTranslate;

--- a/webapp/channels/src/components/file_preview_modal/file_preview_modal.tsx
+++ b/webapp/channels/src/components/file_preview_modal/file_preview_modal.tsx
@@ -94,8 +94,8 @@ export function computeZoomAtCursor(
     }
     const ratio = newScale / oldScale;
     return {
-        x: cursorOffsetX * (1 - ratio) + oldTranslate.x * ratio,
-        y: cursorOffsetY * (1 - ratio) + oldTranslate.y * ratio,
+        x: (cursorOffsetX * (1 - ratio)) + (oldTranslate.x * ratio),
+        y: (cursorOffsetY * (1 - ratio)) + (oldTranslate.y * ratio),
     };
 }
 
@@ -170,6 +170,7 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
         if (!this.state.show || !this.state.showZoomControls || e.ctrlKey || e.metaKey || e.altKey) {
             return;
         }
+
         // Don't hijack '+'/'='/'-'/'0' while the user is typing in an input.
         const target = e.target as HTMLElement | null;
         if (target && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA' || target.isContentEditable)) {
@@ -380,8 +381,8 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
             return;
         }
         const rect = target.getBoundingClientRect();
-        const cursorOffsetX = e.clientX - rect.left - rect.width / 2;
-        const cursorOffsetY = e.clientY - rect.top - rect.height / 2;
+        const cursorOffsetX = e.clientX - rect.left - (rect.width / 2);
+        const cursorOffsetY = e.clientY - rect.top - (rect.height / 2);
 
         // Trackpad pinch / smooth wheel emit many small deltaY events. Scale
         // the step by deltaY magnitude (capped at 1) so trackpad zoom doesn't

--- a/webapp/channels/src/components/file_preview_modal/file_preview_modal.tsx
+++ b/webapp/channels/src/components/file_preview_modal/file_preview_modal.tsx
@@ -139,6 +139,17 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
         return ZoomSettings.DEFAULT_SCALE;
     }
 
+    // Images get a lower zoom-in ceiling than PDFs: beyond ~2x the image
+    // exceeds the modal viewport in both dimensions and panning becomes
+    // tedious. PDFs keep the original 3.0 ceiling.
+    static getMaxScaleForFile(fileInfo: FileInfo | LinkInfo): number {
+        const fileType = Utils.getFileType(fileInfo.extension || '');
+        if (fileType === FileTypes.IMAGE || fileType === FileTypes.SVG) {
+            return ZoomSettings.MAX_SCALE_IMAGE;
+        }
+        return ZoomSettings.MAX_SCALE;
+    }
+
     handleNext = () => {
         let id = this.state.imageIndex + 1;
         if (id > this.props.fileInfos.length - 1) {
@@ -226,6 +237,20 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
             updatedState.loaded = Utils.fillRecord(false, props.fileInfos.length);
             updatedState.progress = Utils.fillRecord(0, props.fileInfos.length);
             updatedState.prevFileInfosCount = props.fileInfos.length;
+
+            // Reconcile scale/translate with the new file list: preserve any
+            // existing per-index entries, seed brand-new indexes with the
+            // file's default, and drop entries past the new length so a
+            // missing entry can never read as `undefined` (which would flip
+            // isZoomed and leak through clamp comparisons).
+            const nextScale: Record<number, number> = {};
+            const nextTranslate: Record<number, Translate> = {};
+            for (let i = 0; i < props.fileInfos.length; i++) {
+                nextScale[i] = state.scale[i] ?? FilePreviewModal.getDefaultScaleForFile(props.fileInfos[i]);
+                nextTranslate[i] = state.translate[i] ?? {x: 0, y: 0};
+            }
+            updatedState.scale = nextScale;
+            updatedState.translate = nextTranslate;
         }
         return Object.keys(updatedState).length ? updatedState : null;
     }
@@ -352,8 +377,10 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
     };
 
     handleZoomIn = () => {
+        const fileInfo = this.props.fileInfos[this.state.imageIndex];
+        const maxScale = FilePreviewModal.getMaxScaleForFile(fileInfo);
         let newScale = this.state.scale[this.state.imageIndex];
-        newScale = Math.min(newScale + ZoomSettings.SCALE_DELTA, ZoomSettings.MAX_SCALE);
+        newScale = Math.min(newScale + ZoomSettings.SCALE_DELTA, maxScale);
         this.setScale(this.state.imageIndex, newScale);
     };
 
@@ -394,9 +421,10 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
             const idx = prev.imageIndex;
             const fileInfo = this.props.fileInfos[idx];
             const defaultScale = FilePreviewModal.getDefaultScaleForFile(fileInfo);
+            const maxScale = FilePreviewModal.getMaxScaleForFile(fileInfo);
             const oldScale = prev.scale[idx] ?? defaultScale;
             const newScale = direction > 0 ?
-                Math.min(oldScale + stepMagnitude, ZoomSettings.MAX_SCALE) :
+                Math.min(oldScale + stepMagnitude, maxScale) :
                 Math.max(oldScale - stepMagnitude, ZoomSettings.MIN_SCALE);
             if (newScale === oldScale) {
                 return null;
@@ -421,6 +449,16 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
             return;
         }
         const idx = this.state.imageIndex;
+        const fileInfo = this.props.fileInfos[idx];
+        const defaultScale = FilePreviewModal.getDefaultScaleForFile(fileInfo);
+        const currentScale = this.state.scale[idx] ?? defaultScale;
+
+        // Only allow drag-to-pan when the image is actually zoomed in. At
+        // default scale the image fits the viewport, so dragging would just
+        // slide it around in empty space.
+        if (currentScale <= defaultScale) {
+            return;
+        }
         const current = this.state.translate[idx] ?? {x: 0, y: 0};
         this.dragState = {
             startX: e.clientX,
@@ -542,6 +580,7 @@ export default class FilePreviewModal extends React.PureComponent<Props, State> 
                         <PopoverBar
                             scale={this.state.scale[this.state.imageIndex]}
                             defaultScale={ZoomSettings.DEFAULT_SCALE_IMAGE}
+                            maxScale={ZoomSettings.MAX_SCALE_IMAGE}
                             showZoomControls={this.state.showZoomControls}
                             handleZoomIn={this.handleZoomIn}
                             handleZoomOut={this.handleZoomOut}

--- a/webapp/channels/src/components/file_preview_modal/image_preview.scss
+++ b/webapp/channels/src/components/file_preview_modal/image_preview.scss
@@ -1,11 +1,30 @@
 .image_preview {
+    user-select: none;
+
     &__image {
         max-height: calc(100vh - 168px);
         border-radius: 8px;
         cursor: default;
+        transform-origin: center center;
 
         @media screen and (max-width: 768px) {
             border-radius: 0;
         }
+
+        // Only the zoomed state pays for the transform compositor layer; at
+        // rest the image renders like before.
+        &--zoomed {
+            transition: transform 0.1s ease-out;
+            will-change: transform;
+        }
+    }
+
+    // The drag handler adds `image_preview--dragging` while a pan is in
+    // progress; suppress the transition then so the cursor stays locked to
+    // the image (the cursor-leaves-anchor case the previous :active trick
+    // didn't handle).
+    &--dragging &__image {
+        cursor: grabbing;
+        transition: none;
     }
 }

--- a/webapp/channels/src/components/file_preview_modal/image_preview.test.tsx
+++ b/webapp/channels/src/components/file_preview_modal/image_preview.test.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {fireEvent} from '@testing-library/react';
 import React from 'react';
 
 import ImagePreview from 'components/file_preview_modal/image_preview';
@@ -69,6 +70,41 @@ describe('components/view_image/ImagePreview', () => {
         );
 
         expect(container).toMatchSnapshot();
+    });
+
+    test('should apply transform when scale is provided and not 1', () => {
+        const props = {
+            ...baseProps,
+            scale: 2,
+        };
+
+        render(<ImagePreview {...props}/>);
+
+        expect(screen.getByTestId('imagePreview')).toHaveStyle('transform: scale(2)');
+    });
+
+    test('should not apply transform when scale is 1', () => {
+        const props = {
+            ...baseProps,
+            scale: 1,
+        };
+
+        render(<ImagePreview {...props}/>);
+
+        expect(screen.getByTestId('imagePreview').getAttribute('style') || '').not.toContain('transform');
+    });
+
+    test('should call onWheel handler when wheel event fires on image', () => {
+        const onWheel = jest.fn();
+        const props = {
+            ...baseProps,
+            onWheel,
+        };
+
+        render(<ImagePreview {...props}/>);
+
+        fireEvent.wheel(screen.getByRole('link'), {deltaY: -100});
+        expect(onWheel).toHaveBeenCalledTimes(1);
     });
 
     test('should not download link for external file', () => {

--- a/webapp/channels/src/components/file_preview_modal/image_preview.tsx
+++ b/webapp/channels/src/components/file_preview_modal/image_preview.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import classNames from 'classnames';
+import React, {useEffect, useRef} from 'react';
 
 import type {FileInfo} from '@mattermost/types/files';
 
@@ -15,10 +16,45 @@ import './image_preview.scss';
 interface Props {
     fileInfo: FileInfo;
     canDownloadFiles: boolean;
+    scale?: number;
+    translate?: {x: number; y: number};
+    isZoomed?: boolean;
+    isDragging?: boolean;
+    onWheel?: (e: WheelEvent) => void;
+    onMouseDown?: (e: React.MouseEvent<HTMLElement>) => void;
 }
 
-export default function ImagePreview({fileInfo, canDownloadFiles}: Props) {
+function buildTransform(scale?: number, translate?: {x: number; y: number}): string | undefined {
+    const hasScale = scale !== undefined && scale !== 1;
+    const hasTranslate = translate && (translate.x !== 0 || translate.y !== 0);
+    if (!hasScale && !hasTranslate) {
+        return undefined;
+    }
+    const parts: string[] = [];
+    if (hasTranslate) {
+        parts.push(`translate(${translate.x}px, ${translate.y}px)`);
+    }
+    if (hasScale) {
+        parts.push(`scale(${scale})`);
+    }
+    return parts.join(' ');
+}
+
+export default function ImagePreview({fileInfo, canDownloadFiles, scale, translate, isZoomed, isDragging, onWheel, onMouseDown}: Props) {
     const isExternalFile = !fileInfo.id;
+
+    // React's synthetic wheel events are passive by default in modern React, so
+    // e.preventDefault() inside them is a no-op. Bind a native non-passive
+    // listener via ref so the page can't scroll while zooming the image.
+    const wrapperRef = useRef<HTMLElement | null>(null);
+    useEffect(() => {
+        const node = wrapperRef.current;
+        if (!node || !onWheel) {
+            return undefined;
+        }
+        node.addEventListener('wheel', onWheel, {passive: false});
+        return () => node.removeEventListener('wheel', onWheel);
+    }, [onWheel]);
 
     let fileUrl;
     let previewUrl;
@@ -30,30 +66,63 @@ export default function ImagePreview({fileInfo, canDownloadFiles}: Props) {
         previewUrl = fileInfo.has_preview_image ? getFilePreviewUrl(fileInfo.id) : fileUrl;
     }
 
+    const transform = buildTransform(scale, translate);
+    const imgStyle: React.CSSProperties = {};
+    if (transform) {
+        imgStyle.transform = transform;
+    }
+    if (isZoomed) {
+        imgStyle.cursor = 'grab';
+    }
+    const imgClassName = classNames('image_preview__image', {
+        'image_preview__image--zoomed': isZoomed,
+    });
+    const wrapperClassName = classNames('image_preview', {
+        'image_preview--dragging': isDragging,
+    });
+
     if (!canDownloadFiles) {
-        return <img src={previewUrl}/>;
+        return (
+            <span
+                ref={wrapperRef as React.RefObject<HTMLSpanElement>}
+                className={wrapperClassName}
+                onMouseDown={onMouseDown}
+            >
+                <img
+                    className={imgClassName}
+                    src={previewUrl}
+                    style={imgStyle}
+                    draggable={false}
+                />
+            </span>
+        );
     }
 
-    let conditionalSVGStyleAttribute;
+    const finalImgStyle: React.CSSProperties = {...imgStyle};
     if (getFileType(fileInfo.extension) === FileTypes.SVG) {
-        conditionalSVGStyleAttribute = {
-            width: fileInfo.width,
-            height: 'auto',
-        };
+        finalImgStyle.width = fileInfo.width;
+        finalImgStyle.height = 'auto';
     }
+
+    const preventLinkNav = (e: React.SyntheticEvent) => e.preventDefault();
 
     return (
         <a
-            className='image_preview'
+            ref={wrapperRef as React.RefObject<HTMLAnchorElement>}
+            className={wrapperClassName}
             href='#'
+            onMouseDown={onMouseDown}
+            onClick={preventLinkNav}
+            onDragStart={preventLinkNav}
         >
             <img
-                className='image_preview__image'
+                className={imgClassName}
                 loading='lazy'
                 data-testid='imagePreview'
                 alt={'preview url image'}
                 src={previewUrl}
-                style={conditionalSVGStyleAttribute}
+                style={finalImgStyle}
+                draggable={false}
             />
         </a>
     );

--- a/webapp/channels/src/components/file_preview_modal/popover_bar/popover_bar.tsx
+++ b/webapp/channels/src/components/file_preview_modal/popover_bar/popover_bar.tsx
@@ -12,6 +12,7 @@ import {ZoomSettings} from 'utils/constants';
 export interface Props {
     scale?: number;
     defaultScale?: number;
+    maxScale?: number;
     showZoomControls?: boolean;
     handleZoomIn?: () => void;
     handleZoomOut?: () => void;
@@ -21,6 +22,7 @@ export interface Props {
 export default class PopoverBar extends React.PureComponent<Props> {
     render() {
         const defaultScale = this.props.defaultScale ?? ZoomSettings.DEFAULT_SCALE;
+        const maxScale = this.props.maxScale ?? ZoomSettings.MAX_SCALE;
         const zoomControls: React.ReactNode[] = [];
         let wrappedZoomControls: React.ReactNode = null;
         if (this.props.showZoomControls) {
@@ -94,7 +96,7 @@ export default class PopoverBar extends React.PureComponent<Props> {
                 </WithTooltip>,
             );
 
-            if (this.props.scale && this.props.scale < ZoomSettings.MAX_SCALE) {
+            if (this.props.scale && this.props.scale < maxScale) {
                 zoomInButton = (
                     <span className='modal-zoom-btn'>
                         <a onClick={this.props.handleZoomIn && debounce(this.props.handleZoomIn, 300, {maxWait: 300})}>

--- a/webapp/channels/src/components/file_preview_modal/popover_bar/popover_bar.tsx
+++ b/webapp/channels/src/components/file_preview_modal/popover_bar/popover_bar.tsx
@@ -11,6 +11,7 @@ import {ZoomSettings} from 'utils/constants';
 
 export interface Props {
     scale?: number;
+    defaultScale?: number;
     showZoomControls?: boolean;
     handleZoomIn?: () => void;
     handleZoomOut?: () => void;
@@ -19,6 +20,7 @@ export interface Props {
 
 export default class PopoverBar extends React.PureComponent<Props> {
     render() {
+        const defaultScale = this.props.defaultScale ?? ZoomSettings.DEFAULT_SCALE;
         const zoomControls: React.ReactNode[] = [];
         let wrappedZoomControls: React.ReactNode = null;
         if (this.props.showZoomControls) {
@@ -55,7 +57,7 @@ export default class PopoverBar extends React.PureComponent<Props> {
                 </WithTooltip>,
             );
 
-            if (this.props.scale && this.props.scale > ZoomSettings.DEFAULT_SCALE) {
+            if (this.props.scale && this.props.scale > defaultScale) {
                 zoomResetButton = (
                     <span className='modal-zoom-btn'>
                         <a onClick={this.props.handleZoomReset}>
@@ -63,7 +65,7 @@ export default class PopoverBar extends React.PureComponent<Props> {
                         </a>
                     </span>
                 );
-            } else if (this.props.scale && this.props.scale < ZoomSettings.DEFAULT_SCALE) {
+            } else if (this.props.scale && this.props.scale < defaultScale) {
                 zoomResetButton = (
                     <span className='modal-zoom-btn'>
                         <a onClick={this.props.handleZoomReset}>

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -1431,6 +1431,7 @@ export const ZoomSettings = {
     SCALE_DELTA: 0.25,
     MIN_SCALE: 0.25,
     MAX_SCALE: 3.0,
+    MAX_SCALE_IMAGE: 2.0,
 };
 
 export const DataSpillagePropertyNames = {

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -1427,6 +1427,7 @@ export const CacheTypes = {
 
 export const ZoomSettings = {
     DEFAULT_SCALE: 1.75,
+    DEFAULT_SCALE_IMAGE: 1.0,
     SCALE_DELTA: 0.25,
     MIN_SCALE: 0.25,
     MAX_SCALE: 3.0,


### PR DESCRIPTION
#### Summary

Enables image zoom in the file preview modal. The modal already had zoom infrastructure (scale state, +/− buttons, popover bar) but it was gated to PDFs only. This PR turns it on for images and adds the interactions users expect from an image viewer.

**What's included:**
- **Popover bar +/− buttons** now show for images (and SVGs), driven by per-file default scale (1.0 for images, 1.75 unchanged for PDFs).
- **Scroll-wheel zoom at cursor position** — the pixel under the cursor stays put across zoom steps. Math lives in `computeZoomAtCursor` (pure helper, unit-tested).
- **Drag-to-pan** when zoomed; pan offsets auto-snap back to (0, 0) when scale returns to default.
- **Keyboard shortcuts**: `+`/`=` zoom in, `-` zoom out, `0` reset. Skipped when an `<input>`/`<textarea>`/`contentEditable` has focus so they don't hijack typing.
- **Overflow clipping** on `.file-preview-modal__content` so the panned image can't slide behind the modal header.

**Implementation notes:**
- Native non-passive wheel listener attached via `useEffect` + ref (React's synthetic `onWheel` is passive, so `preventDefault()` is a no-op there).
- Wheel step is scaled by `min(|deltaY|/100, 1) * SCALE_DELTA` so trackpad pinch deltas don't sprint past max scale in a couple of frames.
- Drag state lives in an instance field (not React state) to avoid extra renders during mousemove; a separate `isDragging` boolean in state drives the `image_preview--dragging` class.
- `will-change: transform` is only applied when actually zoomed, to keep the GPU layer off during normal viewing.
- PDF preview path is untouched — uses its own nested `.file-preview-modal__scrollable` and is unaffected by the new `overflow: hidden`.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-69026

#### Screenshots

[Screencast from 2026-05-28 15-39-05.webm](https://github.com/user-attachments/assets/681bab27-d047-4503-aa87-59386939dba8)

#### Release Note
```release-note
Added zoom and pan support to the image file preview: wheel to zoom at the cursor, click-and-drag to pan, and +/-/0 keyboard shortcuts.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Addition of native non-passive wheel listeners and document-level drag handlers introduces moderate risk of event interaction regressions across browsers/devices (trackpad pinch behavior and preventDefault timing); new exported helper and static methods slightly expand the API surface but are scoped to the file preview feature and covered by unit tests for zoom math.  

**QA Recommendation:** Prioritize manual QA for cross-browser/OS wheel and trackpad interactions (macOS trackpad vs Windows), rapid/edge-case zoom sequences and pan snapping, keyboard shortcut focus-edge cases, and verify event listener cleanup to avoid leaks or global interference.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36775?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->