### PR TITLE
ci: use variables in shell for workflows

### DIFF
--- a/.github/actions/check-e2e-test-only/action.yml
+++ b/.github/actions/check-e2e-test-only/action.yml
@@ -29,6 +29,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
+        GITHUB_REPOSITORY: ${{ github.repository }}
         INPUT_BASE_SHA: ${{ inputs.base_sha }}
         INPUT_HEAD_SHA: ${{ inputs.head_sha }}
         INPUT_PR_NUMBER: ${{ inputs.pr_number }}
@@ -42,7 +43,7 @@ runs:
           fi
 
           echo "Resolving SHAs from PR #${INPUT_PR_NUMBER}"
-          PR_DATA=$(gh api "repos/${{ github.repository }}/pulls/${INPUT_PR_NUMBER}")
+          PR_DATA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${INPUT_PR_NUMBER}")
           INPUT_BASE_SHA=$(echo "$PR_DATA" | jq -r '.base.sha')
           INPUT_HEAD_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
           BASE_REF=$(echo "$PR_DATA" | jq -r '.base.ref')
@@ -54,7 +55,7 @@ runs:
           fi
         elif [ -n "$INPUT_PR_NUMBER" ]; then
           # SHAs provided but we still need the base branch ref
-          BASE_REF=$(gh api "repos/${{ github.repository }}/pulls/${INPUT_PR_NUMBER}" --jq '.base.ref')
+          BASE_REF=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${INPUT_PR_NUMBER}" --jq '.base.ref')
         fi
 
         # Default to master if base ref could not be determined
@@ -67,7 +68,7 @@ runs:
 
         # Get changed files - try git first, fall back to API
         CHANGED_FILES=$(git diff --name-only "$INPUT_BASE_SHA"..."$INPUT_HEAD_SHA" 2>/dev/null || \
-          gh api "repos/${{ github.repository }}/pulls/${INPUT_PR_NUMBER}/files" --jq '.[].filename' 2>/dev/null || echo "")
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${INPUT_PR_NUMBER}/files" --jq '.[].filename' 2>/dev/null || echo "")
 
         if [ -z "$CHANGED_FILES" ]; then
           echo "::warning::Could not determine changed files, assuming not E2E-only"

--- a/.github/workflows/e2e-fulltests-ci.yml
+++ b/.github/workflows/e2e-fulltests-ci.yml
@@ -120,6 +120,11 @@ jobs:
           fetch-depth: 0
       - name: ci/generate-test-variables
         id: generate
+        env:
+          GITHUB_RUN_ID: ${{ github.run_id }}
+          GITHUB_RUN_ATTEMPT: ${{ github.run_attempt }}
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           MM_ENV_HASH=$(md5sum -z <<<"$MM_ENV" | cut -c-8)
           TESTCASE_FAILURE_FATAL="true"
@@ -214,7 +219,7 @@ jobs:
           fi
           # BUILD_ID format: $pipelineID-$imageTag-$testType-$serverType-$serverEdition
           # Reference on BUILD_ID parsing: https://github.com/saturninoabril/automation-dashboard/blob/175891781bf1072c162c58c6ec0abfc5bcb3520e/lib/common_utils.ts#L3-L23
-          BUILD_ID="${{ github.run_id }}_${{ github.run_attempt }}-${SERVER_IMAGE_TAG}${FIPS_SUFFIX}-${BUILD_ID_SUFFIX}"
+          BUILD_ID="${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}-${SERVER_IMAGE_TAG}${FIPS_SUFFIX}-${BUILD_ID_SUFFIX}"
           echo "commit_sha=${COMMIT_SHA}" >> $GITHUB_OUTPUT
           echo "BRANCH=${BRANCH}" >> $GITHUB_OUTPUT
           echo "SERVER_IMAGE=${SERVER_IMAGE_ORG}/${SERVER_IMAGE_NAME}:${SERVER_IMAGE_TAG}" >> $GITHUB_OUTPUT
@@ -232,7 +237,7 @@ jobs:
           echo "ROLLING_RELEASE_SERVER_IMAGE=${ROLLING_RELEASE_SERVER_IMAGE}" >> $GITHUB_OUTPUT
           echo "BUILD_ID=${BUILD_ID}" >> $GITHUB_OUTPUT
           # User notification variables
-          echo "WORKFLOW_RUN_URL=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{github.run_id}}" >> $GITHUB_OUTPUT
+          echo "WORKFLOW_RUN_URL=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> $GITHUB_OUTPUT
           echo "CYCLE_URL=${AUTOMATION_DASHBOARD_URL%%/api}/cycle/${BUILD_ID}" >> $GITHUB_OUTPUT
       - name: ci/notify-user
         env:
@@ -242,15 +247,17 @@ jobs:
           CYCLE_URL: "${{steps.generate.outputs.CYCLE_URL}}"
           RUN_CYPRESS: "${{inputs.RUN_CYPRESS == 'true' || ''}}"
           RUN_PLAYWRIGHT: "${{inputs.RUN_PLAYWRIGHT == 'true' || ''}}"
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           if [ -n "$PR_NUMBER" ]; then
-            gh issue -R "${{ github.repository }}" comment "$PR_NUMBER" --body-file - <<EOF
+            gh issue -R "${GITHUB_REPOSITORY}" comment "$PR_NUMBER" --body-file - <<EOF
           E2E test run is starting for commit \`${COMMIT_SHA}\`${MM_ENV:+, with \`MM_ENV=$MM_ENV\`}${MM_SERVICE_OVERRIDES:+, Cypress service overrides \`$MM_SERVICE_OVERRIDES\`}.
           To check the run progress:
           - Cypress: ${RUN_CYPRESS:+look for commit status \`$STATUS_CHECK_CONTEXT\` or the access the [Automation Dashboard Cycle URL]($CYCLE_URL)}$([ -n "${RUN_CYPRESS:-}" ] || echo -n "will not run").
           - Playwright: ${RUN_PLAYWRIGHT:+look for commit status \`$STATUS_CHECK_CONTEXT-playwright\`}$([ -n "${RUN_PLAYWRIGHT:-}" ] || echo -n "will not run").
           
-          You can also look at the [E2E test's Workflow Run URL]($WORKFLOW_RUN_URL) (run ID \`${{ github.run_id }}\`).
+          You can also look at the [E2E test's Workflow Run URL]($WORKFLOW_RUN_URL) (run ID \`${GITHUB_RUN_ID}\`).
           EOF
           fi
 
@@ -347,13 +354,17 @@ jobs:
       PLAYWRIGHT_REPORT_URL: "${{ needs.e2e-fulltest-playwright.outputs.playwright_report_url }}"
     steps:
       - name: ci/notify-user-test-completion
+        env:
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          CYPRESS_PASS_RATE: ${{ needs.e2e-fulltest-cypress.outputs.pass_rate }}
+          PLAYWRIGHT_PASS_RATE: ${{ needs.e2e-fulltest-playwright.outputs.pass_rate }}
         run: |
           if [ -n "$PR_NUMBER" ]; then
-            gh issue -R "${{ github.repository }}" comment "$PR_NUMBER" --body-file - <<EOF
+            gh issue -R "${GITHUB_REPOSITORY}" comment "$PR_NUMBER" --body-file - <<EOF
           E2E test has completed for commit \`${COMMIT_SHA}\`${MM_ENV:+, with \`MM_ENV=$MM_ENV\`}.
           Results summary:
-          - Cypress: ${RUN_CYPRESS:+pass rate is \`${{ needs.e2e-fulltest-cypress.outputs.pass_rate || 'unknown' }}\` (see [Automation Dashboard]($CYCLE_URL) and commit status check \`$STATUS_CHECK_CONTEXT\`)}$([ -n "${RUN_CYPRESS:-}" ] || echo -n "did not run").
-          - Playwright: ${RUN_PLAYWRIGHT:+pass rate is \`${{ needs.e2e-fulltest-playwright.outputs.pass_rate || 'unknown' }}\` (see [Playwright Report URL]($PLAYWRIGHT_REPORT_URL) and commit status check \`$STATUS_CHECK_CONTEXT-playwright\`)}$([ -n "${RUN_PLAYWRIGHT:-}" ] || echo -n "did not run").
+          - Cypress: ${RUN_CYPRESS:+pass rate is \`${CYPRESS_PASS_RATE:-unknown}\` (see [Automation Dashboard]($CYCLE_URL) and commit status check \`$STATUS_CHECK_CONTEXT\`)}$([ -n "${RUN_CYPRESS:-}" ] || echo -n "did not run").
+          - Playwright: ${RUN_PLAYWRIGHT:+pass rate is \`${PLAYWRIGHT_PASS_RATE:-unknown}\` (see [Playwright Report URL]($PLAYWRIGHT_REPORT_URL) and commit status check \`$STATUS_CHECK_CONTEXT-playwright\`)}$([ -n "${RUN_PLAYWRIGHT:-}" ] || echo -n "did not run").
           
           The run summary artifacts are available in the corresponding [Workflow Run]($WORKFLOW_RUN_URL).
           EOF

--- a/.github/workflows/e2e-tests-ci-template.yml
+++ b/.github/workflows/e2e-tests-ci-template.yml
@@ -171,6 +171,9 @@ jobs:
           BUILD_ID: "${{ inputs.BUILD_ID }}"
           TEST: "${{ inputs.TEST }}"
           TEST_FILTER: "${{ inputs.TEST_FILTER }}"
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           set -e -o pipefail
           make generate-test-cycle | tee generate-test-cycle.out
@@ -179,7 +182,7 @@ jobs:
           if [ -n "$TEST_CYCLE_ID" ]; then
             echo "status_check_url=https://automation-dashboard.vercel.app/cycles/${TEST_CYCLE_ID}" >> $GITHUB_OUTPUT
           else
-            echo "status_check_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
+            echo "status_check_url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> $GITHUB_OUTPUT
           fi
 
   test:
@@ -412,14 +415,18 @@ jobs:
       - name: ci/upload-results-to-s3
         if: (inputs.TEST == 'playwright')
         id: upload-to-s3
+        env:
+          AWS_REGION: us-east-1
+          AWS_S3_BUCKET: mattermost-cypress-report
+          INPUT_PR_NUMBER: ${{ inputs.PR_NUMBER }}
+          INPUT_TEST: ${{ inputs.TEST }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           echo "🔍 Checking if results directory exists..."
 
-          PR_NUMBER="${{ inputs.PR_NUMBER }}"
-          LOCAL_RESULTS_PATH="${{ inputs.TEST }}/results/"
-          LOCAL_LOGS_PATH="${{ inputs.TEST }}/logs/"
-          RUN_ID="${{ github.run_id }}"
-          S3_PATH="server-pr-${PR_NUMBER}/e2e-reports/${{ inputs.TEST }}/${RUN_ID}"
+          LOCAL_RESULTS_PATH="${INPUT_TEST}/results/"
+          LOCAL_LOGS_PATH="${INPUT_TEST}/logs/"
+          S3_PATH="server-pr-${INPUT_PR_NUMBER}/e2e-reports/${INPUT_TEST}/${GITHUB_RUN_ID}"
 
           echo "📤 Uploading to s3://${AWS_S3_BUCKET}/${S3_PATH}/"
 
@@ -433,9 +440,6 @@ jobs:
           echo "✅ Report uploaded to: $REPORT_URL"
 
           echo "report_url=$REPORT_URL" >> "$GITHUB_OUTPUT"
-        env:
-          AWS_REGION: us-east-1
-          AWS_S3_BUCKET: mattermost-cypress-report
 
       - name: ci/report-calculate-results
         id: calculate-results
@@ -470,9 +474,11 @@ jobs:
           echo "$COMMIT_STATUS_MESSAGE"
       - name: ci/e2e-test-assert-results
         if: "${{ inputs.testcase_failure_fatal }}"
+        env:
+          CALCULATE_FAILED: ${{ steps.calculate-results.outputs.failed }}
         run: |
           # Assert that the run contained 0 failures
-          [ "${{ steps.calculate-results.outputs.failed }}" = "0" ]
+          [ "${CALCULATE_FAILED}" = "0" ]
 
   update-failure-final-status:
     runs-on: ubuntu-24.04

--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -46,6 +46,7 @@ jobs:
         id: resolve
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
           INPUT_COMMIT_SHA: ${{ inputs.commit_sha }}
         run: |
@@ -62,7 +63,7 @@ jobs:
           # Manual trigger: PR number provided, resolve commit SHA from PR head
           if [ -n "$INPUT_PR_NUMBER" ]; then
             echo "Manual trigger: resolving commit SHA from PR #${INPUT_PR_NUMBER}"
-            PR_DATA=$(gh api "repos/${{ github.repository }}/pulls/${INPUT_PR_NUMBER}")
+            PR_DATA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${INPUT_PR_NUMBER}")
             COMMIT_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
 
             if [ -z "$COMMIT_SHA" ] || [ "$COMMIT_SHA" = "null" ]; then
@@ -79,7 +80,7 @@ jobs:
           # Argo Events trigger: commit SHA provided, resolve PR number
           if [ -n "$INPUT_COMMIT_SHA" ]; then
             echo "Automated trigger: resolving PR number from commit ${INPUT_COMMIT_SHA}"
-            PR_DATA=$(gh api "repos/${{ github.repository }}/commits/${INPUT_COMMIT_SHA}/pulls" \
+            PR_DATA=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${INPUT_COMMIT_SHA}/pulls" \
               --jq '.[0] // empty' 2>/dev/null || echo "")
             PR_NUMBER=$(echo "$PR_DATA" | jq -r '.number // empty' 2>/dev/null || echo "")
             if [ -z "$PR_NUMBER" ]; then
@@ -139,13 +140,14 @@ jobs:
         id: check
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ needs.resolve-pr.outputs.PR_NUMBER }}
           COMMIT_SHA: ${{ needs.resolve-pr.outputs.COMMIT_SHA }}
           INPUT_PR_NUMBER: ${{ inputs.pr_number }}
           HEAD_REF: ${{ needs.resolve-pr.outputs.HEAD_REF }}
         run: |
           # Get the base branch of the PR and changed files
-          BASE_SHA=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}" --jq '.base.sha')
+          BASE_SHA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.base.sha')
           CHANGED_FILES=$(git diff --name-only "${BASE_SHA}...${COMMIT_SHA}")
 
           echo "Changed files:"

--- a/.github/workflows/e2e-tests-cypress-template-v2.yml
+++ b/.github/workflows/e2e-tests-cypress-template-v2.yml
@@ -156,8 +156,9 @@ jobs:
         id: composite-identity
         env:
           CONTEXT_NAME: ${{ inputs.context_name }}
-          MM_SHA: ${{ inputs.commit_sha }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           MM_BRANCH: ${{ inputs.branch }}
+          MM_SHA: ${{ inputs.commit_sha }}
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           # Derive the test-system-io run name from the GitHub commit-status
@@ -170,7 +171,7 @@ jobs:
           # gh_pr_number is optional; include it only when present.
           if [ -n "$PR_NUMBER" ]; then
             COMPOSITE_IDENTITY=$(jq -nc \
-              --arg repo "${{ github.repository }}" \
+              --arg repo "${GITHUB_REPOSITORY}" \
               --arg sha "${MM_SHA}" \
               --arg run_id "${GITHUB_RUN_ID}" \
               --arg name "${NAME}" \
@@ -180,7 +181,7 @@ jobs:
               '{repository:$repo, commit_sha:$sha, gh_run_id:$run_id, name:$name, gh_run_attempt:$attempt, branch:$branch, gh_pr_number:$pr}')
           else
             COMPOSITE_IDENTITY=$(jq -nc \
-              --arg repo "${{ github.repository }}" \
+              --arg repo "${GITHUB_REPOSITORY}" \
               --arg sha "${MM_SHA}" \
               --arg run_id "${GITHUB_RUN_ID}" \
               --arg name "${NAME}" \
@@ -191,8 +192,10 @@ jobs:
           echo "composite-identity-json=${COMPOSITE_IDENTITY}" >> $GITHUB_OUTPUT
       - name: ci/matrix
         id: matrix
+        env:
+          INPUT_WORKERS: ${{ inputs.workers }}
         run: |
-          echo "workers=$(jq -nc --argjson n ${{ inputs.workers }} '[range(1; $n+1)]')" >> $GITHUB_OUTPUT
+          echo "workers=$(jq -nc --argjson n "${INPUT_WORKERS}" '[range(1; $n+1)]')" >> $GITHUB_OUTPUT
           echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
 
   # Install cypress node_modules once, then workers restore from cache.

--- a/.github/workflows/e2e-tests-cypress-template.yml
+++ b/.github/workflows/e2e-tests-cypress-template.yml
@@ -139,8 +139,10 @@ jobs:
     steps:
       - name: ci/generate-workers
         id: generate-workers
+        env:
+          INPUT_WORKERS: ${{ inputs.workers }}
         run: |
-          echo "workers=$(jq -nc '[range(${{ inputs.workers }})]')" >> $GITHUB_OUTPUT
+          echo "workers=$(jq -nc --argjson n "${INPUT_WORKERS}" '[range($n)]')" >> $GITHUB_OUTPUT
           echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
 
       - name: ci/checkout-repo
@@ -166,6 +168,9 @@ jobs:
           BUILD_ID: "${{ inputs.build_id }}"
           TEST: cypress
           TEST_FILTER: "${{ inputs.test_filter }}"
+          GITHUB_SERVER_URL: ${{ github.server_url }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
           set -e -o pipefail
           make generate-test-cycle | tee generate-test-cycle.out
@@ -173,7 +178,7 @@ jobs:
           if [ -n "$TEST_CYCLE_ID" ]; then
             echo "status_check_url=https://automation-dashboard.vercel.app/cycles/${TEST_CYCLE_ID}" >> $GITHUB_OUTPUT
           else
-            echo "status_check_url=${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" >> $GITHUB_OUTPUT
+            echo "status_check_url=${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" >> $GITHUB_OUTPUT
           fi
 
   run-tests:
@@ -375,21 +380,34 @@ jobs:
       - name: ci/use-previous-calculation
         if: needs.run-failed-tests.result == 'skipped'
         id: use-previous
+        env:
+          CALC_PASSED: ${{ needs.calculate-results.outputs.passed }}
+          CALC_FAILED: ${{ needs.calculate-results.outputs.failed }}
+          CALC_PENDING: ${{ needs.calculate-results.outputs.pending }}
+          CALC_TOTAL_SPECS: ${{ needs.calculate-results.outputs.total_specs }}
+          CALC_FAILED_SPECS: ${{ needs.calculate-results.outputs.failed_specs }}
+          CALC_FAILED_SPECS_COUNT: ${{ needs.calculate-results.outputs.failed_specs_count }}
+          CALC_COMMIT_STATUS_MESSAGE: ${{ needs.calculate-results.outputs.commit_status_message }}
+          CALC_TOTAL: ${{ needs.calculate-results.outputs.total }}
+          CALC_PASS_RATE: ${{ needs.calculate-results.outputs.pass_rate }}
+          CALC_COLOR: ${{ needs.calculate-results.outputs.color }}
+          CALC_TEST_DURATION: ${{ needs.calculate-results.outputs.test_duration }}
+          CALC_FAILED_TESTS: ${{ needs.calculate-results.outputs.failed_tests }}
         run: |
-          echo "passed=${{ needs.calculate-results.outputs.passed }}" >> $GITHUB_OUTPUT
-          echo "failed=${{ needs.calculate-results.outputs.failed }}" >> $GITHUB_OUTPUT
-          echo "pending=${{ needs.calculate-results.outputs.pending }}" >> $GITHUB_OUTPUT
-          echo "total_specs=${{ needs.calculate-results.outputs.total_specs }}" >> $GITHUB_OUTPUT
-          echo "failed_specs=${{ needs.calculate-results.outputs.failed_specs }}" >> $GITHUB_OUTPUT
-          echo "failed_specs_count=${{ needs.calculate-results.outputs.failed_specs_count }}" >> $GITHUB_OUTPUT
-          echo "commit_status_message=${{ needs.calculate-results.outputs.commit_status_message }}" >> $GITHUB_OUTPUT
-          echo "total=${{ needs.calculate-results.outputs.total }}" >> $GITHUB_OUTPUT
-          echo "pass_rate=${{ needs.calculate-results.outputs.pass_rate }}" >> $GITHUB_OUTPUT
-          echo "color=${{ needs.calculate-results.outputs.color }}" >> $GITHUB_OUTPUT
-          echo "test_duration=${{ needs.calculate-results.outputs.test_duration }}" >> $GITHUB_OUTPUT
+          echo "passed=${CALC_PASSED}" >> $GITHUB_OUTPUT
+          echo "failed=${CALC_FAILED}" >> $GITHUB_OUTPUT
+          echo "pending=${CALC_PENDING}" >> $GITHUB_OUTPUT
+          echo "total_specs=${CALC_TOTAL_SPECS}" >> $GITHUB_OUTPUT
+          echo "failed_specs=${CALC_FAILED_SPECS}" >> $GITHUB_OUTPUT
+          echo "failed_specs_count=${CALC_FAILED_SPECS_COUNT}" >> $GITHUB_OUTPUT
+          echo "commit_status_message=${CALC_COMMIT_STATUS_MESSAGE}" >> $GITHUB_OUTPUT
+          echo "total=${CALC_TOTAL}" >> $GITHUB_OUTPUT
+          echo "pass_rate=${CALC_PASS_RATE}" >> $GITHUB_OUTPUT
+          echo "color=${CALC_COLOR}" >> $GITHUB_OUTPUT
+          echo "test_duration=${CALC_TEST_DURATION}" >> $GITHUB_OUTPUT
           {
             echo "failed_tests<<EOF"
-            echo "${{ needs.calculate-results.outputs.failed_tests }}"
+            echo "${CALC_FAILED_TESTS}"
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
@@ -419,38 +437,61 @@ jobs:
       - name: ci/set-final-results
         id: final-results
         env:
+          RUN_FAILED_TESTS_RESULT: ${{ needs.run-failed-tests.result }}
           USE_PREVIOUS_FAILED_TESTS: ${{ steps.use-previous.outputs.failed_tests }}
+          USE_PREVIOUS_PASSED: ${{ steps.use-previous.outputs.passed }}
+          USE_PREVIOUS_FAILED: ${{ steps.use-previous.outputs.failed }}
+          USE_PREVIOUS_PENDING: ${{ steps.use-previous.outputs.pending }}
+          USE_PREVIOUS_TOTAL_SPECS: ${{ steps.use-previous.outputs.total_specs }}
+          USE_PREVIOUS_FAILED_SPECS: ${{ steps.use-previous.outputs.failed_specs }}
+          USE_PREVIOUS_FAILED_SPECS_COUNT: ${{ steps.use-previous.outputs.failed_specs_count }}
+          USE_PREVIOUS_COMMIT_STATUS_MESSAGE: ${{ steps.use-previous.outputs.commit_status_message }}
+          USE_PREVIOUS_TOTAL: ${{ steps.use-previous.outputs.total }}
+          USE_PREVIOUS_PASS_RATE: ${{ steps.use-previous.outputs.pass_rate }}
+          USE_PREVIOUS_COLOR: ${{ steps.use-previous.outputs.color }}
+          USE_PREVIOUS_TEST_DURATION: ${{ steps.use-previous.outputs.test_duration }}
           RECALCULATE_FAILED_TESTS: ${{ steps.recalculate.outputs.failed_tests }}
+          RECALCULATE_PASSED: ${{ steps.recalculate.outputs.passed }}
+          RECALCULATE_FAILED: ${{ steps.recalculate.outputs.failed }}
+          RECALCULATE_PENDING: ${{ steps.recalculate.outputs.pending }}
+          RECALCULATE_TOTAL_SPECS: ${{ steps.recalculate.outputs.total_specs }}
+          RECALCULATE_FAILED_SPECS: ${{ steps.recalculate.outputs.failed_specs }}
+          RECALCULATE_FAILED_SPECS_COUNT: ${{ steps.recalculate.outputs.failed_specs_count }}
+          RECALCULATE_COMMIT_STATUS_MESSAGE: ${{ steps.recalculate.outputs.commit_status_message }}
+          RECALCULATE_TOTAL: ${{ steps.recalculate.outputs.total }}
+          RECALCULATE_PASS_RATE: ${{ steps.recalculate.outputs.pass_rate }}
+          RECALCULATE_COLOR: ${{ steps.recalculate.outputs.color }}
+          RECALCULATE_TEST_DURATION: ${{ steps.recalculate.outputs.test_duration }}
         run: |
-          if [ "${{ needs.run-failed-tests.result }}" == "skipped" ]; then
-            echo "passed=${{ steps.use-previous.outputs.passed }}" >> $GITHUB_OUTPUT
-            echo "failed=${{ steps.use-previous.outputs.failed }}" >> $GITHUB_OUTPUT
-            echo "pending=${{ steps.use-previous.outputs.pending }}" >> $GITHUB_OUTPUT
-            echo "total_specs=${{ steps.use-previous.outputs.total_specs }}" >> $GITHUB_OUTPUT
-            echo "failed_specs=${{ steps.use-previous.outputs.failed_specs }}" >> $GITHUB_OUTPUT
-            echo "failed_specs_count=${{ steps.use-previous.outputs.failed_specs_count }}" >> $GITHUB_OUTPUT
-            echo "commit_status_message=${{ steps.use-previous.outputs.commit_status_message }}" >> $GITHUB_OUTPUT
-            echo "total=${{ steps.use-previous.outputs.total }}" >> $GITHUB_OUTPUT
-            echo "pass_rate=${{ steps.use-previous.outputs.pass_rate }}" >> $GITHUB_OUTPUT
-            echo "color=${{ steps.use-previous.outputs.color }}" >> $GITHUB_OUTPUT
-            echo "test_duration=${{ steps.use-previous.outputs.test_duration }}" >> $GITHUB_OUTPUT
+          if [ "$RUN_FAILED_TESTS_RESULT" == "skipped" ]; then
+            echo "passed=${USE_PREVIOUS_PASSED}" >> $GITHUB_OUTPUT
+            echo "failed=${USE_PREVIOUS_FAILED}" >> $GITHUB_OUTPUT
+            echo "pending=${USE_PREVIOUS_PENDING}" >> $GITHUB_OUTPUT
+            echo "total_specs=${USE_PREVIOUS_TOTAL_SPECS}" >> $GITHUB_OUTPUT
+            echo "failed_specs=${USE_PREVIOUS_FAILED_SPECS}" >> $GITHUB_OUTPUT
+            echo "failed_specs_count=${USE_PREVIOUS_FAILED_SPECS_COUNT}" >> $GITHUB_OUTPUT
+            echo "commit_status_message=${USE_PREVIOUS_COMMIT_STATUS_MESSAGE}" >> $GITHUB_OUTPUT
+            echo "total=${USE_PREVIOUS_TOTAL}" >> $GITHUB_OUTPUT
+            echo "pass_rate=${USE_PREVIOUS_PASS_RATE}" >> $GITHUB_OUTPUT
+            echo "color=${USE_PREVIOUS_COLOR}" >> $GITHUB_OUTPUT
+            echo "test_duration=${USE_PREVIOUS_TEST_DURATION}" >> $GITHUB_OUTPUT
             {
               echo "failed_tests<<EOF"
               echo "$USE_PREVIOUS_FAILED_TESTS"
               echo "EOF"
             } >> $GITHUB_OUTPUT
           else
-            echo "passed=${{ steps.recalculate.outputs.passed }}" >> $GITHUB_OUTPUT
-            echo "failed=${{ steps.recalculate.outputs.failed }}" >> $GITHUB_OUTPUT
-            echo "pending=${{ steps.recalculate.outputs.pending }}" >> $GITHUB_OUTPUT
-            echo "total_specs=${{ steps.recalculate.outputs.total_specs }}" >> $GITHUB_OUTPUT
-            echo "failed_specs=${{ steps.recalculate.outputs.failed_specs }}" >> $GITHUB_OUTPUT
-            echo "failed_specs_count=${{ steps.recalculate.outputs.failed_specs_count }}" >> $GITHUB_OUTPUT
-            echo "commit_status_message=${{ steps.recalculate.outputs.commit_status_message }}" >> $GITHUB_OUTPUT
-            echo "total=${{ steps.recalculate.outputs.total }}" >> $GITHUB_OUTPUT
-            echo "pass_rate=${{ steps.recalculate.outputs.pass_rate }}" >> $GITHUB_OUTPUT
-            echo "color=${{ steps.recalculate.outputs.color }}" >> $GITHUB_OUTPUT
-            echo "test_duration=${{ steps.recalculate.outputs.test_duration }}" >> $GITHUB_OUTPUT
+            echo "passed=${RECALCULATE_PASSED}" >> $GITHUB_OUTPUT
+            echo "failed=${RECALCULATE_FAILED}" >> $GITHUB_OUTPUT
+            echo "pending=${RECALCULATE_PENDING}" >> $GITHUB_OUTPUT
+            echo "total_specs=${RECALCULATE_TOTAL_SPECS}" >> $GITHUB_OUTPUT
+            echo "failed_specs=${RECALCULATE_FAILED_SPECS}" >> $GITHUB_OUTPUT
+            echo "failed_specs_count=${RECALCULATE_FAILED_SPECS_COUNT}" >> $GITHUB_OUTPUT
+            echo "commit_status_message=${RECALCULATE_COMMIT_STATUS_MESSAGE}" >> $GITHUB_OUTPUT
+            echo "total=${RECALCULATE_TOTAL}" >> $GITHUB_OUTPUT
+            echo "pass_rate=${RECALCULATE_PASS_RATE}" >> $GITHUB_OUTPUT
+            echo "color=${RECALCULATE_COLOR}" >> $GITHUB_OUTPUT
+            echo "test_duration=${RECALCULATE_TEST_DURATION}" >> $GITHUB_OUTPUT
             {
               echo "failed_tests<<EOF"
               echo "$RECALCULATE_FAILED_TESTS"
@@ -530,19 +571,21 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
           DURATION_DISPLAY: ${{ steps.duration.outputs.duration_display }}
           RETEST_DISPLAY: ${{ steps.duration.outputs.retest_display }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SERVER_IMAGE: ${{ env.SERVER_IMAGE }}
         run: |
           # Capitalize test type
           TEST_TYPE_CAP=$(echo "$TEST_TYPE" | sed 's/.*/\u&/')
 
           # Build source line based on report type
           COMMIT_SHORT="${COMMIT_SHA::7}"
-          COMMIT_URL="https://github.com/${{ github.repository }}/commit/${COMMIT_SHA}"
+          COMMIT_URL="https://github.com/${GITHUB_REPOSITORY}/commit/${COMMIT_SHA}"
           if [ "$REPORT_TYPE" = "RELEASE_CUT" ]; then
             SOURCE_LINE=":github_round: [${COMMIT_SHORT}](${COMMIT_URL}) on \`${REF_BRANCH}\`"
           elif [ "$REPORT_TYPE" = "MASTER" ] || [ "$REPORT_TYPE" = "RELEASE" ]; then
             SOURCE_LINE=":git_merge: [${COMMIT_SHORT}](${COMMIT_URL}) on \`${REF_BRANCH}\`"
           else
-            SOURCE_LINE=":open-pull-request: [mattermost-pr-${PR_NUMBER}](https://github.com/${{ github.repository }}/pull/${PR_NUMBER})"
+            SOURCE_LINE=":open-pull-request: [mattermost-pr-${PR_NUMBER}](https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER})"
           fi
 
           # Build retest part for message
@@ -558,7 +601,7 @@ jobs:
             "icon_url": "https://mattermost.com/wp-content/uploads/2022/02/icon_WS.png",
             "attachments": [{
               "color": "${COLOR}",
-              "text": "**Results - Cypress ${TEST_TYPE_CAP} Tests**\n\n${SOURCE_LINE}\n:docker: \`${{ env.SERVER_IMAGE }}\`\n${COMMIT_STATUS_MESSAGE}${RETEST_PART} | [full report](${REPORT_URL})\n${DURATION_DISPLAY}"
+              "text": "**Results - Cypress ${TEST_TYPE_CAP} Tests**\n\n${SOURCE_LINE}\n:docker: \`${SERVER_IMAGE}\`\n${COMMIT_STATUS_MESSAGE}${RETEST_PART} | [full report](${REPORT_URL})\n${DURATION_DISPLAY}"
             }]
           }
           EOF
@@ -622,8 +665,10 @@ jobs:
             echo "[View Full Report](${STATUS_CHECK_URL})"
           } >> $GITHUB_STEP_SUMMARY
       - name: ci/assert-results
+        env:
+          FINAL_RESULTS_FAILED: ${{ steps.final-results.outputs.failed }}
         run: |
-          [ "${{ steps.final-results.outputs.failed }}" = "0" ]
+          [ "${FINAL_RESULTS_FAILED}" = "0" ]
 
   update-success-status:
     runs-on: ubuntu-24.04

--- a/.github/workflows/e2e-tests-cypress.yml
+++ b/.github/workflows/e2e-tests-cypress.yml
@@ -80,10 +80,15 @@ jobs:
         id: build-vars
         env:
           COMMIT_SHA: ${{ inputs.commit_sha }}
-          PR_NUMBER: ${{ inputs.pr_number }}
+          INPUT_REF_BRANCH: ${{ inputs.ref_branch }}
+          INPUT_REPORT_TYPE: ${{ inputs.report_type }}
+          INPUT_SERVER_EDITION: ${{ inputs.server_edition }}
+          INPUT_SERVER_IMAGE_ALIASES: ${{ inputs.server_image_aliases }}
+          INPUT_SERVER_IMAGE_REPO: ${{ inputs.server_image_repo }}
           INPUT_SERVER_IMAGE_TAG: ${{ inputs.server_image_tag }}
-          RUN_ID: ${{ github.run_id }}
+          PR_NUMBER: ${{ inputs.pr_number }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           # Use provided server_image_tag or derive from commit SHA
           if [ -n "$INPUT_SERVER_IMAGE_TAG" ]; then
@@ -105,7 +110,7 @@ jobs:
           # build on that branch instead of treating each image tag as its
           # own "branch". PR and commit-only fallback paths keep their
           # synthetic prefix because there's no real branch to use.
-          REF_BRANCH="${{ inputs.ref_branch }}"
+          REF_BRANCH="${INPUT_REF_BRANCH}"
           if [ -n "$PR_NUMBER" ]; then
             echo "branch=pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
           elif [ -n "$REF_BRANCH" ]; then
@@ -115,8 +120,8 @@ jobs:
           fi
 
           # Determine server image name
-          EDITION="${{ inputs.server_edition }}"
-          REPO="${{ inputs.server_image_repo }}"
+          EDITION="${INPUT_SERVER_EDITION}"
+          REPO="${INPUT_SERVER_IMAGE_REPO}"
           REPO="${REPO:-mattermostdevelopment}"
           case "$EDITION" in
             fips) IMAGE_NAME="mattermost-enterprise-fips-edition" ;;
@@ -127,7 +132,7 @@ jobs:
           echo "server_image=${SERVER_IMAGE}" >> $GITHUB_OUTPUT
 
           # Validate server_image_aliases format if provided
-          ALIASES="${{ inputs.server_image_aliases }}"
+          ALIASES="${INPUT_SERVER_IMAGE_ALIASES}"
           if [ -n "$ALIASES" ] && ! [[ "$ALIASES" =~ ^[a-zA-Z0-9._,\ -]+$ ]]; then
             echo "::error::Invalid server_image_aliases format: ${ALIASES}"
             exit 1
@@ -141,7 +146,7 @@ jobs:
           fi
 
           # Generate context name suffix based on report type
-          REPORT_TYPE="${{ inputs.report_type }}"
+          REPORT_TYPE="${INPUT_REPORT_TYPE}"
           case "$REPORT_TYPE" in
             MASTER) echo "context_suffix=/master" >> $GITHUB_OUTPUT ;;
             RELEASE) echo "context_suffix=/release" >> $GITHUB_OUTPUT ;;
@@ -160,15 +165,17 @@ jobs:
     steps:
       - name: ci/post-skip-status
         env:
-          GH_TOKEN: ${{ github.token }}
           COMMIT_SHA: ${{ inputs.commit_sha }}
           CONTEXT_NAME: "e2e-test/cypress-full/${{ inputs.server_edition || 'enterprise' }}${{ needs.generate-build-variables.outputs.context_suffix }}"
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${COMMIT_SHA} \
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${COMMIT_SHA}" \
             -f state=success \
             -f context="${CONTEXT_NAME}" \
             -f description="No E2E-relevant changes - skipped" \
-            -f target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f target_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           echo "Posted success for ${CONTEXT_NAME}"
 
   # ── Routing fork ─────────────────────────────────────────────────────

--- a/.github/workflows/e2e-tests-override-status.yml
+++ b/.github/workflows/e2e-tests-override-status.yml
@@ -25,9 +25,10 @@ jobs:
         id: pr-info
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
-          PR_DATA=$(gh api repos/${{ github.repository }}/pulls/${PR_NUMBER})
+          PR_DATA=$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}")
           HEAD_SHA=$(echo "$PR_DATA" | jq -r '.head.sha')
           echo "head_sha=$HEAD_SHA" >> $GITHUB_OUTPUT
 
@@ -35,6 +36,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           COMMIT_SHA: ${{ steps.pr-info.outputs.head_sha }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           # Only full tests can be overridden (smoke tests must pass)
           FULL_TEST_CONTEXTS=("e2e-test/playwright-full/enterprise" "e2e-test/cypress-full/enterprise" "e2e-test/playwright-full/fips" "e2e-test/cypress-full/fips")
@@ -43,7 +45,7 @@ jobs:
             echo "Checking: $CONTEXT_NAME"
 
             # Get current status
-            STATUS_JSON=$(gh api repos/${{ github.repository }}/commits/${COMMIT_SHA}/statuses \
+            STATUS_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${COMMIT_SHA}/statuses" \
               --jq "[.[] | select(.context == \"$CONTEXT_NAME\")] | first // empty")
 
             if [ -z "$STATUS_JSON" ]; then
@@ -79,7 +81,7 @@ jobs:
             echo "  New: $NEW_MSG"
 
             # Update status via GitHub API
-            gh api repos/${{ github.repository }}/statuses/${COMMIT_SHA} \
+            gh api "repos/${GITHUB_REPOSITORY}/statuses/${COMMIT_SHA}" \
               -f state=success \
               -f context="$CONTEXT_NAME" \
               -f description="$NEW_MSG" \

--- a/.github/workflows/e2e-tests-playwright-template-v2.yml
+++ b/.github/workflows/e2e-tests-playwright-template-v2.yml
@@ -122,8 +122,9 @@ jobs:
         id: composite-identity
         env:
           CONTEXT_NAME: ${{ inputs.context_name }}
-          MM_SHA: ${{ inputs.commit_sha }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           MM_BRANCH: ${{ inputs.branch }}
+          MM_SHA: ${{ inputs.commit_sha }}
           PR_NUMBER: ${{ inputs.pr_number }}
         run: |
           # Derive the test-system-io run name from the GitHub commit-status
@@ -135,7 +136,7 @@ jobs:
           NAME="${NAME//\//-}"
           if [ -n "$PR_NUMBER" ]; then
             COMPOSITE_IDENTITY=$(jq -nc \
-              --arg repo "${{ github.repository }}" \
+              --arg repo "${GITHUB_REPOSITORY}" \
               --arg sha "${MM_SHA}" \
               --arg run_id "${GITHUB_RUN_ID}" \
               --arg name "${NAME}" \
@@ -145,7 +146,7 @@ jobs:
               '{repository:$repo, commit_sha:$sha, gh_run_id:$run_id, name:$name, gh_run_attempt:$attempt, branch:$branch, gh_pr_number:$pr}')
           else
             COMPOSITE_IDENTITY=$(jq -nc \
-              --arg repo "${{ github.repository }}" \
+              --arg repo "${GITHUB_REPOSITORY}" \
               --arg sha "${MM_SHA}" \
               --arg run_id "${GITHUB_RUN_ID}" \
               --arg name "${NAME}" \
@@ -156,8 +157,10 @@ jobs:
           echo "composite-identity-json=${COMPOSITE_IDENTITY}" >> $GITHUB_OUTPUT
       - name: ci/matrix
         id: matrix
+        env:
+          INPUT_WORKERS: ${{ inputs.workers }}
         run: |
-          echo "workers=$(jq -nc --argjson n ${{ inputs.workers }} '[range(1; $n+1)]')" >> $GITHUB_OUTPUT
+          echo "workers=$(jq -nc --argjson n "${INPUT_WORKERS}" '[range(1; $n+1)]')" >> $GITHUB_OUTPUT
           echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
 
   # Build @mattermost/client + @mattermost/types and install playwright deps once,

--- a/.github/workflows/e2e-tests-playwright-template.yml
+++ b/.github/workflows/e2e-tests-playwright-template.yml
@@ -130,8 +130,10 @@ jobs:
     steps:
       - name: ci/generate-workers
         id: generate-workers
+        env:
+          INPUT_WORKERS: ${{ inputs.workers }}
         run: |
-          echo "workers=$(jq -nc '[range(1; ${{ inputs.workers }} + 1)]')" >> $GITHUB_OUTPUT
+          echo "workers=$(jq -nc --argjson n "${INPUT_WORKERS}" '[range(1; $n + 1)]')" >> $GITHUB_OUTPUT
           echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
 
   run-tests:
@@ -468,19 +470,21 @@ jobs:
           PR_NUMBER: ${{ inputs.pr_number }}
           DURATION_DISPLAY: ${{ steps.duration.outputs.duration_display }}
           RETEST_DISPLAY: ${{ steps.duration.outputs.retest_display }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          SERVER_IMAGE: ${{ env.SERVER_IMAGE }}
         run: |
           # Capitalize test type
           TEST_TYPE_CAP=$(echo "$TEST_TYPE" | sed 's/.*/\u&/')
 
           # Build source line based on report type
           COMMIT_SHORT="${COMMIT_SHA::7}"
-          COMMIT_URL="https://github.com/${{ github.repository }}/commit/${COMMIT_SHA}"
+          COMMIT_URL="https://github.com/${GITHUB_REPOSITORY}/commit/${COMMIT_SHA}"
           if [ "$REPORT_TYPE" = "RELEASE_CUT" ]; then
             SOURCE_LINE=":github_round: [${COMMIT_SHORT}](${COMMIT_URL}) on \`${REF_BRANCH}\`"
           elif [ "$REPORT_TYPE" = "MASTER" ] || [ "$REPORT_TYPE" = "RELEASE" ]; then
             SOURCE_LINE=":git_merge: [${COMMIT_SHORT}](${COMMIT_URL}) on \`${REF_BRANCH}\`"
           else
-            SOURCE_LINE=":open-pull-request: [mattermost-pr-${PR_NUMBER}](https://github.com/${{ github.repository }}/pull/${PR_NUMBER})"
+            SOURCE_LINE=":open-pull-request: [mattermost-pr-${PR_NUMBER}](https://github.com/${GITHUB_REPOSITORY}/pull/${PR_NUMBER})"
           fi
 
           # Build retest part for message
@@ -496,7 +500,7 @@ jobs:
             "icon_url": "https://mattermost.com/wp-content/uploads/2022/02/icon_WS.png",
             "attachments": [{
               "color": "${COLOR}",
-              "text": "**Results - Playwright ${TEST_TYPE_CAP} Tests**\n\n${SOURCE_LINE}\n:docker: \`${{ env.SERVER_IMAGE }}\`\n${COMMIT_STATUS_MESSAGE}${RETEST_PART} | [full report](${REPORT_URL})\n${DURATION_DISPLAY}"
+              "text": "**Results - Playwright ${TEST_TYPE_CAP} Tests**\n\n${SOURCE_LINE}\n:docker: \`${SERVER_IMAGE}\`\n${COMMIT_STATUS_MESSAGE}${RETEST_PART} | [full report](${REPORT_URL})\n${DURATION_DISPLAY}"
             }]
           }
           EOF
@@ -560,8 +564,10 @@ jobs:
             echo "[View Full Report](${REPORT_URL})"
           } >> $GITHUB_STEP_SUMMARY
       - name: ci/assert-results
+        env:
+          FINAL_RESULTS_FAILED: ${{ steps.final-results.outputs.failed }}
         run: |
-          [ "${{ steps.final-results.outputs.failed }}" = "0" ]
+          [ "${FINAL_RESULTS_FAILED}" = "0" ]
 
   update-success-status:
     runs-on: ubuntu-24.04

--- a/.github/workflows/e2e-tests-playwright.yml
+++ b/.github/workflows/e2e-tests-playwright.yml
@@ -74,10 +74,15 @@ jobs:
         id: build-vars
         env:
           COMMIT_SHA: ${{ inputs.commit_sha }}
-          PR_NUMBER: ${{ inputs.pr_number }}
+          INPUT_REF_BRANCH: ${{ inputs.ref_branch }}
+          INPUT_REPORT_TYPE: ${{ inputs.report_type }}
+          INPUT_SERVER_EDITION: ${{ inputs.server_edition }}
+          INPUT_SERVER_IMAGE_ALIASES: ${{ inputs.server_image_aliases }}
+          INPUT_SERVER_IMAGE_REPO: ${{ inputs.server_image_repo }}
           INPUT_SERVER_IMAGE_TAG: ${{ inputs.server_image_tag }}
-          RUN_ID: ${{ github.run_id }}
+          PR_NUMBER: ${{ inputs.pr_number }}
           RUN_ATTEMPT: ${{ github.run_attempt }}
+          RUN_ID: ${{ github.run_id }}
         run: |
           # Use provided server_image_tag or derive from commit SHA
           if [ -n "$INPUT_SERVER_IMAGE_TAG" ]; then
@@ -99,7 +104,7 @@ jobs:
           # build on that branch instead of treating each image tag as its
           # own "branch". PR and commit-only fallback paths keep their
           # synthetic prefix because there's no real branch to use.
-          REF_BRANCH="${{ inputs.ref_branch }}"
+          REF_BRANCH="${INPUT_REF_BRANCH}"
           if [ -n "$PR_NUMBER" ]; then
             echo "branch=pr-${PR_NUMBER}" >> $GITHUB_OUTPUT
           elif [ -n "$REF_BRANCH" ]; then
@@ -109,8 +114,8 @@ jobs:
           fi
 
           # Determine server image name
-          EDITION="${{ inputs.server_edition }}"
-          REPO="${{ inputs.server_image_repo }}"
+          EDITION="${INPUT_SERVER_EDITION}"
+          REPO="${INPUT_SERVER_IMAGE_REPO}"
           REPO="${REPO:-mattermostdevelopment}"
           case "$EDITION" in
             fips) IMAGE_NAME="mattermost-enterprise-fips-edition" ;;
@@ -121,7 +126,7 @@ jobs:
           echo "server_image=${SERVER_IMAGE}" >> $GITHUB_OUTPUT
 
           # Validate server_image_aliases format if provided
-          ALIASES="${{ inputs.server_image_aliases }}"
+          ALIASES="${INPUT_SERVER_IMAGE_ALIASES}"
           if [ -n "$ALIASES" ] && ! [[ "$ALIASES" =~ ^[a-zA-Z0-9._,\ -]+$ ]]; then
             echo "::error::Invalid server_image_aliases format: ${ALIASES}"
             exit 1
@@ -135,7 +140,7 @@ jobs:
           fi
 
           # Generate context name suffix based on report type
-          REPORT_TYPE="${{ inputs.report_type }}"
+          REPORT_TYPE="${INPUT_REPORT_TYPE}"
           case "$REPORT_TYPE" in
             MASTER) echo "context_suffix=/master" >> $GITHUB_OUTPUT ;;
             RELEASE) echo "context_suffix=/release" >> $GITHUB_OUTPUT ;;
@@ -154,15 +159,17 @@ jobs:
     steps:
       - name: ci/post-skip-status
         env:
-          GH_TOKEN: ${{ github.token }}
           COMMIT_SHA: ${{ inputs.commit_sha }}
           CONTEXT_NAME: "e2e-test/playwright-full/${{ inputs.server_edition || 'enterprise' }}${{ needs.generate-build-variables.outputs.context_suffix }}"
+          GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
+          GITHUB_RUN_ID: ${{ github.run_id }}
         run: |
-          gh api repos/${{ github.repository }}/statuses/${COMMIT_SHA} \
+          gh api "repos/${GITHUB_REPOSITORY}/statuses/${COMMIT_SHA}" \
             -f state=success \
             -f context="${CONTEXT_NAME}" \
             -f description="No E2E-relevant changes - skipped" \
-            -f target_url="https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+            -f target_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           echo "Posted success for ${CONTEXT_NAME}"
 
   # ── Routing fork ─────────────────────────────────────────────────────

--- a/.github/workflows/e2e-tests-verified-label.yml
+++ b/.github/workflows/e2e-tests-verified-label.yml
@@ -17,10 +17,11 @@ jobs:
         id: check-permission
         env:
           GH_TOKEN: ${{ github.token }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
           LABEL_AUTHOR: ${{ github.event.sender.login }}
         run: |
           # Check if user has write permission to the repository
-          PERMISSION=$(gh api repos/${{ github.repository }}/collaborators/${LABEL_AUTHOR}/permission --jq '.permission' 2>/dev/null || echo "none")
+          PERMISSION=$(gh api "repos/${GITHUB_REPOSITORY}/collaborators/${LABEL_AUTHOR}/permission" --jq '.permission' 2>/dev/null || echo "none")
           if [[ "$PERMISSION" != "admin" && "$PERMISSION" != "write" ]]; then
             echo "User ${LABEL_AUTHOR} doesn't have write permission to the repository (permission: ${PERMISSION})"
             exit 1
@@ -32,6 +33,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+          GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           # Only full tests can be overridden (smoke tests must pass)
           FULL_TEST_CONTEXTS=("e2e-test/playwright-full/enterprise" "e2e-test/cypress-full/enterprise" "e2e-test/playwright-full/fips" "e2e-test/cypress-full/fips")
@@ -42,7 +44,7 @@ jobs:
             echo "Checking: $CONTEXT_NAME"
 
             # Get current status
-            STATUS_JSON=$(gh api repos/${{ github.repository }}/commits/${COMMIT_SHA}/statuses \
+            STATUS_JSON=$(gh api "repos/${GITHUB_REPOSITORY}/commits/${COMMIT_SHA}/statuses" \
               --jq "[.[] | select(.context == \"$CONTEXT_NAME\")] | first // empty")
 
             if [ -z "$STATUS_JSON" ]; then
@@ -72,7 +74,7 @@ jobs:
             echo "  New: $NEW_MSG"
 
             # Update status via GitHub API
-            gh api repos/${{ github.repository }}/statuses/${COMMIT_SHA} \
+            gh api "repos/${GITHUB_REPOSITORY}/statuses/${COMMIT_SHA}" \
               -f state=success \
               -f context="$CONTEXT_NAME" \
               -f description="$NEW_MSG" \

--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -28,6 +28,13 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       COMPOSE_PROJECT_NAME: ghactions
+      INPUT_DATASOURCE: ${{ inputs.datasource }}
+      INPUT_FIPS_ENABLED: ${{ inputs.fips-enabled }}
+      INPUT_GO_VERSION: ${{ inputs.go-version }}
+      INPUT_LOGSARTIFACT: ${{ inputs.logsartifact }}
+      INPUT_NAME: ${{ inputs.name }}
+      INPUT_PR_NUMBER: ${{ github.event.pull_request.number }}
+      REF_NAME: ${{ github.ref_name }}
     steps:
       - name: buildenv/docker-login
         # Only FIPS requires login for private build container. (Forks won't have credentials.)
@@ -44,18 +51,18 @@ jobs:
       - name: Setup BUILD_IMAGE
         id: build
         run: |
-          if [[ ${{ inputs.fips-enabled }} == 'true' ]]; then
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
-            echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}-fips" >> "${GITHUB_OUTPUT}"
+          if [[ "$INPUT_FIPS_ENABLED" == 'true' ]]; then
+            echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${INPUT_GO_VERSION}" >> "${GITHUB_OUTPUT}"
+            echo "LOG_ARTIFACT_NAME=${INPUT_LOGSARTIFACT}-fips" >> "${GITHUB_OUTPUT}"
           else
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
-            echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}" >> "${GITHUB_OUTPUT}"
+            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${INPUT_GO_VERSION}" >> "${GITHUB_OUTPUT}"
+            echo "LOG_ARTIFACT_NAME=${INPUT_LOGSARTIFACT}" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Store required variables for publishing results
         run: |
-          echo "${{ inputs.name }}" > server/test-name
-          echo "${{ github.event.pull_request.number }}" > server/pr-number
+          echo "$INPUT_NAME" > server/test-name
+          echo "$INPUT_PR_NUMBER" > server/pr-number
       - name: Run docker compose
         env:
           POSTGRES_PASSWORD: ${{ inputs.fips-enabled && 'mostest-fips-test' || 'mostest' }}
@@ -72,7 +79,7 @@ jobs:
         env:
           BUILD_IMAGE: ${{ steps.build.outputs.BUILD_IMAGE }}
         run: |
-          if [[ ${{ github.ref_name }} == 'master' ]]; then
+          if [[ "$REF_NAME" == 'master' ]]; then
             export TESTFLAGS="-timeout 90m -race"
           else
             export TESTFLAGS="-timeout 30m"
@@ -80,10 +87,10 @@ jobs:
           docker run --net ghactions_mm-test \
             --ulimit nofile=8096:8096 \
             --env-file=server/build/dotenv/test.env \
-            --env TEST_DATABASE_POSTGRESQL_DSN="${{ inputs.datasource }}" \
-            --env MM_SQLSETTINGS_DATASOURCE="${{ inputs.datasource }}" \
+            --env TEST_DATABASE_POSTGRESQL_DSN="$INPUT_DATASOURCE" \
+            --env MM_SQLSETTINGS_DATASOURCE="$INPUT_DATASOURCE" \
             --env MMCTL_TESTFLAGS="$TESTFLAGS" \
-            --env FIPS_ENABLED="${{ inputs.fips-enabled }}" \
+            --env FIPS_ENABLED="$INPUT_FIPS_ENABLED" \
             -v $PWD:/mattermost \
             -w /mattermost/server \
             $BUILD_IMAGE \

--- a/.github/workflows/server-ci-artifacts.yml
+++ b/.github/workflows/server-ci-artifacts.yml
@@ -55,18 +55,22 @@ jobs:
           echo "EOF" >> "${GITHUB_ENV}"
 
       - name: cd/upload-artifacts-to-s3
-        run: aws s3 sync server/dist/ s3://pr-builds.mattermost.com/mattermost/commit/${{ github.event.workflow_run.head_sha }}/ --cache-control no-cache --no-progress --acl public-read
+        env:
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
+        run: aws s3 sync server/dist/ "s3://pr-builds.mattermost.com/mattermost/commit/${WORKFLOW_RUN_HEAD_SHA}/" --cache-control no-cache --no-progress --acl public-read
 
       - name: cd/generate-summary
+        env:
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           echo "### Download links for Mattermost team package" >> "${GITHUB_STEP_SUMMARY}"
           echo " " >> "${GITHUB_STEP_SUMMARY}"
-          echo "Mattermost Repo SHA: \`${{ github.event.workflow_run.head_sha }}\`" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Mattermost Repo SHA: \`${WORKFLOW_RUN_HEAD_SHA}\`" >> "${GITHUB_STEP_SUMMARY}"
           echo "|Download Link|" >> "${GITHUB_STEP_SUMMARY}"
           echo "| --- |" >> "${GITHUB_STEP_SUMMARY}"
           for package in ${PACKAGES_FILE_LIST}
             do
-              echo "|[${package}](https://pr-builds.mattermost.com/mattermost/commit/${{ github.event.workflow_run.head_sha }}/${package})|" >> "${GITHUB_STEP_SUMMARY}"
+              echo "|[${package}](https://pr-builds.mattermost.com/mattermost/commit/${WORKFLOW_RUN_HEAD_SHA}/${package})|" >> "${GITHUB_STEP_SUMMARY}"
           done
 
   build-docker:
@@ -109,8 +113,10 @@ jobs:
 
       - name: cd/set-docker-tag
         id: set_tag
+        env:
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
-          echo "TAG=$(echo '${{ github.event.workflow_run.head_sha }}' | cut -c1-7)" >> $GITHUB_OUTPUT
+          echo "TAG=$(echo "${WORKFLOW_RUN_HEAD_SHA}" | cut -c1-7)" >> $GITHUB_OUTPUT
 
       - name: cd/docker-build-and-push
         id: docker
@@ -124,15 +130,17 @@ jobs:
 
       - name: cd/generate-summary
         env:
+          DOCKERHUB_IMAGE_DIGEST: ${{ steps.docker.outputs.DOCKERHUB_IMAGE_DIGEST }}
           TAG: ${{ steps.set_tag.outputs.TAG }}
+          WORKFLOW_RUN_HEAD_SHA: ${{ github.event.workflow_run.head_sha }}
         run: |
           echo "### Docker Image for Mattermost team package" >> "${GITHUB_STEP_SUMMARY}"
           echo " " >> "${GITHUB_STEP_SUMMARY}"
-          echo "Mattermost Repo SHA: \`${{ github.event.workflow_run.head_sha }}\`" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Mattermost Repo SHA: \`${WORKFLOW_RUN_HEAD_SHA}\`" >> "${GITHUB_STEP_SUMMARY}"
           echo " " >> "${GITHUB_STEP_SUMMARY}"
           echo "Docker Image: \`mattermostdevelopment/mattermost-team-edition:${TAG}\`" >> "${GITHUB_STEP_SUMMARY}"
-          echo "Image Digest: \`${{ steps.docker.outputs.DOCKERHUB_IMAGE_DIGEST }}\`" >> "${GITHUB_STEP_SUMMARY}"
-          echo "Secure Image: \`mattermostdevelopment/mattermost-team-edition:${TAG}@${{ steps.docker.outputs.DOCKERHUB_IMAGE_DIGEST }}\`" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Image Digest: \`${DOCKERHUB_IMAGE_DIGEST}\`" >> "${GITHUB_STEP_SUMMARY}"
+          echo "Secure Image: \`mattermostdevelopment/mattermost-team-edition:${TAG}@${DOCKERHUB_IMAGE_DIGEST}\`" >> "${GITHUB_STEP_SUMMARY}"
 
   scan-docker-image:
     runs-on: ubuntu-22.04
@@ -151,12 +159,16 @@ jobs:
           WIZ_CLIENT_SECRET: ${{ secrets.WIZ_DEVOPS_CLIENT_SECRET }}
 
       - name: cd/download-container-image
+        env:
+          DOCKER_TAG: ${{ needs.build-docker.outputs.TAG }}
         run: |
-          docker pull mattermostdevelopment/mattermost-team-edition:${{ needs.build-docker.outputs.TAG }}
+          docker pull "mattermostdevelopment/mattermost-team-edition:${DOCKER_TAG}"
 
       - name: cd/scan-image
+        env:
+          DOCKER_TAG: ${{ needs.build-docker.outputs.TAG }}
         run: |
-          ./wizcli docker scan --image mattermostdevelopment/mattermost-team-edition:${{ needs.build-docker.outputs.TAG }} --policy "$POLICY"
+          ./wizcli docker scan --image "mattermostdevelopment/mattermost-team-edition:${DOCKER_TAG}" --policy "$POLICY"
 
   update-failure-final-status:
     if: (failure() || cancelled()) && github.event.workflow_run.event == 'pull_request'

--- a/.github/workflows/server-ci-report.yml
+++ b/.github/workflows/server-ci-report.yml
@@ -111,12 +111,13 @@ jobs:
         uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
         if: ${{ steps.report.outputs.flaky_summary != '<table><tr><th>Test</th><th>Retries</th></tr></table>' && steps.report.outputs.failed == '0' && github.event.workflow_run.event == 'pull_request' }}
         env:
-          TEST_NAME: "${{ matrix.test.name }}"
           FLAKY_SUMMARY: "${{ steps.report.outputs.flaky_summary }}"
           PR_NUMBER: "${{ steps.incoming-pr.outputs.NUMBER }}"
+          TEST_NAME: "${{ matrix.test.name }}"
+          WORKFLOW_RUN_HTML_URL: ${{ github.event.workflow_run.html_url }}
         with:
           script: |
-            const body = `#### ⚠️  One or more flaky tests detected ⚠️\n* Workflow run: [github.com/mattermost/mattermost:${process.env.TEST_NAME}](${{ github.event.workflow_run.html_url }})\n* Double check your code to ensure you have not introduced a flaky test.\n\n${process.env.FLAKY_SUMMARY}`
+            const body = `#### ⚠️  One or more flaky tests detected ⚠️\n* Workflow run: [github.com/mattermost/mattermost:${process.env.TEST_NAME}](${process.env.WORKFLOW_RUN_HTML_URL})\n* Double check your code to ensure you have not introduced a flaky test.\n\n${process.env.FLAKY_SUMMARY}`
 
             await github.rest.issues.createComment({
               issue_number: process.env.PR_NUMBER,

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -75,6 +75,18 @@ jobs:
     continue-on-error: ${{ inputs.allow-failure }} # Used to avoid blocking PRs in case of flakiness
     env:
       COMPOSE_PROJECT_NAME: ghactions
+      INPUT_DATASOURCE: ${{ inputs.datasource }}
+      INPUT_DRIVERNAME: ${{ inputs.drivername }}
+      INPUT_ENABLECOVERAGE: ${{ inputs.enablecoverage }}
+      INPUT_FIPS_ENABLED: ${{ inputs.fips-enabled }}
+      INPUT_FULLYPARALLEL: ${{ inputs.fullyparallel }}
+      INPUT_GO_VERSION: ${{ inputs.go-version }}
+      INPUT_LOGSARTIFACT: ${{ inputs.logsartifact }}
+      INPUT_NAME: ${{ inputs.name }}
+      INPUT_PR_NUMBER: ${{ github.event.pull_request.number }}
+      INPUT_RACE_ENABLED: ${{ inputs.race-enabled }}
+      INPUT_SHARD_TOTAL: ${{ inputs.shard-total }}
+      INPUT_TEST_TARGET: ${{ inputs.test-target }}
     steps:
       - name: buildenv/docker-login
         # Only FIPS requires login for private build container. (Forks won't have credentials.)
@@ -112,18 +124,18 @@ jobs:
       - name: Setup BUILD_IMAGE
         id: build
         run: |
-          if [[ ${{ inputs.fips-enabled }} == 'true' ]]; then
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
-            echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}-fips" >> "${GITHUB_OUTPUT}"
+          if [[ "$INPUT_FIPS_ENABLED" == 'true' ]]; then
+            echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${INPUT_GO_VERSION}" >> "${GITHUB_OUTPUT}"
+            echo "LOG_ARTIFACT_NAME=${INPUT_LOGSARTIFACT}-fips" >> "${GITHUB_OUTPUT}"
           else
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
-            echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}" >> "${GITHUB_OUTPUT}"
+            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${INPUT_GO_VERSION}" >> "${GITHUB_OUTPUT}"
+            echo "LOG_ARTIFACT_NAME=${INPUT_LOGSARTIFACT}" >> "${GITHUB_OUTPUT}"
           fi
 
       - name: Store required variables for publishing results
         run: |
-          echo "${{ inputs.name }}" > server/test-name
-          echo "${{ github.event.pull_request.number }}" > server/pr-number
+          echo "$INPUT_NAME" > server/test-name
+          echo "$INPUT_PR_NUMBER" > server/pr-number
 
       - name: Run docker compose
         env:
@@ -205,18 +217,19 @@ jobs:
         env:
           BUILD_IMAGE: ${{ steps.build.outputs.BUILD_IMAGE }}
         run: |
-          if [[ "${{ inputs.race-enabled }}" == "true" ]]; then
-            export RACE_MODE="-race"
+          RACE_MODE=""
+          if [[ "$INPUT_RACE_ENABLED" == "true" ]]; then
+            RACE_MODE="-race"
           fi
 
-          TEST_TARGET="${{ inputs.test-target }}${RACE_MODE}"
+          TEST_TARGET="${INPUT_TEST_TARGET}${RACE_MODE}"
           BUILD_NUMBER="${GITHUB_HEAD_REF}-${GITHUB_RUN_ID}"
           DOCKER_CMD="make ${TEST_TARGET}"
 
           # When sharding is active, use the multi-run wrapper script.
           # run-shard-tests.sh detects heavy runs itself and falls back to
           # light-only mode when shard-heavy-runs.txt is absent or empty.
-          if [[ "${{ inputs.shard-total }}" -gt 1 && -f server/shard-te-packages.txt ]]; then
+          if [[ "$INPUT_SHARD_TOTAL" -gt 1 && -f server/shard-te-packages.txt ]]; then
             cp server/scripts/run-shard-tests.sh server/run-shard-tests.sh
             chmod +x server/run-shard-tests.sh
             DOCKER_CMD="/mattermost/server/run-shard-tests.sh"
@@ -225,12 +238,12 @@ jobs:
           docker run --net ghactions_mm-test \
             --ulimit nofile=8096:8096 \
             --env-file=server/build/dotenv/test.env \
-            --env MM_SQLSETTINGS_DRIVERNAME="${{ inputs.drivername }}" \
-            --env MM_SQLSETTINGS_DATASOURCE="${{ inputs.datasource }}" \
-            --env TEST_DATABASE_POSTGRESQL_DSN="${{ inputs.datasource }}" \
-            --env ENABLE_FULLY_PARALLEL_TESTS="${{ inputs.fullyparallel }}" \
-            --env ENABLE_COVERAGE="${{ inputs.enablecoverage }}" \
-            --env FIPS_ENABLED="${{ inputs.fips-enabled }}" \
+            --env MM_SQLSETTINGS_DRIVERNAME="$INPUT_DRIVERNAME" \
+            --env MM_SQLSETTINGS_DATASOURCE="$INPUT_DATASOURCE" \
+            --env TEST_DATABASE_POSTGRESQL_DSN="$INPUT_DATASOURCE" \
+            --env ENABLE_FULLY_PARALLEL_TESTS="$INPUT_FULLYPARALLEL" \
+            --env ENABLE_COVERAGE="$INPUT_ENABLECOVERAGE" \
+            --env FIPS_ENABLED="$INPUT_FIPS_ENABLED" \
             --env RACE_MODE \
             --env TEST_TARGET \
             --env BUILD_NUMBER \

--- a/.github/workflows/tag-public-module.yaml
+++ b/.github/workflows/tag-public-module.yaml
@@ -57,9 +57,9 @@ jobs:
         run: |
           echo "RELEASE_NOTES<<EOF" >> ${GITHUB_ENV}
           if [ -z "$COMMIT_SHA" ]; then
-            echo "$(git log --oneline --graph --decorate --abbrev-commit server/public/${{ env.LATEST_MODULE_TAG }}...$(git rev-parse HEAD) server/public)" >> ${GITHUB_ENV}
+            echo "$(git log --oneline --graph --decorate --abbrev-commit "server/public/${LATEST_MODULE_TAG}"...$(git rev-parse HEAD) server/public)" >> ${GITHUB_ENV}
           else
-            echo "$(git log --oneline --graph --decorate --abbrev-commit server/public/${{ env.LATEST_MODULE_TAG }}...${COMMIT_SHA} server/public)" >> ${GITHUB_ENV}
+            echo "$(git log --oneline --graph --decorate --abbrev-commit "server/public/${LATEST_MODULE_TAG}"...${COMMIT_SHA} server/public)" >> ${GITHUB_ENV}
           fi
           echo "EOF" >> ${GITHUB_ENV}
 

--- a/.github/workflows/webapp-ci.yml
+++ b/.github/workflows/webapp-ci.yml
@@ -172,9 +172,10 @@ jobs:
         uses: ./.github/actions/webapp-setup
       - name: ci/test
         env:
+          MATRIX_SHARD: ${{ matrix.shard }}
           NODE_OPTIONS: --max_old_space_size=5120
         run: |
-          npm run test-ci -- --config jest.config.channels.js --coverageDirectory=coverage/shard-${{ matrix.shard }} --shard=${{ matrix.shard }}/4
+          npm run test-ci -- --config jest.config.channels.js --coverageDirectory="coverage/shard-${MATRIX_SHARD}" --shard="${MATRIX_SHARD}/4"
       - name: ci/upload-coverage-artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:


### PR DESCRIPTION
#### Summary
- ci: use variables in shell for workflows
 
#### Ticket Link
https://mattermost.atlassian.net/browse/SEC-10342

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** These changes refactor many CI/workflow files to use step/job environment variables instead of inline GitHub context expressions; functionality is expected to be equivalent but the broad scope (many workflow templates and workflows) raises the chance of subtle environment- vs expression-evaluation differences in edge cases.  
**QA Recommendation:** Run a full CI validation across representative workflows (Cypress, Playwright, server, mmctl, and artifact/release flows) to ensure environment variable propagation and URL/status generation behave identically; manual validation of end-to-end CI runs is recommended because workflow-level automated tests are limited.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->