### PR TITLE
Fix long username truncation in account menu

### DIFF
--- a/webapp/channels/src/components/user_account_menu/user_account_menu.scss
+++ b/webapp/channels/src/components/user_account_menu/user_account_menu.scss
@@ -12,6 +12,8 @@
 
         .label-elements {
             gap: 0;
+            min-width: 0;
+            overflow: hidden;
         }
 
         span.userAccountMenu_nameMenuItem_primaryLabel {


### PR DESCRIPTION
Fixes #34662

## Problem
The username in the account menu was being clipped instead 
of showing an ellipsis. The `.label-elements` flex container 
was missing `min-width: 0`, which prevented the child span's 
`text-overflow: ellipsis` from triggering correctly.

## Fix
Added `min-width: 0` and `overflow: hidden` to `.label-elements` 
inside `#userAccountMenu .userAccountMenu_nameMenuItem`.

## Verification
Verified via browser DevTools on community.mattermost.com — 
username now truncates correctly with ellipsis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is an isolated CSS styling fix affecting only the user account menu's label display container. The addition of `min-width: 0` and `overflow: hidden` are standard CSS techniques for enabling text truncation with ellipsis on flex items and pose minimal regression risk since they target a specific styling issue without affecting DOM structure, component logic, or functionality.

**QA Recommendation:** Minimal manual QA required. Focus on verifying that long usernames now properly truncate with ellipsis in the account menu (opened from the top-right global header) across different browsers and viewport sizes. Verify the menu layout remains intact with various username and name combination lengths, and that the interactive functionality (clicking the menu item) is unaffected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->