### PR TITLE
ci: scope GitHub Actions workflows

### DIFF
--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -19,13 +19,12 @@ on:
 env:
   CHAINCTL_IDENTITY: ee399b4c72dd4e58e3d617f78fc47b74733c9557/922f2d48307d6f5f
 
-# Permissions required for chainguard-dev/setup-chainctl
-permissions:
-  id-token: write
-  contents: read
+permissions: {}
 
 jobs:
   build-image:
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     steps:
       - name: buildenv/checkout-repo
@@ -71,6 +70,9 @@ jobs:
           tags: mattermost/mattermost-build-server:${{ steps.go.outputs.GO_VERSION }}
 
   build-image-fips:
+    permissions:
+      contents: read
+      id-token: write
     runs-on: ubuntu-22.04
     steps:
       - uses: chainguard-dev/setup-chainctl@c125f765e82b09a42af3185f3214465314d75c5d # v0.5.0

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,6 +10,8 @@ on:
   pull_request_review:
     types: [submitted]
 
+permissions: {}
+
 jobs:
   claude:
     if: |

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,12 +7,12 @@ on:
   schedule:
     - cron: "30 5,17 * * *"
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   analyze:
     permissions:
+      contents: read
       security-events: write # for github/codeql-action/autobuild to send a status report
     name: Analyze
     if: github.repository_owner == 'mattermost'

--- a/.github/workflows/config-change-checker.yml
+++ b/.github/workflows/config-change-checker.yml
@@ -27,7 +27,9 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
- 
+
+permissions: {}
+
 jobs:
   check-release-notes:
     name: Detect release-note-worthy changes

--- a/.github/workflows/docker-push-mirrored.yml
+++ b/.github/workflows/docker-push-mirrored.yml
@@ -7,6 +7,9 @@ on:
     paths:
       - server/scripts/mirror-docker-images.*
 
+permissions:
+  contents: read
+
 jobs:
   build-docker:
     name: cd/Push mirrored docker images

--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -10,14 +10,15 @@ concurrency:
   group: ${{ format('docs-impact-{0}', github.event.pull_request.number) }}
   cancel-in-progress: true
  
-permissions:
-  contents: read
-  pull-requests: write
-  issues: write
-  id-token: write
- 
+permissions: {}
+
 jobs:
   docs-impact-review:
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
     if: github.event.pull_request.draft == false && !startsWith(github.event.pull_request.user.login, 'unified-ci-app')
     runs-on: ubuntu-24.04
     env:

--- a/.github/workflows/e2e-fulltests-ci.yml
+++ b/.github/workflows/e2e-fulltests-ci.yml
@@ -56,6 +56,8 @@ concurrency:
   group: "${{ github.workflow }}-${{ inputs.REPORT_TYPE }}-${{ inputs.FIPS_ENABLED }}-${{ inputs.PR_NUMBER || inputs.ref }}-${{ inputs.MM_ENV }}"
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   generate-test-variables:
     runs-on: ubuntu-24.04

--- a/.github/workflows/e2e-fulltests-ci.yml
+++ b/.github/workflows/e2e-fulltests-ci.yml
@@ -62,6 +62,7 @@ jobs:
   generate-test-variables:
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
       issues: write
       pull-requests: write
     defaults:

--- a/.github/workflows/e2e-tests-check.yml
+++ b/.github/workflows/e2e-tests-check.yml
@@ -8,6 +8,9 @@ on:
       - "webapp/platform/types/**"
       - ".github/workflows/e2e-*.yml"
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-24.04

--- a/.github/workflows/e2e-tests-check.yml
+++ b/.github/workflows/e2e-tests-check.yml
@@ -9,7 +9,9 @@ on:
       - ".github/workflows/e2e-*.yml"
 
 permissions:
+  actions: write
   contents: read
+  pull-requests: read
 
 jobs:
   check:

--- a/.github/workflows/e2e-tests-ci-template.yml
+++ b/.github/workflows/e2e-tests-ci-template.yml
@@ -97,8 +97,12 @@ on:
       playwright_report_url:
         value: ${{ jobs.report.outputs.playwright_report_url }}
 
+permissions: {}
+
 jobs:
   update-initial-status:
+    permissions:
+      statuses: write
     runs-on: ubuntu-24.04
     steps:
       - uses: mattermost/actions/delivery/update-commit-status@f324ac89b05cc3511cb06e60642ac2fb829f0a63
@@ -112,6 +116,8 @@ jobs:
           status: pending
 
   generate-build-variables:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     needs:
       - update-initial-status
@@ -139,6 +145,8 @@ jobs:
           echo "node-cache-dependency-path=e2e-tests/${TEST}/package-lock.json" >> $GITHUB_OUTPUT
 
   generate-test-cycle:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     needs:
       - generate-build-variables
@@ -183,6 +191,9 @@ jobs:
           fi
 
   test:
+    permissions:
+      contents: read
+      actions: write
     continue-on-error: true # Individual runner failures shouldn't prevent the completion of an E2E run
     strategy:
       fail-fast: false # Individual runner failures shouldn't prevent the completion of an E2E run
@@ -327,6 +338,9 @@ jobs:
           retention-days: 1
 
   report:
+    permissions:
+      actions: write
+      contents: read
     runs-on: ubuntu-24.04
     needs:
       - test
@@ -475,6 +489,8 @@ jobs:
           [ "${{ steps.calculate-results.outputs.failed }}" = "0" ]
 
   update-failure-final-status:
+    permissions:
+      statuses: write
     runs-on: ubuntu-24.04
     if: failure() || cancelled()
     needs:
@@ -498,6 +514,8 @@ jobs:
 
 
   update-success-final-status:
+    permissions:
+      statuses: write
     runs-on: ubuntu-24.04
     if: success()
     needs:

--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -23,12 +23,13 @@ on:
         type: string
         required: false
 
-permissions:
-  contents: read
-  statuses: write
+permissions: {}
 
 jobs:
   resolve-pr:
+    permissions:
+      contents: read
+      pull-requests: read
     runs-on: ubuntu-24.04
     outputs:
       PR_NUMBER: "${{ steps.resolve.outputs.PR_NUMBER }}"
@@ -122,6 +123,9 @@ jobs:
 
 
   check-changes:
+    permissions:
+      contents: read
+      pull-requests: read
     needs: resolve-pr
     if: needs.resolve-pr.outputs.PR_NUMBER != ''
     runs-on: ubuntu-24.04

--- a/.github/workflows/e2e-tests-cypress.yml
+++ b/.github/workflows/e2e-tests-cypress.yml
@@ -62,9 +62,7 @@ on:
       CWS_EXTRA_HTTP_HEADERS:
         required: false
 
-permissions:
-  contents: read
-  statuses: write
+permissions: {}
 
 jobs:
   generate-build-variables:

--- a/.github/workflows/e2e-tests-on-merge.yml
+++ b/.github/workflows/e2e-tests-on-merge.yml
@@ -16,8 +16,12 @@ on:
         required: true
         description: "Docker image tag (e.g., 'abc1234_def5678' or 'master')"
 
+permissions: {}
+
 jobs:
   generate-build-variables:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     outputs:
       report_type: "${{ steps.vars.outputs.report_type }}"

--- a/.github/workflows/e2e-tests-on-release.yml
+++ b/.github/workflows/e2e-tests-on-release.yml
@@ -20,8 +20,12 @@ on:
         required: false
         description: "Comma-separated alias tags (e.g., 'release-11.4, release-11')"
 
+permissions: {}
+
 jobs:
   validate:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     outputs:
       ref_branch: "${{ steps.check.outputs.ref_branch }}"

--- a/.github/workflows/e2e-tests-override-status.yml
+++ b/.github/workflows/e2e-tests-override-status.yml
@@ -9,8 +9,14 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   override-status:
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
     runs-on: ubuntu-24.04
     steps:
       - name: Validate inputs

--- a/.github/workflows/e2e-tests-playwright.yml
+++ b/.github/workflows/e2e-tests-playwright.yml
@@ -56,9 +56,7 @@ on:
       AWS_SECRET_ACCESS_KEY:
         required: true
 
-permissions:
-  contents: read
-  statuses: write
+permissions: {}
 
 jobs:
   generate-build-variables:

--- a/.github/workflows/e2e-tests-verified-label.yml
+++ b/.github/workflows/e2e-tests-verified-label.yml
@@ -8,8 +8,14 @@ on:
 env:
   REPORT_WEBHOOK_URL: ${{ secrets.MM_E2E_REPORT_WEBHOOK_URL }}
 
+permissions: {}
+
 jobs:
   approve-e2e:
+    permissions:
+      contents: read
+      pull-requests: read
+      statuses: write
     if: github.event.label.name == 'E2E Tests/verified'
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/i18n-ci-pr.yml
+++ b/.github/workflows/i18n-ci-pr.yml
@@ -18,7 +18,6 @@ permissions:
   contents: read
 
 jobs:
-  # Caller job permissions are passed to the reusable workflow run (checkout + changed-files only).
   pr-ci:
     permissions:
       contents: read

--- a/.github/workflows/i18n-ci-pr.yml
+++ b/.github/workflows/i18n-ci-pr.yml
@@ -14,7 +14,13 @@ concurrency:
 # and it _always_ cancels pending workflows. So master CI builds
 # always kept getting canceled.
 
+permissions:
+  contents: read
+
 jobs:
+  # Caller job permissions are passed to the reusable workflow run (checkout + changed-files only).
   pr-ci:
+    permissions:
+      contents: read
     uses: ./.github/workflows/i18n-ci-template.yml
     secrets: inherit

--- a/.github/workflows/i18n-ci-template.yml
+++ b/.github/workflows/i18n-ci-template.yml
@@ -4,6 +4,9 @@ name: i18n CI Template
 on:
   workflow_call:
 
+permissions:
+  contents: read
+
 jobs:
   check-files:
     name: Check only English translation files changed

--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -22,6 +22,10 @@ on:
         default: false
         type: boolean
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   test:
     name: ${{ inputs.name }}

--- a/.github/workflows/pr-test-analysis-override.yml
+++ b/.github/workflows/pr-test-analysis-override.yml
@@ -9,6 +9,8 @@ concurrency:
   group: test-analyzer-${{ github.event.issue.number }}
   cancel-in-progress: false
 
+permissions: {}
+
 jobs:
   override:
     permissions:

--- a/.github/workflows/pr-test-analysis.yml
+++ b/.github/workflows/pr-test-analysis.yml
@@ -22,6 +22,8 @@ concurrency:
   group: test-analyzer-${{ github.event.pull_request.number || inputs.pr_number }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   analyze:
     permissions:

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -14,7 +14,6 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
-      actions: write
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).

--- a/.github/workflows/scorecards-analysis.yml
+++ b/.github/workflows/scorecards-analysis.yml
@@ -5,8 +5,7 @@ on:
   schedule:
     - cron: "44 6 * * *"
 
-# Declare default permissions as read only.
-permissions: read-all
+permissions: {}
 
 jobs:
   analysis:
@@ -14,6 +13,8 @@ jobs:
     if: github.repository_owner == 'mattermost'
     runs-on: ubuntu-24.04
     permissions:
+      contents: read
+      actions: write
       # Needed to upload the results to code-scanning dashboard.
       security-events: write
       # Needed to publish results and get a badge (see publish_results below).

--- a/.github/workflows/sentry.yaml
+++ b/.github/workflows/sentry.yaml
@@ -8,6 +8,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   sentry:
     name: Send build info to sentry

--- a/.github/workflows/server-ci-artifacts.yml
+++ b/.github/workflows/server-ci-artifacts.yml
@@ -10,10 +10,14 @@ on:
 env:
   COSIGN_VERSION: 2.2.0
 
+permissions: {}
+
 jobs:
   ## We only need the condition on the first job
   ## This will run only when a pull request is created with server changes
   update-initial-status:
+    permissions:
+      statuses: write
     if: github.repository_owner == 'mattermost' && github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_repository.full_name == github.repository
     runs-on: ubuntu-22.04
     steps:
@@ -28,6 +32,9 @@ jobs:
           status: pending
 
   upload-artifacts:
+    permissions:
+      actions: read
+      contents: read
     runs-on: ubuntu-22.04
     needs:
       - update-initial-status
@@ -70,6 +77,9 @@ jobs:
           done
 
   build-docker:
+    permissions:
+      actions: read
+      contents: read
     runs-on: ubuntu-22.04
     needs:
       - upload-artifacts
@@ -159,6 +169,8 @@ jobs:
           ./wizcli docker scan --image mattermostdevelopment/mattermost-team-edition:${{ needs.build-docker.outputs.TAG }} --policy "$POLICY"
 
   update-failure-final-status:
+    permissions:
+      statuses: write
     if: (failure() || cancelled()) && github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-22.04
     needs:
@@ -175,6 +187,8 @@ jobs:
           status: failure
 
   update-success-final-status:
+    permissions:
+      statuses: write
     if: success() && github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-22.04
     needs:

--- a/.github/workflows/server-ci-nightly-race.yml
+++ b/.github/workflows/server-ci-nightly-race.yml
@@ -39,6 +39,9 @@ jobs:
   test-race:
     name: Race Detector
     needs: go
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/server-test-template.yml
     secrets: inherit
     with:

--- a/.github/workflows/server-ci-report.yml
+++ b/.github/workflows/server-ci-report.yml
@@ -70,7 +70,6 @@ jobs:
       actions: read
       pull-requests: write
       checks: write
-      issues: write
     strategy:
       matrix: ${{ fromJson(needs.generate-report-matrix.outputs.REPORT_MATRIX) }}
     steps:

--- a/.github/workflows/server-ci-report.yml
+++ b/.github/workflows/server-ci-report.yml
@@ -9,8 +9,13 @@ on:
     types:
       - completed
 
+permissions: {}
+
 jobs:
   generate-report-matrix:
+    permissions:
+      actions: read
+      contents: read
     runs-on: ubuntu-22.04
     outputs:
       REPORT_MATRIX: ${{ steps.report.outputs.REPORT_MATRIX }}
@@ -62,6 +67,7 @@ jobs:
     needs:
       - generate-report-matrix
     permissions:
+      actions: read
       pull-requests: write
       checks: write
       issues: write

--- a/.github/workflows/server-ci-weekly.yml
+++ b/.github/workflows/server-ci-weekly.yml
@@ -40,6 +40,9 @@ jobs:
   test-postgres-binary:
     name: Postgres with binary parameters
     needs: go
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/server-test-template.yml
     secrets: inherit
     with:
@@ -57,6 +60,9 @@ jobs:
   test-postgres-normal-fips:
     name: Postgres FIPS
     needs: go
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/server-test-template.yml
     secrets: inherit
     with:
@@ -72,6 +78,9 @@ jobs:
   test-mmctl-fips:
     name: Run mmctl tests (FIPS)
     needs: go
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/mmctl-test-template.yml
     secrets: inherit
     with:

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -28,6 +28,9 @@ concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   go:
     name: Compute Go Version
@@ -281,6 +284,9 @@ jobs:
       fail-fast: false # Let all shards complete so we get full test results
       matrix:
         shard: [0, 1, 2, 3]
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/server-test-template.yml
     secrets: inherit
     with:
@@ -299,6 +305,9 @@ jobs:
     name: Merge Postgres Test Results
     needs: test-postgres-normal
     if: always()
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/server-test-merge-template.yml
     with:
       artifact-pattern: postgres-server-test-logs-shard-*
@@ -309,6 +318,9 @@ jobs:
   test-elasticsearch-v8:
     name: Elasticsearch v8 Compatibility
     needs: go
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/server-test-template.yml
     secrets: inherit
     with:
@@ -324,6 +336,9 @@ jobs:
   test-opensearch-v2:
     name: OpenSearch v2 Compatibility
     needs: go
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/server-test-template.yml
     secrets: inherit
     with:
@@ -346,6 +361,9 @@ jobs:
       fail-fast: false
       matrix:
         shard: [0, 1, 2, 3]
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/server-test-template.yml
     secrets: inherit
     with:
@@ -361,6 +379,9 @@ jobs:
     name: Merge Postgres FIPS Test Results
     needs: test-postgres-normal-fips
     if: needs.test-postgres-normal-fips.result != 'skipped'
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/server-test-merge-template.yml
     with:
       artifact-pattern: postgres-server-fips-test-logs-shard-*
@@ -369,6 +390,9 @@ jobs:
   test-mmctl:
     name: Run mmctl tests
     needs: go
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/mmctl-test-template.yml
     secrets: inherit
     with:
@@ -382,6 +406,9 @@ jobs:
     if: contains(github.head_ref, 'fips') || needs.go.outputs.gomod-changed == 'true'
     name: Run mmctl tests (FIPS)
     needs: go
+    permissions:
+      contents: read
+      actions: write
     uses: ./.github/workflows/mmctl-test-template.yml
     secrets: inherit
     with:
@@ -395,6 +422,9 @@ jobs:
   build-mattermost-server:
     name: Build mattermost server app
     needs: go
+    permissions:
+      contents: read
+      actions: write
     runs-on: ubuntu-22.04
     container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     defaults:

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -35,6 +35,9 @@ jobs:
   go:
     name: Compute Go Version
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: read
     outputs:
       version: ${{ steps.calculate.outputs.GO_VERSION }}
       gomod-changed: ${{ steps.changed-files.outputs.any_changed }}

--- a/.github/workflows/server-test-merge-template.yml
+++ b/.github/workflows/server-test-merge-template.yml
@@ -22,6 +22,10 @@ on:
         type: boolean
         default: false
 
+permissions:
+  contents: read
+  actions: write
+
 jobs:
   merge:
     name: Merge

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -67,6 +67,7 @@ on:
 
 permissions:
   contents: read
+  actions: write
 
 jobs:
   test:

--- a/.github/workflows/tag-public-module.yaml
+++ b/.github/workflows/tag-public-module.yaml
@@ -17,6 +17,8 @@ on:
         description: The commit sha to tag. Defaults to HEAD master
         required: false
 
+permissions: {}
+
 jobs:
   tag-public-module:
     permissions:

--- a/.github/workflows/tools-ci.yml
+++ b/.github/workflows/tools-ci.yml
@@ -13,6 +13,9 @@ concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   check-style:
     name: check-style (mattermost-govet)

--- a/.github/workflows/webapp-ci.yml
+++ b/.github/workflows/webapp-ci.yml
@@ -14,8 +14,12 @@ concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions: {}
+
 jobs:
   check-lint:
+    permissions:
+      contents: read
     runs-on: ubuntu-24.04
     defaults:
       run:
@@ -32,6 +36,8 @@ jobs:
           npm run check
 
   check-i18n:
+    permissions:
+      contents: read
     needs: check-lint
     runs-on: ubuntu-24.04
     defaults:
@@ -50,6 +56,8 @@ jobs:
           npm run i18n-extract:check
 
   check-external-links:
+    permissions:
+      contents: read
     needs: check-lint
     runs-on: ubuntu-24.04
     timeout-minutes: 15
@@ -69,6 +77,8 @@ jobs:
           npm run check-external-links -- --markdown | tee -a $GITHUB_STEP_SUMMARY
 
   check-types:
+    permissions:
+      contents: read
     needs: check-lint
     runs-on: ubuntu-24.04
     defaults:
@@ -90,6 +100,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
+      contents: read
+      actions: write
       checks: write
       pull-requests: write
     name: test (platform)
@@ -123,6 +135,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
+      contents: read
+      actions: write
       checks: write
       pull-requests: write
     name: test (mattermost-redux)
@@ -153,6 +167,8 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     permissions:
+      contents: read
+      actions: write
       checks: write
       pull-requests: write
     strategy:
@@ -183,6 +199,9 @@ jobs:
           retention-days: 1
 
   upload-coverage:
+    permissions:
+      contents: read
+      actions: read
     runs-on: ubuntu-24.04
     needs: [test-platform, test-mattermost-redux, test-channels]
     if: ${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.base.ref, 'release-') }}
@@ -242,6 +261,8 @@ jobs:
           flags: webapp
 
   build:
+    permissions:
+      contents: read
     needs: check-lint
     runs-on: ubuntu-24.04
     defaults:


### PR DESCRIPTION
#### Summary
ci: Scope GitHub Actions workflow and job permissions

#### Ticket Link
https://mattermost.atlassian.net/browse/SEC-10342

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Changes restrict GitHub token permissions across many workflows and jobs, creating moderate risk that workflows may fail if any required permission was missed; however most permissions were moved deliberately to job-level scopes (e.g., preserving id-token where needed), reducing likelihood of widespread breakage.

**QA Recommendation:** Run focused CI smoke runs and spot-check critical workflows (Server CI, E2E suites, image builds including FIPS/chainctl flows); prioritize verifying jobs that require id-token, statuses, or artifact uploads. Automated workflow runs should catch most issues—perform limited manual validation on highly privileged or deployment-related workflows.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->