### PR TITLE
Remove dynamic-virtualized-list from ignoreDependencies in config.yaml 

### DIFF
--- a/server/build/notice-file/config.yaml
+++ b/server/build/notice-file/config.yaml
@@ -7,6 +7,5 @@ search:
   - "webapp/package.json"
   - "webapp/channels/package.json"
 ignoreDependencies:
-  - "@mattermost/dynamic-virtualized-list"
   - "@mattermost/shared"
 includeDevDependencies: false

--- a/webapp/channels/src/components/dynamic_virtualized_list/README.md
+++ b/webapp/channels/src/components/dynamic_virtualized_list/README.md
@@ -1,0 +1,24 @@
+# dynamic_virtualized_list
+
+A virtualized list that supports **dynamically-sized, unmeasured items** — rows whose
+heights are not known ahead of time and are measured as they render. It is the rendering
+engine behind Mattermost's long, variable-height message lists.
+
+## Origin
+
+This code originated from [`mattermost/dynamic-virtualized-list`](https://github.com/mattermost/dynamic-virtualized-list)
+("React components for efficiently rendering dynamically sized lists", MIT-licensed). That
+package was built from a fork of an alpha version of [`react-window`](https://github.com/bvaughn/react-window),
+but took a substantially different approach — using relative rather than absolute positioning —
+to render items whose sizes aren't known ahead of time.
+
+It has since been **vendored into this monorepo** rather than consumed as an npm
+dependency, so this directory is now the canonical source.
+
+## Files
+
+| File | Purpose |
+| --- | --- |
+| `list_item.tsx` | Wrapper around each rendered row that reports its measured size back to the list. |
+| `list_item_size_observer.ts` | Tracks rendered item sizes so the list can position rows without pre-measuring them. |
+ |

--- a/webapp/channels/src/components/dynamic_virtualized_list/README.md
+++ b/webapp/channels/src/components/dynamic_virtualized_list/README.md
@@ -15,4 +15,3 @@ but took a substantially different approach — using relative rather than absol
 | --- | --- |
 | `list_item.tsx` | Wrapper around each rendered row that reports its measured size back to the list. |
 | `list_item_size_observer.ts` | Tracks rendered item sizes so the list can position rows without pre-measuring them. |
- |

--- a/webapp/channels/src/components/dynamic_virtualized_list/README.md
+++ b/webapp/channels/src/components/dynamic_virtualized_list/README.md
@@ -6,14 +6,8 @@ engine behind Mattermost's long, variable-height message lists.
 
 ## Origin
 
-This code originated from [`mattermost/dynamic-virtualized-list`](https://github.com/mattermost/dynamic-virtualized-list)
-("React components for efficiently rendering dynamically sized lists", MIT-licensed). That
-package was built from a fork of an alpha version of [`react-window`](https://github.com/bvaughn/react-window),
-but took a substantially different approach — using relative rather than absolute positioning —
-to render items whose sizes aren't known ahead of time.
-
-It has since been **vendored into this monorepo** rather than consumed as an npm
-dependency, so this directory is now the canonical source.
+This package was built from a fork of an alpha version of [`react-window`](https://github.com/bvaughn/react-window),
+but took a substantially different approach — using relative rather than absolute positioning to render items whose sizes aren't known ahead of time.
 
 ## Files
 


### PR DESCRIPTION
#### Summary
This pull request primarily documents and clarifies the purpose and origin of the `dynamic_virtualized_list` component, and updates the dependency ignore list configuration. The most significant change is the addition of a README file describing how the virtualized list works and its background.

Documentation improvements:

* Added a new `README.md` file in `webapp/channels/src/components/dynamic_virtualized_list` explaining the purpose, origin, and main files of the `dynamic_virtualized_list` component. This helps developers understand its function as a virtualized list for dynamically-sized, unmeasured items, and its relationship to `react-window`.

Configuration updates:

* Removed `@mattermost/dynamic-virtualized-list` from the `ignoreDependencies` section in `server/build/notice-file/config.yaml`, ensuring it is no longer excluded from dependency checks.

#### Ticket Link
<!--
Fixes: https://github.com/mattermost/mattermost/issues/XXX
Fixes: https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!-- Include screenshots or GIFs for UI changes. -->

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The changes only add documentation and remove a package from the dependency ignore list in a build/notice config; no runtime code or public APIs were modified, so regression risk is minimal. The only potential impact is that dependency scanning will now include `@mattermost/dynamic-virtualized-list`, which may surface licensing/notice items but does not affect application behavior.

**QA Recommendation:** Manual QA not required; verify documentation content and that CI/dependency notice generation runs without unexpected failures.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->