### PR TITLE
MM-69057: Verify post ownership on inbound shared-channel edit/delete

### DIFF
--- a/server/platform/services/sharedchannel/sync_recv.go
+++ b/server/platform/services/sharedchannel/sync_recv.go
@@ -524,6 +524,10 @@ func (scs *Service) upsertSyncPost(post *model.Post, targetChannel *model.Channe
 			)
 		}
 	} else if post.DeleteAt > 0 {
+		// make sure the post being deleted is owned by the remote
+		if rpost.GetRemoteID() != rc.RemoteId {
+			return nil, fmt.Errorf("post sync failed: %w", ErrRemoteIDMismatch)
+		}
 		// delete post
 		rpost, appErr = scs.app.DeletePost(rctx, post.Id, post.UserId)
 		if appErr == nil {
@@ -533,6 +537,10 @@ func (scs *Service) upsertSyncPost(post *model.Post, targetChannel *model.Channe
 			)
 		}
 	} else if post.EditAt > rpost.EditAt || post.Message != rpost.Message || post.UpdateAt > rpost.UpdateAt || post.Metadata != nil {
+		// make sure the post being edited is owned by the remote
+		if rpost.GetRemoteID() != rc.RemoteId {
+			return nil, fmt.Errorf("post sync failed: %w", ErrRemoteIDMismatch)
+		}
 		scs.transformMentionsOnReceive(rctx, post, targetChannel, rc, mentionTransforms)
 		var priority *model.PostPriority
 		var acknowledgements []*model.PostAcknowledgement

--- a/server/platform/services/sharedchannel/sync_recv_test.go
+++ b/server/platform/services/sharedchannel/sync_recv_test.go
@@ -299,3 +299,68 @@ func TestUpsertSyncUserStatus(t *testing.T) {
 		mockApp.AssertNotCalled(t, "SaveAndBroadcastStatus")
 	})
 }
+
+func TestUpsertSyncPost(t *testing.T) {
+	remoteID := model.NewId()
+	channelID := model.NewId()
+	channel := &model.Channel{Id: channelID, Type: model.ChannelTypeOpen}
+	rc := &model.RemoteCluster{RemoteId: remoteID, Name: "test-remote"}
+
+	setup := func(t *testing.T, existing *model.Post) (*Service, *MockAppIface) {
+		mockPostStore := &mocks.PostStore{}
+		mockPostStore.On("GetSingle", mock.Anything, existing.Id, true).Return(existing, nil)
+
+		mockStore := &mocks.Store{}
+		mockStore.On("Post").Return(mockPostStore)
+
+		logger := mlog.CreateConsoleTestLogger(t)
+		mockServer := &MockServerIface{}
+		mockServer.On("GetStore").Return(mockStore)
+		mockServer.On("Log").Return(logger)
+
+		mockApp := &MockAppIface{}
+
+		return &Service{server: mockServer, app: mockApp}, mockApp
+	}
+
+	t.Run("rejects edit of a post owned by a different remote", func(t *testing.T) {
+		otherRemoteID := model.NewId()
+		postID := model.NewId()
+		existing := &model.Post{Id: postID, ChannelId: channelID, Message: "original", RemoteId: new(otherRemoteID)}
+
+		scs, mockApp := setup(t, existing)
+
+		_, err := scs.upsertSyncPost(&model.Post{Id: postID, ChannelId: channelID, Message: "tampered"}, channel, rc, nil)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrRemoteIDMismatch)
+		mockApp.AssertNotCalled(t, "UpdatePost", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("rejects delete of a post owned by a local user", func(t *testing.T) {
+		postID := model.NewId()
+		existing := &model.Post{Id: postID, ChannelId: channelID, Message: "original", RemoteId: nil}
+
+		scs, mockApp := setup(t, existing)
+
+		_, err := scs.upsertSyncPost(&model.Post{Id: postID, ChannelId: channelID, DeleteAt: model.GetMillis()}, channel, rc, nil)
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, ErrRemoteIDMismatch)
+		mockApp.AssertNotCalled(t, "DeletePost", mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("allows edit of a post owned by the sending remote", func(t *testing.T) {
+		postID := model.NewId()
+		existing := &model.Post{Id: postID, ChannelId: channelID, Message: "original", RemoteId: new(remoteID)}
+
+		scs, mockApp := setup(t, existing)
+		updated := &model.Post{Id: postID, ChannelId: channelID, Message: "updated"}
+		mockApp.On("UpdatePost", mock.Anything, mock.Anything, mock.Anything).Return(updated, false, (*model.AppError)(nil))
+
+		_, err := scs.upsertSyncPost(&model.Post{Id: postID, ChannelId: channelID, Message: "updated"}, channel, rc, nil)
+
+		require.NoError(t, err)
+		mockApp.AssertCalled(t, "UpdatePost", mock.Anything, mock.Anything, mock.Anything)
+	})
+}


### PR DESCRIPTION
#### Summary

Hardens the inbound shared-channel sync handler so that post edits and deletes are only applied when the existing post is owned by the originating remote, bringing it in line with the ownership checks already used elsewhere in the same handler. Includes regression tests for the relevant cases.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-69057

#### Release Note
```release-note
NONE
```