### PR TITLE
MM-42492 Improve emoji picker search with spaces

### DIFF
--- a/server/channels/store/sqlstore/emoji_store.go
+++ b/server/channels/store/sqlstore/emoji_store.go
@@ -6,6 +6,7 @@ package sqlstore
 import (
 	"database/sql"
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -108,13 +109,7 @@ func (es SqlEmojiStore) Delete(emoji *model.Emoji, time int64) error {
 func (es SqlEmojiStore) Search(name string, prefixOnly bool, limit int) ([]*model.Emoji, error) {
 	emojis := []*model.Emoji{}
 
-	name = sanitizeSearchTerm(name, "\\")
-
-	term := ""
-	if !prefixOnly {
-		term = "%"
-	}
-	term += name + "%"
+	term := emojiSearchTerm(name, prefixOnly)
 
 	query := es.emojiSelectQuery.
 		Where(sq.Like{"Name": term}).
@@ -125,6 +120,26 @@ func (es SqlEmojiStore) Search(name string, prefixOnly bool, limit int) ([]*mode
 		return nil, errors.Wrapf(err, "could not search emojis by name %s", name)
 	}
 	return emojis, nil
+}
+
+func emojiSearchTerm(name string, prefixOnly bool) string {
+	words := strings.Fields(name)
+	var term string
+	if len(words) > 1 {
+		sanitizedWords := make([]string, 0, len(words))
+		for _, word := range words {
+			sanitizedWords = append(sanitizedWords, sanitizeSearchTerm(word, "\\"))
+		}
+		term = strings.Join(sanitizedWords, "_")
+	} else {
+		term = sanitizeSearchTerm(name, "\\")
+	}
+
+	if !prefixOnly {
+		term = "%" + term
+	}
+
+	return term + "%"
 }
 
 // getBy returns one active (not deleted) emoji, found by any one column (what/key).

--- a/server/channels/store/storetest/emoji_store.go
+++ b/server/channels/store/storetest/emoji_store.go
@@ -301,4 +301,68 @@ func testEmojiSearch(t *testing.T, rctx request.CTX, ss store.Store) {
 
 		assert.Equal(t, shouldFind[i], found, emoji.Name)
 	}
+
+	separatorSuffix := model.NewId()
+	separatorEmojis := []model.Emoji{
+		{
+			CreatorId: model.NewId(),
+			Name:      "spider-man-" + separatorSuffix,
+		},
+		{
+			CreatorId: model.NewId(),
+			Name:      "spider_man_" + separatorSuffix,
+		},
+		{
+			CreatorId: model.NewId(),
+			Name:      "spider+man+" + separatorSuffix,
+		},
+		{
+			CreatorId: model.NewId(),
+			Name:      model.NewId() + "_spider-man-" + separatorSuffix,
+		},
+	}
+
+	for i, emoji := range separatorEmojis {
+		data, err := ss.Emoji().Save(&emoji)
+		require.NoError(t, err)
+		separatorEmojis[i] = *data
+	}
+	defer func() {
+		for _, emoji := range separatorEmojis {
+			err := ss.Emoji().Delete(&emoji, time.Now().Unix())
+			require.NoError(t, err)
+		}
+	}()
+
+	result, err = ss.Emoji().Search("spider man", true, 100)
+	require.NoError(t, err)
+	shouldFind = []bool{true, true, true, false}
+	for i, emoji := range separatorEmojis {
+		found := false
+
+		for _, savedEmoji := range result {
+			if emoji.Id == savedEmoji.Id {
+				found = true
+				break
+			}
+		}
+
+		assert.Equal(t, shouldFind[i], found, emoji.Name)
+	}
+
+	result, err = ss.Emoji().Search("spider man", false, 100)
+	require.NoError(t, err)
+	shouldFind = []bool{true, true, true, true}
+	for i, emoji := range separatorEmojis {
+		found := false
+
+		for _, savedEmoji := range result {
+			if emoji.Id == savedEmoji.Id {
+				found = true
+				break
+			}
+		}
+
+		assert.Equal(t, shouldFind[i], found, emoji.Name)
+	}
 }

--- a/webapp/channels/src/components/emoji_picker/utils/index.test.ts
+++ b/webapp/channels/src/components/emoji_picker/utils/index.test.ts
@@ -75,6 +75,11 @@ const thumbsdownEmoji = {
     short_names: ['thumbs_down', 'down'],
     name: 'thumbsdown',
 };
+const umbrellaWithRainDropsEmoji = {
+    unified: '2614',
+    short_names: ['umbrella_with_rain_drops'],
+    name: 'UMBRELLA WITH RAIN DROPS',
+};
 const okEmoji = {
     unified: 'ok',
     short_names: ['ok', 'ok_hand'],
@@ -245,6 +250,17 @@ describe('getFilteredEmojis', () => {
         const userSkinTone = '';
 
         expect(getFilteredEmojis(allEmojis as any, filter, recentEmojisString, userSkinTone)).toStrictEqual([thumbsdownEmoji]);
+    });
+
+    test('Should normalize spaces and separators in the filter', () => {
+        const allEmojis = {
+            umbrellaWithRainDrops: umbrellaWithRainDropsEmoji,
+        };
+        const filter = 'umbrella with rain drops';
+        const recentEmojisString: string[] = [];
+        const userSkinTone = '';
+
+        expect(getFilteredEmojis(allEmojis as any, filter, recentEmojisString, userSkinTone)).toStrictEqual([umbrellaWithRainDropsEmoji]);
     });
 });
 

--- a/webapp/channels/src/components/emoji_picker/utils/index.ts
+++ b/webapp/channels/src/components/emoji_picker/utils/index.ts
@@ -58,12 +58,21 @@ function isEmojiIdEqual(firstEmoji: Emoji, secondEmoji: Emoji): boolean {
     return firstEmojiId === secondEmojId;
 }
 
+function normalizeEmojiSearchTerm(term: string): string {
+    return term.toLowerCase().replace(/[\s_+-]+/g, '');
+}
+
 export function getFilteredEmojis(allEmojis: Record<string, Emoji>, filter: string, recentEmojisString: string[], userSkinTone: string): Emoji[] {
+    const normalizedFilter = normalizeEmojiSearchTerm(filter);
+    if (filter.length > 0 && normalizedFilter.length === 0) {
+        return [];
+    }
+
     const filteredEmojisWithRecent = Object.values(allEmojis).filter((emoji) => {
         const aliases = isSystemEmoji(emoji) ? emoji.short_names : [emoji.name];
 
         for (let i = 0; i < aliases.length; i++) {
-            if (aliases[i].toLowerCase().includes(filter.toLowerCase())) {
+            if (normalizeEmojiSearchTerm(aliases[i]).includes(normalizedFilter)) {
                 return true;
             }
         }


### PR DESCRIPTION
#### Summary
Improves emoji picker search so system emoji aliases match when users type spaces instead of emoji name separators. For custom emojis, server-side search now treats spaces between words as a single separator character, allowing searches like `spider man` to match names such as `spider-man`, `spider_man`, and `spider+man`.

Added focused coverage for system emoji filtering and custom emoji store search.

Validation:
- `git diff --check`
- `go test ./channels/store/sqlstore -run 'TestEmojiStore/EmojiSearch'` could not run locally because `go` is not installed in this environment.\n- `npm test -- --runTestsByPath src/components/emoji_picker/utils/index.test.ts --runInBand` could not run locally because `webapp/channels/node_modules` is missing (`cross-env: command not found`).\n\n#### Ticket Link\nFixes: https://github.com/mattermost/mattermost/issues/19792\nFixes: https://mattermost.atlassian.net/browse/MM-42492\n\n#### Release Note\n```release-note\nImproved emoji picker search to match emoji names containing separators when users type spaces.\n```