### PR TITLE
Fix auto-translation infinite shimmer for region-specific locales lik…

### DIFF
--- a/webapp/channels/src/utils/post_utils.test.tsx
+++ b/webapp/channels/src/utils/post_utils.test.tsx
@@ -1604,3 +1604,50 @@ describe('shouldShowActionsMenu', () => {
         expect(PostUtils.shouldShowActionsMenu(baseState, borPost)).toBe(false);
     });
 });
+
+describe('getPostTranslation', () => {
+    test('should return exact match first (fixes zh-CN translation bug)', () => {
+        const post = TestHelper.getPostMock({
+            metadata: {
+                translations: {
+                    zh: {
+                        state: 'processing',
+                        source_lang: 'en',
+                    },
+                    'zh-CN': {
+                        state: 'ready',
+                        source_lang: 'en',
+                        object: {message: '你好，世界'},
+                    },
+                },
+            },
+        } as any);
+
+        // Before the fix, this would incorrectly return the 'zh' (processing) state
+        // because it blindly stripped '-CN' and only checked the prefix.
+        // With the fix, it checks 'zh-CN' first and returns the ready state.
+        const translation = PostUtils.getPostTranslation(post, 'zh-CN');
+        expect(translation?.state).toBe('ready');
+        expect(translation?.object?.message).toBe('你好，世界');
+    });
+
+    test('should fallback to prefix match if exact match not found', () => {
+        const post = TestHelper.getPostMock({
+            metadata: {
+                translations: {
+                    es: {
+                        state: 'ready',
+                        source_lang: 'en',
+                        object: {message: 'Hola mundo'},
+                    },
+                },
+            },
+        } as any);
+
+        // Even though 'es-ES' isn't explicitly in translations,
+        // it falls back to 'es' correctly.
+        const translation = PostUtils.getPostTranslation(post, 'es-ES');
+        expect(translation?.state).toBe('ready');
+        expect(translation?.object?.message).toBe('Hola mundo');
+    });
+});

--- a/webapp/channels/src/utils/post_utils.ts
+++ b/webapp/channels/src/utils/post_utils.ts
@@ -912,6 +912,9 @@ export function hasRequestedPersistentNotifications(priority?: PostPriorityMetad
 }
 
 export function getPostTranslation(post: Post, locale: string): PostTranslation | undefined {
+    if (post.metadata?.translations?.[locale]) {
+        return post.metadata.translations[locale];
+    }
     const normalizedLocale = locale.split('-')[0];
     return post.metadata?.translations?.[normalizedLocale];
 }


### PR DESCRIPTION
#### Summary

Fixes a locale lookup issue in the auto-translation feature for region-specific locales such as `zh-CN`.

`getPostTranslation()` normalized locales before performing the lookup (for example, `zh-CN` → `zh`). When translations were stored under the full locale key, the frontend could fail to retrieve the correct translation entry.

This change attempts an exact locale match first and falls back to the normalized locale when an exact match is not available.

Also adds unit tests covering:

* Exact locale matching (`zh-CN`)
* Fallback behavior (`es-ES` → `es`)
* Preference of exact matches over normalized locale entries

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/36578

#### Screenshots

N/A (no UI changes)

#### Release Note

```release-note
Fixed a locale lookup issue in auto-translation for region-specific languages such as Simplified Chinese (zh-CN).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change adds an exact locale match check before falling back to normalized locale lookup in the `getPostTranslation()` utility function. This is a non-breaking modification—translations stored under base locale keys (e.g., 'zh') will still be found via the fallback path, and the function behavior is strictly additive with no logic removal.

**QA Recommendation:** Focus manual QA on translation display for region-specific locales (zh-CN, es-ES) and verify base locales (zh, es) still render correctly. Since comprehensive test coverage for both exact matching and fallback scenarios has been added and the function is isolated (does not modify data or trigger side effects), automated testing should be sufficient for deployment validation.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36801?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->