### PR TITLE
add PushNotification.Transport and related const

### DIFF
--- a/api/v4/source/definitions.yaml
+++ b/api/v4/source/definitions.yaml
@@ -3289,6 +3289,15 @@ components:
           type: string
         type:
           type: string
+        sub_type:
+          type: string
+          description: Additional message type information for mobile clients. Use "calls" for Calls plugin notifications.
+        transport:
+          type: string
+          description: Delivery path for the push proxy. Use "voip" for VoIP (CallKit) notifications; omit for standard delivery.
+          enum:
+            - ""
+            - voip
         sender_id:
           type: string
         sender_name:
@@ -3301,8 +3310,13 @@ components:
           type: string
         version:
           type: string
+        is_crt_enabled:
+          type: boolean
+          description: Whether Collapsed Reply Threads is enabled for the recipient.
         is_id_loaded:
           type: boolean
+        signature:
+          type: string
     PluginStatus:
       type: object
       properties:

--- a/server/public/model/push_notification.go
+++ b/server/public/model/push_notification.go
@@ -50,6 +50,14 @@ type PushSubType string
 // PushSubTypeCalls is used by the Calls plugin
 const PushSubTypeCalls PushSubType = "calls"
 
+// PushTransport selects which delivery path the push proxy uses.
+type PushTransport string
+
+const (
+	PushTransportStandard PushTransport = ""
+	PushTransportVoIP     PushTransport = "voip"
+)
+
 type PushNotificationAck struct {
 	Id               string `json:"id"`
 	ClientReceivedAt int64  `json:"received_at"`
@@ -60,33 +68,34 @@ type PushNotificationAck struct {
 }
 
 type PushNotification struct {
-	AckId            string      `json:"ack_id"`
-	Platform         string      `json:"platform"`
-	ServerId         string      `json:"server_id"`
-	DeviceId         string      `json:"device_id"`
-	PostId           string      `json:"post_id"`
-	Category         string      `json:"category,omitempty"`
-	Sound            string      `json:"sound,omitempty"`
-	Message          string      `json:"message,omitempty"`
-	Badge            int         `json:"badge,omitempty"`
-	ContentAvailable int         `json:"cont_ava,omitempty"`
-	TeamId           string      `json:"team_id,omitempty"`
-	ChannelId        string      `json:"channel_id,omitempty"`
-	RootId           string      `json:"root_id,omitempty"`
-	ChannelName      string      `json:"channel_name,omitempty"`
-	Type             string      `json:"type,omitempty"`
-	SubType          PushSubType `json:"sub_type,omitempty"`
-	SenderId         string      `json:"sender_id,omitempty"`
-	SenderName       string      `json:"sender_name,omitempty"`
-	OverrideUsername string      `json:"override_username,omitempty"`
-	OverrideIconURL  string      `json:"override_icon_url,omitempty"`
-	FromWebhook      string      `json:"from_webhook,omitempty"`
-	Version          string      `json:"version,omitempty"`
-	IsCRTEnabled     bool        `json:"is_crt_enabled"`
-	IsIdLoaded       bool        `json:"is_id_loaded"`
-	PostType         string      `json:"-"`
-	ChannelType      ChannelType `json:"-"`
-	Signature        string      `json:"signature"`
+	AckId            string        `json:"ack_id"`
+	Platform         string        `json:"platform"`
+	ServerId         string        `json:"server_id"`
+	DeviceId         string        `json:"device_id"`
+	PostId           string        `json:"post_id"`
+	Category         string        `json:"category,omitempty"`
+	Sound            string        `json:"sound,omitempty"`
+	Message          string        `json:"message,omitempty"`
+	Badge            int           `json:"badge,omitempty"`
+	ContentAvailable int           `json:"cont_ava,omitempty"`
+	TeamId           string        `json:"team_id,omitempty"`
+	ChannelId        string        `json:"channel_id,omitempty"`
+	RootId           string        `json:"root_id,omitempty"`
+	ChannelName      string        `json:"channel_name,omitempty"`
+	Type             string        `json:"type,omitempty"`
+	SubType          PushSubType   `json:"sub_type,omitempty"`
+	Transport        PushTransport `json:"transport,omitempty"`
+	SenderId         string        `json:"sender_id,omitempty"`
+	SenderName       string        `json:"sender_name,omitempty"`
+	OverrideUsername string        `json:"override_username,omitempty"`
+	OverrideIconURL  string        `json:"override_icon_url,omitempty"`
+	FromWebhook      string        `json:"from_webhook,omitempty"`
+	Version          string        `json:"version,omitempty"`
+	IsCRTEnabled     bool          `json:"is_crt_enabled"`
+	IsIdLoaded       bool          `json:"is_id_loaded"`
+	PostType         string        `json:"-"`
+	ChannelType      ChannelType   `json:"-"`
+	Signature        string        `json:"signature"`
 }
 
 func (pn *PushNotification) DeepCopy() *PushNotification {


### PR DESCRIPTION
#### Summary
Supporting change for https://github.com/mattermost/mattermost-plugin-calls/pull/1189, originally in https://github.com/mattermost/mattermost/pull/36726.

#### Ticket Link
Relates-to: https://mattermost.atlassian.net/browse/MM-68727

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** Adds new exported type/fields and extends the public API schema (PushNotification.transport, sub_type, is_crt_enabled, signature), which is backwards-compatible for existing clients but alters public contracts and could affect integrations that validate or strictly type the PushNotification payloads. There is moderate risk around untested integration points (push proxy, calls plugin, and client SDKs) that consume the API.

**QA Recommendation:** Perform targeted integration tests for push delivery (standard and VoIP transports), validate API schema consumers (clients and plugins) for graceful handling of the new fields, and add unit tests for JSON marshaling/unmarshaling; manual QA recommended for push-related flows and the calls plugin integration.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->