### PR TITLE
[MM-69028] Enable ClassificationMarkings feature flag by default

### DIFF
--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -191,7 +191,7 @@ func (f *FeatureFlags) SetDefaults() {
 
 	f.AutoTranslation = true
 
-	f.ClassificationMarkings = false
+	f.ClassificationMarkings = true
 
 	f.BurnOnRead = true
 

--- a/server/public/model/feature_flags_test.go
+++ b/server/public/model/feature_flags_test.go
@@ -13,17 +13,17 @@ func TestFeatureFlagsSetDefaults(t *testing.T) {
 	f := &FeatureFlags{}
 	f.SetDefaults()
 
-	t.Run("ClassificationMarkings should default to false", func(t *testing.T) {
-		require.False(t, f.ClassificationMarkings)
+	t.Run("ClassificationMarkings should default to true", func(t *testing.T) {
+		require.True(t, f.ClassificationMarkings)
 	})
 
 	t.Run("ClassificationMarkings should serialize correctly", func(t *testing.T) {
 		m := f.ToMap()
-		require.Equal(t, "false", m["ClassificationMarkings"])
-
-		f.ClassificationMarkings = true
-		m = f.ToMap()
 		require.Equal(t, "true", m["ClassificationMarkings"])
+
+		f.ClassificationMarkings = false
+		m = f.ToMap()
+		require.Equal(t, "false", m["ClassificationMarkings"])
 	})
 }
 


### PR DESCRIPTION
### Summary
- Sets `ClassificationMarkings` feature flag default from `false` to `true` in `SetDefaults()`

### Ticket Link
https://mattermost.atlassian.net/browse/MM-69028

### Release Notes
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** Changing the default for ClassificationMarkings from false to true may enable system- and channel-level classification UI and any conditionally-registered property API endpoints by default; this is unlikely to break core flows but could surface untested UI/API paths and integration behavior. The change is localized to feature flag defaults and covered by updated unit tests, reducing but not eliminating regression risk.

**QA Recommendation:** Perform focused manual QA to verify classification markings UI (system and channel banners) behaves correctly with the flag enabled by default, confirm related property API endpoints are correctly gated when the flag is toggled, and validate that disabling the flag still properly hides or disables the features.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36776?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->