### PR TITLE
Automated cherry pick of #36693

### DIFF
--- a/e2e-tests/playwright/lib/src/ui/components/channels/channel_settings/configuration_settings.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/channel_settings/configuration_settings.ts
@@ -95,7 +95,7 @@ export default class ConfigurationSettings {
         await textBox.fill(text);
     }
 
-    async setChannelBannerTextColor(color: string) {
+    async setChannelBannerBackgroundColor(color: string) {
         const colorInput = this.container.locator('#channel_banner_banner_background_color_picker-inputColorValue');
         await expect(colorInput).toBeVisible();
         await colorInput.fill(color);

--- a/e2e-tests/playwright/specs/functional/channels/channel_banner/channel_banner.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/channel_banner/channel_banner.spec.ts
@@ -21,7 +21,7 @@ test('Should show channel banner when configured', async ({pw}) => {
 
     await configurationTab.enableChannelBanner();
     await configurationTab.setChannelBannerText('Example channel banner text');
-    await configurationTab.setChannelBannerTextColor('77DD88');
+    await configurationTab.setChannelBannerBackgroundColor('77DD88');
 
     await configurationTab.save();
     await channelSettingsModal.close();
@@ -67,7 +67,7 @@ test('Should show channel banner in thread view', async ({pw}) => {
 
     await configurationTab.enableChannelBanner();
     await configurationTab.setChannelBannerText('Thread banner text');
-    await configurationTab.setChannelBannerTextColor('AA33BB');
+    await configurationTab.setChannelBannerBackgroundColor('AA33BB');
 
     await configurationTab.save();
     await channelSettingsModal.close();
@@ -119,7 +119,7 @@ test('Should render image emoticons without clipping', async ({pw}) => {
     const configurationTab = await channelSettingsModal.openConfigurationTab();
 
     await configurationTab.enableChannelBanner();
-    await configurationTab.setChannelBannerTextColor('77DD88');
+    await configurationTab.setChannelBannerBackgroundColor('77DD88');
     // :dog: is in Mattermost's emoji map → renders as .emoticon (background-image).
     // Unicode emojis that are also in the map (e.g. 🐶) follow the same path.
     await configurationTab.setChannelBannerText('Hello :dog:');
@@ -144,7 +144,7 @@ test('Should render unsupported unicode emoji without clipping', async ({pw}) =>
     const configurationTab = await channelSettingsModal.openConfigurationTab();
 
     await configurationTab.enableChannelBanner();
-    await configurationTab.setChannelBannerTextColor('77DD88');
+    await configurationTab.setChannelBannerBackgroundColor('77DD88');
     // 🫠 (U+1FAE0, Unicode 14.0) is above Mattermost's emoji map ceiling (1FAD6)
     // so it falls through to the .emoticon--unicode span path.
     await configurationTab.setChannelBannerText('Hello 🫠');
@@ -169,7 +169,7 @@ test('Should render text with descenders without clipping', async ({pw}) => {
     const configurationTab = await channelSettingsModal.openConfigurationTab();
 
     await configurationTab.enableChannelBanner();
-    await configurationTab.setChannelBannerTextColor('77DD88');
+    await configurationTab.setChannelBannerBackgroundColor('77DD88');
     // Characters with descenders (parts that extend below the baseline).
     // Previously clipped because line-height equalled font-size (13px), leaving
     // no room below the baseline for g, j, p, q, y etc.
@@ -196,7 +196,7 @@ test('Should render markdown', async ({pw}) => {
 
     await configurationTab.enableChannelBanner();
     await configurationTab.setChannelBannerText('**bold** *italic* ~~strikethrough~~');
-    await configurationTab.setChannelBannerTextColor('77DD88');
+    await configurationTab.setChannelBannerBackgroundColor('77DD88');
 
     await configurationTab.save();
     await channelSettingsModal.close();

--- a/e2e-tests/playwright/specs/functional/channels/channel_classification/channel_classification.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/channel_classification/channel_classification.spec.ts
@@ -323,6 +323,59 @@ test.describe('Channel Classification - Existing channel settings', () => {
         expect(colorValue.toLowerCase().replace('#', '')).toBe(selectedLevel!.color.toLowerCase().replace('#', ''));
     });
 
+    test('Disabling classification with a custom banner color preserves it server-side, and re-enabling restores the Save button', async ({
+        pw,
+    }) => {
+        const {adminUser, team, adminClient} = await initSetupTracked(pw);
+
+        const channel = await adminClient.createChannel(
+            pw.random.channel({teamId: team.id, name: `cls-${pw.random.id()}`, displayName: `Cls ${pw.random.id()}`}),
+        );
+        await adminClient.addToChannel(adminUser.id, channel.id);
+
+        const {channelsPage} = await pw.testBrowser.login(adminUser);
+        await channelsPage.goto(team.name, channel.name);
+        await expect(channelsPage.page.getByTestId('channel_view')).toBeVisible({timeout: 60000});
+
+        // Step 1: enable classification, select a level, save
+        const channelSettingsModal = await channelsPage.openChannelSettings();
+        const configurationTab = await channelSettingsModal.openConfigurationTab();
+
+        const classificationToggle = channelsPage.page.getByTestId('channelClassificationToggle-button');
+        await classificationToggle.click();
+
+        const dropdownContainer = channelsPage.page.getByTestId('channelClassificationLevel');
+        await dropdownContainer.click();
+        const selectedLevel = classificationLevels.find((l) => l.name === 'SECRET')!;
+        await channelsPage.page.locator('.DropDown__menu').getByText(selectedLevel.name, {exact: true}).click();
+        await configurationTab.save();
+
+        // Step 2: in the same open modal, disable classification, enable a manual banner,
+        // set a custom color, save. The manual banner toggle is needed because master no
+        // longer auto-enables banner_info.enabled when classification is on, so the banner
+        // section body (and its color input) is hidden after toggling classification off
+        // until a manual banner is enabled.
+        await classificationToggle.click();
+        await configurationTab.enableChannelBanner();
+        const customColor = 'aa00aa';
+        await configurationTab.setChannelBannerBackgroundColor(customColor);
+        await configurationTab.save();
+
+        // Symptom 1 guard: color input reflects what we typed and the server persisted the custom color
+        const colorInput = channelsPage.page.locator('#channel_banner_banner_background_color_picker-inputColorValue');
+        await expect(colorInput).toHaveValue(`#${customColor}`);
+        const persisted = await adminClient.getChannel(channel.id);
+        expect(persisted.banner_info?.background_color?.toLowerCase().replace('#', '')).toBe(customColor);
+
+        // Symptom 2 guard: re-enable classification → Save button reappears (panel transitions out of 'saved')
+        await classificationToggle.click();
+        const saveButton = channelsPage.page.getByTestId('SaveChangesPanel__save-btn');
+        await expect(saveButton).toBeVisible();
+        await expect(saveButton).toBeEnabled();
+
+        await channelSettingsModal.close();
+    });
+
     test('Editing banner text and saving updates the banner in real time', async ({pw}) => {
         const {adminUser, team, adminClient} = await initSetupTracked(pw);
 

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_configuration_tab.test.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_configuration_tab.test.tsx
@@ -971,16 +971,116 @@ describe('ChannelSettingsConfigurationTab', () => {
             });
         });
 
-        it('resets classification form to initial state when Reset is clicked', async () => {
+        it('preserves a saved regular banner color and shows Save when classification is re-enabled', async () => {
+            const {Client4} = require('mattermost-redux/client');
+            const {patchChannel} = require('mattermost-redux/actions/channels');
+            patchChannel.mockReturnValue({type: 'MOCK_ACTION', data: {}});
+            Client4.patchPropertyValues.mockResolvedValueOnce([]);
             enableClassification({
                 hasClassification: true,
                 classificationId: LEVEL_UNCLASSIFIED.id,
                 bannerText: `**${LEVEL_UNCLASSIFIED.name}**`,
             });
 
+            const classifiedChannel = TestHelper.getChannelMock({
+                ...mockChannel,
+                banner_info: {
+                    enabled: true,
+                    text: `**${LEVEL_UNCLASSIFIED.name}**`,
+                    background_color: LEVEL_UNCLASSIFIED.color,
+                },
+            });
+            const savedRegularBannerChannel = TestHelper.getChannelMock({
+                ...mockChannel,
+                banner_info: {
+                    enabled: true,
+                    text: `**${LEVEL_UNCLASSIFIED.name}**`,
+                    background_color: '#aa00aa',
+                },
+            });
+
+            const {rerender} = renderWithContext(
+                <ChannelSettingsConfigurationTab
+                    {...baseProps}
+                    channel={classifiedChannel}
+                    canManageSharedChannels={true}
+                />,
+                {},
+                {useMockedStore: true},
+            );
+
+            await userEvent.click(screen.getByTestId('channelClassificationToggle-button'));
+
+            const colorInput = screen.getByTestId('color-inputColorValue');
+            await userEvent.clear(colorInput);
+            await userEvent.type(colorInput, '#AA00AA');
+
+            const saveButton = await screen.findByRole('button', {name: 'Save'});
+            await userEvent.click(saveButton);
+
+            await waitFor(() => {
+                expect(patchChannel).toHaveBeenCalledWith(
+                    'channel1',
+                    expect.objectContaining({
+                        banner_info: expect.objectContaining({
+                            enabled: true,
+                            background_color: '#aa00aa',
+                        }),
+                    }),
+                );
+            });
+            expect(Client4.patchPropertyValues).toHaveBeenCalledWith(
+                'access_control',
+                'channel',
+                'channel1',
+                [{field_id: CHANNEL_FIELD_ID, value: null}],
+            );
+
+            mockedUseChannelClassificationBanner.mockReturnValue({
+                hasClassification: false,
+                classificationBanner: undefined,
+                classificationId: undefined,
+                bannerText: undefined,
+            });
+            rerender(
+                <ChannelSettingsConfigurationTab
+                    {...baseProps}
+                    channel={savedRegularBannerChannel}
+                    canManageSharedChannels={true}
+                />,
+            );
+
+            await waitFor(() => {
+                expect(screen.getByTestId('color-inputColorValue')).toHaveValue('#aa00aa');
+            });
+            expect(screen.queryByRole('button', {name: 'Save'})).not.toBeInTheDocument();
+
+            await userEvent.click(screen.getByTestId('channelClassificationToggle-button'));
+
+            await waitFor(() => {
+                expect(screen.getByRole('button', {name: 'Save'})).toBeEnabled();
+            });
+        });
+
+        it('resets classification form to initial state when Reset is clicked', async () => {
+            enableClassification({
+                hasClassification: true,
+                classificationId: LEVEL_UNCLASSIFIED.id,
+                bannerText: `**${LEVEL_UNCLASSIFIED.name}**`,
+            });
+            const classifiedChannel = TestHelper.getChannelMock({
+                ...mockChannel,
+                banner_info: {
+                    enabled: true,
+                    text: `**${LEVEL_UNCLASSIFIED.name}**`,
+                    background_color: LEVEL_UNCLASSIFIED.color,
+                },
+            });
+
             renderWithContext(
                 <ChannelSettingsConfigurationTab
                     {...baseProps}
+                    channel={classifiedChannel}
                     canManageSharedChannels={true}
                 />,
             );

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_configuration_tab.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_configuration_tab.tsx
@@ -111,27 +111,7 @@ function ChannelSettingsConfigurationTab({
     const canManageClassification = classification.available && canManageChannelRoles;
     const [classificationEnabled, setClassificationEnabled] = useState(classificationBanner.hasClassification);
     const [selectedClassificationId, setSelectedClassificationId] = useState(classificationBanner.classificationId || '');
-
     const bannerLockedByClassification = classificationEnabled && Boolean(selectedClassificationId);
-
-    useEffect(() => {
-        setClassificationEnabled(classificationBanner.hasClassification);
-        setSelectedClassificationId(classificationBanner.classificationId || '');
-
-        // Mirror the classification text/color into the local banner_info form
-        // state so the user can edit text while a classification is active —
-        // but never flip banner_info.enabled. The classification banner renders
-        // off the property value (see channel_banner.tsx); leaving banner_info
-        // disabled means deleting the property value makes the banner disappear
-        // without dragging stale text/color into the manual banner slot.
-        if (classificationBanner.hasClassification && classificationBanner.classificationBanner) {
-            setUpdatedChannelBanner((prev) => ({
-                ...prev,
-                text: classificationBanner.classificationBanner?.text ?? prev.text,
-                background_color: classificationBanner.classificationBanner?.background_color || prev.background_color || DEFAULT_CHANNEL_BANNER.background_color,
-            }));
-        }
-    }, [classificationBanner.hasClassification, classificationBanner.classificationId, classificationBanner.classificationBanner]);
 
     const classificationOptions = useMemo(() => {
         return classification.levels.
@@ -164,7 +144,7 @@ function ChannelSettingsConfigurationTab({
     }), [classificationBanner.hasClassification, classificationBanner.classificationId]);
 
     const hasClassificationChanges = classificationEnabled !== initialClassificationState.enabled ||
-        selectedClassificationId !== initialClassificationState.classificationId;
+        (classificationEnabled && selectedClassificationId !== initialClassificationState.classificationId);
 
     const handleClassificationToggle = useCallback(() => {
         setClassificationEnabled((prev) => {
@@ -361,8 +341,39 @@ function ChannelSettingsConfigurationTab({
         (canManageSharedChannels && hasWorkspaceChanges);
 
     useEffect(() => {
+        if (hasUnsavedChanges) {
+            return;
+        }
+
+        setClassificationEnabled(classificationBanner.hasClassification);
+        setSelectedClassificationId(classificationBanner.classificationId || '');
+
+        // Mirror the classification text/color into the local banner_info form
+        // state so the user can edit text while a classification is active —
+        // but never flip banner_info.enabled. The classification banner renders
+        // off the property value (see channel_banner.tsx); leaving banner_info
+        // disabled means deleting the property value makes the banner disappear
+        // without dragging stale text/color into the manual banner slot.
+        if (classificationBanner.hasClassification && classificationBanner.classificationBanner) {
+            setUpdatedChannelBanner((prev) => ({
+                ...prev,
+                text: classificationBanner.classificationBanner?.text ?? prev.text,
+                background_color: classificationBanner.classificationBanner?.background_color || prev.background_color || DEFAULT_CHANNEL_BANNER.background_color,
+            }));
+        }
+    }, [
+        classificationBanner.hasClassification,
+        classificationBanner.classificationId,
+        classificationBanner.classificationBanner,
+        hasUnsavedChanges,
+    ]);
+
+    useEffect(() => {
         setRequireConfirm(hasUnsavedChanges);
         setAreThereUnsavedChanges?.(hasUnsavedChanges);
+        if (hasUnsavedChanges) {
+            setSaveChangesPanelState((current) => (current === 'saved' ? undefined : current));
+        }
     }, [hasUnsavedChanges, setAreThereUnsavedChanges]);
 
     const handleServerError = useCallback((err: ServerError) => {


### PR DESCRIPTION
Cherry pick of #36693 on release-11.8.

/cc  @cursor[bot]

```release-note
NONE
```