### PR TITLE
Add additional PluggableErrorBoundaries

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/ai_actions_menu.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/ai_actions_menu.test.tsx
@@ -4,6 +4,7 @@
 import {fireEvent} from '@testing-library/react';
 import React from 'react';
 
+import {testPluginComponentErrorHandling} from 'tests/helpers/plugin_error_handling';
 import {renderWithContext, screen} from 'tests/react_testing_utils';
 
 import type {PostDraft} from 'types/store/draft';
@@ -419,5 +420,36 @@ describe('AIActionsMenu', () => {
         expect(receivedProps.draft).toBeDefined();
         expect(receivedProps.getSelectedText).toBeDefined();
         expect(receivedProps.updateText).toBeDefined();
+    });
+
+    testPluginComponentErrorHandling((pluginComponent) => {
+        renderWithContext(
+            <AIActionsMenu
+                {...getBaseProps()}
+                aiRewriteEnabled={false}
+            />,
+            {
+                entities: {
+                    general: {config: {}},
+                    preferences: {myPreferences: {}},
+                    users: {currentUserId: 'user1'},
+                },
+                plugins: {
+                    components: {
+                        AIActionMenuItem: [
+                            {
+                                ...pluginComponent,
+                                icon: <span>{'icon'}</span>,
+                                text: 'Hover Me',
+                                sortOrder: 1,
+                            },
+                        ],
+                    },
+                },
+            } as any,
+        );
+
+        // The plugin component is only rendered once its submenu is opened by hovering the menu item.
+        fireEvent.mouseEnter(screen.getByText('Hover Me').closest('li')!);
     });
 });

--- a/webapp/channels/src/components/advanced_text_editor/ai_actions_menu.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/ai_actions_menu.tsx
@@ -14,6 +14,7 @@ import {ChevronRightIcon, CreationOutlineIcon, PencilOutlineIcon} from '@matterm
 
 import * as Menu from 'components/menu';
 
+import PluggableErrorBoundary from 'plugins/pluggable/error_boundary';
 import Constants from 'utils/constants';
 import {isKeyPressed} from 'utils/keyboard';
 
@@ -289,13 +290,15 @@ const AIActionsMenu = ({
                         {activePluginItem?.component && (() => {
                             const PluginComponent = activePluginItem.component;
                             return (
-                                <PluginComponent
-                                    draft={draft}
-                                    getSelectedText={getSelectedText}
-                                    updateText={updateText}
-                                    channelId={channelId}
-                                    isRHS={isRHS}
-                                />
+                                <PluggableErrorBoundary>
+                                    <PluginComponent
+                                        draft={draft}
+                                        getSelectedText={getSelectedText}
+                                        updateText={updateText}
+                                        channelId={channelId}
+                                        isRHS={isRHS}
+                                    />
+                                </PluggableErrorBoundary>
                             );
                         })()}
                     </div>

--- a/webapp/channels/src/components/advanced_text_editor/ai_actions_menu.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/ai_actions_menu.tsx
@@ -290,7 +290,7 @@ const AIActionsMenu = ({
                         {activePluginItem?.component && (() => {
                             const PluginComponent = activePluginItem.component;
                             return (
-                                <PluggableErrorBoundary>
+                                <PluggableErrorBoundary pluginId={activePluginItem.pluginId}>
                                     <PluginComponent
                                         draft={draft}
                                         getSelectedText={getSelectedText}

--- a/webapp/channels/src/components/advanced_text_editor/use_plugin_items.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_plugin_items.test.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React, {useRef} from 'react';
+
+import {testPluginComponentErrorHandling} from 'tests/helpers/plugin_error_handling';
+import {renderWithContext} from 'tests/react_testing_utils';
+
+import type {PostDraft} from 'types/store/draft';
+
+import usePluginItems from './use_plugin_items';
+
+describe('components/advanced_text_editor/use_plugin_items', () => {
+    const draft = {
+        message: '',
+        fileInfos: [],
+        uploadsInProgress: [],
+        createAt: 0,
+        updateAt: 0,
+        channelId: 'channel1',
+        rootId: '',
+        metadata: {},
+    } as PostDraft;
+
+    // Host component that renders the plugin items returned by the hook so they can be exercised.
+    function TestHost() {
+        const textboxRef = useRef(null) as any;
+        const items = usePluginItems(draft, textboxRef, jest.fn());
+        return <div>{items}</div>;
+    }
+
+    testPluginComponentErrorHandling((pluginComponent) => {
+        renderWithContext(
+            <TestHost/>,
+            {
+                plugins: {
+                    components: {
+                        PostEditorAction: [pluginComponent],
+                    },
+                },
+            } as any,
+        );
+    });
+});

--- a/webapp/channels/src/components/advanced_text_editor/use_plugin_items.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_plugin_items.tsx
@@ -51,7 +51,10 @@ const usePluginItems = (
 
             const Component = item.component as any;
             return (
-                <PluggableErrorBoundary key={item.id}>
+                <PluggableErrorBoundary
+                    key={item.id}
+                    pluginId={item.pluginId}
+                >
                     <Component
                         draft={draft}
                         getSelectedText={getSelectedText}

--- a/webapp/channels/src/components/advanced_text_editor/use_plugin_items.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_plugin_items.tsx
@@ -7,6 +7,8 @@ import {useSelector} from 'react-redux';
 import {usePluginVisibilityInSharedChannel} from 'components/common/hooks/usePluginVisibilityInSharedChannel';
 import type TextboxClass from 'components/textbox/textbox';
 
+import PluggableErrorBoundary from 'plugins/pluggable/error_boundary';
+
 import type {GlobalState} from 'types/store';
 import type {PostDraft} from 'types/store/draft';
 
@@ -49,12 +51,13 @@ const usePluginItems = (
 
             const Component = item.component as any;
             return (
-                <Component
-                    key={item.id}
-                    draft={draft}
-                    getSelectedText={getSelectedText}
-                    updateText={updateText}
-                />
+                <PluggableErrorBoundary key={item.id}>
+                    <Component
+                        draft={draft}
+                        getSelectedText={getSelectedText}
+                        updateText={updateText}
+                    />
+                </PluggableErrorBoundary>
             );
         });
     }, [postEditorActions, draft, getSelectedText, updateText, pluginItemsVisible]);

--- a/webapp/channels/src/components/code_block/code_block.test.tsx
+++ b/webapp/channels/src/components/code_block/code_block.test.tsx
@@ -3,6 +3,7 @@
 
 import React from 'react';
 
+import {testPluginComponentErrorHandling} from 'tests/helpers/plugin_error_handling';
 import {act, renderWithContext, screen} from 'tests/react_testing_utils';
 
 import CodeBlock from './code_block';
@@ -90,5 +91,21 @@ it shouldn't highlight, it's just garbage`;
 
         expect(container.querySelector('code')).toHaveTextContent('foo foo foo foofoo foo foo foo');
         expect(container.querySelector('code')).not.toHaveTextContent('foo foo foo foo foo foo foo foo');
+    });
+
+    testPluginComponentErrorHandling((pluginComponent) => {
+        renderWithContext(
+            <CodeBlock
+                code='some code'
+                language='txt'
+            />,
+            {
+                plugins: {
+                    components: {
+                        CodeBlockAction: [pluginComponent],
+                    },
+                },
+            } as any,
+        );
     });
 });

--- a/webapp/channels/src/components/code_block/code_block.tsx
+++ b/webapp/channels/src/components/code_block/code_block.tsx
@@ -95,7 +95,10 @@ const CodeBlock: React.FC<Props> = ({code, language, searchedContent, channelId}
 
             const Component = item.component as any;
             return (
-                <PluggableErrorBoundary key={item.id}>
+                <PluggableErrorBoundary
+                    key={item.id}
+                    pluginId={item.pluginId}
+                >
                     <Component
                         code={code}
                     />

--- a/webapp/channels/src/components/code_block/code_block.tsx
+++ b/webapp/channels/src/components/code_block/code_block.tsx
@@ -7,6 +7,7 @@ import {useSelector} from 'react-redux';
 import {usePluginVisibilityInSharedChannel} from 'components/common/hooks/usePluginVisibilityInSharedChannel';
 import CopyButton from 'components/copy_button';
 
+import PluggableErrorBoundary from 'plugins/pluggable/error_boundary';
 import * as SyntaxHighlighting from 'utils/syntax_highlighting';
 import * as TextFormatting from 'utils/text_formatting';
 
@@ -94,10 +95,11 @@ const CodeBlock: React.FC<Props> = ({code, language, searchedContent, channelId}
 
             const Component = item.component as any;
             return (
-                <Component
-                    key={item.id}
-                    code={code}
-                />
+                <PluggableErrorBoundary key={item.id}>
+                    <Component
+                        code={code}
+                    />
+                </PluggableErrorBoundary>
             );
         }) : [];
 

--- a/webapp/channels/src/components/new_search/search_box_hints.tsx
+++ b/webapp/channels/src/components/new_search/search_box_hints.tsx
@@ -69,7 +69,7 @@ const SearchBoxHints = ({searchTerms, searchTeam, setSearchTerms, searchType, re
     const Component = pluginComponentInfo.component;
 
     return (
-        <ErrorBoundary>
+        <ErrorBoundary pluginId={pluginComponentInfo.pluginId}>
             <Component
                 key={pluginComponentInfo.pluginId}
                 onChangeSearch={searchChangeCallback}

--- a/webapp/channels/src/components/new_search/search_box_suggestions.tsx
+++ b/webapp/channels/src/components/new_search/search_box_suggestions.tsx
@@ -97,7 +97,7 @@ const SearchSuggestions = ({
     const Component = pluginComponentInfo.component;
 
     return (
-        <ErrorBoundary>
+        <ErrorBoundary pluginId={pluginComponentInfo.pluginId}>
             <Component
                 key={pluginComponentInfo.pluginId}
                 searchTerms={searchTerms}

--- a/webapp/channels/src/components/new_search/search_box_type_selector.tsx
+++ b/webapp/channels/src/components/new_search/search_box_type_selector.tsx
@@ -87,7 +87,7 @@ const SearchTypeSelector = ({searchType, setSearchType}: Props) => {
                         onClick={() => setSearchType(pluginId)}
                         role='radio'
                     >
-                        <ErrorBoundary>
+                        <ErrorBoundary pluginId={pluginId}>
                             <Component/>
                         </ErrorBoundary>
                     </SearchTypeItem>

--- a/webapp/channels/src/components/post/post_options.test.tsx
+++ b/webapp/channels/src/components/post/post_options.test.tsx
@@ -7,6 +7,7 @@ import type {SystemEmoji} from '@mattermost/types/emojis';
 
 import {Permissions} from 'mattermost-redux/constants';
 
+import {testPluginComponentErrorHandling} from 'tests/helpers/plugin_error_handling';
 import {renderWithContext, screen} from 'tests/react_testing_utils';
 import {Locations} from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
@@ -124,4 +125,13 @@ describe('PostOptions - quick reaction count (MM-68681)', () => {
 
         expect(screen.getAllByTestId('post-menu__item_emoji')).toHaveLength(3);
     });
+
+    testPluginComponentErrorHandling((pluginComponent) => (
+        <PostOptions
+            {...baseProps}
+            isExpanded={true}
+            hover={true}
+            pluginActions={[pluginComponent]}
+        />
+    ));
 });

--- a/webapp/channels/src/components/post/post_options.test.tsx
+++ b/webapp/channels/src/components/post/post_options.test.tsx
@@ -126,12 +126,14 @@ describe('PostOptions - quick reaction count (MM-68681)', () => {
         expect(screen.getAllByTestId('post-menu__item_emoji')).toHaveLength(3);
     });
 
-    testPluginComponentErrorHandling((pluginComponent) => (
-        <PostOptions
-            {...baseProps}
-            isExpanded={true}
-            hover={true}
-            pluginActions={[pluginComponent]}
-        />
-    ));
+    testPluginComponentErrorHandling((pluginComponent) => {
+        renderWithContext(
+            <PostOptions
+                {...baseProps}
+                isExpanded={true}
+                hover={true}
+                pluginActions={[pluginComponent]}
+            />,
+        );
+    });
 });

--- a/webapp/channels/src/components/post/post_options.tsx
+++ b/webapp/channels/src/components/post/post_options.tsx
@@ -24,6 +24,7 @@ import {Locations, Constants} from 'utils/constants';
 import {isSystemMessage, fromAutoResponder} from 'utils/post_utils';
 
 import type {PostActionComponent} from 'types/store/plugins';
+import PluggableErrorBoundary from 'plugins/pluggable/error_boundary';
 
 type Props = {
     post: Post;
@@ -217,9 +218,11 @@ const PostOptions = (props: Props): JSX.Element => {
                     const Component = item.component;
                     return (
                         <li key={item.id}>
-                            <Component
-                                post={props.post}
-                            />
+                            <PluggableErrorBoundary>
+                                <Component
+                                    post={props.post}
+                                />
+                            </PluggableErrorBoundary>
                         </li>
                     );
                 }

--- a/webapp/channels/src/components/post/post_options.tsx
+++ b/webapp/channels/src/components/post/post_options.tsx
@@ -218,7 +218,7 @@ const PostOptions = (props: Props): JSX.Element => {
                     const Component = item.component;
                     return (
                         <li key={item.id}>
-                            <PluggableErrorBoundary>
+                            <PluggableErrorBoundary pluginId={item.pluginId}>
                                 <Component
                                     post={props.post}
                                 />

--- a/webapp/channels/src/components/post/post_options.tsx
+++ b/webapp/channels/src/components/post/post_options.tsx
@@ -20,11 +20,11 @@ import PostFlagIcon from 'components/post_view/post_flag_icon';
 import PostReaction from 'components/post_view/post_reaction';
 import PostRecentReactions from 'components/post_view/post_recent_reactions';
 
+import PluggableErrorBoundary from 'plugins/pluggable/error_boundary';
 import {Locations, Constants} from 'utils/constants';
 import {isSystemMessage, fromAutoResponder} from 'utils/post_utils';
 
 import type {PostActionComponent} from 'types/store/plugins';
-import PluggableErrorBoundary from 'plugins/pluggable/error_boundary';
 
 type Props = {
     post: Post;

--- a/webapp/channels/src/components/post_view/new_message_separator/new_message_separator.test.tsx
+++ b/webapp/channels/src/components/post_view/new_message_separator/new_message_separator.test.tsx
@@ -31,10 +31,12 @@ describe('components/post_view/new_message_separator', () => {
         expect(separator).toHaveClass('Separator NotificationSeparator');
     });
 
-    testPluginComponentErrorHandling((pluginComponent) => (
-        <NewMessageSeparator
-            {...baseProps}
-            newMessagesSeparatorActions={[pluginComponent]}
-        />
-    ));
+    testPluginComponentErrorHandling((pluginComponent) => {
+        renderWithContext(
+            <NewMessageSeparator
+                {...baseProps}
+                newMessagesSeparatorActions={[pluginComponent]}
+            />,
+        );
+    });
 });

--- a/webapp/channels/src/components/post_view/new_message_separator/new_message_separator.test.tsx
+++ b/webapp/channels/src/components/post_view/new_message_separator/new_message_separator.test.tsx
@@ -3,16 +3,21 @@
 
 import React from 'react';
 
+import {testPluginComponentErrorHandling} from 'tests/helpers/plugin_error_handling';
 import {renderWithContext, screen} from 'tests/react_testing_utils';
 
 import NewMessageSeparator from './new_message_separator';
 
 describe('components/post_view/new_message_separator', () => {
+    const baseProps = {
+        separatorId: '1234',
+        newMessagesSeparatorActions: [],
+    };
+
     test('should render new_message_separator', () => {
         renderWithContext(
             <NewMessageSeparator
-                separatorId='1234'
-                newMessagesSeparatorActions={[]}
+                {...baseProps}
             />,
         );
 
@@ -25,4 +30,11 @@ describe('components/post_view/new_message_separator', () => {
         expect(separator).toBeInTheDocument();
         expect(separator).toHaveClass('Separator NotificationSeparator');
     });
+
+    testPluginComponentErrorHandling((pluginComponent) => (
+        <NewMessageSeparator
+            {...baseProps}
+            newMessagesSeparatorActions={[pluginComponent]}
+        />
+    ));
 });

--- a/webapp/channels/src/components/post_view/new_message_separator/new_message_separator.tsx
+++ b/webapp/channels/src/components/post_view/new_message_separator/new_message_separator.tsx
@@ -37,7 +37,10 @@ const NewMessageSeparator = ({
 
             const Component = item.component;
             return (
-                <PluggableErrorBoundary key={item.id}>
+                <PluggableErrorBoundary
+                    key={item.id}
+                    pluginId={item.pluginId}
+                >
                     <Component
                         lastViewedAt={lastViewedAt}
                         channelId={channelId}

--- a/webapp/channels/src/components/post_view/new_message_separator/new_message_separator.tsx
+++ b/webapp/channels/src/components/post_view/new_message_separator/new_message_separator.tsx
@@ -9,6 +9,7 @@ import * as PostList from 'mattermost-redux/utils/post_list';
 import NotificationSeparator from 'components/widgets/separator/notification-separator';
 
 import type {NewMessagesSeparatorActionComponent} from 'types/store/plugins';
+import PluggableErrorBoundary from 'plugins/pluggable/error_boundary';
 
 type Props = {
     separatorId: string;
@@ -35,12 +36,13 @@ const NewMessageSeparator = ({
 
             const Component = item.component;
             return (
-                <Component
-                    key={item.id}
-                    lastViewedAt={lastViewedAt}
-                    channelId={channelId}
-                    threadId={threadId}
-                />
+                <PluggableErrorBoundary key={item.id}>
+                    <Component
+                        lastViewedAt={lastViewedAt}
+                        channelId={channelId}
+                        threadId={threadId}
+                    />
+                </PluggableErrorBoundary>
             );
         });
 

--- a/webapp/channels/src/components/post_view/new_message_separator/new_message_separator.tsx
+++ b/webapp/channels/src/components/post_view/new_message_separator/new_message_separator.tsx
@@ -8,8 +8,9 @@ import * as PostList from 'mattermost-redux/utils/post_list';
 
 import NotificationSeparator from 'components/widgets/separator/notification-separator';
 
-import type {NewMessagesSeparatorActionComponent} from 'types/store/plugins';
 import PluggableErrorBoundary from 'plugins/pluggable/error_boundary';
+
+import type {NewMessagesSeparatorActionComponent} from 'types/store/plugins';
 
 type Props = {
     separatorId: string;

--- a/webapp/channels/src/components/post_view/post_body_additional_content/post_body_additional_content.test.tsx
+++ b/webapp/channels/src/components/post_view/post_body_additional_content/post_body_additional_content.test.tsx
@@ -12,7 +12,8 @@ import type {
 
 import {getEmbedFromMetadata} from 'mattermost-redux/utils/post_utils';
 
-import {render, screen, userEvent} from 'tests/react_testing_utils';
+import {testPluginComponentErrorHandling} from 'tests/helpers/plugin_error_handling';
+import {render, renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
 
 import PostBodyAdditionalContent from './post_body_additional_content';
 import type {Props} from './post_body_additional_content';
@@ -485,5 +486,31 @@ describe('PostBodyAdditionalContent', () => {
             const {container} = render(<PostBodyAdditionalContent {...props}/>);
             expect(container).toMatchSnapshot();
         });
+    });
+
+    testPluginComponentErrorHandling((pluginComponent) => {
+        const linkUrl = 'https://example.com/song.mp3';
+
+        renderWithContext(
+            <PostBodyAdditionalContent
+                {...baseProps}
+                post={{
+                    ...baseProps.post,
+                    message: linkUrl,
+                    metadata: {
+                        embeds: [{
+                            type: 'link',
+                            url: linkUrl,
+                        }],
+                    } as PostMetadata,
+                }}
+                isEmbedVisible={true}
+                pluginPostWillRenderEmbedComponents={[{
+                    ...pluginComponent,
+                    match: ({url}: PostEmbed) => url === linkUrl,
+                    toggleable: false,
+                }]}
+            />,
+        );
     });
 });

--- a/webapp/channels/src/components/post_view/post_body_additional_content/post_body_additional_content.tsx
+++ b/webapp/channels/src/components/post_view/post_body_additional_content/post_body_additional_content.tsx
@@ -18,6 +18,7 @@ import PostMessagePreview from 'components/post_view/post_message_preview';
 import YoutubeVideo from 'components/youtube_video';
 
 import webSocketClient from 'client/web_websocket_client';
+import PluggableErrorBoundary from 'plugins/pluggable/error_boundary';
 import type {TextFormattingOptions} from 'utils/text_formatting';
 
 import type {PostWillRenderEmbedComponent} from 'types/store/plugins';
@@ -64,10 +65,12 @@ export default class PostBodyAdditionalContent extends React.PureComponent<Props
             if (c.match(embed)) {
                 const Component = c.component;
                 return this.props.isEmbedVisible && (
-                    <Component
-                        embed={embed}
-                        webSocketClient={webSocketClient}
-                    />
+                    <PluggableErrorBoundary>
+                        <Component
+                            embed={embed}
+                            webSocketClient={webSocketClient}
+                        />
+                    </PluggableErrorBoundary>
                 );
             }
         }

--- a/webapp/channels/src/components/post_view/post_body_additional_content/post_body_additional_content.tsx
+++ b/webapp/channels/src/components/post_view/post_body_additional_content/post_body_additional_content.tsx
@@ -65,7 +65,7 @@ export default class PostBodyAdditionalContent extends React.PureComponent<Props
             if (c.match(embed)) {
                 const Component = c.component;
                 return this.props.isEmbedVisible && (
-                    <PluggableErrorBoundary>
+                    <PluggableErrorBoundary pluginId={c.pluginId}>
                         <Component
                             embed={embed}
                             webSocketClient={webSocketClient}

--- a/webapp/channels/src/components/post_view/post_message_view/post_message_view.test.tsx
+++ b/webapp/channels/src/components/post_view/post_message_view/post_message_view.test.tsx
@@ -10,6 +10,7 @@ import type {Theme} from 'mattermost-redux/selectors/entities/preferences';
 
 import PostMessageView from 'components/post_view/post_message_view/post_message_view';
 
+import {testPluginComponentErrorHandling} from 'tests/helpers/plugin_error_handling';
 import {act, renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
 
 jest.mock('components/properties_card_view/propertyValueRenderer/post_preview_property_renderer/post_preview_property_renderer', () => {
@@ -166,5 +167,17 @@ describe('components/post_view/PostAttachment', () => {
 
         // Should not cause additional re-render since height is 0
         expect(PostMarkdown.mock.calls.length).toEqual(callCountAfterFirst);
+    });
+
+    testPluginComponentErrorHandling((pluginComponent) => {
+        renderWithContext(
+            <PostMessageView
+                {...baseProps}
+                post={{...post, type: 'custom_plugin_type' as PostType}}
+                pluginPostTypes={{
+                    custom_plugin_type: pluginComponent as any,
+                }}
+            />,
+        );
     });
 });

--- a/webapp/channels/src/components/post_view/post_message_view/post_message_view.tsx
+++ b/webapp/channels/src/components/post_view/post_message_view/post_message_view.tsx
@@ -18,6 +18,7 @@ import ShowMore from 'components/post_view/show_more';
 import type {AttachmentTextOverflowType} from 'components/post_view/show_more/show_more';
 
 import Pluggable from 'plugins/pluggable';
+import PluggableErrorBoundary from 'plugins/pluggable/error_boundary';
 import {PostTypes} from 'utils/constants';
 import {getPostTranslatedMessage, getPostTranslation} from 'utils/post_utils';
 import type {TextFormattingOptions} from 'utils/text_formatting';
@@ -135,12 +136,14 @@ export default class PostMessageView extends React.PureComponent<Props, State> {
         if (pluginPostTypes && Object.hasOwn(pluginPostTypes, postType)) {
             const PluginComponent = pluginPostTypes[postType].component;
             return (
-                <PluginComponent
-                    post={post}
-                    compactDisplay={compactDisplay}
-                    isRHS={isRHS}
-                    theme={theme}
-                />
+                <PluggableErrorBoundary>
+                    <PluginComponent
+                        post={post}
+                        compactDisplay={compactDisplay}
+                        isRHS={isRHS}
+                        theme={theme}
+                    />
+                </PluggableErrorBoundary>
             );
         }
 

--- a/webapp/channels/src/components/post_view/post_message_view/post_message_view.tsx
+++ b/webapp/channels/src/components/post_view/post_message_view/post_message_view.tsx
@@ -136,7 +136,7 @@ export default class PostMessageView extends React.PureComponent<Props, State> {
         if (pluginPostTypes && Object.hasOwn(pluginPostTypes, postType)) {
             const PluginComponent = pluginPostTypes[postType].component;
             return (
-                <PluggableErrorBoundary>
+                <PluggableErrorBoundary pluginId={pluginPostTypes[postType].pluginId}>
                     <PluginComponent
                         post={post}
                         compactDisplay={compactDisplay}

--- a/webapp/channels/src/components/rhs_card/rhs_card.test.tsx
+++ b/webapp/channels/src/components/rhs_card/rhs_card.test.tsx
@@ -4,6 +4,7 @@
 import React from 'react';
 import type {ComponentProps} from 'react';
 
+import {testPluginComponentErrorHandling} from 'tests/helpers/plugin_error_handling';
 import {renderWithContext} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';
 
@@ -71,5 +72,17 @@ describe('comoponents/rhs_card/RhsCard', () => {
         );
 
         expect(container).toMatchSnapshot();
+    });
+
+    testPluginComponentErrorHandling((pluginComponent) => {
+        const cardPost = {...post, type: 'custom_plugin_type' as any};
+
+        renderWithContext(
+            <RhsCard
+                {...baseProps}
+                selected={cardPost}
+                pluginPostCardTypes={{custom_plugin_type: pluginComponent as unknown as PostPluginComponent}}
+            />,
+        );
     });
 });

--- a/webapp/channels/src/components/rhs_card/rhs_card.tsx
+++ b/webapp/channels/src/components/rhs_card/rhs_card.tsx
@@ -99,7 +99,7 @@ export default class RhsCard extends React.Component<Props, State> {
         if (pluginPostCardTypes && Object.hasOwn(pluginPostCardTypes, postType)) {
             const PluginComponent = pluginPostCardTypes[postType].component;
             content = (
-                <PluggableErrorBoundary>
+                <PluggableErrorBoundary pluginId={pluginPostCardTypes[postType].pluginId}>
                     <PluginComponent post={selected}/>
                 </PluggableErrorBoundary>
             );

--- a/webapp/channels/src/components/rhs_card/rhs_card.tsx
+++ b/webapp/channels/src/components/rhs_card/rhs_card.tsx
@@ -19,6 +19,7 @@ import PostProfilePicture from 'components/post_profile_picture';
 import RhsCardHeader from 'components/rhs_card_header';
 import UserProfile from 'components/user_profile';
 
+import PluggableErrorBoundary from 'plugins/pluggable/error_boundary';
 import Constants from 'utils/constants';
 import DelayedAction from 'utils/delayed_action';
 
@@ -97,7 +98,11 @@ export default class RhsCard extends React.Component<Props, State> {
         let content: ReactNode = null;
         if (pluginPostCardTypes && Object.hasOwn(pluginPostCardTypes, postType)) {
             const PluginComponent = pluginPostCardTypes[postType].component;
-            content = <PluginComponent post={selected}/>;
+            content = (
+                <PluggableErrorBoundary>
+                    <PluginComponent post={selected}/>
+                </PluggableErrorBoundary>
+            );
         }
 
         if (!content) {

--- a/webapp/channels/src/components/root/actions/index.test.ts
+++ b/webapp/channels/src/components/root/actions/index.test.ts
@@ -90,5 +90,3 @@ describe('loadConfigAndMe', () => {
         ]);
     });
 });
-
-describe('');

--- a/webapp/channels/src/components/root/actions/index.test.ts
+++ b/webapp/channels/src/components/root/actions/index.test.ts
@@ -90,3 +90,5 @@ describe('loadConfigAndMe', () => {
         ]);
     });
 });
+
+describe('');

--- a/webapp/channels/src/plugins/pluggable/error_boundary.tsx
+++ b/webapp/channels/src/plugins/pluggable/error_boundary.tsx
@@ -7,7 +7,7 @@ import styled from 'styled-components';
 
 type Props = {
     children: React.ReactNode;
-    pluginId?: string;
+    pluginId: string;
 }
 
 type State = {

--- a/webapp/channels/src/tests/helpers/plugin_error_handling.tsx
+++ b/webapp/channels/src/tests/helpers/plugin_error_handling.tsx
@@ -1,0 +1,56 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
+
+import type {PluginComponent} from 'types/store/plugins';
+
+export function testPluginComponentErrorHandling(renderCallback: (pluginComponent: PluginComponent & {component: any}) => React.JSX.Element) {
+    describe('error handling', () => {
+        const origError = console.error;
+        beforeEach(() => {
+            console.error = jest.fn();
+        });
+        afterEach(() => {
+            console.error = origError;
+        });
+
+        test('should render fallback when an error occurs in a plugin component', async () => {
+            let throwError = true;
+            function TestComponent(): JSX.Element {
+                let obj: any;
+                if (throwError) {
+                    obj = {};
+                } else {
+                    obj = {
+                        someField: {
+                            thatDoesnt: {
+                                exist: [1, 2, 3],
+                            },
+                        },
+                    };
+                }
+
+                return <span>{'TestComponent ' + obj.someField.thatDoesnt.exist.toString()}</span>;
+            }
+
+            renderWithContext(renderCallback({
+                id: 'testId',
+                component: TestComponent,
+                pluginId: 'testPluginId',
+            }));
+
+            expect(screen.queryByText('An error occurred', {exact: false})).toBeVisible();
+            expect(screen.queryByText('TestComponent 1,2,3')).toBeNull();
+
+            throwError = false;
+
+            await userEvent.click(screen.getByText('Refresh?'));
+
+            expect(screen.queryByText('An error occurred', {exact: false})).toBeNull();
+            expect(screen.queryByText('TestComponent 1,2,3')).toBeVisible();
+        });
+    });
+}

--- a/webapp/channels/src/tests/helpers/plugin_error_handling.tsx
+++ b/webapp/channels/src/tests/helpers/plugin_error_handling.tsx
@@ -3,11 +3,19 @@
 
 import React from 'react';
 
-import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
+import {screen, userEvent} from 'tests/react_testing_utils';
 
 import type {PluginComponent} from 'types/store/plugins';
 
-export function testPluginComponentErrorHandling(renderCallback: (pluginComponent: PluginComponent & {component: any}) => React.JSX.Element) {
+/**
+ * testPluginComponentErrorHandling tests that a component that renders some number of components from plugins won't
+ * crash when an error occurs in those plugin components (either because they use Pluggable or PluggableErrorBoundary).
+ * It tests that the component both renders a fallback when the plugin component crashes and the actual component when
+ * it doesn't.
+ *
+ * @param renderCallback - A callback that receives a fake PluginComponent that should be rendered by the caller
+ */
+export function testPluginComponentErrorHandling(renderCallback: (pluginComponent: PluginComponent & {component: any}) => void) {
     describe('error handling', () => {
         const origError = console.error;
         beforeEach(() => {
@@ -36,11 +44,11 @@ export function testPluginComponentErrorHandling(renderCallback: (pluginComponen
                 return <span>{'TestComponent ' + obj.someField.thatDoesnt.exist.toString()}</span>;
             }
 
-            renderWithContext(renderCallback({
+            renderCallback({
                 id: 'testId',
                 component: TestComponent,
                 pluginId: 'testPluginId',
-            }));
+            });
 
             expect(screen.queryByText('An error occurred', {exact: false})).toBeVisible();
             expect(screen.queryByText('TestComponent 1,2,3')).toBeNull();

--- a/webapp/channels/src/types/store/plugins.ts
+++ b/webapp/channels/src/types/store/plugins.ts
@@ -125,7 +125,7 @@ export type Menu = {
     isHeader?: boolean;
 }
 
-type PluginComponent = {
+export type PluginComponent = {
     id: string;
     pluginId: string;
 };


### PR DESCRIPTION
#### Summary
This should cover everywhere in the web app where we render a component for a plugin that isn't done so through a `Pluggable` which has the error boundary built into it

#### Ticket Link
MM-69102

#### Release Note
```release-note
Hardened web app against being crashed by a component rendered by a plugin
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change makes `pluginId` a mandatory prop on `PluggableErrorBoundary` (previously optional), which is a contract change that must be consistently applied. While the changes are applied throughout the codebase and are primarily defensive (wrapping plugin components), any missing `pluginId` prop could cause failures. The risk is mitigated by comprehensive test coverage and the fact that modifications are isolated to error boundary instantiation.

**QA Recommendation:** Focus manual QA on plugin-rendered components across the affected areas (AI actions menu, code blocks, post actions, search results, message separators, embeds, post types, and RHS cards). Test both error and non-error paths to ensure the error boundaries don't interfere with normal plugin component rendering. Full automated test coverage exists per the commit changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->