### PR TITLE
Upgrade "@mattermost/compass-icons" to 0.1.61

### DIFF
--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -16,7 +16,7 @@
         "platform/types"
       ],
       "dependencies": {
-        "@mattermost/compass-icons": "0.1.53",
+        "@mattermost/compass-icons": "0.1.61",
         "react-intl": "7.1.14",
         "typescript": "5.6.3"
       },
@@ -6089,9 +6089,9 @@
       "link": true
     },
     "node_modules/@mattermost/compass-icons": {
-      "version": "0.1.53",
-      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.53.tgz",
-      "integrity": "sha512-MPcwJ9bKWxOxppxoqYCK5BW/a9qkaozxQr/fTdu55TLBjV5t0W6EPVa+msnFLr2iStYsYVnHwEo3fArsX0Bnew==",
+      "version": "0.1.61",
+      "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.61.tgz",
+      "integrity": "sha512-Xq7QHyxq7NPljgqlzwRp6tWGe5sD49tWTzG41q9+sYsI+DdymJmteezupkfO3NxNxYXJiDD+q2kF0Ai2he1Mcg==",
       "license": "MIT",
       "peer": true
     },
@@ -27929,7 +27929,7 @@
       },
       "peerDependencies": {
         "@babel/runtime-corejs3": "^7.17.8",
-        "@mattermost/compass-icons": "0.1.53",
+        "@mattermost/compass-icons": "0.1.61",
         "@mattermost/shared": "11.8.0",
         "classnames": "^2.3.1",
         "lodash": "^4.17.21",

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -23,7 +23,7 @@
     "check-external-links": "node scripts/check-external-links.mjs"
   },
   "dependencies": {
-    "@mattermost/compass-icons": "0.1.53",
+    "@mattermost/compass-icons": "0.1.61",
     "react-intl": "7.1.14",
     "typescript": "5.6.3"
   },

--- a/webapp/platform/components/package.json
+++ b/webapp/platform/components/package.json
@@ -40,7 +40,7 @@
   },
   "peerDependencies": {
     "@babel/runtime-corejs3": "^7.17.8",
-    "@mattermost/compass-icons": "0.1.53",
+    "@mattermost/compass-icons": "0.1.61",
     "@mattermost/shared": "11.8.0",
     "classnames": "^2.3.1",
     "lodash": "^4.17.21",


### PR DESCRIPTION
#### Summary

Bumps `@mattermost/compass-icons` from `0.1.53` to `0.1.61` in `webapp/package.json`, `webapp/platform/components/package.json`, and `webapp/package-lock.json`.

This is the first compass-icons version to actually reach the npm registry since `0.1.53`. Releases `0.1.54` through `0.1.60` all failed the [publish.yml](https://github.com/mattermost/compass-icons/blob/master/.github/workflows/publish.yml) workflow after trusted publishing was introduced in [compass-icons#112](https://github.com/mattermost/compass-icons/pull/112); [compass-icons#122](https://github.com/mattermost/compass-icons/pull/122) added the `package.json` `repository` field needed for sigstore provenance validation. `0.1.61` includes that fix.

Adds (among other things):

- `icon-shield-lock-outline`
- `icon-shield-check`
- `icon-file-help-outline-large`
- `icon-account-minus-outline`

Mirrors the pattern of prior bumps ([#34717](https://github.com/mattermost/mattermost/pull/34717), [#31213](https://github.com/mattermost/mattermost/pull/31213)) — three files, version + tarball URL + integrity only.

#### Ticket Link

n/a

#### Screenshots

n/a

#### Release Note

```release-note
NONE
```