### PR TITLE
Gate PostTypeCard search indexing behind IntegratedBoards feature flag

### DIFF
--- a/server/channels/store/searchlayer/post_layer.go
+++ b/server/channels/store/searchlayer/post_layer.go
@@ -25,8 +25,7 @@ func (s SearchPostStore) indexPost(rctx request.CTX, post *model.Post) {
 				if post.Type == model.PostTypeBurnOnRead {
 					return
 				}
-				// FIXME(IntegratedBoardMVP): Temporarily excluded
-				if post.Type == model.PostTypeCard {
+				if post.Type == model.PostTypeCard && !s.rootStore.getConfig().FeatureFlags.IntegratedBoards {
 					return
 				}
 				channel, chanErr := s.rootStore.Channel().Get(post.ChannelId, true)

--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -2173,10 +2173,12 @@ func (s *SqlPostStore) search(teamId string, userId string, params *model.Search
 	).From("Posts q2").
 		Where("q2.DeleteAt = 0").
 		Where(fmt.Sprintf("q2.Type NOT LIKE '%s%%'", model.PostSystemMessagePrefix)).
-		// FIXME(IntegratedBoardMVP): Temporarily excluded
-		Where(sq.NotEq{"q2.Type": model.PostTypeCard}).
 		OrderByClause("q2.CreateAt DESC").
 		Limit(100)
+
+	if !s.getFeatureFlags().IntegratedBoards {
+		baseQuery = baseQuery.Where(sq.NotEq{"q2.Type": model.PostTypeCard})
+	}
 
 	var err error
 	baseQuery, err = s.buildSearchPostFilterClause(teamId, params.FromUsers, params.ExcludedUsers, userByUsername, baseQuery)

--- a/server/enterprise/elasticsearch/common/indexing_job.go
+++ b/server/enterprise/elasticsearch/common/indexing_job.go
@@ -442,8 +442,7 @@ func (worker *IndexerWorker) BulkIndexPosts(posts []*model.PostForIndexing, prog
 		if post.Type == model.PostTypeBurnOnRead {
 			continue
 		}
-		// FIXME(IntegratedBoardMVP): Temporarily excluded
-		if post.Type == model.PostTypeCard {
+		if post.Type == model.PostTypeCard && !worker.jobServer.Config().FeatureFlags.IntegratedBoards {
 			continue
 		}
 


### PR DESCRIPTION
Replaces three FIXME(IntegratedBoardMVP) comments with feature-flag-gated checks across SQL search, search engine layer, and Elasticsearch indexing. Cards remain excluded when the flag is disabled (default), preserving current behavior.

<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary

**`server/enterprise/elasticsearch/common/indexing_job.go`** - `PostTypeCard` skip in `BulkIndexPosts` gated on `!worker.jobServer.Config().FeatureFlags.IntegratedBoards`

**`server/channels/store/searchlayer/post_layer.go`** - `PostTypeCard` early-return in `indexPost` gated on `!s.rootStore.getConfig().FeatureFlags.IntegratedBoards`

**`server/channels/store/sqlstore/post_store.go`**  - `PostTypeCard` filter in SQL `search` method gated on `!s.getFeatureFlags().IntegratedBoards`



#### Release Note
<!--

NONE

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes replace unconditional FIXME-commented code with feature-flag-gated logic across three search/indexing layers. Default behavior (PostTypeCard exclusion) is preserved, mitigating regression risk. However, the changes span multiple modules (SQL, SearchEngine, Elasticsearch), introducing coordination complexity that requires verification across all three paths when the feature flag is enabled.

**QA Recommendation:** Focused manual testing recommended on search/indexing functionality when IntegratedBoards feature flag is toggled on/off. Verify that PostTypeCard posts are correctly excluded when the flag is disabled (default) and properly searchable/indexed when enabled. Given the multi-layer nature of these changes, integration testing across SQL, SearchEngine, and Elasticsearch indexing paths is important.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->