### PR TITLE
MM-68976 Preserve PluginSettings.SignaturePublicKeyFiles on config patch endpoint

### DIFF
--- a/api/v4/source/system.yaml
+++ b/api/v4/source/system.yaml
@@ -673,8 +673,8 @@
       summary: Update configuration
       description: >
         Submit a new configuration for the server to use. As of server version
-        4.8, the `PluginSettings.EnableUploads` setting cannot be modified by
-        this endpoint.
+        4.8, the `PluginSettings.EnableUploads` and `PluginSettings.SignaturePublicKeyFiles`
+        settings cannot be modified by this endpoint.
 
         Note that the parameters that aren't set in the configuration that you
         provide will be reset to default values. Therefore, if you want to
@@ -815,8 +815,8 @@
       summary: Patch configuration
       description: >
         Submit configuration to patch. As of server version 4.8, the
-        `PluginSettings.EnableUploads` setting cannot be modified by this
-        endpoint.
+        `PluginSettings.EnableUploads` and `PluginSettings.SignaturePublicKeyFiles`
+        settings cannot be modified by this endpoint.
 
         ##### Permissions
 

--- a/server/channels/api4/config.go
+++ b/server/channels/api4/config.go
@@ -308,6 +308,11 @@ func patchConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Do not allow certificates to be changed through the API. Mirror the full
+	// update endpoint by silently preserving the existing value rather than
+	// rejecting the request.
+	cfg.PluginSettings.SignaturePublicKeyFiles = appCfg.PluginSettings.SignaturePublicKeyFiles
+
 	// Do not allow import directory to be changed through the API
 	if cfg.ImportSettings.Directory != nil && *cfg.ImportSettings.Directory != *appCfg.ImportSettings.Directory {
 		c.Err = model.NewAppError("patchConfig", "api.config.update_config.not_allowed_security.app_error", map[string]any{"Name": "ImportSettings.Directory"}, "", http.StatusForbidden)

--- a/server/channels/api4/config_test.go
+++ b/server/channels/api4/config_test.go
@@ -912,6 +912,20 @@ func TestPatchConfig(t *testing.T) {
 		assert.Equal(t, newURL, *cfg.PluginSettings.MarketplaceURL)
 	})
 
+	t.Run("Should not be able to modify PluginSettings.SignaturePublicKeyFiles", func(t *testing.T) {
+		// Mirror the behavior of the full update endpoint (TestUpdateConfig):
+		// changes to this field are silently preserved, not rejected.
+		oldPublicKeys := th.App.Config().PluginSettings.SignaturePublicKeyFiles
+
+		cfg := th.App.Config().Clone()
+		cfg.PluginSettings.SignaturePublicKeyFiles = append(cfg.PluginSettings.SignaturePublicKeyFiles, "new_signature")
+
+		updatedConfig, _, err := th.SystemAdminClient.PatchConfig(context.Background(), cfg)
+		require.NoError(t, err)
+		assert.Equal(t, oldPublicKeys, updatedConfig.PluginSettings.SignaturePublicKeyFiles)
+		assert.Equal(t, oldPublicKeys, th.App.Config().PluginSettings.SignaturePublicKeyFiles)
+	})
+
 	t.Run("System Admin should not be able to clear Site URL", func(t *testing.T) {
 		cfg, _, err := th.SystemAdminClient.GetConfig(context.Background())
 		require.NoError(t, err)


### PR DESCRIPTION
#### Summary

The full update endpoint `PUT /api/v4/config` (`updateConfig`) silently preserves `PluginSettings.SignaturePublicKeyFiles` — a protection added in #13682 to prevent modifying plugin signature keys through the API. Its sibling sparse endpoint `PUT /api/v4/config/patch` (`patchConfig`) had no equivalent guard, so a session holding `sysconsole_write_plugins` could modify the field through the patch endpoint, leaving the #13682 protection only partially effective.

This aligns `patchConfig` with `updateConfig` by silently preserving the existing value of the field (rather than rejecting the request), mirroring the full endpoint's exact behavior. A regression test equivalent to the existing one in `TestUpdateConfig` is added to `TestPatchConfig`.

Note: this does not expand the practical capabilities of a user with `sysconsole_write_plugins` (they can already disable `RequirePluginSignature` and upload unsigned plugins directly); it closes a consistency gap between the two configuration endpoints. Surfaced via a BugCrowd submission closed as P5 Informational.

QA steps:
- As a user with `sysconsole_write_plugins`, send `PUT /api/v4/config/patch` with a modified `PluginSettings.SignaturePublicKeyFiles` value.
- Verify the request succeeds but the stored value is unchanged (matching the behavior of `PUT /api/v4/config`).

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68976

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is localized to the patchConfig handler and API documentation, aligning its behavior with the already-covered updateConfig path; existing tests were extended to cover the regression, so untested paths are minimal. There are no modifications to shared utilities, authentication, or persistence layers beyond preserving an existing config field.

**QA Recommendation:** Run automated tests (including the updated TestPatchConfig) and perform a brief manual smoke test by issuing PUT /api/v4/config/patch as a sysconsole_write_plugins user to confirm the request succeeds but PluginSettings.SignaturePublicKeyFiles remains unchanged.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->