### PR TITLE
Fix: Scroll pop caused because of delayed correction.

### DIFF
--- a/webapp/channels/src/components/dynamic_virtualized_list/list_item.test.tsx
+++ b/webapp/channels/src/components/dynamic_virtualized_list/list_item.test.tsx
@@ -18,15 +18,6 @@ jest.mock('./list_item_size_observer', () => {
     };
 });
 
-jest.mock('lodash/debounce', () => {
-    return jest.fn((fn) => {
-        const debouncedFn = (...args: any[]) => fn(...args);
-        debouncedFn.cancel = jest.fn();
-        debouncedFn.flush = jest.fn();
-        return debouncedFn;
-    });
-});
-
 import ListItem from './list_item';
 
 describe('ListItem', () => {

--- a/webapp/channels/src/components/dynamic_virtualized_list/list_item.tsx
+++ b/webapp/channels/src/components/dynamic_virtualized_list/list_item.tsx
@@ -1,13 +1,10 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import debounce from 'lodash/debounce';
 import type {ReactNode} from 'react';
 import React, {memo, useLayoutEffect, useRef} from 'react';
 
 import {ListItemSizeObserver} from './list_item_size_observer';
-
-const RESIZE_DEBOUNCE_TIME = 200; // in ms
 
 const listItemSizeObserver = ListItemSizeObserver.getInstance();
 
@@ -49,7 +46,7 @@ const ListItem = (props: Props) => {
 
     // This effects adds the observer which calls height change callback debounced
     useLayoutEffect(() => {
-        const debouncedOnHeightChange = debounce((changedHeight: number) => {
+        const debouncedOnHeightChange = (changedHeight: number) => {
             // Check if component is still mounted as it may have been
             // unmounted by the time the debounced function is called
             if (!rowRef.current) {
@@ -63,7 +60,7 @@ const ListItem = (props: Props) => {
             heightRef.current = changedHeight;
 
             props.onHeightChange(props.itemId, changedHeight, forceScrollCorrection);
-        }, RESIZE_DEBOUNCE_TIME);
+        };
 
         function itemRowSizeObserverCallback(changedHeight: number) {
             if (!rowRef.current) {
@@ -85,7 +82,6 @@ const ListItem = (props: Props) => {
         return () => {
             // We remove the observer here from a row
             cleanupSizeObserver?.();
-            debouncedOnHeightChange?.cancel();
             props.onUnmount(props.itemId, indexRef.current);
         };
     }, [props.itemId]);

--- a/webapp/channels/src/components/dynamic_virtualized_list/list_item.tsx
+++ b/webapp/channels/src/components/dynamic_virtualized_list/list_item.tsx
@@ -44,7 +44,7 @@ const ListItem = (props: Props) => {
         props.onHeightChange(props.itemId, newHeight, false);
     }, [props.itemId]);
 
-    // This effects adds the observer which calls height change callback debounced
+    // This effects adds the observer which calls height change callback
     useLayoutEffect(() => {
         function itemRowSizeObserverCallback(changedHeight: number) {
             if (!rowRef.current) {

--- a/webapp/channels/src/components/dynamic_virtualized_list/list_item.tsx
+++ b/webapp/channels/src/components/dynamic_virtualized_list/list_item.tsx
@@ -46,29 +46,19 @@ const ListItem = (props: Props) => {
 
     // This effects adds the observer which calls height change callback debounced
     useLayoutEffect(() => {
-        const debouncedOnHeightChange = (changedHeight: number) => {
-            // Check if component is still mounted as it may have been
-            // unmounted by the time the debounced function is called
-            if (!rowRef.current) {
-                return;
-            }
-
-            // If width of container has changed then scroll bar position will be out of sync
-            // so we need to force a scroll correction
-            const forceScrollCorrection = rowRef.current.offsetWidth !== widthRef.current;
-
-            heightRef.current = changedHeight;
-
-            props.onHeightChange(props.itemId, changedHeight, forceScrollCorrection);
-        };
-
         function itemRowSizeObserverCallback(changedHeight: number) {
             if (!rowRef.current) {
                 return;
             }
 
             if (changedHeight !== heightRef.current) {
-                debouncedOnHeightChange(changedHeight);
+            // If width of container has changed then scroll bar position will be out of sync
+            // so we need to force a scroll correction
+                const forceScrollCorrection = rowRef.current.offsetWidth !== widthRef.current;
+
+                heightRef.current = changedHeight;
+
+                props.onHeightChange(props.itemId, changedHeight, forceScrollCorrection);
             }
         }
 


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
 * Debounce on resize Observer is causing a delayed scroll correction. causing scroll pop. Can be seen on a recurring visit to channel or on opening RHS for threads.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69171

#### Screenshots
The gifs highlights the issue of stack trace call of debounce matching the scroll correction.
<img width="1680" height="932" alt="Jun-03-2026 17-30-00" src="https://github.com/user-attachments/assets/c5fba7b5-36b5-4b5d-9f7a-e2efe3c765cb" />


#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Removing the debounce from the ResizeObserver in the ListItem component reduces delay for height corrections but can increase layout churn or extra reflows during rapid size changes; the change is localized to virtualized list rendering and does not touch authentication, persistence, or public APIs.  
**QA Recommendation:** Manual QA focused on virtualized list scenarios is recommended: recurring channel visits, RHS thread open/close, rapid list re-renders, and large-list/slow-device scenarios to confirm no new jank or regressions.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->