### PR TITLE
MM-67616: Load synced remote member profiles so participant list refreshes

### DIFF
--- a/webapp/channels/src/actions/websocket_actions.test.jsx
+++ b/webapp/channels/src/actions/websocket_actions.test.jsx
@@ -47,6 +47,7 @@ import {
     handlePluginDisabled,
     handlePostEditEvent,
     handlePostUnreadEvent,
+    handleUserAddedEvent,
     handleUserRemovedEvent,
     handleLeaveTeamEvent,
     reconnect,
@@ -444,6 +445,68 @@ describe('handlePostUnreadEvent', () => {
 
         handlePostUnreadEvent(msg);
         expect(store.dispatch).toHaveBeenCalledWith(expectedAction);
+    });
+});
+
+describe('handleUserAddedEvent', () => {
+    const currentChannelId = mockState.entities.channels.currentChannelId;
+
+    // getLicense() must resolve to an object for handleUserAddedEvent, so add one
+    // to a local copy of the state rather than mutating the shared mockState.
+    const stateWithLicense = {
+        ...mockState,
+        entities: {
+            ...mockState.entities,
+            general: {
+                ...mockState.entities.general,
+                license: {},
+            },
+        },
+    };
+
+    test('should load the added user profile when it is not already in the store', async () => {
+        const testStore = configureStore(stateWithLicense);
+        const msg = {
+            data: {
+                user_id: 'remoteUser',
+            },
+            broadcast: {
+                channel_id: currentChannelId,
+            },
+        };
+
+        await testStore.dispatch(handleUserAddedEvent(msg));
+        expect(getUser).toHaveBeenCalledWith('remoteUser');
+    });
+
+    test('should not load the added user profile when it is already in the store', async () => {
+        const testStore = configureStore(stateWithLicense);
+        const msg = {
+            data: {
+                user_id: 'user',
+            },
+            broadcast: {
+                channel_id: currentChannelId,
+            },
+        };
+
+        await testStore.dispatch(handleUserAddedEvent(msg));
+        expect(getUser).not.toHaveBeenCalled();
+    });
+
+    test('should not load the added user profile when the channel is not the current channel', async () => {
+        const testStore = configureStore(stateWithLicense);
+        const msg = {
+            data: {
+                user_id: 'remoteUser',
+            },
+            broadcast: {
+                channel_id: 'someOtherChannel',
+            },
+        };
+
+        await testStore.dispatch(handleUserAddedEvent(msg));
+        expect(getUser).not.toHaveBeenCalled();
     });
 });
 

--- a/webapp/channels/src/actions/websocket_actions.ts
+++ b/webapp/channels/src/actions/websocket_actions.ts
@@ -1274,7 +1274,7 @@ function handleGroupAddedEvent(msg: WebSocketMessages.GroupChannelCreated) {
     return fetchChannelAndAddToSidebar(msg.broadcast.channel_id);
 }
 
-function handleUserAddedEvent(msg: WebSocketMessages.UserAddedToChannel): ThunkActionFunc<void> {
+export function handleUserAddedEvent(msg: WebSocketMessages.UserAddedToChannel): ThunkActionFunc<void> {
     return async (doDispatch, doGetState) => {
         const state = doGetState();
         const config = getConfig(state);
@@ -1286,6 +1286,15 @@ function handleUserAddedEvent(msg: WebSocketMessages.UserAddedToChannel): ThunkA
                 type: UserTypes.RECEIVED_PROFILE_IN_CHANNEL,
                 data: {id: msg.broadcast.channel_id, user_id: msg.data.user_id},
             });
+
+            // The membership relation alone is not enough to render the member in the
+            // participant list: the member list selectors drop users whose profile is
+            // not loaded. This happens for remote users synced into a shared channel,
+            // since the viewer has never loaded their profile. Fetch it if missing.
+            if (!getUser(state, msg.data.user_id)) {
+                doDispatch(loadUser(msg.data.user_id));
+            }
+
             if (license?.IsLicensed === 'true' && license?.LDAPGroups === 'true' && config.EnableConfirmNotificationsToChannel === 'true') {
                 doDispatch(getChannelMemberCountsByGroup(currentChannelId));
             }


### PR DESCRIPTION
#### Summary
Reopened MM-67616: channel membership changes synced from a remote workspace were not reflected in the participant/member list in real time, even though the change was correctly applied to the database and the `user_added` websocket event was delivered.

Root cause is client-side. `handleUserAddedEvent` recorded the membership relation (`RECEIVED_PROFILE_IN_CHANNEL`) but never loaded the added user's profile object. The member-list selectors run through `injectProfiles`, which silently drops any user whose profile is not loaded in the store. For a remote user synced in from another workspace, the viewer has never loaded that profile, so the new member never appeared, the count (from `getChannelStats`) updated and the user showed up when they posted (post loading fetches the author profile), but the participant list did not refresh. This matches the behavior reported on the ticket.

The original server-side fix (#35619, ChannelMemberHistory cursor sync) is working correctly; this PR only addresses the client refresh gap.

#### Changes
- `handleUserAddedEvent` now fetches the added user's profile when it is not already in the store, using the same missing-profile idiom already used in `handleUserRemovedEvent`. The fetch stays scoped to the currently viewed channel. This is a general fix that also covers any non-shared-channel case where a viewer lacks the added user's profile.
- Exported `handleUserAddedEvent` (consistent with the other handlers in this file that are exported for testing) and added unit tests covering: profile missing (fetch), profile already loaded (no fetch), and event for a non-current channel (no fetch).

#### Ticket Link
fixes: https://mattermost.atlassian.net/browse/MM-67616

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change adds a profile fetch dispatch to the `handleUserAddedEvent` websocket handler, following the same pattern as `handleUserRemovedEvent`. While the pattern is consistent with existing code, websocket event handlers carry inherent risk for timing/race conditions and async dispatch interactions. The modification is isolated to a single handler with proper scoping (current channel only), reducing the likelihood of unintended side effects.

**QA Recommendation:** Automated test coverage is comprehensive (three test cases covering missing profile, already-loaded, and non-current-channel scenarios), but manual QA should focus on: (1) real-time member list refresh when users are added to a channel via remote sync, (2) member list consistency under rapid membership changes, and (3) profile loading behavior across multiple concurrent channel operations. This is not a critical path but affects collaborative real-time features where timing issues are difficult to detect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->