### PR TITLE
POC - Audit logging based post tracking

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -1102,6 +1102,8 @@ func getPinnedPosts(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}
 
+	c.App.AuditPostDeliveredBulk(c.AppContext, c.AppContext.Session().UserId, clientPostList.Order, c.Params.ChannelId, model.AuditMechAPIDirect)
+
 	auditRec := c.MakeAuditRecord(model.AuditEventUpdateChannelMemberRoles, model.AuditStatusSuccess)
 	defer c.LogAuditRec(auditRec)
 	model.AddEventParameterToAuditRec(auditRec, "channel_id", c.Params.ChannelId)

--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -344,6 +344,8 @@ func getPostsForChannel(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}
 
+	c.App.AuditPostDeliveredBulk(c.AppContext, c.AppContext.Session().UserId, clientPostList.Order, channelId, model.AuditMechChannelView)
+
 	auditRec := c.MakeAuditRecord(model.AuditEventGetPostsForChannel, model.AuditStatusSuccess)
 	defer c.LogAuditRec(auditRec)
 	model.AddEventParameterToAuditRec(auditRec, "channel_id", channelId)
@@ -427,6 +429,8 @@ func getPostsForChannelAroundLastUnread(c *Context, w http.ResponseWriter, r *ht
 	if err := clientPostList.EncodeJSON(w); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}
+
+	c.App.AuditPostDeliveredBulk(c.AppContext, c.AppContext.Session().UserId, clientPostList.Order, channelId, model.AuditMechChannelView)
 
 	auditRec := c.MakeAuditRecord(model.AuditEventGetPostsForChannelAroundLastUnread, model.AuditStatusSuccess)
 	defer c.LogAuditRec(auditRec)
@@ -537,6 +541,8 @@ func getFlaggedPostsForUser(c *Context, w http.ResponseWriter, r *http.Request) 
 	if err := clientPostList.EncodeJSON(w); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}
+
+	c.App.AuditPostDeliveredBulk(c.AppContext, c.AppContext.Session().UserId, clientPostList.Order, "", model.AuditMechAPIDirect)
 }
 
 // getPost also sets a header to indicate, if post is inaccessible due to the cloud plan's limit.
@@ -579,6 +585,8 @@ func getPost(c *Context, w http.ResponseWriter, r *http.Request) {
 	if err := post.EncodeJSON(w); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}
+
+	c.App.AuditPostDelivered(c.AppContext, c.AppContext.Session().UserId, post.Id, post.ChannelId, model.AuditMechAPIDirect)
 
 	auditRec := c.MakeAuditRecord(model.AuditEventGetPost, model.AuditStatusSuccess)
 	defer c.LogAuditRec(auditRec)
@@ -656,6 +664,8 @@ func getPostsByIds(c *Context, w http.ResponseWriter, r *http.Request) {
 	if err := json.NewEncoder(w).Encode(posts); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}
+
+	c.App.AuditPostDeliveredPosts(c.AppContext, c.AppContext.Session().UserId, posts, "", model.AuditMechAPIDirect)
 
 	auditRec := c.MakeAuditRecord(model.AuditEventGetPostsByIds, model.AuditStatusSuccess)
 	defer c.LogAuditRec(auditRec)
@@ -905,6 +915,8 @@ func getPostThread(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}
 
+	c.App.AuditPostDeliveredBulk(c.AppContext, c.AppContext.Session().UserId, clientPostList.Order, "", model.AuditMechThreadView)
+
 	auditRec := c.MakeAuditRecord(model.AuditEventGetPostThread, model.AuditStatusSuccess)
 	defer c.LogAuditRec(auditRec)
 	model.AddEventParameterToAuditRec(auditRec, "post_id", c.Params.PostId)
@@ -1015,6 +1027,8 @@ func searchPosts(c *Context, w http.ResponseWriter, r *http.Request, teamId stri
 	if err := results.EncodeJSON(w); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}
+
+	c.App.AuditPostDeliveredBulk(c.AppContext, c.AppContext.Session().UserId, clientPostList.Order, "", model.AuditMechSearchResult)
 }
 
 func postEditTimeLimitExpired(cfg *model.Config, post *model.Post) bool {

--- a/server/channels/app/audit_delivery.go
+++ b/server/channels/app/audit_delivery.go
@@ -1,0 +1,77 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+)
+
+// AuditPostDelivered emits a single postDelivered audit record for one
+// (recipient, post, mechanism) tuple. Errors during emission never
+// propagate — audit failure must not fail the user-facing request.
+//
+// Pass the session user's ID as recipientUserID from API handlers (the
+// viewer of the post). Pass the actual recipient's ID in app-layer paths
+// (push/email/webhook recipient, fan-out member).
+//
+// channelID may be empty if not readily available; mechanism must be one of
+// the model.AuditMech* string constants.
+func (a *App) AuditPostDelivered(rctx request.CTX, recipientUserID, postID, channelID, mechanism string) {
+	if recipientUserID == "" || postID == "" {
+		return
+	}
+	rec := a.MakeAuditRecord(rctx, model.AuditEventPostDelivered, model.AuditStatusSuccess)
+	rec.Actor.UserId = recipientUserID
+	model.AddEventParameterToAuditRec(rec, "mechanism", mechanism)
+	model.AddEventParameterToAuditRec(rec, "post_id", postID)
+	if channelID != "" {
+		model.AddEventParameterToAuditRec(rec, "channel_id", channelID)
+	}
+	a.LogAuditRec(rctx, rec, nil)
+}
+
+// AuditPostDeliveredBulk emits one postDelivered record per post for a
+// single recipient. Use for API handler paths that return a PostList
+// (channel view, thread view, search, getPostsByIds, flagged, pinned).
+func (a *App) AuditPostDeliveredBulk(rctx request.CTX, recipientUserID string, postIDs []string, channelID, mechanism string) {
+	if recipientUserID == "" || len(postIDs) == 0 {
+		return
+	}
+	for _, pid := range postIDs {
+		a.AuditPostDelivered(rctx, recipientUserID, pid, channelID, mechanism)
+	}
+}
+
+// AuditPostDeliveredFanOut emits one postDelivered record per recipient
+// for a single post. Use for the websocket-broadcast fan-out where the
+// same post is delivered to every online channel member.
+func (a *App) AuditPostDeliveredFanOut(rctx request.CTX, recipientUserIDs []string, postID, channelID, mechanism string) {
+	if postID == "" || len(recipientUserIDs) == 0 {
+		return
+	}
+	for _, uid := range recipientUserIDs {
+		a.AuditPostDelivered(rctx, uid, postID, channelID, mechanism)
+	}
+}
+
+// AuditPostDeliveredPosts is the post-slice variant of AuditPostDeliveredBulk.
+// Use when the caller already has a []*model.Post so the call site doesn't
+// have to allocate an intermediate []string. If channelID is empty, each
+// record uses the post's own ChannelId.
+func (a *App) AuditPostDeliveredPosts(rctx request.CTX, recipientUserID string, posts []*model.Post, channelID, mechanism string) {
+	if recipientUserID == "" || len(posts) == 0 {
+		return
+	}
+	for _, p := range posts {
+		if p == nil || p.Id == "" {
+			continue
+		}
+		cid := channelID
+		if cid == "" {
+			cid = p.ChannelId
+		}
+		a.AuditPostDelivered(rctx, recipientUserID, p.Id, cid, mechanism)
+	}
+}

--- a/server/channels/app/notification.go
+++ b/server/channels/app/notification.go
@@ -737,6 +737,16 @@ func (a *App) SendNotifications(rctx request.CTX, post *model.Post, team *model.
 		return nil, appErr
 	}
 
+	// Mechanism 16: post broadcast over websocket to all channel members the
+	// notifier is aware of. One delivery record per recipient.
+	if len(profileMap) > 0 {
+		recipientIDs := make([]string, 0, len(profileMap))
+		for uid := range profileMap {
+			recipientIDs = append(recipientIDs, uid)
+		}
+		a.AuditPostDeliveredFanOut(rctx, recipientIDs, post.Id, channel.Id, model.AuditMechWebsocketBroadcast)
+	}
+
 	// If this is a reply in a thread, notify participants
 	if isCRTAllowed && post.RootId != "" {
 		for uid := range followers {

--- a/server/channels/app/notification_email.go
+++ b/server/channels/app/notification_email.go
@@ -145,6 +145,8 @@ func (a *App) sendNotificationEmail(rctx request.CTX, notification *PostNotifica
 	channel := notification.Channel
 	post := notification.Post
 
+	a.AuditPostDelivered(rctx, user.Id, post.Id, channel.Id, model.AuditMechEmailNotif)
+
 	if channel.IsGroupOrDirect() {
 		teams, err := a.Srv().Store().Team().GetTeamsByUserId(user.Id)
 		if err != nil {

--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -87,6 +87,15 @@ func (a *App) sendPushNotificationSync(rctx request.CTX, post *model.Post, user 
 		return appErr
 	}
 
+	// Mechanism 6/7: derived from the *built* message, not the raw config —
+	// BuildPushNotificationMessage may downgrade ID-loaded to generic/full
+	// when the license check fails, so msg.IsIdLoaded is the source of truth.
+	pushMech := model.AuditMechPushFull
+	if msg.IsIdLoaded {
+		pushMech = model.AuditMechPushIDOnly
+	}
+	a.AuditPostDelivered(rctx, user.Id, post.Id, channel.Id, pushMech)
+
 	return a.sendPushNotificationToAllSessions(rctx, msg, user.Id, "")
 }
 

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -403,6 +403,10 @@ func (a *App) CreatePost(rctx request.CTX, post *model.Post, channel *model.Chan
 				hooks.MessageHasBeenPosted(pluginContext, pluginPost)
 				return true
 			}, plugin.MessageHasBeenPostedID)
+			// Mechanism 12: dispatched once per post (outside the per-plugin
+			// callback). Attribute the delivery to the post author since there
+			// is no per-plugin user identity at this hook point.
+			a.AuditPostDelivered(rctx, rpost.UserId, rpost.Id, rpost.ChannelId, model.AuditMechPluginHook)
 		})
 	}
 

--- a/server/channels/app/post_metadata.go
+++ b/server/channels/app/post_metadata.go
@@ -351,6 +351,10 @@ func (a *App) SanitizePostMetadataForUser(rctx request.CTX, post *model.Post, us
 					removePermalinkMetadataFromPost(post)
 					// Since we remove the permalink metadata, we return true for isMember
 					isMemberForPreviews = true
+				} else {
+					// Mechanism 8: user retained access to the previewed post —
+					// record the embedded post as delivered to this viewer.
+					a.AuditPostDelivered(rctx, userID, previewPost.Post.Id, previewPost.Post.ChannelId, model.AuditMechPermalinkPreview)
 				}
 			}
 		}

--- a/server/channels/app/webhook.go
+++ b/server/channels/app/webhook.go
@@ -99,6 +99,10 @@ func (a *App) handleWebhookEvents(rctx request.CTX, post *model.Post, team *mode
 func (a *App) TriggerWebhook(rctx request.CTX, payload *model.OutgoingWebhookPayload, hook *model.OutgoingWebhook, post *model.Post, channel *model.Channel) {
 	logger := rctx.Logger().With(mlog.String("outgoing_webhook_id", hook.Id), mlog.String("post_id", post.Id), mlog.String("channel_id", channel.Id), mlog.String("content_type", hook.ContentType))
 
+	// Mechanism 11: post leaves the channel via outgoing webhook. The webhook's
+	// CreatorId is the user accountable for the integration.
+	a.AuditPostDelivered(rctx, hook.CreatorId, post.Id, channel.Id, model.AuditMechOutgoingWebhook)
+
 	var jsonBytes []byte
 	var err error
 	contentType := "application/x-www-form-urlencoded"

--- a/server/public/model/audit_events.go
+++ b/server/public/model/audit_events.go
@@ -308,6 +308,7 @@ const (
 	AuditEventMoveThread                         = "moveThread"                         // move thread and replies to different channel
 	AuditEventNotificationAck                    = "notificationAck"                    // notification ack
 	AuditEventPatchPost                          = "patchPost"                          // update post meta properties
+	AuditEventPostDelivered                      = "postDelivered"                      // post delivered to a user (see post_delivery_mechanism.go for mechanism values)
 	AuditEventRestorePostVersion                 = "restorePostVersion"                 // restore post to previous version
 	AuditEventSaveIsPinnedPost                   = "saveIsPinnedPost"                   // pin or unpin post
 	AuditEventSearchPosts                        = "searchPosts"                        // search for posts

--- a/server/public/model/post_delivery_mechanism.go
+++ b/server/public/model/post_delivery_mechanism.go
@@ -1,0 +1,22 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+// Post delivery mechanisms — values for the "mechanism" parameter on the
+// AuditEventPostDelivered audit record. Numbering matches the Confluence
+// doc "Mechanisms of Viewing Post Contents". Gaps (3, 4, 10, 13, 14)
+// intentionally match the doc's numbering so cross-referencing is direct.
+const (
+	AuditMechChannelView        = "channel_view"        // mech 1
+	AuditMechThreadView         = "thread_view"         // mech 2
+	AuditMechEmailNotif         = "email_notif"         // mech 5
+	AuditMechPushFull           = "push_full"           // mech 6
+	AuditMechPushIDOnly         = "push_id_only"        // mech 7
+	AuditMechPermalinkPreview   = "permalink_preview"   // mech 8
+	AuditMechAPIDirect          = "api_direct"          // mech 9
+	AuditMechOutgoingWebhook    = "outgoing_webhook"    // mech 11
+	AuditMechPluginHook         = "plugin_hook"         // mech 12
+	AuditMechSearchResult       = "search_result"       // mech 15
+	AuditMechWebsocketBroadcast = "websocket_broadcast" // mech 16
+)


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
<!-- What does this PR do? Include QA steps if not covered in the ticket. -->

#### Ticket Link
<!--
Fixes: https://github.com/mattermost/mattermost/issues/XXX
Fixes: https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!-- Include screenshots or GIFs for UI changes. -->

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
Added `AuditEventPostDelivered` audit log event.
```

```release-note
NONE
```
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The PR adds audit-delivery instrumentation at ~11 high-frequency post-delivery integration points (API endpoints, notifications, email, push, webhooks, plugin hooks, permalink previews) and introduces shared audit helper methods and mechanism constants; these changes are additive but untested, and silent discarding of audit errors may mask failures and could introduce DB contention or performance regressions under load. Zero automated tests cover the new paths, increasing the risk that edge branches (e.g., push IsIdLoaded, fan-out recipient building, channel ID semantics) are incorrect or regress behavior.

**QA Recommendation:** Medium manual QA recommended: validate end-to-end post delivery flows (create post, API retrievals, thread/search/pinned endpoints), each notification mechanism (push full vs ID-only, email, websocket fan-out, outgoing webhooks, plugin hooks, permalink previews) for correct audit records and acceptable latency; add unit/integration tests for AuditPostDelivered* helpers and branch coverage (push message ID flag, fan-out recipient lists, channel ID cases) before merging.

*Generated by CodeRabbitAI*

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36806?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->