### PR TITLE
MM-60669 Prevent bot users from becoming the first system admin

### DIFF
--- a/server/channels/app/users/users.go
+++ b/server/channels/app/users/users.go
@@ -43,11 +43,16 @@ func (us *UserService) CreateUser(rctx request.CTX, user *model.User, opts UserC
 	}
 
 	// Below is a special case where the first user in the entire
-	// system is granted the system_admin role
-	if ok, err := us.store.IsEmpty(true); err != nil {
-		return nil, errors.Wrap(UserStoreIsEmptyError, err.Error())
-	} else if ok {
-		user.Roles = model.SystemAdminRoleId + " " + model.SystemUserRoleId
+	// system is granted the system_admin role. Bot users must never be
+	// granted this role: on a fresh install the bots created by plugins
+	// can be the only accounts present, and they should not be treated
+	// as the "first user".
+	if !user.IsBot {
+		if ok, err := us.store.IsEmpty(true); err != nil {
+			return nil, errors.Wrap(UserStoreIsEmptyError, err.Error())
+		} else if ok {
+			user.Roles = model.SystemAdminRoleId + " " + model.SystemUserRoleId
+		}
 	}
 
 	if _, ok := i18n.GetSupportedLocales()[user.Locale]; !ok {

--- a/server/channels/app/users/users_test.go
+++ b/server/channels/app/users/users_test.go
@@ -86,3 +86,37 @@ func TestFirstUserPromoted(t *testing.T) {
 
 	require.Equal(t, model.SystemUserRoleId, user4.Roles)
 }
+
+func TestFirstUserNotPromotedIfBot(t *testing.T) {
+	th := Setup(t)
+
+	// On a completely fresh install the store is empty, but a bot user
+	// (one created by a plugin) must never become the first system admin.
+	botUser, err := th.service.CreateUser(th.Context, &model.User{
+		Username: model.NewUsername(),
+		Password: model.NewId(),
+		Email:    "bot@example.com",
+		IsBot:    true,
+	}, UserCreateOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, botUser)
+	require.Equal(t, model.SystemUserRoleId, botUser.Roles)
+
+	// Record the corresponding bot so the store correctly excludes it.
+	_, err = th.dbStore.Bot().Save(&model.Bot{
+		UserId:   botUser.Id,
+		OwnerId:  model.NewId(),
+		Username: botUser.Username,
+	})
+	require.NoError(t, err)
+
+	// The first non-bot user is still promoted to system admin.
+	user, err := th.service.CreateUser(th.Context, &model.User{
+		Username: model.NewUsername(),
+		Password: model.NewId(),
+		Email:    "user@example.com",
+	}, UserCreateOptions{})
+	require.NoError(t, err)
+	require.NotNil(t, user)
+	require.Equal(t, model.SystemAdminRoleId+" "+model.SystemUserRoleId, user.Roles)
+}


### PR DESCRIPTION
#### Summary

On a fresh install, the first user created in the system is granted the `system_admin` role. That decision lived in `UserService.CreateUser` and was gated only on `store.IsEmpty(true)`, so it applied to *any* user being created — including bot users. On a fresh database where a plugin creates a bot before any human signs up, the bot could be promoted to the first system admin.

This change skips the first-user `system_admin` promotion when the user being created is a bot, so a bot is never eligible to become the first system admin. The first **non-bot** user is still promoted as before.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-60669

#### Release Note
```release-note
Fixed an issue where a bot user created by a plugin could become the first system admin on a fresh install.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change touches authorization and role assignment during user creation—a critical path. However, the modification is isolated to a single conditional check (`!user.IsBot`) that restrictively gates the "first user promotion" logic rather than expanding it. Existing test coverage is adequate: `TestFirstUserPromoted` validates backward compatibility for non-bot users, while `TestFirstUserNotPromotedIfBot` validates the new bot exclusion behavior. The risk of regression is limited to fresh-install scenarios and bot account creation paths.

**QA Recommendation:** Minimal manual QA needed beyond automated test coverage. Verify fresh install scenarios: (1) first non-bot user receives system_admin role, (2) bot users created on empty systems do not receive system_admin, (3) role promotion behavior after deletion and recreation remains consistent. Focus on plugin-initiated bot creation workflows if applicable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->