### PR TITLE
[MM-68972] MBE Phase 12: expose channel modals + favorite actions to plugins; reposition new-channel extraContent

### DIFF
--- a/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
+++ b/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
@@ -499,12 +499,6 @@ const NewChannelModal = () => {
                         />
                     </div>
                 )}
-                {activePluginOption?.extraContent && (
-                    <activePluginOption.extraContent
-                        formState={formState}
-                        setCanCreate={setPluginCanCreate}
-                    />
-                )}
                 <div className='new-channel-modal-purpose-container'>
                     <Input
                         id='new-channel-modal-purpose'
@@ -619,6 +613,13 @@ const NewChannelModal = () => {
                             </div>
                         )}
                     </div>
+                )}
+                {activePluginOption?.extraContent && (
+                    <activePluginOption.extraContent
+                        formState={formState}
+                        setFormState={mergeFormState}
+                        setCanCreate={setPluginCanCreate}
+                    />
                 )}
             </div>
         </GenericModal>

--- a/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
+++ b/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
@@ -617,7 +617,6 @@ const NewChannelModal = () => {
                 {activePluginOption?.extraContent && (
                     <activePluginOption.extraContent
                         formState={formState}
-                        setFormState={mergeFormState}
                         setCanCreate={setPluginCanCreate}
                     />
                 )}

--- a/webapp/channels/src/plugins/export.test.ts
+++ b/webapp/channels/src/plugins/export.test.ts
@@ -7,6 +7,30 @@ import './export';
 
 jest.mock('utils/message_html_to_component');
 
+describe('window.Components exposes plugin modals', () => {
+    test('EditChannelHeaderModal is defined', () => {
+        expect((window as any).Components.EditChannelHeaderModal).toBeDefined();
+    });
+
+    test('ChannelNotificationsModal is defined', () => {
+        expect((window as any).Components.ChannelNotificationsModal).toBeDefined();
+    });
+});
+
+describe('window.WebappUtils.channels exposes channel actions', () => {
+    test('favoriteChannel is defined', () => {
+        expect((window as any).WebappUtils.channels.favoriteChannel).toBeDefined();
+    });
+
+    test('unfavoriteChannel is defined', () => {
+        expect((window as any).WebappUtils.channels.unfavoriteChannel).toBeDefined();
+    });
+
+    test('isFavoriteChannel is defined', () => {
+        expect((window as any).WebappUtils.channels.isFavoriteChannel).toBeDefined();
+    });
+});
+
 describe('messageHtmlToComponent wrapper', () => {
     const message = 'test';
     const options = {emoji: true, images: false};

--- a/webapp/channels/src/plugins/export.ts
+++ b/webapp/channels/src/plugins/export.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-/* eslint-disable @typescript-eslint/no-require-imports */
+import {favoriteChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
+import {isFavoriteChannel} from 'mattermost-redux/selectors/entities/channels';
 
 import {notifyMe} from 'actions/notification_actions';
 import {openModal} from 'actions/views/modals';
@@ -11,7 +12,9 @@ import {getSelectedPostId, getIsRhsOpen} from 'selectors/rhs';
 import AdvancedTextEditor from 'components/advanced_text_editor/advanced_text_editor';
 import ChannelInviteModal from 'components/channel_invite_modal';
 import ChannelMembersModal from 'components/channel_members_modal';
+import ChannelNotificationsModal from 'components/channel_notifications_modal';
 import DatePicker from 'components/date_picker/date_picker';
+import EditChannelHeaderModal from 'components/edit_channel_header_modal';
 import * as Menu from 'components/menu';
 import {useNotifyAdmin} from 'components/notify_admin_cta/notify_admin_cta';
 import PostMessagePreview from 'components/post_view/post_message_preview';
@@ -70,6 +73,11 @@ interface WindowWithLibraries {
         sendDesktopNotificationToMe: typeof notifyMe;
         openUserSettings: (dialogProps: any) => void;
         browserHistory: ReturnType<typeof getHistory>;
+        channels: {
+            favoriteChannel: typeof favoriteChannel;
+            unfavoriteChannel: typeof unfavoriteChannel;
+            isFavoriteChannel: typeof isFavoriteChannel;
+        };
         popouts: {
             sendToParent: typeof sendToParent;
             onMessageFromParent: typeof onMessageFromParent;
@@ -85,6 +93,8 @@ interface WindowWithLibraries {
         Timestamp: typeof Timestamp;
         ChannelInviteModal: typeof ChannelInviteModal;
         ChannelMembersModal: typeof ChannelMembersModal;
+        ChannelNotificationsModal: typeof ChannelNotificationsModal;
+        EditChannelHeaderModal: typeof EditChannelHeaderModal;
         Avatar: typeof Avatar;
         imageURLForUser: typeof imageURLForUser;
         BotBadge: typeof BotTag;
@@ -151,6 +161,7 @@ window.WebappUtils = {
         dialogType: UserSettingsModal,
         dialogProps,
     }),
+    channels: {favoriteChannel, unfavoriteChannel, isFavoriteChannel},
     popouts: {
         sendToParent,
         onMessageFromParent,
@@ -173,6 +184,8 @@ window.Components = {
     Timestamp,
     ChannelInviteModal,
     ChannelMembersModal,
+    ChannelNotificationsModal,
+    EditChannelHeaderModal,
     Avatar,
     imageURLForUser,
     BotBadge: BotTag,

--- a/webapp/channels/src/plugins/export.ts
+++ b/webapp/channels/src/plugins/export.ts
@@ -1,6 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+/* eslint-disable @typescript-eslint/no-require-imports */
+
 import {favoriteChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
 import {isFavoriteChannel} from 'mattermost-redux/selectors/entities/channels';
 


### PR DESCRIPTION
#### Summary

Phase 12 delivers the MBE plugin's end-to-end webapp MVP (shield identity, channel-intro panel, encrypted-channel creation dialog). This server slice is the host support that work needs: it exposes two more channel modals and the channel-favorite actions on the internal plugin API, and repositions the new-channel modal's plugin `extraContent` slot at the bottom of the dialog (where it's like "additional" content, rather than somewhere in the middle of the modal).

Companion plugin PR: https://github.com/mattermost/message-based-encryption/pull/15

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68972

#### Release Note

```release-note
Phase 12 of the mbe-tech-preview.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The PR extends the plugin contract by adding new `window`-exposed modal components and channel-favorite utilities, so downstream plugins may depend on these new global bindings. Reordering `NewChannelModal`’s `extraContent` slot can subtly affect plugin-rendered UI placement, with added automated checks covering only export presence rather than integration behavior.

**QA Recommendation:** Spot-check plugin flows that consume the newly exposed globals (favorites actions and both modals) and verify new-channel creation rendering with plugins that supply `extraContent`, alongside a quick pass to ensure existing channel management still behaves normally.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->