### PR TITLE
ci: pass explicitly variables to reusable server CI workflows

### DIFF
--- a/.github/workflows/i18n-ci-pr.yml
+++ b/.github/workflows/i18n-ci-pr.yml
@@ -17,4 +17,3 @@ concurrency:
 jobs:
   pr-ci:
     uses: ./.github/workflows/i18n-ci-template.yml
-    secrets: inherit

--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -21,6 +21,15 @@ on:
         required: false
         default: false
         type: boolean
+    secrets:
+      # Only if fips-enabled is true
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
+      # Only master / release and there is report
+      MM_E2E_ZEPHYR_API_KEY:
+        required: false
 
 jobs:
   test:

--- a/.github/workflows/server-ci-nightly-race.yml
+++ b/.github/workflows/server-ci-nightly-race.yml
@@ -40,7 +40,6 @@ jobs:
     name: Race Detector
     needs: go
     uses: ./.github/workflows/server-test-template.yml
-    secrets: inherit
     with:
       name: Race Detector
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10

--- a/.github/workflows/server-ci-weekly.yml
+++ b/.github/workflows/server-ci-weekly.yml
@@ -41,7 +41,6 @@ jobs:
     name: Postgres with binary parameters
     needs: go
     uses: ./.github/workflows/server-test-template.yml
-    secrets: inherit
     with:
       name: Postgres with binary parameters
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes
@@ -58,7 +57,9 @@ jobs:
     name: Postgres FIPS
     needs: go
     uses: ./.github/workflows/server-test-template.yml
-    secrets: inherit
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
       name: Postgres FIPS
       datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
@@ -73,7 +74,10 @@ jobs:
     name: Run mmctl tests (FIPS)
     needs: go
     uses: ./.github/workflows/mmctl-test-template.yml
-    secrets: inherit
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      MM_E2E_ZEPHYR_API_KEY: ${{ secrets.MM_E2E_ZEPHYR_API_KEY }}
     with:
       name: mmctl
       datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -282,7 +282,8 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3]
     uses: ./.github/workflows/server-test-template.yml
-    secrets: inherit
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
       name: "Postgres (shard ${{ matrix.shard }})"
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
@@ -310,7 +311,6 @@ jobs:
     name: Elasticsearch v8 Compatibility
     needs: go
     uses: ./.github/workflows/server-test-template.yml
-    secrets: inherit
     with:
       name: Elasticsearch v8 Compatibility
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
@@ -325,7 +325,6 @@ jobs:
     name: OpenSearch v2 Compatibility
     needs: go
     uses: ./.github/workflows/server-test-template.yml
-    secrets: inherit
     with:
       name: OpenSearch v2 Compatibility
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
@@ -347,7 +346,9 @@ jobs:
       matrix:
         shard: [0, 1, 2, 3]
     uses: ./.github/workflows/server-test-template.yml
-    secrets: inherit
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     with:
       name: "Postgres FIPS (shard ${{ matrix.shard }})"
       datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
@@ -370,7 +371,8 @@ jobs:
     name: Run mmctl tests
     needs: go
     uses: ./.github/workflows/mmctl-test-template.yml
-    secrets: inherit
+    secrets:
+      MM_E2E_ZEPHYR_API_KEY: ${{ secrets.MM_E2E_ZEPHYR_API_KEY }}
     with:
       name: mmctl
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
@@ -383,7 +385,10 @@ jobs:
     name: Run mmctl tests (FIPS)
     needs: go
     uses: ./.github/workflows/mmctl-test-template.yml
-    secrets: inherit
+    secrets:
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+      MM_E2E_ZEPHYR_API_KEY: ${{ secrets.MM_E2E_ZEPHYR_API_KEY }}
     with:
       name: mmctl
       datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -64,6 +64,15 @@ on:
         required: false
         type: boolean
         default: false
+    secrets:
+      # Only if enablecoverage is true
+      CODECOV_TOKEN:
+        required: false
+      # Only if fips-enabled is true
+      DOCKERHUB_USERNAME:
+        required: false
+      DOCKERHUB_TOKEN:
+        required: false
 
 permissions:
   contents: read


### PR DESCRIPTION
#### Summary
ci: pass explicitly variables to reusable server CI workflows

#### Ticket Link
https://mattermost.atlassian.net/browse/SEC-10342

#### Release Note

```release-note
NONE
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 **Medium**

**Regression Risk:** The PR replaces implicit secret inheritance (`secrets: inherit`) with explicit secret passing across six workflow files, creating risk that CI pipelines may fail if callers don't explicitly pass the now-required secrets. While secrets are marked optional (required: false) to prevent immediate failures, workflows that depend on these secrets for Docker registry access, code coverage, or E2E testing may fail at runtime if secrets aren't properly mapped.

**QA Recommendation:** Manual QA should focus on verifying that all affected CI workflows (PR CI, nightly race, weekly tests, mmctl tests) successfully authenticate with Docker registries and external services. Validate that FIPS-enabled builds and E2E test reports work correctly with the new explicit secret passing. Run a subset of affected workflows end-to-end to confirm no regressions in deployment or testing pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->