### PR TITLE
[MM-69078] Surface plugin upload rejections as a toast (parity with download rejections)

### DIFF
--- a/server/channels/app/file.go
+++ b/server/channels/app/file.go
@@ -2018,6 +2018,25 @@ func (a *App) sendFileDownloadRejectedEvent(info *model.FileInfo, userID string,
 	a.Publish(message)
 }
 
+// sendFileUploadRejectedEvent sends a websocket event to notify the user that their file upload was
+// rejected by a plugin. It mirrors sendFileDownloadRejectedEvent so the webapp can surface the
+// rejection as a toast instead of an inline composer error. When connectionID is provided, the event
+// is only sent to that specific connection.
+func (a *App) sendFileUploadRejectedEvent(info *model.FileInfo, userID string, connectionID string, rejectionReason string) {
+	if userID == "" {
+		return
+	}
+
+	message := model.NewWebSocketEvent(model.WebsocketEventFileUploadRejected, "", info.ChannelId, userID, nil, "")
+	if connectionID != "" {
+		message.GetBroadcast().ConnectionId = connectionID
+	}
+	message.Add("file_name", info.Name)
+	message.Add("rejection_reason", rejectionReason)
+	message.Add("channel_id", info.ChannelId)
+	a.Publish(message)
+}
+
 // RunFileWillBeDownloadedHook executes the FileWillBeDownloaded hook with a timeout.
 // Returns empty string to allow download, or a rejection reason to block it.
 func (a *App) RunFileWillBeDownloadedHook(rctx request.CTX, fileInfo *model.FileInfo, userID string, connectionID string, downloadType model.FileDownloadType) string {

--- a/server/channels/app/file_test.go
+++ b/server/channels/app/file_test.go
@@ -1207,3 +1207,53 @@ func TestFilterFilesByChannelPermissions_ABAC(t *testing.T) {
 		mockACS.AssertNotCalled(t, "AccessEvaluation")
 	})
 }
+
+func TestSendFileUploadRejectedEvent(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	info := &model.FileInfo{
+		Id:        model.NewId(),
+		Name:      "secret.tdf",
+		ChannelId: th.BasicChannel.Id,
+		CreatorId: th.BasicUser.Id,
+	}
+
+	t.Run("publishes the event with populated fields", func(t *testing.T) {
+		wsMessages, closeWS := connectFakeWebSocket(t, th, th.BasicUser.Id, "", []model.WebsocketEventType{model.WebsocketEventFileUploadRejected})
+		defer closeWS()
+
+		th.App.sendFileUploadRejectedEvent(info, th.BasicUser.Id, "", "blocked by policy")
+
+		var received *model.WebSocketEvent
+		require.Eventually(t, func() bool {
+			select {
+			case received = <-wsMessages:
+				return true
+			default:
+				return false
+			}
+		}, 5*time.Second, 100*time.Millisecond, "did not receive file_upload_rejected event in time")
+
+		data := received.GetData()
+		assert.Equal(t, info.Name, data["file_name"])
+		assert.Equal(t, "blocked by policy", data["rejection_reason"])
+		assert.Equal(t, info.ChannelId, data["channel_id"])
+	})
+
+	t.Run("does not publish when userID is empty", func(t *testing.T) {
+		wsMessages, closeWS := connectFakeWebSocket(t, th, th.BasicUser.Id, "", []model.WebsocketEventType{model.WebsocketEventFileUploadRejected})
+		defer closeWS()
+
+		th.App.sendFileUploadRejectedEvent(info, "", "", "blocked by policy")
+
+		require.Never(t, func() bool {
+			select {
+			case <-wsMessages:
+				return true
+			default:
+				return false
+			}
+		}, 1*time.Second, 100*time.Millisecond, "should not publish file_upload_rejected event when userID is empty")
+	})
+}

--- a/server/channels/app/upload.go
+++ b/server/channels/app/upload.go
@@ -75,6 +75,7 @@ func (a *App) runPluginsHook(rctx request.CTX, info *model.FileInfo, file io.Rea
 			if rejStr != "" {
 				rejErr = model.NewAppError("runPluginsHook", "app.upload.run_plugins_hook.rejected",
 					map[string]any{"Filename": info.Name, "Reason": rejStr}, "", http.StatusBadRequest)
+				a.sendFileUploadRejectedEvent(info, info.CreatorId, rctx.ConnectionId(), rejStr)
 				return false
 			}
 			if newInfo != nil {

--- a/server/public/model/websocket_message.go
+++ b/server/public/model/websocket_message.go
@@ -115,6 +115,7 @@ const (
 	WebsocketEventPropertyFieldDeleted       WebsocketEventType = "property_field_deleted"
 	WebsocketEventPropertyValuesUpdated      WebsocketEventType = "property_values_updated"
 	WebsocketEventFileDownloadRejected       WebsocketEventType = "file_download_rejected"
+	WebsocketEventFileUploadRejected         WebsocketEventType = "file_upload_rejected"
 	WebsocketEventShowToast                  WebsocketEventType = "show_toast"
 	WebsocketEventSharedChannelRemoteUpdated WebsocketEventType = "shared_channel_remote_updated"
 	WebsocketEventChannelJoinRequestCreated  WebsocketEventType = "channel_join_request_created"

--- a/webapp/channels/src/actions/file_actions.test.ts
+++ b/webapp/channels/src/actions/file_actions.test.ts
@@ -1,0 +1,89 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {uploadFile} from 'actions/file_actions';
+
+import testConfigureStore from 'tests/test_store';
+
+jest.mock('selectors/general', () => ({
+    ...jest.requireActual('selectors/general'),
+    getConnectionId: jest.fn(() => ''),
+}));
+
+jest.mock('utils/utils', () => ({
+    ...jest.requireActual('utils/utils'),
+    localizeMessage: jest.fn((descriptor: {id: string; defaultMessage: string}) => descriptor.defaultMessage || descriptor.id),
+}));
+
+class MockXMLHttpRequest {
+    status = 0;
+    readyState = 0;
+    response = '';
+    upload: {onprogress?: (event: ProgressEvent) => void} = {};
+    onload: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    open = jest.fn();
+    setRequestHeader = jest.fn();
+    send = jest.fn();
+}
+
+describe('actions/file_actions', () => {
+    describe('uploadFile', () => {
+        const originalXHR = window.XMLHttpRequest;
+        let mockXhr: MockXMLHttpRequest;
+
+        beforeEach(() => {
+            mockXhr = new MockXMLHttpRequest();
+            window.XMLHttpRequest = jest.fn(() => mockXhr) as unknown as typeof XMLHttpRequest;
+        });
+
+        afterEach(() => {
+            window.XMLHttpRequest = originalXHR;
+        });
+
+        function startUpload(onError: jest.Mock) {
+            const store = testConfigureStore();
+            store.dispatch(uploadFile({
+                file: new File(['data'], 'secret.tdf'),
+                name: 'secret.tdf',
+                type: 'application/octet-stream',
+                rootId: 'root1',
+                channelId: 'channel1',
+                clientId: 'client1',
+                onProgress: jest.fn(),
+                onSuccess: jest.fn(),
+                onError,
+            }));
+        }
+
+        test('suppresses the inline error on plugin rejection by passing an empty message', () => {
+            const onError = jest.fn();
+            startUpload(onError);
+
+            mockXhr.status = 400;
+            mockXhr.readyState = 4;
+            mockXhr.response = JSON.stringify({
+                id: 'app.upload.run_plugins_hook.rejected',
+                message: 'Unable to upload the file. File rejected by plugin. blocked by policy',
+            });
+            mockXhr.onload!();
+
+            expect(onError).toHaveBeenCalledWith('', 'client1', 'channel1', 'root1');
+        });
+
+        test('passes the original error message for non-plugin upload failures', () => {
+            const onError = jest.fn();
+            startUpload(onError);
+
+            mockXhr.status = 400;
+            mockXhr.readyState = 4;
+            mockXhr.response = JSON.stringify({
+                id: 'api.file.upload_file.too_large.app_error',
+                message: 'File is too large',
+            });
+            mockXhr.onload!();
+
+            expect(onError).toHaveBeenCalledWith('File is too large', 'client1', 'channel1', 'root1');
+        });
+    });
+});

--- a/webapp/channels/src/actions/file_actions.ts
+++ b/webapp/channels/src/actions/file_actions.ts
@@ -103,8 +103,13 @@ export function uploadFile({file, name, type, rootId, channelId, clientId, onPro
                     onSuccess(response, channelId, rootId);
                 } else if (xhr.status >= 400 && xhr.readyState === 4) {
                     let errorMessage = '';
+                    let pluginRejected = false;
                     try {
                         const errorResponse = JSON.parse(xhr.response);
+
+                        // Plugin upload rejections are surfaced as a toast via the
+                        // file_upload_rejected websocket event, so suppress the inline composer error.
+                        pluginRejected = errorResponse?.id === 'app.upload.run_plugins_hook.rejected';
                         errorMessage =
                         (errorResponse?.id && errorResponse?.message) ? localizeMessage({id: errorResponse.id, defaultMessage: errorResponse.message}) : localizeMessage({id: 'file_upload.generic_error', defaultMessage: 'There was a problem uploading your files.'});
                     } catch (e) {
@@ -118,7 +123,9 @@ export function uploadFile({file, name, type, rootId, channelId, clientId, onPro
                         rootId,
                     });
 
-                    onError?.(errorMessage, clientId, channelId, rootId);
+                    // Pass an empty message on plugin rejection so the in-progress upload is cleared
+                    // without showing the inline error; the websocket-driven toast explains the rejection.
+                    onError?.(pluginRejected ? '' : errorMessage, clientId, channelId, rootId);
                 }
             };
         }

--- a/webapp/channels/src/actions/websocket_actions.test.jsx
+++ b/webapp/channels/src/actions/websocket_actions.test.jsx
@@ -30,14 +30,17 @@ import store from 'stores/redux_store';
 import {invalidateAccessControlAttributesCache} from 'components/common/hooks/useAccessControlAttributes';
 
 import mergeObjects from 'packages/mattermost-redux/test/merge_objects';
+import {defaultIntl} from 'tests/helpers/intl-test-helper';
 import configureStore from 'tests/test_store';
 import {getHistory} from 'utils/browser_history';
-import Constants, {ActionTypes, UserStatuses} from 'utils/constants';
+import Constants, {ActionTypes, ModalIdentifiers, UserStatuses} from 'utils/constants';
+import {setIntl} from 'utils/i18n';
 
 import {
     handleChannelUpdatedEvent,
     handleChannelAccessControlUpdatedEvent,
     handleEvent,
+    handleFileUploadRejected,
     handleNewPostEvent,
     handleNewPostEvents,
     handlePluginEnabled,
@@ -2000,5 +2003,51 @@ describe('handleSharedChannelRemoteUpdatedEvent', () => {
         handleEvent(msg);
 
         expect(fetchChannelRemotes).not.toHaveBeenCalled();
+    });
+});
+
+describe('handleFileUploadRejected', () => {
+    beforeAll(() => {
+        setIntl(defaultIntl);
+    });
+
+    afterAll(() => {
+        setIntl(null);
+    });
+
+    const msg = {
+        event: WebSocketEvents.FileUploadRejected,
+        data: {
+            file_name: 'secret.tdf',
+            rejection_reason: 'blocked by policy',
+            channel_id: 'channel1',
+        },
+        broadcast: {},
+    };
+
+    test('opens an info toast with the rejection reason', () => {
+        const testStore = configureStore();
+
+        testStore.dispatch(handleFileUploadRejected(msg));
+
+        const openModalAction = testStore.getActions().find((action) => action.type === ActionTypes.MODAL_OPEN);
+        expect(openModalAction).toBeDefined();
+        expect(openModalAction.modalId).toBe(ModalIdentifiers.INFO_TOAST);
+        expect(openModalAction.dialogProps.position).toBe('bottom-center');
+        expect(openModalAction.dialogProps.content.message).toContain('blocked by policy');
+        expect(typeof openModalAction.dialogProps.onExited).toBe('function');
+    });
+
+    test('onExited closes the info toast', () => {
+        const testStore = configureStore();
+
+        testStore.dispatch(handleFileUploadRejected(msg));
+
+        const openModalAction = testStore.getActions().find((action) => action.type === ActionTypes.MODAL_OPEN);
+        openModalAction.dialogProps.onExited();
+
+        const closeModalAction = testStore.getActions().find((action) => action.type === ActionTypes.MODAL_CLOSE);
+        expect(closeModalAction).toBeDefined();
+        expect(closeModalAction.modalId).toBe(ModalIdentifiers.INFO_TOAST);
     });
 });

--- a/webapp/channels/src/actions/websocket_actions.ts
+++ b/webapp/channels/src/actions/websocket_actions.ts
@@ -763,6 +763,9 @@ export function handleEvent(msg: WebSocketMessage) {
     case WebSocketEvents.FileDownloadRejected:
         dispatch(handleFileDownloadRejected(msg));
         break;
+    case WebSocketEvents.FileUploadRejected:
+        dispatch(handleFileUploadRejected(msg));
+        break;
     case WebSocketEvents.ShowToast:
         dispatch(handleShowToast(msg));
         break;
@@ -2360,6 +2363,33 @@ export function handleFileDownloadRejected(msg: WebSocketMessages.FileDownloadRe
                 position: 'bottom-center',
                 onExited: () => {
                     // Close the modal when the toast is dismissed
+                    dispatch(closeModal(ModalIdentifiers.INFO_TOAST));
+                },
+            },
+        }));
+    };
+}
+
+export function handleFileUploadRejected(msg: WebSocketMessages.FileUploadRejected): ThunkActionFunc<void> {
+    return (dispatch) => {
+        const {rejection_reason: rejectionReason} = msg.data;
+
+        const intl = getIntl();
+        const displayMessage = intl.formatMessage(
+            {id: 'file_upload.rejected.file', defaultMessage: 'File upload blocked: {reason}'},
+            {reason: rejectionReason},
+        );
+
+        dispatch(openModal({
+            modalId: ModalIdentifiers.INFO_TOAST,
+            dialogType: InfoToast,
+            dialogProps: {
+                content: {
+                    icon: React.createElement(AlertCircleOutlineIcon, {size: 18}),
+                    message: displayMessage,
+                },
+                position: 'bottom-center',
+                onExited: () => {
                     dispatch(closeModal(ModalIdentifiers.INFO_TOAST));
                 },
             },

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4978,6 +4978,7 @@
   "file_upload.limited": "Uploads limited to {count, number} files maximum. Please use additional posts for more files.",
   "file_upload.menuAriaLabel": "Upload type selector",
   "file_upload.pasted": "Image Pasted at ",
+  "file_upload.rejected.file": "File upload blocked: {reason}",
   "file_upload.upload_files": "Upload files",
   "file_upload.zeroBytesFile": "You are uploading an empty file: {filename}",
   "file_upload.zeroBytesFiles": "You are uploading empty files: {filenames}",

--- a/webapp/platform/client/src/websocket_events.ts
+++ b/webapp/platform/client/src/websocket_events.ts
@@ -97,6 +97,7 @@ export const enum WebSocketEvents {
     RecapUpdated = 'recap_updated',
     PostTranslationUpdated = 'post_translation_updated',
     FileDownloadRejected = 'file_download_rejected',
+    FileUploadRejected = 'file_upload_rejected',
     ShowToast = 'show_toast',
     SharedChannelRemoteUpdated = 'shared_channel_remote_updated',
     ChannelJoinRequestCreated = 'channel_join_request_created',

--- a/webapp/platform/client/src/websocket_message.ts
+++ b/webapp/platform/client/src/websocket_message.ts
@@ -100,6 +100,7 @@ export type WebSocketMessage = (
     Messages.RecapUpdated |
 
     Messages.FileDownloadRejected |
+    Messages.FileUploadRejected |
     Messages.ShowToast |
 
     Messages.Plugin |

--- a/webapp/platform/client/src/websocket_messages.ts
+++ b/webapp/platform/client/src/websocket_messages.ts
@@ -504,6 +504,12 @@ export type FileDownloadRejected = BaseWebSocketMessage<WebSocketEvents.FileDown
     download_type: string;
 }>;
 
+export type FileUploadRejected = BaseWebSocketMessage<WebSocketEvents.FileUploadRejected, {
+    file_name: string;
+    rejection_reason: string;
+    channel_id: string;
+}>;
+
 export type ShowToast = BaseWebSocketMessage<WebSocketEvents.ShowToast, {
     message: string;
     position?: string;


### PR DESCRIPTION

#### Summary
When a plugin rejects a file upload via the FileWillBeUploaded hook, the server returns a 400 and the webapp renders the rejection reason as inline red text under the message composer (app.upload.run_plugins_hook.rejected).

When a plugin rejects a file download via FileWillBeDownloaded, the experience is different: the server emits a file_download_rejected WebSocket event and the webapp shows a bottom-center toast (InfoToast).

This inconsistency is confusing for policy-enforcement plugins (e.g. the OTDF bridge), where uploads and downloads are two halves of the same policy gate but produce visually different feedback. The inline composer error is also easy to miss and looks like a validation error rather than a policy decision.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69078


#### Screenshots
<img width="606" height="160" alt="image" src="https://github.com/user-attachments/assets/ab98213d-a973-4403-aaf5-55fd9e959363" />


#### Release Note

```release-note
Added a toast notification for plugin-rejected file uploads, consistent with the existing notification for rejected downloads.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change is additive but touches both server-side websocket event emission and client-side upload/error handling; the new event and suppression logic mirror existing download-rejection behavior, limiting risk, though the inline-error suppression and websocket-driven UI path create a user-visible behavioral change that could regress composer error handling in edge cases.  

**QA Recommendation:** Targeted manual QA on the plugin-rejected upload flow is recommended: verify toast content/formatting, ensure inline composer errors are suppressed only for plugin rejections, test websocket delivery under latency and multiple connections, and exercise concurrent upload scenarios; existing unit tests added reduce but do not eliminate the need for focused QA.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->