### PR TITLE
[MM-69058] Don't enable native channel banner when creating a classification banner

### DIFF
--- a/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
+++ b/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
@@ -176,8 +176,9 @@ const NewChannelModal = () => {
             default_category_name: defaultCategoryName,
             managed_category_name: managedCategoryName,
             ...(classificationEnabled && selectedClassificationId && bannerText ? {
+                // Leave banner_info disabled: the classification banner renders
+                // off the property value, not banner_info.enabled.
                 banner_info: {
-                    enabled: true,
                     text: bannerText,
                     background_color: selectedClassificationLevel?.color || '',
                 },

--- a/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
+++ b/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
@@ -176,6 +176,7 @@ const NewChannelModal = () => {
             default_category_name: defaultCategoryName,
             managed_category_name: managedCategoryName,
             ...(classificationEnabled && selectedClassificationId && bannerText ? {
+
                 // Leave banner_info disabled: the classification banner renders
                 // off the property value, not banner_info.enabled.
                 banner_info: {


### PR DESCRIPTION
### Summary

When creating a channel with a classification via the new channel modal, `banner_info.enabled` was being set to `true`. This turns on the **native** channel banner, which is wrong: the classification banner is meant to render off the classification property value, not `banner_info.enabled`.

Leaving the native banner enabled means clearing the classification later would leave a stale native banner behind if disabled. This change drops the `enabled` attribute so it defaults to `false`, matching the save logic already used in the channel settings configuration tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### Ticket Link
https://mattermost.atlassian.net/browse/MM-69058

### Release Notes

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change removes `banner_info.enabled` from classified channel creation payloads, relying on the channel_banner display logic (`showBanner = classificationBanner.hasClassification || showNativeBanner`) to render correctly. The affected code path in NewChannelModal has no unit test coverage despite automation recommendations, and the PR author explicitly declined to add regression tests, creating a gap where logic changes in the classification banner hook or display logic could reintroduce the bug.

**QA Recommendation:** Manual QA should verify banner behavior in classified channel workflows: (1) create new channels with different classification levels and confirm banners display via classification state (not `banner_info.enabled`), (2) verify no stale banners appear after channel creation, (3) confirm clearing classifications later properly hides banners. E2E test coverage exists but unit-level payload validation is absent, warranting focused manual testing on this regression risk.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/mattermost/mattermost/pull/36810?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->