### PR TITLE
ci: invoke post-server-ci workflows via workflow_call from Server CI

### DIFF
--- a/.github/workflows/sentry.yaml
+++ b/.github/workflows/sentry.yaml
@@ -1,12 +1,15 @@
-## Upload sentry results when Server CI Master is completed
+## Upload sentry results when Server CI master push completes (via workflow_call from server-ci.yml).
 name: Sentry Upload
 
 on:
-  workflow_run:
-    workflows:
-      - "Server CI"
-    types:
-      - completed
+  workflow_call:
+    secrets:
+      SENTRY_AUTH_TOKEN:
+        required: true
+      SENTRY_ORG:
+        required: true
+      SENTRY_PROJECT:
+        required: true
 
 permissions:
   contents: read
@@ -16,9 +19,9 @@ jobs:
     name: Send build info to sentry
     runs-on: ubuntu-22.04
     env:
-      SENTRY_AUTH_TOKEN: ${{ secrets.MM_SERVER_SENTRY_AUTH_TOKEN }}
-      SENTRY_ORG: ${{ secrets.MM_SERVER_SENTRY_ORG }}
-      SENTRY_PROJECT: ${{ secrets.MM_SERVER_SENTRY_PROJECT }}
+      SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}
     steps:
       - name: cd/Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/.github/workflows/server-ci-artifacts.yml
+++ b/.github/workflows/server-ci-artifacts.yml
@@ -1,11 +1,35 @@
 name: Server CI Artifacts
 
 on:
-  workflow_run:
-    workflows:
-      - "Server CI"
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      source-run-id:
+        description: Server CI workflow run ID (for artifact download)
+        required: true
+        type: string
+      source-event:
+        description: github.event_name from the Server CI run
+        required: true
+        type: string
+      head-sha:
+        description: Commit SHA for status and published artifacts
+        required: true
+        type: string
+      head-repository:
+        description: head_repository.full_name from the Server CI run
+        required: true
+        type: string
+    secrets:
+      PR_BUILDS_BUCKET_AWS_ACCESS_KEY_ID:
+        required: true
+      PR_BUILDS_BUCKET_AWS_SECRET_ACCESS_KEY:
+        required: true
+      DOCKERHUB_DEV_TOKEN:
+        required: true
+      WIZ_DEVOPS_CLIENT_ID:
+        required: true
+      WIZ_DEVOPS_CLIENT_SECRET:
+        required: true
 
 env:
   COSIGN_VERSION: 2.2.0
@@ -18,7 +42,7 @@ jobs:
   update-initial-status:
     permissions:
       statuses: write
-    if: github.repository_owner == 'mattermost' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name == github.repository
+    if: github.repository_owner == 'mattermost' && inputs.source-event == 'pull_request' && inputs.head-repository == github.repository
     runs-on: ubuntu-22.04
     steps:
       - uses: mattermost/actions/delivery/update-commit-status@f324ac89b05cc3511cb06e60642ac2fb829f0a63
@@ -26,7 +50,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           repository_full_name: ${{ github.repository }}
-          commit_sha: ${{ github.event.workflow_run.head_sha }}
+          commit_sha: ${{ inputs.head-sha }}
           context: Server CI/Artifacts Build
           description: Artifacts upload and build for mattermost team platform
           status: pending
@@ -49,7 +73,7 @@ jobs:
       - name: cd/download-artifacts-from-PR-workflow
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.source-run-id }}
           github-token: ${{ github.token }}
           name: server-dist-artifact
           path: server/dist
@@ -63,12 +87,12 @@ jobs:
 
       - name: cd/upload-artifacts-to-s3
         env:
-          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ inputs.head-sha }}
         run: aws s3 sync server/dist/ "s3://pr-builds.mattermost.com/mattermost/commit/${WORKFLOW_RUN_HEAD_SHA}/" --cache-control no-cache --no-progress --acl public-read
 
       - name: cd/generate-summary
         env:
-          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ inputs.head-sha }}
         run: |
           echo "### Download links for Mattermost team package" >> "${GITHUB_STEP_SUMMARY}"
           echo " " >> "${GITHUB_STEP_SUMMARY}"
@@ -97,7 +121,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_DEV_TOKEN }}
 
       - name: cd/checkout-build-files
-        if: github.event.workflow_run.head_repository.full_name != github.repository
+        if: inputs.head-repository != github.repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
@@ -105,10 +129,10 @@ jobs:
           sparse-checkout-cone-mode: true
 
       - name: cd/download-build-artifact
-        if: github.event.workflow_run.head_repository.full_name == github.repository
+        if: inputs.head-repository == github.repository
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.source-run-id }}
           github-token: ${{ github.token }}
           name: server-build-artifact
           path: server/build/
@@ -124,14 +148,14 @@ jobs:
       - name: cd/set-docker-tag
         id: set_tag
         env:
-          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ inputs.head-sha }}
         run: |
           echo "TAG=$(echo "${WORKFLOW_RUN_HEAD_SHA}" | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: cd/docker-build-and-push
         id: docker
         env:
-          MM_PACKAGE: https://pr-builds.mattermost.com/mattermost/commit/${{ github.event.workflow_run.head_sha }}/mattermost-team-linux-amd64.tar.gz
+          MM_PACKAGE: https://pr-builds.mattermost.com/mattermost/commit/${{ inputs.head-sha }}/mattermost-team-linux-amd64.tar.gz
           TAG: ${{ steps.set_tag.outputs.TAG }}
         run: |
           cd server/build
@@ -142,7 +166,7 @@ jobs:
         env:
           DOCKERHUB_IMAGE_DIGEST: ${{ steps.docker.outputs.DOCKERHUB_IMAGE_DIGEST }}
           TAG: ${{ steps.set_tag.outputs.TAG }}
-          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ inputs.head-sha }}
         run: |
           echo "### Docker Image for Mattermost team package" >> "${GITHUB_STEP_SUMMARY}"
           echo " " >> "${GITHUB_STEP_SUMMARY}"
@@ -183,7 +207,7 @@ jobs:
   update-failure-final-status:
     permissions:
       statuses: write
-    if: (failure() || cancelled()) && github.event.workflow_run.event == 'pull_request'
+    if: (failure() || cancelled()) && inputs.source-event == 'pull_request'
     runs-on: ubuntu-22.04
     needs:
       - build-docker
@@ -193,7 +217,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           repository_full_name: ${{ github.repository }}
-          commit_sha: ${{ github.event.workflow_run.head_sha }}
+          commit_sha: ${{ inputs.head-sha }}
           context: Server CI/Artifacts Build
           description: Artifacts upload and build for mattermost team platform
           status: failure
@@ -201,7 +225,7 @@ jobs:
   update-success-final-status:
     permissions:
       statuses: write
-    if: success() && github.event.workflow_run.event == 'pull_request'
+    if: success() && inputs.source-event == 'pull_request'
     runs-on: ubuntu-22.04
     needs:
       - build-docker
@@ -211,7 +235,7 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         with:
           repository_full_name: ${{ github.repository }}
-          commit_sha: ${{ github.event.workflow_run.head_sha }}
+          commit_sha: ${{ inputs.head-sha }}
           context: Server CI/Artifacts Build
           description: Artifacts upload and build for mattermost team platform
           status: success

--- a/.github/workflows/server-ci-report.yml
+++ b/.github/workflows/server-ci-report.yml
@@ -1,13 +1,36 @@
-# Server CI Report can be triggered by any branch, but always runs on the default branch.
-# That means changes to this file won't reflect in a pull request but must first be merged.
+# Server CI Report is invoked via workflow_call from server-ci.yml after test jobs finish.
 name: Server CI Report
 
 on:
-  workflow_run:
-    workflows:
-      - Server CI
-    types:
-      - completed
+  workflow_call:
+    inputs:
+      source-run-id:
+        description: Server CI workflow run ID (for artifact download)
+        required: true
+        type: string
+      source-event:
+        description: github.event_name from the Server CI run
+        required: true
+        type: string
+      head-commit-id:
+        description: Commit ID for junit report annotations
+        required: true
+        type: string
+      head-repository:
+        description: head_repository.full_name from the Server CI run
+        required: true
+        type: string
+      workflow-url:
+        description: HTML URL of the Server CI workflow run
+        required: true
+        type: string
+    secrets:
+      WEBHOOK_URL_FLAKY_TEST:
+        required: false
+      WEBHOOK_AUTH_TOKEN_FLAKY_TEST:
+        required: false
+      WEBHOOK_URL_FLAKY_TEST_MM:
+        required: false
 
 permissions: {}
 
@@ -16,6 +39,7 @@ jobs:
     permissions:
       actions: read
       contents: read
+    if: inputs.head-repository == github.repository
     runs-on: ubuntu-22.04
     outputs:
       REPORT_MATRIX: ${{ steps.report.outputs.REPORT_MATRIX }}
@@ -23,7 +47,7 @@ jobs:
       - name: report/download-artifacts-from-PR-workflow
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.source-run-id }}
           github-token: ${{ github.token }}
           pattern: "*-test-logs"
           path: reports
@@ -76,12 +100,12 @@ jobs:
       - name: report/download-artifacts-from-PR-workflow
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
-          run-id: ${{ github.event.workflow_run.id }}
+          run-id: ${{ inputs.source-run-id }}
           github-token: ${{ github.token }}
           name: ${{ matrix.test.artifact }}
           path: ${{ matrix.test.artifact }}
       - name: report/fetch-pr-number
-        if: github.event.workflow_run.event == 'pull_request'
+        if: inputs.source-event == 'pull_request'
         id: incoming-pr
         env:
           ARTIFACT: "${{ matrix.test.artifact }}"
@@ -105,7 +129,7 @@ jobs:
           report_paths: ${{ matrix.test.artifact }}/report.xml
           check_name: ${{ matrix.test.name }} (Results)
           job_name: ${{ matrix.test.name }}
-          commit: ${{ github.event.workflow_run.head_commit.id }}
+          commit: ${{ inputs.head-commit-id }}
           require_tests: true
           check_retries: true
           flaky_summary: true
@@ -116,7 +140,7 @@ jobs:
         if: >-
           steps.report.outputs.flaky_summary != '<table><tr><th>Test</th><th>Retries</th></tr></table>'
           && steps.report.outputs.failed == '0'
-          && github.event.workflow_run.event == 'pull_request'
+          && inputs.source-event == 'pull_request'
           && env.WEBHOOK_URL_FLAKY_TEST_MM != ''
         continue-on-error: true
         env:
@@ -125,7 +149,7 @@ jobs:
           PR_NUMBER: ${{ steps.incoming-pr.outputs.NUMBER }}
           TEST_NAME: ${{ matrix.test.name }}
           REPO: ${{ github.repository }}
-          WORKFLOW_RUN_HTML_URL: ${{ github.event.workflow_run.html_url }}
+          WORKFLOW_RUN_HTML_URL: ${{ inputs.workflow-url }}
           SERVER_URL: ${{ github.server_url }}
         run: |
           PR_URL="${SERVER_URL}/${REPO}/pull/${PR_NUMBER}"
@@ -169,7 +193,7 @@ jobs:
         if: >-
           steps.report.outputs.flaky_summary != '<table><tr><th>Test</th><th>Retries</th></tr></table>'
           && steps.report.outputs.failed == '0'
-          && github.event.workflow_run.event == 'pull_request'
+          && inputs.source-event == 'pull_request'
           && env.WEBHOOK_URL_FLAKY_TEST != ''
           && env.WEBHOOK_AUTH_TOKEN_FLAKY_TEST != ''
         continue-on-error: true

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -475,3 +475,94 @@ jobs:
           name: server-build-artifact
           path: server/build/
           retention-days: 2
+
+  # ci-complete is used to determine if the Server CI is complete since
+  # fips steps are optional and can be skipped. When we build with fips,
+  # we want to ensure that the Server CI is complete before running the
+  # artifacts upload workflow.
+  ci-complete:
+    name: Server CI Complete
+    if: >-
+      always() &&
+      (needs.test-mmctl-fips.result == 'success' || needs.test-mmctl-fips.result == 'skipped' || needs.test-mmctl-fips.result == 'failure') &&
+      (needs.merge-postgres-fips-test-results.result == 'success' || needs.merge-postgres-fips-test-results.result == 'skipped' || needs.merge-postgres-fips-test-results.result == 'failure')
+    permissions: {}
+    runs-on: ubuntu-22.04
+    needs:
+      - merge-postgres-test-results
+      - test-elasticsearch-v8
+      - test-opensearch-v2
+      - test-mmctl
+      - test-mmctl-fips
+      - build-mattermost-server
+      - merge-postgres-fips-test-results
+    steps:
+      - name: Server CI Complete
+        run: echo "Server CI Complete"
+
+  ci-report:
+    name: Server CI Report
+    if: always()
+    permissions:
+      contents: read
+      actions: read
+      checks: write
+      pull-requests: write
+      issues: write
+    needs:
+      - ci-complete
+    uses: ./.github/workflows/server-ci-report.yml
+    secrets:
+      WEBHOOK_URL_FLAKY_TEST: ${{ secrets.WEBHOOK_URL_FLAKY_TEST }}
+      WEBHOOK_AUTH_TOKEN_FLAKY_TEST: ${{ secrets.WEBHOOK_AUTH_TOKEN_FLAKY_TEST }}
+      WEBHOOK_URL_FLAKY_TEST_MM: ${{ secrets.WEBHOOK_URL_FLAKY_TEST_MM }}
+    with:
+      source-run-id: ${{ github.run_id }}
+      source-event: ${{ github.event_name }}
+      head-commit-id: ${{ github.event.pull_request.head.sha || github.sha }}
+      head-repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+      workflow-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+  ci-artifacts:
+    name: Server CI Artifacts
+    if: >-
+      success('ci-complete') &&
+      github.repository_owner == 'mattermost' &&
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    permissions:
+      contents: read
+      actions: read
+      statuses: write
+    needs:
+      - ci-complete
+    uses: ./.github/workflows/server-ci-artifacts.yml
+    secrets:
+      PR_BUILDS_BUCKET_AWS_ACCESS_KEY_ID: ${{ secrets.PR_BUILDS_BUCKET_AWS_ACCESS_KEY_ID }}
+      PR_BUILDS_BUCKET_AWS_SECRET_ACCESS_KEY: ${{ secrets.PR_BUILDS_BUCKET_AWS_SECRET_ACCESS_KEY }}
+      DOCKERHUB_DEV_TOKEN: ${{ secrets.DOCKERHUB_DEV_TOKEN }}
+      WIZ_DEVOPS_CLIENT_ID: ${{ secrets.WIZ_DEVOPS_CLIENT_ID }}
+      WIZ_DEVOPS_CLIENT_SECRET: ${{ secrets.WIZ_DEVOPS_CLIENT_SECRET }}
+    with:
+      source-run-id: ${{ github.run_id }}
+      source-event: ${{ github.event_name }}
+      head-sha: ${{ github.event.pull_request.head.sha }}
+      head-repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+  ci-sentry:
+    name: Sentry Upload
+    # Only run Sentry upload for master branch as mentioned in old workflow title.
+    if: >-
+      always() &&
+      github.repository_owner == 'mattermost' &&
+      github.event_name == 'push' &&
+      github.ref == 'refs/heads/master'
+    permissions:
+      contents: read
+    needs:
+      - ci-complete
+    uses: ./.github/workflows/sentry.yaml
+    secrets:
+      SENTRY_AUTH_TOKEN: ${{ secrets.MM_SERVER_SENTRY_AUTH_TOKEN }}
+      SENTRY_ORG: ${{ secrets.MM_SERVER_SENTRY_ORG }}
+      SENTRY_PROJECT: ${{ secrets.MM_SERVER_SENTRY_PROJECT }}


### PR DESCRIPTION
#### Summary
ci: invoke post-server-ci workflows via workflow_call from Server CI

#### Ticket Link
https://mattermost.atlassian.net/browse/SEC-10331

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The refactor from `workflow_run` to `workflow_call` alters CI orchestration and parameter passing across multiple workflows; misconfigured inputs, secrets, or `ci-complete` conditions could break downstream reporting, artifact uploads, or Sentry uploads for PRs and master builds.  
**QA Recommendation:** Perform full manual CI validation across key scenarios (PR builds, master pushes, and FIPS-related runs) to confirm `ci-report`, `ci-artifacts`, and `ci-sentry` trigger and receive correct inputs before merging.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->