### PR TITLE
fix(api4/group): prevent 500 error by validating duplicate user_ids

### DIFF
--- a/server/channels/api4/group.go
+++ b/server/channels/api4/group.go
@@ -1442,14 +1442,14 @@ func addGroupMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	visited := make(map[string]bool)
+	visitedUsers := make(map[string]bool)
 
 	for _, userID := range newMembers.UserIds {
-		if visited[userID] {
+		if visitedUsers[userID] {
 			c.SetInvalidParamWithDetails("user_ids", fmt.Sprintf("Duplicate UserID %s is not allowed", userID))
 			return
 		}
-		visited[userID] = true
+		visitedUsers[userID] = true
 
 		if !model.IsValidId(userID) {
 			c.SetInvalidParamWithDetails("user_id", fmt.Sprintf("UserID %s is invalid", userID))

--- a/server/channels/api4/group.go
+++ b/server/channels/api4/group.go
@@ -1442,7 +1442,15 @@ func addGroupMembers(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	visited := make(map[string]bool)
+
 	for _, userID := range newMembers.UserIds {
+		if visited[userID] {
+			c.SetInvalidParamWithDetails("user_ids", fmt.Sprintf("Duplicate UserID %s is not allowed", userID))
+			return
+		}
+		visited[userID] = true
+
 		if !model.IsValidId(userID) {
 			c.SetInvalidParamWithDetails("user_id", fmt.Sprintf("UserID %s is invalid", userID))
 			return


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
Fixed a bug in the `addGroupMembers` endpoint where sending a request payload with duplicate user IDs in the `user_ids` array caused an internal server error (HTTP 500) during database operations. Added validation logic using a memory map to check for duplicate IDs before processing, returning a proper HTTP 400 Bad Request error if duplicates are detected.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/30333

#### Screenshots
<!-- Include screenshots or GIFs for UI changes. -->
None (Backend validation change).

#### Release Note
<!--
The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.
-->
```release-note
Fixed a potential HTTP 500 error in the custom groups API by adding validation to reject duplicate user IDs with an HTTP 400 Bad Request.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change adds input validation that rejects duplicate user IDs with HTTP 400 instead of allowing the request to fail downstream with HTTP 500. While this prevents a database error, it modifies the endpoint's error response contract—any client code expecting HTTP 500 for this scenario or relying on the old behavior could be affected. The validation logic is straightforward (single in-memory map check), reducing the likelihood of new bugs.

**QA Recommendation:** Manual testing of the duplicate user ID rejection flow is recommended given the behavioral change from HTTP 500 to HTTP 400. Verify the error message is clear and actionable. Existing test coverage already includes verification of duplicate rejection (TestAddMembersToGroup includes case: "Add one user twice in same request"), which reduces the need for extensive manual testing but should be confirmed as passing in the test suite.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36783?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->