### PR TITLE
MM-69053 Log server message when a user has concurrent React enabled

### DIFF
--- a/server/channels/api4/system.go
+++ b/server/channels/api4/system.go
@@ -478,6 +478,8 @@ func postLog(c *Context, w http.ResponseWriter, r *http.Request) {
 	fields := []mlog.Field{
 		mlog.String("type", "client_message"),
 		mlog.String("user_agent", c.AppContext.UserAgent()),
+		mlog.String("session_id", c.AppContext.Session().Id),
+		mlog.String("user_id", c.AppContext.Session().UserId),
 	}
 
 	if !forceToDebug && lvl == "ERROR" {

--- a/webapp/channels/src/components/root/actions/index.ts
+++ b/webapp/channels/src/components/root/actions/index.ts
@@ -3,6 +3,7 @@
 
 import type {History} from 'history';
 
+import {LogLevel} from '@mattermost/types/client4';
 import type {ServerError} from '@mattermost/types/errors';
 import type {UserProfile} from '@mattermost/types/users';
 
@@ -27,7 +28,6 @@ import {doesCookieContainsMMUserId} from 'utils/utils';
 
 import type {ActionFuncAsync, ThunkActionFunc} from 'types/store';
 import type {Translations} from 'types/store/i18n';
-import {LogLevel} from '@mattermost/types/client4';
 
 export type TranslationPluginFunction = (locale: string) => Translations
 
@@ -171,5 +171,5 @@ export function logIfConcurrentReactEnabled(): ActionFuncAsync<boolean> {
         }
 
         return {data: concurrentReactEnabled};
-    }
+    };
 }

--- a/webapp/channels/src/components/root/actions/index.ts
+++ b/webapp/channels/src/components/root/actions/index.ts
@@ -25,8 +25,9 @@ import {reloadPage} from 'utils/browser_utils';
 import {StoragePrefixes} from 'utils/constants';
 import {doesCookieContainsMMUserId} from 'utils/utils';
 
-import type {ThunkActionFunc} from 'types/store';
+import type {ActionFuncAsync, ThunkActionFunc} from 'types/store';
 import type {Translations} from 'types/store/i18n';
+import {LogLevel} from '@mattermost/types/client4';
 
 export type TranslationPluginFunction = (locale: string) => Translations
 
@@ -155,4 +156,20 @@ export function handleLoginLogoutSignal(e: StorageEvent): ThunkActionFunc<void> 
             window.addEventListener('focus', reloadOnFocus);
         }
     };
+}
+
+export function logIfConcurrentReactEnabled(): ActionFuncAsync<boolean> {
+    return async () => {
+        const concurrentReactEnabled = localStorage.getItem('enable_concurrent_react_experimental') === 'true';
+
+        if (concurrentReactEnabled) {
+            Client4.logClientError(
+                "This user's session is using experimental concurrent React which may cause visual bugs. It can be " +
+                    'disabled from Settings > Advanced or by clearing their browser storage.',
+                LogLevel.Debug,
+            );
+        }
+
+        return {data: concurrentReactEnabled};
+    }
 }

--- a/webapp/channels/src/components/root/index.ts
+++ b/webapp/channels/src/components/root/index.ts
@@ -32,6 +32,7 @@ import {
     loadConfigAndMe,
     handleLoginLogoutSignal,
     redirectToOnboardingOrDefaultTeam,
+    logIfConcurrentReactEnabled,
 } from './actions';
 import Root from './root';
 
@@ -77,6 +78,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
         actions: bindActionCreators({
             loadConfigAndMe,
             loadRecentlyUsedCustomEmojis,
+            logIfConcurrentReactEnabled,
             migrateRecentEmojis,
             initializeProducts,
             handleLoginLogoutSignal,

--- a/webapp/channels/src/components/root/root.test.tsx
+++ b/webapp/channels/src/components/root/root.test.tsx
@@ -71,6 +71,7 @@ describe('components/Root', () => {
                 });
             }),
             loadRecentlyUsedCustomEmojis: jest.fn(),
+            logIfConcurrentReactEnabled: jest.fn(),
             migrateRecentEmojis: jest.fn(),
             initializeProducts: jest.fn(),
             ...bindActionCreators({

--- a/webapp/channels/src/components/root/root.tsx
+++ b/webapp/channels/src/components/root/root.tsx
@@ -231,6 +231,8 @@ export default class Root extends React.PureComponent<Props, State> {
     initiateMeRequests = async () => {
         const {isLoaded, isMeRequested} = await this.props.actions.loadConfigAndMe();
 
+        this.props.actions.logIfConcurrentReactEnabled();
+
         if (isLoaded) {
             const isUserAtRootRoute = this.props.location.pathname === '/';
 


### PR DESCRIPTION
#### Summary
As it says on the tin. I also added something to server logs sent by the client so that you can tell which user/session sent a client error to the server.

#### Ticket Link
MM-69053

#### Release Note
```release-note
Added debug logging when a user has experimental support for concurrent React enabled
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Low — changes are additive logging on the server (including session_id and user_id fields) and a client-side localStorage check plus a debug client error; they do not modify core business logic, authentication, or persistence, with primary risk limited to logging behavior and startup wiring. There are minimal untested paths (client-to-server error reporting enrichment and root startup action invocation) that could affect observability or produce noisy logs.

**QA Recommendation:** Targeted smoke tests: (1) set localStorage enable_concurrent_react_experimental=true and verify the client debug log is sent, (2) trigger a client-reported error and confirm server logs include session_id and user_id, and (3) confirm Root startup still proceeds without performance or startup regressions.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->