### PR TITLE
Accept release-branch ref for RELEASE in e2e-fulltests-ci

### DIFF
--- a/.github/workflows/e2e-fulltests-ci.yml
+++ b/.github/workflows/e2e-fulltests-ci.yml
@@ -173,10 +173,23 @@ jobs:
             RELEASE | RELEASE_CLOUD)
               ### Populate support variables
               _TEST_FILTER_CYPRESS_VARIABLE="TEST_FILTER_CYPRESS_PROD_${SERVER@U}"
-              ### For ref and image tag generation: assume the 'inputs.ref' is a tag, and use the first two digits to construct the branch name
               COMMIT_SHA="$(git rev-parse --verify HEAD)"
-              BRANCH=$(sed -E "s/v([0-9]+)\.([0-9]+)\..+$/release-\1.\2/g" <<<$REF)
-              SERVER_IMAGE_TAG="$(cut -c2- <<<$REF)"   # Remove the leading 'v' from the given tag name, to generate the docker image tag
+              if [[ "$REF" =~ ^release-[0-9]+\.[0-9]+$ ]]; then
+                ### Release-branch testing: 'inputs.ref' is a release branch (e.g. 'release-11.4'),
+                ### as used by the automated branch-cut / push triggers. The server image is the
+                ### branch-tagged image published by the platform packaging pipeline (e.g. 'release-11.4').
+                BRANCH="$REF"
+                SERVER_IMAGE_TAG="$REF"
+                ### Run sanity assertions after variable generations
+                git show-ref --verify "refs/remotes/origin/${BRANCH}" # The given release branch must exist
+              else
+                ### Tag testing (default): assume 'inputs.ref' is a tag, and use the first two digits to construct the branch name
+                BRANCH=$(sed -E "s/v([0-9]+)\.([0-9]+)\..+$/release-\1.\2/g" <<<$REF)
+                SERVER_IMAGE_TAG="$(cut -c2- <<<$REF)"   # Remove the leading 'v' from the given tag name, to generate the docker image tag
+                ### Run sanity assertions after variable generations
+                git show-ref --verify "refs/tags/${REF}"              # 'inputs.ref' must be a tag, for release report types
+                git show-ref --verify "refs/remotes/origin/${BRANCH}" # The release branch computed from the given tag must exist
+              fi
               SERVER_IMAGE_ORG=mattermost
               BUILD_ID_SUFFIX="release-${SERVER}-ent"
               BUILD_ID_SUFFIX_IN_STATUS_CHECK=true
@@ -184,9 +197,6 @@ jobs:
               TEST_FILTER_CYPRESS="${!_TEST_FILTER_CYPRESS_VARIABLE}"
               TM4J_ENABLE=true
               COMPUTED_REPORT_TYPE=RELEASE
-              ### Run sanity assertions after variable generations
-              git show-ref --verify "refs/tags/${REF}"              # 'inputs.ref' must be a tag, for release report types
-              git show-ref --verify "refs/remotes/origin/${BRANCH}" # The release branch computed from the given tag must exist
               ;;
             *)
               echo "Fatal: unimplemented test type. Aborting."


### PR DESCRIPTION
## Summary

The `RELEASE`/`RELEASE_CLOUD` path in `generate-test-variables` (in `e2e-fulltests-ci.yml`) previously required `inputs.ref` to be a git tag (`vX.Y.Z`). This change also accepts a **release-branch** ref (`release-X.Y`): when `ref` matches `release-X.Y`, it is used directly as the branch and as the server image tag (the branch-tagged image published by the packaging pipeline). The existing tag path is preserved unchanged.

## Why

Enables the `delivery-platform` branch-cut sensor to trigger the **Rolling Release upgrade test** against a freshly-cut `release-X.Y` branch. The rolling-release plumbing (`ROLLING_RELEASE_FROM_TAG`) only exists in this workflow, which is why it must accept a branch ref.

## Companion PR

Driven by new Argo Events sensors in `mattermost/delivery-platform` (branch `automate-release-e2e-rolling`).

## Verification

- Full workflow YAML parses; the modified `generate` step passes `bash -n`.
- Behavioral check: `release-11.4` → branch mode (image tag `release-11.4`); `v11.4.0` / `v11.4.0-rc3` → tag mode (branch `release-11.4`, image `11.4.0` / `11.4.0-rc3`). Tag path output is unchanged from before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change introduces a new conditional path in the e2e workflow to accept release-branch refs (e.g., release-X.Y) alongside existing tag-based handling; tag behavior is preserved but the new regex/branch-selection and git-ref checks are new and could have edge-case failures in bash or git-ref resolution.  
**QA Recommendation:** Perform manual QA: trigger the workflow with a release branch ref (e.g., release-11.4) to confirm branch mode sets BRANCH and SERVER_IMAGE_TAG correctly, and validate tag-mode with v11.4.0 and v11.4.0-rc3 to ensure no regressions; verify git show-ref assertions before relying on automated runs.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->