### PR TITLE
chore(webapp): remove orphaned @types/react-custom-scrollbars

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -117,7 +117,6 @@
     "@types/react-beautiful-dnd": "13.1.2",
     "@types/react-bootstrap": "0.32.35",
     "@types/react-color": "3.0.6",
-    "@types/react-custom-scrollbars": "4.0.10",
     "@types/react-dom": "18.2.25",
     "@types/react-overlays": "1.1.3",
     "@types/react-router-dom": "5.3.3",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -170,7 +170,6 @@
         "@types/react-beautiful-dnd": "13.1.2",
         "@types/react-bootstrap": "0.32.35",
         "@types/react-color": "3.0.6",
-        "@types/react-custom-scrollbars": "4.0.10",
         "@types/react-dom": "18.2.25",
         "@types/react-overlays": "1.1.3",
         "@types/react-router-dom": "5.3.3",
@@ -10008,16 +10007,6 @@
       "dependencies": {
         "@types/react": "*",
         "@types/reactcss": "*"
-      }
-    },
-    "node_modules/@types/react-custom-scrollbars": {
-      "version": "4.0.10",
-      "resolved": "https://registry.npmjs.org/@types/react-custom-scrollbars/-/react-custom-scrollbars-4.0.10.tgz",
-      "integrity": "sha512-1T430E+usndUjymkXB8k/zGpWehggircq/QaQMuFLMJceccAcD9vcmbUXF1LjeVP/+P4wI/bad6BF1E+7IGlqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/react": "*"
       }
     },
     "node_modules/@types/react-dom": {


### PR DESCRIPTION
- Follows up #33783

The `@types/react-custom-scrollbars` devDependency provides types for the `react-custom-scrollbars` runtime package, but that package is no longer a dependency of any webapp workspace and is not imported anywhere in webapp/channels (scrollbars now use simplebar-react) after PR 33783. The type definitions are therefore dead.

Remove it from webapp/channels/package.json and prune its entries from webapp/package-lock.json (the channels devDep reference and the node_modules/@types/react-custom-scrollbars package block). It has no dependents in the lockfile, so no other entries are affected.

#### Summary

Remove it from webapp/channels/package.json and prune its entries from webapp/package-lock.json as it has been orphaned after #33783.

#### Ticket Link

n/a

#### Screenshots

n/a

#### Release Note

```release-note
NONE
```
