### PR TITLE
[MM-69115] Fixed issue where channels could end up in two categories

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -4596,7 +4596,7 @@ func (a *App) addChannelToDefaultCategory(rctx request.CTX, userID string, chann
 			if err != nil {
 				mlog.Error("Failed to create default category", mlog.String("user_id", userID), mlog.String("team_id", channel.TeamId), mlog.String("category_name", channel.DefaultCategoryName), mlog.Err(err))
 			}
-		} else {
+		} else if !slices.Contains(targetCategory.Channels, channel.Id) {
 			targetCategory.Channels = append([]string{channel.Id}, targetCategory.Channels...)
 			categoriesToUpdate = append(categoriesToUpdate, targetCategory)
 		}

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -4560,17 +4560,18 @@ func (a *App) addChannelToDefaultCategory(rctx request.CTX, userID string, chann
 			}
 		}
 
-		// Find the original category if the channel is already in a category. This includes the
-		// default Channels category, so a channel currently shown there is moved rather than duplicated.
+		// Find the original category if the channel is already in a category
 		var originalCategory *model.SidebarCategoryWithChannels
 		for _, category := range categories.Categories {
-			if category == targetCategory {
-				continue
-			}
-			if (category.Type == model.SidebarCategoryCustom || category.Type == model.SidebarCategoryChannels) && slices.Contains(category.Channels, channel.Id) {
+			if category.Type != model.SidebarCategoryDirectMessages && slices.Contains(category.Channels, channel.Id) {
 				originalCategory = category
 				break
 			}
+		}
+
+		// The channel is already in the target category, so there's nothing to move.
+		if originalCategory != nil && originalCategory == targetCategory {
+			return
 		}
 
 		var categoriesToUpdate []*model.SidebarCategoryWithChannels
@@ -4596,7 +4597,7 @@ func (a *App) addChannelToDefaultCategory(rctx request.CTX, userID string, chann
 			if err != nil {
 				mlog.Error("Failed to create default category", mlog.String("user_id", userID), mlog.String("team_id", channel.TeamId), mlog.String("category_name", channel.DefaultCategoryName), mlog.Err(err))
 			}
-		} else if !slices.Contains(targetCategory.Channels, channel.Id) {
+		} else {
 			targetCategory.Channels = append([]string{channel.Id}, targetCategory.Channels...)
 			categoriesToUpdate = append(categoriesToUpdate, targetCategory)
 		}

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -4560,10 +4560,14 @@ func (a *App) addChannelToDefaultCategory(rctx request.CTX, userID string, chann
 			}
 		}
 
-		// Find the original category if the channel is already in a category
+		// Find the original category if the channel is already in a category. This includes the
+		// default Channels category, so a channel currently shown there is moved rather than duplicated.
 		var originalCategory *model.SidebarCategoryWithChannels
 		for _, category := range categories.Categories {
-			if category.Type == model.SidebarCategoryCustom && category.Channels != nil && slices.Contains(category.Channels, channel.Id) {
+			if category == targetCategory {
+				continue
+			}
+			if (category.Type == model.SidebarCategoryCustom || category.Type == model.SidebarCategoryChannels) && slices.Contains(category.Channels, channel.Id) {
 				originalCategory = category
 				break
 			}
@@ -4571,7 +4575,8 @@ func (a *App) addChannelToDefaultCategory(rctx request.CTX, userID string, chann
 
 		var categoriesToUpdate []*model.SidebarCategoryWithChannels
 		if originalCategory != nil {
-			originalCategory.Channels = slices.Delete(originalCategory.Channels, slices.Index(originalCategory.Channels, channel.Id), 1)
+			idx := slices.Index(originalCategory.Channels, channel.Id)
+			originalCategory.Channels = slices.Delete(originalCategory.Channels, idx, idx+1)
 			categoriesToUpdate = append(categoriesToUpdate, originalCategory)
 		}
 

--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -4058,3 +4058,37 @@ func TestPatchChannelDefaultCategoryMovesOutOfChannels(t *testing.T) {
 		}
 	}
 }
+
+func TestPatchChannelDefaultCategoryReapplyIsIdempotent(t *testing.T) {
+	th := Setup(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.TeamSettings.EnableChannelCategorySorting = true
+	})
+
+	channel := th.createChannel(t, th.BasicTeam, model.ChannelTypeOpen)
+
+	patch := &model.ChannelPatch{DefaultCategoryName: new("Reapply Category")}
+	channel, appErr := th.App.PatchChannel(th.Context, channel, patch, th.BasicUser.Id)
+	require.Nil(t, appErr)
+
+	// Patching again re-runs the default category logic while the channel is already in the target
+	// category. This must not error or list the channel twice in the category.
+	_, appErr = th.App.PatchChannel(th.Context, channel, &model.ChannelPatch{Header: new("updated header")}, th.BasicUser.Id)
+	require.Nil(t, appErr)
+
+	categories, appErr := th.App.GetSidebarCategoriesForTeamForUser(th.Context, th.BasicUser.Id, th.BasicTeam.Id)
+	require.Nil(t, appErr)
+
+	for _, category := range categories.Categories {
+		if category.DisplayName == "Reapply Category" {
+			count := 0
+			for _, channelID := range category.Channels {
+				if channelID == channel.Id {
+					count++
+				}
+			}
+			assert.Equal(t, 1, count, "channel should appear exactly once in the default category")
+		}
+	}
+}

--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -3996,3 +3996,65 @@ func TestPatchChannelWithCategorySorting(t *testing.T) {
 	require.Equal(t, "Disabled Category/Channel Name", patchedChannel.DisplayName)
 	require.Equal(t, "New Category", patchedChannel.DefaultCategoryName)
 }
+
+func TestPatchChannelDefaultCategoryMovesOutOfChannels(t *testing.T) {
+	th := Setup(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.TeamSettings.EnableChannelCategorySorting = true
+	})
+
+	// Create several channels so the target sits at an index > 0 in the default Channels category,
+	// exercising the path that previously panicked when removing the channel from its original category.
+	var channels []*model.Channel
+	for range 3 {
+		c := th.createChannel(t, th.BasicTeam, model.ChannelTypeOpen)
+		channels = append(channels, c)
+	}
+
+	categories, appErr := th.App.GetSidebarCategoriesForTeamForUser(th.Context, th.BasicUser.Id, th.BasicTeam.Id)
+	require.Nil(t, appErr)
+
+	var channelsCategory *model.SidebarCategoryWithChannels
+	for _, category := range categories.Categories {
+		if category.Type == model.SidebarCategoryChannels {
+			channelsCategory = category
+			break
+		}
+	}
+	require.NotNil(t, channelsCategory)
+
+	created := make(map[string]*model.Channel, len(channels))
+	for _, c := range channels {
+		created[c.Id] = c
+	}
+
+	// Pick the created channel sitting at the highest index in the default Channels category so the
+	// removal path operates on an index > 1, which previously triggered an out-of-range panic.
+	var target *model.Channel
+	targetIndex := -1
+	for i, channelID := range channelsCategory.Channels {
+		if c, ok := created[channelID]; ok && i > targetIndex {
+			target = c
+			targetIndex = i
+		}
+	}
+	require.NotNil(t, target)
+	require.Greater(t, targetIndex, 1, "expected a created channel beyond index 1 to exercise the removal path")
+
+	patch := &model.ChannelPatch{DefaultCategoryName: new("Moved Category")}
+	_, appErr = th.App.PatchChannel(th.Context, target, patch, th.BasicUser.Id)
+	require.Nil(t, appErr)
+
+	categories, appErr = th.App.GetSidebarCategoriesForTeamForUser(th.Context, th.BasicUser.Id, th.BasicTeam.Id)
+	require.Nil(t, appErr)
+
+	for _, category := range categories.Categories {
+		switch {
+		case category.DisplayName == "Moved Category":
+			assert.Contains(t, category.Channels, target.Id, "channel should be in the new default category")
+		case category.Type == model.SidebarCategoryChannels:
+			assert.NotContains(t, category.Channels, target.Id, "channel should no longer be in the default Channels category")
+		}
+	}
+}


### PR DESCRIPTION
#### Summary
When a channel that was sitting in the default Channels category had a default category assigned, it could end up in both categories. The original-category lookup only matched custom categories, so the channel was never removed from Channels. Broadening that lookup to include the Channels category then exposed a latent bug in the removal: `slices.Delete(channels, idx, 1)` passed a literal `1` as the end index, which only works when the channel is first in the list and panics when its index is greater than 1.

This PR makes the lookup also consider the default Channels category (excluding the target) and fixes the deletion to remove the correct element via `slices.Delete(channels, idx, idx+1)`, so the channel is moved out of its original category instead of being duplicated.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69115

#### Release Note
```release-note
Fixed an issue where a channel could appear in two sidebar categories when a default category was assigned.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Small, focused fix in sidebar category lookup and slice deletion confined to channel category handling; unit tests added for the affected flows reduce regression risk and no core auth, persistence, or public API changes are introduced.  
**QA Recommendation:** Minimal manual QA: smoke-test moving channels between default/custom categories (including non-first indices) to confirm no duplicates or panics; automated tests cover idempotency.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->