### PR TITLE
Harden post action request verification (#36840)

### DIFF
--- a/server/channels/api4/integration_action.go
+++ b/server/channels/api4/integration_action.go
@@ -62,6 +62,10 @@ func doPostAction(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.Err = model.NewAppError("DoPostAction", "api.post.do_action.action_integration.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 			return
 		}
+		if cookie.PostId != c.Params.PostId {
+			c.SetPermissionError(model.PermissionReadChannelContent)
+			return
+		}
 		channel, err := c.App.GetChannel(c.AppContext, cookie.ChannelId)
 		if err != nil {
 			c.Err = err

--- a/server/channels/api4/integration_action_test.go
+++ b/server/channels/api4/integration_action_test.go
@@ -273,7 +273,7 @@ func TestOpenDialog(t *testing.T) {
 
 	t.Run("Should fail if trigger timeout is extended", func(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.ServiceSettings.OutgoingIntegrationRequestsTimeout = model.NewPointer(int64(1))
+			cfg.ServiceSettings.OutgoingIntegrationRequestsTimeout = new(int64(1))
 		})
 
 		time.Sleep(2 * time.Second)
@@ -531,5 +531,91 @@ func TestLookupDialog(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, lookupResp)
 		assert.Empty(t, lookupResp.Items)
+	})
+}
+
+func newAttachmentActionPostInChannel(t *testing.T, th *TestHelper, channelID, userID, upstreamURL string) (*model.Post, string) {
+	t.Helper()
+	post := &model.Post{
+		Message:   "attachment action post",
+		ChannelId: channelID,
+		UserId:    userID,
+		Props: model.StringInterface{
+			model.PostPropsAttachments: []*model.MessageAttachment{
+				{
+					Text: "hello",
+					Actions: []*model.PostAction{
+						{
+							Type:        model.PostActionTypeButton,
+							Name:        "click",
+							Integration: &model.PostActionIntegration{URL: upstreamURL},
+						},
+					},
+				},
+			},
+		},
+	}
+	created, _, appErr := th.App.CreatePostAsUser(th.Context, post, "", true)
+	require.Nil(t, appErr)
+
+	withCookies := model.AddPostActionCookies(created, th.App.PostActionCookieSecret())
+	attachments, ok := withCookies.GetProp(model.PostPropsAttachments).([]*model.MessageAttachment)
+	require.True(t, ok)
+	require.NotEmpty(t, attachments)
+	require.NotEmpty(t, attachments[0].Actions)
+	action := attachments[0].Actions[0]
+	require.NotEmpty(t, action.Id)
+	return withCookies, action.Id
+}
+
+func TestDoPostActionCookieChannelAuthorization(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost,127.0.0.1"
+	})
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("{}"))
+	}))
+	defer ts.Close()
+
+	privateChannel := th.CreatePrivateChannel(t)
+	privatePost, privateActionID := newAttachmentActionPostInChannel(t, th, privateChannel.Id, th.BasicUser.Id, ts.URL)
+
+	_, appErr := th.App.AddUserToChannel(th.Context, th.BasicUser2, th.BasicChannel, false)
+	require.Nil(t, appErr)
+	readablePost, _ := newAttachmentActionPostInChannel(t, th, th.BasicChannel.Id, th.BasicUser.Id, ts.URL)
+	readableAttachments, ok := readablePost.GetProp(model.PostPropsAttachments).([]*model.MessageAttachment)
+	require.True(t, ok)
+	readableCookie := readableAttachments[0].Actions[0].Cookie
+	require.NotEmpty(t, readableCookie)
+
+	nonMember := th.CreateClient()
+	th.LoginBasic2WithClient(t, nonMember)
+
+	t.Run("non-member cannot act on the private post without a cookie", func(t *testing.T) {
+		resp, err := nonMember.DoPostAction(context.Background(), privatePost.Id, privateActionID)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("a cookie from a readable channel cannot authorize a different post", func(t *testing.T) {
+		resp, err := nonMember.DoPostActionWithCookie(context.Background(), privatePost.Id, privateActionID, "", readableCookie)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("a member can still act using the post's own cookie", func(t *testing.T) {
+		legitAttachments, ok := privatePost.GetProp(model.PostPropsAttachments).([]*model.MessageAttachment)
+		require.True(t, ok)
+		legitCookie := legitAttachments[0].Actions[0].Cookie
+		require.NotEmpty(t, legitCookie)
+
+		resp, err := th.Client.DoPostActionWithCookie(context.Background(), privatePost.Id, privateActionID, "", legitCookie)
+		require.NoError(t, err)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 }

--- a/server/channels/api4/integration_action_test.go
+++ b/server/channels/api4/integration_action_test.go
@@ -273,7 +273,7 @@ func TestOpenDialog(t *testing.T) {
 
 	t.Run("Should fail if trigger timeout is extended", func(t *testing.T) {
 		th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.ServiceSettings.OutgoingIntegrationRequestsTimeout = new(int64(1))
+			cfg.ServiceSettings.OutgoingIntegrationRequestsTimeout = model.NewPointer(int64(1))
 		})
 
 		time.Sleep(2 * time.Second)


### PR DESCRIPTION
## Summary

Manual cherry-pick of #36840 onto `release-11.7`.

- Require post action cookies to match the target post ID in `doPostAction` (`integration_action.go`)
- Add `newAttachmentActionPostInChannel` helper and `TestDoPostActionCookieChannelAuthorization` coverage (`integration_action_test.go`)

## Conflict resolution

The automated cherry-pick failed on `server/channels/api4/integration_action_test.go`. The conflict was not in the security change itself but in surrounding test code: `master` has additional post-action tests (`newAttachmentActionPost`, `TestDoPostActionQuery_*`, `TestDoPostActionMalformedBody`) that do not exist on `release-11.7`, so git could not line up the append point.

Resolved by applying only this PR's additions on top of `release-11.7`:
- The single `cookie.PostId != c.Params.PostId` permission check in `doPostAction`.
- The `newAttachmentActionPostInChannel` helper and `TestDoPostActionCookieChannelAuthorization` test, appended after the last existing test in the file.

No unrelated `master`-only code was pulled in; the net change is the same +90 line security fix as the original PR.

#### Release Note
```release-note
NONE
```
