### PR TITLE
MM-68952: Resolve public channel mentions for non-members under Compliance

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/mentions/channel_mention_resolution.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/mentions/channel_mention_resolution.spec.ts
@@ -1,0 +1,140 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+/**
+ * Coverage for MM-68952 / PR #36815 — per-viewer resolution of `~channel` mentions.
+ *
+ * The server populates `post.props.channel_mentions` for the post creator, then strips it
+ * per-viewer using `HasPermissionToResolveChannelMention`. The webapp only renders a clickable
+ * `a.mention-link` (display name) when the viewer's `channel_mentions` still contains the channel;
+ * otherwise it renders the literal `~slug` text.
+ *
+ * `HasPermissionToResolveChannelMention` resolves PUBLIC channels for any team member (independent
+ * of Compliance Monitoring), but keeps PRIVATE/DM/GM and cross-team channels stripped.
+ */
+test.describe('channel mention resolution', () => {
+    /**
+     * @objective A public channel mention authored on one team renders as the raw `~slug`
+     * (unresolved, non-clickable) for a viewer who does not belong to that channel's team.
+     *
+     * @precondition The viewer shares only a DM with the author and never joins the author's team.
+     *
+     * This is the license-free half of the fix (cross-team disclosure stays prevented) and is the
+     * simplest scenario whose rendering differs from the pre-fix behavior without Compliance Monitoring.
+     */
+    test(
+        'keeps a cross-team public channel mention unresolved for a non-team viewer',
+        {tag: '@mentions'},
+        async ({pw}) => {
+            // # Initialize the author on team A
+            const {adminClient, user: author, userClient, team: teamA} = await pw.initSetup();
+
+            // # Create a public channel on team A with a display name distinct from its slug, so a
+            // resolved mention (display name) is clearly distinguishable from an unresolved one (slug)
+            const channelName = `cross-team-public-${pw.random.id()}`;
+            const channelDisplayName = 'Cross Team Secret';
+            const publicChannel = await adminClient.createChannel({
+                team_id: teamA.id,
+                name: channelName,
+                display_name: channelDisplayName,
+                type: 'O',
+            });
+            await adminClient.addToChannel(author.id, publicChannel.id);
+
+            // # Create a viewer that belongs only to a different team B (never to team A)
+            const viewer = await pw.createNewUserProfile(adminClient);
+            const teamB = await pw.createNewTeam(adminClient);
+            await adminClient.addToTeam(teamB.id, viewer.id);
+
+            // # Open a DM between author and viewer (DMs are the only cross-team-visible channel)
+            const dmChannel = await adminClient.createDirectChannel([author.id, viewer.id]);
+
+            // # Author posts the public channel mention into the DM. current_team_id scopes the
+            // server-side name lookup to team A so the mention resolves for the author at creation time.
+            await userClient.createPost({
+                channel_id: dmChannel.id,
+                message: `Check out ~${channelName}`,
+                user_id: author.id,
+                props: {current_team_id: teamA.id},
+            });
+
+            // # Log in as the viewer and open the DM via team B
+            const {channelsPage} = await pw.testBrowser.login(viewer);
+            await channelsPage.goto(teamB.name, `@${author.username}`);
+            await channelsPage.toBeVisible();
+
+            const lastPost = await channelsPage.getLastPost();
+
+            // * The mention is NOT resolved into a clickable channel link for the cross-team viewer
+            await expect(lastPost.body.locator('a.mention-link[data-channel-mention]')).toHaveCount(0);
+
+            // * The raw `~slug` is rendered as plain text and the display name is never disclosed
+            await expect(lastPost.body).toContainText(`~${channelName}`);
+            await expect(lastPost.body).not.toContainText(channelDisplayName);
+        },
+    );
+
+    /**
+     * @objective With Compliance Monitoring enabled, a public channel mention resolves into a
+     * clickable `a.mention-link` (display name) for a team member who is NOT a member of the channel.
+     *
+     * @precondition Enterprise license + Compliance Monitoring. This is the exact regression from
+     * MM-68952: before the fix the per-viewer permission check (HasPermissionToReadChannel) failed
+     * under Compliance for non-members, so the mention was stripped to the raw `~slug`.
+     */
+    test(
+        'resolves a public channel mention for a non-member team member when Compliance Monitoring is on',
+        {tag: '@mentions'},
+        async ({pw}) => {
+            // Requires an enterprise license; skipped on unlicensed servers (e.g. local dev).
+            await pw.skipIfNoLicense();
+
+            const {adminClient, user: author, userClient, team} = await pw.initSetup();
+
+            // NOTE: ComplianceSettings is a global, server-wide setting. Toggling it can affect other
+            // tests running in parallel; we restore it in a finally block to limit the blast radius.
+            await adminClient.patchConfig({ComplianceSettings: {Enable: true}});
+
+            try {
+                // # Create a public channel; the author is a member, the viewer will not be
+                const channelName = `compliance-public-${pw.random.id()}`;
+                const channelDisplayName = 'Compliance Public Channel';
+                const publicChannel = await adminClient.createChannel({
+                    team_id: team.id,
+                    name: channelName,
+                    display_name: channelDisplayName,
+                    type: 'O',
+                });
+                await adminClient.addToChannel(author.id, publicChannel.id);
+
+                // # Create a viewer who is a team member but NOT a member of the public channel
+                const viewer = await pw.createNewUserProfile(adminClient);
+                await adminClient.addToTeam(team.id, viewer.id);
+
+                // # Author posts the mention in town-square (both users are members)
+                const townSquare = await adminClient.getChannelByName(team.id, 'town-square');
+                await userClient.createPost({
+                    channel_id: townSquare.id,
+                    message: `Please see ~${channelName}`,
+                    user_id: author.id,
+                });
+
+                // # Log in as the viewer and open town-square
+                const {channelsPage} = await pw.testBrowser.login(viewer);
+                await channelsPage.goto(team.name, 'town-square');
+                await channelsPage.toBeVisible();
+
+                const lastPost = await channelsPage.getLastPost();
+
+                // * The mention resolves to a clickable channel link showing the display name
+                const mentionLink = lastPost.body.locator(`a.mention-link[data-channel-mention="${channelName}"]`);
+                await expect(mentionLink).toBeVisible();
+                await expect(mentionLink).toContainText(channelDisplayName);
+            } finally {
+                await adminClient.patchConfig({ComplianceSettings: {Enable: false}});
+            }
+        },
+    );
+});

--- a/server/channels/app/authorization.go
+++ b/server/channels/app/authorization.go
@@ -475,6 +475,28 @@ func (a *App) HasPermissionToReadChannel(rctx request.CTX, userID string, channe
 	return false, false
 }
 
+// HasPermissionToResolveChannelMention determines whether the specified user may have a
+// ~channel mention resolved to its display name and link.
+//
+// Unlike HasPermissionToReadChannel, this exposes only the public channel NAME and link —
+// never post/file content — so it is intentionally INDEPENDENT of ComplianceSettings.
+// A public channel name is already discoverable within its team via browse/search/autocomplete,
+// and following the link still requires joining the channel (which creates the compliance trail).
+//
+// Private/DM/GM channels resolve only for members (via the content-read check). Public channels
+// on a team the user does not belong to stay unresolved, preventing cross-team disclosure.
+func (a *App) HasPermissionToResolveChannelMention(rctx request.CTX, userID string, channel *model.Channel) bool {
+	if ok, _ := a.HasPermissionToChannel(rctx, userID, channel.Id, model.PermissionReadChannelContent); ok {
+		return true
+	}
+
+	if channel.Type == model.ChannelTypeOpen || channel.Type == model.ChannelTypeOpenBoard {
+		return a.HasPermissionToTeam(rctx, userID, channel.TeamId, model.PermissionReadPublicChannel)
+	}
+
+	return false
+}
+
 func (a *App) HasPermissionToChannelMemberCount(rctx request.CTX, userID string, channel *model.Channel) bool {
 	if ok, _ := a.HasPermissionToChannel(rctx, userID, channel.Id, model.PermissionReadChannelContent); ok {
 		return true

--- a/server/channels/app/authorization_test.go
+++ b/server/channels/app/authorization_test.go
@@ -890,6 +890,146 @@ func TestHasPermissionToReadChannel(t *testing.T) {
 	}
 }
 
+func TestHasPermissionToResolveChannelMention(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	ttcc := []struct {
+		name                    string
+		configComplianceEnabled bool
+		channelType             model.ChannelType
+		isChannelMember         bool
+		isTeamMember            bool
+		expected                bool
+	}{
+		{
+			name:                    "public, team member, not channel member, compliance ON -> resolves",
+			configComplianceEnabled: true,
+			channelType:             model.ChannelTypeOpen,
+			isChannelMember:         false,
+			isTeamMember:            true,
+			expected:                true,
+		},
+		{
+			name:                    "public, team member, not channel member, compliance OFF -> resolves",
+			configComplianceEnabled: false,
+			channelType:             model.ChannelTypeOpen,
+			isChannelMember:         false,
+			isTeamMember:            true,
+			expected:                true,
+		},
+		{
+			name:                    "public, NOT team member, compliance ON -> stripped",
+			configComplianceEnabled: true,
+			channelType:             model.ChannelTypeOpen,
+			isChannelMember:         false,
+			isTeamMember:            false,
+			expected:                false,
+		},
+		{
+			name:                    "public, NOT team member, compliance OFF -> stripped",
+			configComplianceEnabled: false,
+			channelType:             model.ChannelTypeOpen,
+			isChannelMember:         false,
+			isTeamMember:            false,
+			expected:                false,
+		},
+		{
+			name:                    "open board, team member, compliance ON -> resolves",
+			configComplianceEnabled: true,
+			channelType:             model.ChannelTypeOpenBoard,
+			isChannelMember:         false,
+			isTeamMember:            true,
+			expected:                true,
+		},
+		{
+			name:                    "private, channel member -> resolves",
+			configComplianceEnabled: false,
+			channelType:             model.ChannelTypePrivate,
+			isChannelMember:         true,
+			isTeamMember:            true,
+			expected:                true,
+		},
+		{
+			name:                    "private, team member but not channel member, compliance OFF -> stripped",
+			configComplianceEnabled: false,
+			channelType:             model.ChannelTypePrivate,
+			isChannelMember:         false,
+			isTeamMember:            true,
+			expected:                false,
+		},
+		{
+			name:                    "private, not member, compliance ON -> stripped",
+			configComplianceEnabled: true,
+			channelType:             model.ChannelTypePrivate,
+			isChannelMember:         false,
+			isTeamMember:            false,
+			expected:                false,
+		},
+	}
+
+	for _, tc := range ttcc {
+		t.Run(tc.name, func(t *testing.T) {
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				enabled := tc.configComplianceEnabled
+				cfg.ComplianceSettings.Enable = &enabled
+			})
+
+			team := th.CreateTeam(t)
+			if tc.isTeamMember {
+				th.LinkUserToTeam(t, th.BasicUser2, team)
+			}
+
+			var channel *model.Channel
+			switch tc.channelType {
+			case model.ChannelTypeOpenBoard:
+				kanban := &model.KanbanProps{
+					GroupBy: model.KanbanGroupBy{
+						FieldID: model.NewId(),
+						Columns: []model.KanbanColumn{
+							{ID: model.NewId(), Name: "Todo", OptionIDs: []string{model.NewId()}},
+						},
+					},
+				}
+				viewProps, _ := kanban.ToProps()
+				view := &model.View{CreatorId: th.SystemAdminUser.Id, Type: model.ViewTypeKanban, Title: "Board", Props: viewProps}
+				ch, _, storeErr := th.App.Srv().Store().Channel().SaveBoardChannel(th.Context, &model.Channel{
+					TeamId:      team.Id,
+					DisplayName: "Board " + model.NewId(),
+					Name:        "board-" + model.NewId(),
+					Type:        tc.channelType,
+					CreatorId:   th.SystemAdminUser.Id,
+				}, -1, view)
+				require.NoError(t, storeErr)
+				channel = ch
+			case model.ChannelTypePrivate:
+				channel = th.CreatePrivateChannel(t, team)
+			default:
+				channel = th.CreateChannel(t, team)
+			}
+
+			if tc.isChannelMember {
+				_, err := th.App.AddUserToChannel(th.Context, th.BasicUser2, channel, false)
+				require.Nil(t, err)
+			}
+
+			require.Equal(t, tc.expected, th.App.HasPermissionToResolveChannelMention(th.Context, th.BasicUser2.Id, channel))
+		})
+	}
+
+	t.Run("DM, non-member -> stripped", func(t *testing.T) {
+		// DM between BasicUser and SystemAdminUser; BasicUser2 (the viewer) is not a participant.
+		dm := th.CreateDmChannel(t, th.SystemAdminUser)
+		require.False(t, th.App.HasPermissionToResolveChannelMention(th.Context, th.BasicUser2.Id, dm))
+	})
+
+	t.Run("GM, non-member -> stripped", func(t *testing.T) {
+		// GM between BasicUser and two fresh users; BasicUser2 (the viewer) is not a participant.
+		gm := th.CreateGroupChannel(t, th.CreateUser(t), th.CreateUser(t))
+		require.False(t, th.App.HasPermissionToResolveChannelMention(th.Context, th.BasicUser2.Id, gm))
+	})
+}
+
 func TestSessionHasPermissionToChannelByPost(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)

--- a/server/channels/app/platform/helper_test.go
+++ b/server/channels/app/platform/helper_test.go
@@ -60,6 +60,10 @@ func (ms *mockSuite) HasPermissionToReadChannel(rctx request.CTX, userID string,
 	return true, true
 }
 
+func (ms *mockSuite) HasPermissionToResolveChannelMention(rctx request.CTX, userID string, channel *model.Channel) bool {
+	return true
+}
+
 func (ms *mockSuite) HasPermissionToFileAction(rctx request.CTX, userID string, roles string, channelID string, action string) bool {
 	return true
 }

--- a/server/channels/app/platform/mocks/SuiteIFace.go
+++ b/server/channels/app/platform/mocks/SuiteIFace.go
@@ -94,6 +94,24 @@ func (_m *SuiteIFace) HasPermissionToReadChannel(rctx request.CTX, userID string
 	return r0, r1
 }
 
+// HasPermissionToResolveChannelMention provides a mock function with given fields: rctx, userID, channel
+func (_m *SuiteIFace) HasPermissionToResolveChannelMention(rctx request.CTX, userID string, channel *model.Channel) bool {
+	ret := _m.Called(rctx, userID, channel)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasPermissionToResolveChannelMention")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(request.CTX, string, *model.Channel) bool); ok {
+		r0 = rf(rctx, userID, channel)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // LogAuditRec provides a mock function with given fields: rctx, auditRec, err
 func (_m *SuiteIFace) LogAuditRec(rctx request.CTX, auditRec *model.AuditRecord, err error) {
 	_m.Called(rctx, auditRec, err)

--- a/server/channels/app/platform/web_hub.go
+++ b/server/channels/app/platform/web_hub.go
@@ -29,6 +29,7 @@ type SuiteIFace interface {
 	GetSession(token string) (*model.Session, *model.AppError)
 	RolesGrantPermission(roleNames []string, permissionId string) bool
 	HasPermissionToReadChannel(rctx request.CTX, userID string, channel *model.Channel) (bool, bool)
+	HasPermissionToResolveChannelMention(rctx request.CTX, userID string, channel *model.Channel) bool
 	HasPermissionToFileAction(rctx request.CTX, userID string, roles string, channelID string, action string) bool
 	UserCanSeeOtherUser(rctx request.CTX, userID string, otherUserId string) (bool, *model.AppError)
 	MFARequired(rctx request.CTX) *model.AppError

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -568,9 +568,8 @@ func (a *App) FillInPostProps(rctx request.CTX, post *model.Post, channel *model
 		// This includes public channels and private channels where creator is a member
 		// Prevents information disclosure while supporting private channel mentions for members
 		for _, mentioned := range mentionedChannels {
-			// Check if post creator has permission to read this channel
-			// HasPermissionToReadChannel returns (hasPermission, isMember) for audit logging
-			if hasPermission, _ := a.HasPermissionToReadChannel(rctx, post.UserId, mentioned); hasPermission {
+			// Resolve the channel mention if the post creator may see the channel's name/link.
+			if a.HasPermissionToResolveChannelMention(rctx, post.UserId, mentioned) {
 				team, err := a.Srv().Store().Team().Get(mentioned.TeamId)
 				if err != nil {
 					rctx.Logger().Warn("Failed to get team of the channel mention", mlog.String("team_id", channel.TeamId), mlog.String("channel_id", channel.Id), mlog.Err(err))

--- a/server/channels/app/post_metadata.go
+++ b/server/channels/app/post_metadata.go
@@ -406,10 +406,8 @@ func (a *App) sanitizeChannelMentionsForUser(rctx request.CTX, post *model.Post,
 			continue
 		}
 
-		// Check if user has permission to read this channel
-		// HasPermissionToReadChannel returns (hasPermission, isMember)
-		hasPermission, _ := a.HasPermissionToReadChannel(rctx, userID, channel)
-		if hasPermission {
+		// Resolve the channel mention if the viewer may see the channel's name/link.
+		if a.HasPermissionToResolveChannelMention(rctx, userID, channel) {
 			// User has permission - include in sanitized props with fresh display_name
 			// Reuse team_name from original props to avoid additional DB query
 			// (team renames are extremely rare and don't warrant the performance cost)

--- a/server/channels/app/post_metadata_test.go
+++ b/server/channels/app/post_metadata_test.go
@@ -3614,6 +3614,97 @@ func TestSanitizeChannelMentionsForUser(t *testing.T) {
 		// Should have current display name from database, not stale data
 		require.Equal(t, th.BasicChannel.DisplayName, channelData["display_name"])
 	})
+
+	t.Run("retains same-team public channel mention for non-channel-member under compliance", func(t *testing.T) {
+		th := Setup(t).InitBasic(t)
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.ComplianceSettings.Enable = model.NewPointer(true)
+		})
+
+		// BasicUser2 is a member of BasicTeam (via InitBasic) but NOT of this fresh channel.
+		ch := th.CreateChannel(t, th.BasicTeam)
+
+		post := &model.Post{
+			Message: "Check ~" + ch.Name,
+		}
+		post.AddProp(model.PostPropsChannelMentions, map[string]any{
+			ch.Name: map[string]any{
+				"display_name": ch.DisplayName,
+				"team_name":    th.BasicTeam.Name,
+			},
+		})
+
+		result, _, err := th.App.SanitizePostMetadataForUser(th.Context, post, th.BasicUser2.Id)
+		require.Nil(t, err)
+		require.NotNil(t, result)
+
+		mentions := result.GetProp(model.PostPropsChannelMentions)
+		require.NotNil(t, mentions)
+		mentionsMap, ok := mentions.(map[string]any)
+		require.True(t, ok)
+		require.Contains(t, mentionsMap, ch.Name)
+	})
+
+	t.Run("strips cross-team public channel mention for non-member regardless of compliance", func(t *testing.T) {
+		for _, compliance := range []bool{true, false} {
+			t.Run(fmt.Sprintf("compliance=%t", compliance), func(t *testing.T) {
+				th := Setup(t).InitBasic(t)
+
+				th.App.UpdateConfig(func(cfg *model.Config) {
+					cfg.ComplianceSettings.Enable = model.NewPointer(compliance)
+				})
+
+				team2 := th.CreateTeam(t)
+				ch := th.CreateChannel(t, team2)
+
+				post := &model.Post{
+					Message: "Check ~" + ch.Name,
+				}
+				post.AddProp(model.PostPropsChannelMentions, map[string]any{
+					ch.Name: map[string]any{
+						"display_name": ch.DisplayName,
+						"team_name":    team2.Name,
+					},
+				})
+
+				result, _, err := th.App.SanitizePostMetadataForUser(th.Context, post, th.BasicUser2.Id)
+				require.Nil(t, err)
+				require.NotNil(t, result)
+				require.Nil(t, result.GetProp(model.PostPropsChannelMentions))
+			})
+		}
+	})
+
+	t.Run("strips private channel mention for non-member regardless of compliance", func(t *testing.T) {
+		for _, compliance := range []bool{true, false} {
+			t.Run(fmt.Sprintf("compliance=%t", compliance), func(t *testing.T) {
+				th := Setup(t).InitBasic(t)
+
+				th.App.UpdateConfig(func(cfg *model.Config) {
+					cfg.ComplianceSettings.Enable = model.NewPointer(compliance)
+				})
+
+				priv := th.CreatePrivateChannel(t, th.BasicTeam)
+				_ = th.App.RemoveUserFromChannel(th.Context, th.BasicUser2.Id, "", priv)
+
+				post := &model.Post{
+					Message: "Check ~" + priv.Name,
+				}
+				post.AddProp(model.PostPropsChannelMentions, map[string]any{
+					priv.Name: map[string]any{
+						"display_name": priv.DisplayName,
+						"team_name":    th.BasicTeam.Name,
+					},
+				})
+
+				result, _, err := th.App.SanitizePostMetadataForUser(th.Context, post, th.BasicUser2.Id)
+				require.Nil(t, err)
+				require.NotNil(t, result)
+				require.Nil(t, result.GetProp(model.PostPropsChannelMentions))
+			})
+		}
+	})
 }
 
 func TestFillInPostPropsWithCurrentTeamId(t *testing.T) {

--- a/server/channels/app/post_test.go
+++ b/server/channels/app/post_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -784,10 +785,12 @@ func TestFillInPostPropsChannelMentionResolution(t *testing.T) {
 	// `inChannel`, and returns the persisted channel_mentions map (or nil).
 	resolve := func(t *testing.T, inChannel *model.Channel, mentioned ...*model.Channel) map[string]any {
 		t.Helper()
-		message := "hello"
+		var builder strings.Builder
+		builder.WriteString("hello")
 		for _, m := range mentioned {
-			message += fmt.Sprintf(" ~%s", m.Name)
+			fmt.Fprintf(&builder, " ~%s", m.Name)
 		}
+		message := builder.String()
 		post := &model.Post{
 			Message:   message,
 			ChannelId: inChannel.Id,
@@ -835,14 +838,14 @@ func TestFillInPostPropsChannelMentionResolution(t *testing.T) {
 		setCompliance(false)
 
 		mentions := resolve(t, otherTeamPostChannel, otherTeamPublic)
-		assert.NotContains(t, mentions, otherTeamPublic.Name)
+		assert.Nil(t, mentions)
 	})
 
 	t.Run("private channel the author is not a member of => not persisted", func(t *testing.T) {
 		setCompliance(false)
 
 		mentions := resolve(t, postChannel, privateNonMember)
-		assert.NotContains(t, mentions, privateNonMember.Name)
+		assert.Nil(t, mentions)
 	})
 
 	t.Run("channel the author is a member of => persisted", func(t *testing.T) {

--- a/server/channels/app/post_test.go
+++ b/server/channels/app/post_test.go
@@ -714,6 +714,158 @@ func TestPostChannelMentions(t *testing.T) {
 	assert.Nil(t, result.GetProp(model.PostPropsChannelMentions))
 }
 
+// TestFillInPostPropsChannelMentionResolution locks in the author-side persistence of the
+// channel_mentions prop after FillInPostProps switched from HasPermissionToReadChannel to
+// HasPermissionToResolveChannelMention. The post author is the subject of every case.
+func TestFillInPostPropsChannelMentionResolution(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	// Author is a member of BasicTeam (and BasicChannel) but NOT of the referenced channels below.
+	author := th.BasicUser
+	postChannel := th.BasicChannel
+
+	// Public channel on the author's team where the author is NOT a member.
+	// Created with membership=false so the creator is not added as a member.
+	publicNonMember, err := th.App.CreateChannel(th.Context, &model.Channel{
+		DisplayName: "Public Non-Member",
+		Name:        "public-non-member-" + model.NewId(),
+		Type:        model.ChannelTypeOpen,
+		TeamId:      th.BasicTeam.Id,
+	}, false)
+	require.Nil(t, err)
+
+	// Private channel on the author's team where the author is NOT a member.
+	privateNonMember, err := th.App.CreateChannel(th.Context, &model.Channel{
+		DisplayName: "Private Non-Member",
+		Name:        "private-non-member-" + model.NewId(),
+		Type:        model.ChannelTypePrivate,
+		TeamId:      th.BasicTeam.Id,
+	}, false)
+	require.Nil(t, err)
+
+	// Public channel on the author's team where the author IS a member.
+	publicMember, err := th.App.CreateChannel(th.Context, &model.Channel{
+		DisplayName: "Public Member",
+		Name:        "public-member-" + model.NewId(),
+		Type:        model.ChannelTypeOpen,
+		TeamId:      th.BasicTeam.Id,
+	}, false)
+	require.Nil(t, err)
+	_, err = th.App.AddUserToChannel(th.Context, author, publicMember, false)
+	require.Nil(t, err)
+
+	// A second team the author does NOT belong to, with a public channel on it. The post used for
+	// the cross-team case lives on this team so that GetChannelsByNames (scoped to the post's team)
+	// actually resolves the channel and the permission check is what drops it.
+	otherTeam := th.CreateTeam(t)
+	otherTeamPublic, err := th.App.CreateChannel(th.Context, &model.Channel{
+		DisplayName: "Other Team Public",
+		Name:        "other-team-public-" + model.NewId(),
+		Type:        model.ChannelTypeOpen,
+		TeamId:      otherTeam.Id,
+	}, false)
+	require.Nil(t, err)
+	otherTeamPostChannel, err := th.App.CreateChannel(th.Context, &model.Channel{
+		DisplayName: "Other Team Post Channel",
+		Name:        "other-team-post-" + model.NewId(),
+		Type:        model.ChannelTypeOpen,
+		TeamId:      otherTeam.Id,
+	}, false)
+	require.Nil(t, err)
+
+	setCompliance := func(enabled bool) {
+		th.App.UpdateConfig(func(c *model.Config) {
+			c.ComplianceSettings.Enable = model.NewPointer(enabled)
+		})
+	}
+
+	// resolve runs FillInPostProps for a post authored by `author` mentioning the given channels in
+	// `inChannel`, and returns the persisted channel_mentions map (or nil).
+	resolve := func(t *testing.T, inChannel *model.Channel, mentioned ...*model.Channel) map[string]any {
+		t.Helper()
+		message := "hello"
+		for _, m := range mentioned {
+			message += fmt.Sprintf(" ~%s", m.Name)
+		}
+		post := &model.Post{
+			Message:   message,
+			ChannelId: inChannel.Id,
+			UserId:    author.Id,
+		}
+		appErr := th.App.FillInPostProps(th.Context, post, inChannel)
+		require.Nil(t, appErr)
+
+		prop := post.GetProp(model.PostPropsChannelMentions)
+		if prop == nil {
+			return nil
+		}
+		mentions, ok := prop.(map[string]any)
+		require.True(t, ok)
+		return mentions
+	}
+
+	assertResolved := func(t *testing.T, mentions map[string]any, channel *model.Channel, teamName string) {
+		t.Helper()
+		require.Contains(t, mentions, channel.Name)
+		entry, ok := mentions[channel.Name].(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, channel.DisplayName, entry["display_name"])
+		assert.Equal(t, teamName, entry["team_name"])
+	}
+
+	t.Run("public channel, author is a team member but not a channel member, compliance ON => persisted", func(t *testing.T) {
+		setCompliance(true)
+		defer setCompliance(false)
+
+		mentions := resolve(t, postChannel, publicNonMember)
+		require.NotNil(t, mentions, "channel_mentions prop must be persisted under compliance")
+		assertResolved(t, mentions, publicNonMember, th.BasicTeam.Name)
+	})
+
+	t.Run("public channel, author is a team member but not a channel member, compliance OFF => persisted", func(t *testing.T) {
+		setCompliance(false)
+
+		mentions := resolve(t, postChannel, publicNonMember)
+		require.NotNil(t, mentions)
+		assertResolved(t, mentions, publicNonMember, th.BasicTeam.Name)
+	})
+
+	t.Run("public channel on a team the author does not belong to => not persisted", func(t *testing.T) {
+		setCompliance(false)
+
+		mentions := resolve(t, otherTeamPostChannel, otherTeamPublic)
+		assert.NotContains(t, mentions, otherTeamPublic.Name)
+	})
+
+	t.Run("private channel the author is not a member of => not persisted", func(t *testing.T) {
+		setCompliance(false)
+
+		mentions := resolve(t, postChannel, privateNonMember)
+		assert.NotContains(t, mentions, privateNonMember.Name)
+	})
+
+	t.Run("channel the author is a member of => persisted", func(t *testing.T) {
+		setCompliance(true)
+		defer setCompliance(false)
+
+		mentions := resolve(t, postChannel, publicMember)
+		require.NotNil(t, mentions)
+		assertResolved(t, mentions, publicMember, th.BasicTeam.Name)
+	})
+
+	t.Run("mixed mentions resolve per-channel boundary", func(t *testing.T) {
+		setCompliance(true)
+		defer setCompliance(false)
+
+		mentions := resolve(t, postChannel, publicNonMember, privateNonMember, publicMember)
+		require.NotNil(t, mentions)
+		assertResolved(t, mentions, publicNonMember, th.BasicTeam.Name)
+		assertResolved(t, mentions, publicMember, th.BasicTeam.Name)
+		assert.NotContains(t, mentions, privateNonMember.Name)
+	})
+}
+
 func TestImageProxy(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := SetupWithStoreMock(t)

--- a/server/channels/app/web_broadcast_hooks.go
+++ b/server/channels/app/web_broadcast_hooks.go
@@ -297,15 +297,14 @@ func (h *channelMentionsBroadcastHook) Process(msg *platform.HookedWebSocketEven
 			continue
 		}
 
-		// Check if the recipient has permission to read this channel
+		// Resolve the mention if the recipient may see the channel's name/link.
 		channel, appErr := webConn.Platform.Store.Channel().Get(channelID, true)
 		if appErr != nil {
 			// If we can't get the channel, don't include the mention
 			continue
 		}
 
-		hasPermission, _ := webConn.Suite.HasPermissionToReadChannel(rctx, webConn.UserId, channel)
-		if hasPermission {
+		if webConn.Suite.HasPermissionToResolveChannelMention(rctx, webConn.UserId, channel) {
 			filteredMentions[channelName] = channelInfo
 		}
 	}

--- a/server/channels/app/web_broadcast_hooks_test.go
+++ b/server/channels/app/web_broadcast_hooks_test.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -459,6 +460,125 @@ func TestChannelMentionsBroadcastHook(t *testing.T) {
 		gotJSON, ok := msg.Get("post").(string)
 		require.True(t, ok)
 		assert.Equal(t, cleanJSON, gotJSON)
+	})
+
+	t.Run("retains same-team public channel mention for non-member recipient under compliance", func(t *testing.T) {
+		th.App.UpdateConfig(func(c *model.Config) {
+			c.ComplianceSettings.Enable = model.NewPointer(true)
+		})
+		defer th.App.UpdateConfig(func(c *model.Config) {
+			c.ComplianceSettings.Enable = model.NewPointer(false)
+		})
+
+		// BasicUser is a BasicTeam member (via InitBasic) but NOT a member of this fresh
+		// channel (created without adding the creator as a member).
+		pub, appErr := th.App.CreateChannel(th.Context, &model.Channel{
+			TeamId:      th.BasicTeam.Id,
+			Name:        "name_" + model.NewId(),
+			DisplayName: "Public Channel",
+			Type:        model.ChannelTypeOpen,
+		}, false)
+		require.Nil(t, appErr)
+
+		msg := platform.MakeHookedWebSocketEvent(wsEvent)
+		err = hook.Process(msg, wc, map[string]any{
+			"channel_mentions": map[string]any{
+				pub.Name: map[string]any{
+					"id":           pub.Id,
+					"display_name": pub.DisplayName,
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		gotJSON, ok := msg.Get("post").(string)
+		require.True(t, ok)
+
+		var gotPost model.Post
+		err = json.Unmarshal([]byte(gotJSON), &gotPost)
+		require.NoError(t, err)
+
+		mentions := gotPost.GetProp(model.PostPropsChannelMentions)
+		require.NotNil(t, mentions)
+		mentionsMap, ok := mentions.(map[string]any)
+		require.True(t, ok)
+		assert.Contains(t, mentionsMap, pub.Name)
+	})
+
+	t.Run("strips cross-team public channel mention for non-member recipient regardless of compliance", func(t *testing.T) {
+		team2 := th.CreateTeam(t)
+		// Created without adding the creator so BasicUser is neither a team nor channel member.
+		ch, appErr := th.App.CreateChannel(th.Context, &model.Channel{
+			TeamId:      team2.Id,
+			Name:        "name_" + model.NewId(),
+			DisplayName: "Cross Team Channel",
+			Type:        model.ChannelTypeOpen,
+		}, false)
+		require.Nil(t, appErr)
+
+		for _, compliance := range []bool{true, false} {
+			t.Run(fmt.Sprintf("compliance=%t", compliance), func(t *testing.T) {
+				th.App.UpdateConfig(func(c *model.Config) {
+					c.ComplianceSettings.Enable = model.NewPointer(compliance)
+				})
+				defer th.App.UpdateConfig(func(c *model.Config) {
+					c.ComplianceSettings.Enable = model.NewPointer(false)
+				})
+
+				msg := platform.MakeHookedWebSocketEvent(wsEvent)
+				err = hook.Process(msg, wc, map[string]any{
+					"channel_mentions": map[string]any{
+						ch.Name: map[string]any{
+							"id":           ch.Id,
+							"display_name": ch.DisplayName,
+						},
+					},
+				})
+				require.NoError(t, err)
+
+				gotJSON, ok := msg.Get("post").(string)
+				require.True(t, ok)
+
+				var gotPost model.Post
+				err = json.Unmarshal([]byte(gotJSON), &gotPost)
+				require.NoError(t, err)
+
+				assert.Nil(t, gotPost.GetProp(model.PostPropsChannelMentions))
+			})
+		}
+	})
+
+	t.Run("strips private channel mention for non-member recipient regardless of compliance", func(t *testing.T) {
+		for _, compliance := range []bool{true, false} {
+			t.Run(fmt.Sprintf("compliance=%t", compliance), func(t *testing.T) {
+				th.App.UpdateConfig(func(c *model.Config) {
+					c.ComplianceSettings.Enable = model.NewPointer(compliance)
+				})
+				defer th.App.UpdateConfig(func(c *model.Config) {
+					c.ComplianceSettings.Enable = model.NewPointer(false)
+				})
+
+				msg := platform.MakeHookedWebSocketEvent(wsEvent)
+				err = hook.Process(msg, wc, map[string]any{
+					"channel_mentions": map[string]any{
+						privateChannel.Name: map[string]any{
+							"id":           privateChannel.Id,
+							"display_name": privateChannel.DisplayName,
+						},
+					},
+				})
+				require.NoError(t, err)
+
+				gotJSON, ok := msg.Get("post").(string)
+				require.True(t, ok)
+
+				var gotPost model.Post
+				err = json.Unmarshal([]byte(gotJSON), &gotPost)
+				require.NoError(t, err)
+
+				assert.Nil(t, gotPost.GetProp(model.PostPropsChannelMentions))
+			})
+		}
 	})
 }
 


### PR DESCRIPTION
#### Summary

Channel mention (`~channel`) name resolution reused `HasPermissionToReadChannel`, which is a content-read permission check. For an open (public) channel that check returns `false` for a user who is not a member when Compliance Monitoring is enabled (the MM-45272 behavior) or when the channel belongs to a team the user is not on (the MM-66791 behavior). Since #34235 the `channel_mentions` post prop is filtered per viewer using that check, so for those users the prop was stripped and the webapp fell back to rendering the raw channel slug (made very visible by the Anonymous URLs feature, which obfuscates slugs) instead of a clickable link.

This change introduces `HasPermissionToResolveChannelMention`, which authorizes exposing only a public channel's display name and link (never content) and is therefore intentionally independent of `ComplianceSettings`. It still requires:

- team membership for public channels (so cross-team mentions stay unresolved, preserving MM-66791), and
- channel membership for private/DM/GM channels (so private channel names are never disclosed to non-members).

The three channel-mention call sites (`FillInPostProps`, `sanitizeChannelMentionsForUser`, and the `channelMentionsBroadcastHook`) now use this helper. `HasPermissionToReadChannel` and all content-read paths are unchanged, so reading channel content still requires membership under Compliance (MM-45272 is preserved).

QA steps:

1. Enable Compliance Monitoring (`ComplianceSettings.Enable = true`).
2. As user A (member of a public channel), post a mention of that channel in a channel where user B (a team member who is not a member of the referenced channel) can see it.
3. User B sees the mention rendered as a clickable channel link with its display name (previously it showed the raw slug).
4. Confirm a mention of a private channel A belongs to, but B does not, remains unresolved for B; and that a public channel on a team B is not on remains unresolved for B.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68952

#### Release Note

```release-note
Fixed an issue where public channel mention links were shown as an unresolved channel slug instead of the channel name (and were not clickable) for users who were not members of the referenced channel when Compliance Monitoring was enabled.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change affects authorization logic for resolving channel mentions across three shared code paths (post rendering, sanitization, and broadcast hooks), so subtle deviations in permission semantics compared to the prior read-permission checks could alter visible mention behavior across team/channel boundaries. Unit, integration, and E2E tests were added, but differences in corner membership cases (cross-team, private, DM/GM) retain moderate regression risk.

**QA Recommendation:** Manual QA recommended for core scenarios: (1) same-team vs cross-team public channel mentions with Compliance Monitoring on/off, (2) private/DM/GM mention visibility for non-members/participants, and (3) real-time broadcast recipient permutations; prioritize reproducing mixed-mention posts and broadcast delivery to multiple recipient types.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->