### PR TITLE
Tighten CI workflows

### DIFF
--- a/.github/workflows/server-ci-artifacts.yml
+++ b/.github/workflows/server-ci-artifacts.yml
@@ -14,7 +14,7 @@ jobs:
   ## We only need the condition on the first job
   ## This will run only when a pull request is created with server changes
   update-initial-status:
-    if: github.repository_owner == 'mattermost' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    if: github.repository_owner == 'mattermost' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-22.04
     steps:
       - uses: mattermost/actions/delivery/update-commit-status@f324ac89b05cc3511cb06e60642ac2fb829f0a63

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -348,6 +348,7 @@ jobs:
           make build-cmd
           make package
       - name: Persist dist artifacts
+        if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
           name: server-dist-artifact


### PR DESCRIPTION
> Re-opened from #36672 as a same-repo PR so the required workflow checks can run end to end.

## Summary

Align the `server-dist-artifact` upload condition with `server-build-artifact`.

## Jira ticket
https://mattermost.atlassian.net/browse/MM-68928

## Release Note
```release-note
NONE
```