### PR TITLE
Fix Bot Accounts search pagination

### DIFF
--- a/api/v4/source/bots.yaml
+++ b/api/v4/source/bots.yaml
@@ -75,6 +75,12 @@
             orphaned if its owner has been deactivated.
           schema:
             type: boolean
+        - name: search
+          in: query
+          description: A term to search for bots by username, display name, description,
+            or owner username.
+          schema:
+            type: string
       responses:
         "200":
           description: Bot page retrieval successful

--- a/server/channels/api4/bot.go
+++ b/server/channels/api4/bot.go
@@ -156,6 +156,7 @@ func getBot(c *Context, w http.ResponseWriter, r *http.Request) {
 func getBots(c *Context, w http.ResponseWriter, r *http.Request) {
 	includeDeleted, _ := strconv.ParseBool(r.URL.Query().Get("include_deleted"))
 	onlyOrphaned, _ := strconv.ParseBool(r.URL.Query().Get("only_orphaned"))
+	search := r.URL.Query().Get("search")
 
 	var OwnerId string
 	if c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionReadOthersBots) {
@@ -175,6 +176,7 @@ func getBots(c *Context, w http.ResponseWriter, r *http.Request) {
 		OwnerId:        OwnerId,
 		IncludeDeleted: includeDeleted,
 		OnlyOrphaned:   onlyOrphaned,
+		Search:         search,
 	})
 	if appErr != nil {
 		c.Err = appErr

--- a/server/channels/api4/bot_test.go
+++ b/server/channels/api4/bot_test.go
@@ -1027,6 +1027,28 @@ func TestGetBots(t *testing.T) {
 		CheckEtag(t, bots, resp)
 	})
 
+	t.Run("search bots, include deleted", func(t *testing.T) {
+		defaultPerms := th.SaveDefaultRolePermissions(t)
+		defer th.RestoreDefaultRolePermissions(t, defaultPerms)
+
+		th.AddPermissionToRole(t, model.PermissionReadBots.Id, model.TeamUserRoleId)
+		th.AddPermissionToRole(t, model.PermissionReadOthersBots.Id, model.TeamUserRoleId)
+		_, appErr := th.App.UpdateUserRoles(th.Context, th.BasicUser.Id, model.TeamUserRoleId, false)
+		assert.Nil(t, appErr)
+
+		expectedBotList := []*model.Bot{bot2}
+		th.TestForAllClients(t, func(t *testing.T, client *model.Client4) {
+			bots, resp, err := client.GetBotsIncludeDeletedWithSearch(context.Background(), 0, 1, "second", "")
+			require.NoError(t, err)
+			CheckOKStatus(t, resp)
+			require.Equal(t, expectedBotList, bots)
+		})
+
+		botList := model.BotList(expectedBotList)
+		bots, resp, _ := th.Client.GetBotsIncludeDeletedWithSearch(context.Background(), 0, 1, "second", botList.Etag())
+		CheckEtag(t, bots, resp)
+	})
+
 	t.Run("get bots, page=0, perPage=10, only orphaned", func(t *testing.T) {
 		defaultPerms := th.SaveDefaultRolePermissions(t)
 		defer th.RestoreDefaultRolePermissions(t, defaultPerms)

--- a/server/channels/store/sqlstore/bot_store.go
+++ b/server/channels/store/sqlstore/bot_store.go
@@ -107,7 +107,7 @@ func (us SqlBotStore) Get(botUserId string, includeDeleted bool) (*model.Bot, er
 func (us SqlBotStore) GetAll(options *model.BotGetOptions) ([]*model.Bot, error) {
 	var conditions []string
 	var conditionsSql string
-	var additionalJoin string
+	var joins []string
 	var args []any
 
 	if !options.IncludeDeleted {
@@ -118,8 +118,17 @@ func (us SqlBotStore) GetAll(options *model.BotGetOptions) ([]*model.Bot, error)
 		args = append(args, options.OwnerId)
 	}
 	if options.OnlyOrphaned {
-		additionalJoin = "JOIN Users o ON (o.Id = b.OwnerId)"
+		joins = append(joins, "LEFT JOIN Users o ON (o.Id = b.OwnerId)")
 		conditions = append(conditions, "o.DeleteAt != 0")
+	}
+	search := strings.TrimSpace(options.Search)
+	if search != "" {
+		if !options.OnlyOrphaned {
+			joins = append(joins, "LEFT JOIN Users o ON (o.Id = b.OwnerId)")
+		}
+		searchTerm := wildcardSearchTerm(sanitizeSearchTerm(search, "*"))
+		conditions = append(conditions, "(LOWER(u.Username) LIKE ? ESCAPE '*' OR LOWER(u.FirstName) LIKE ? ESCAPE '*' OR LOWER(b.Description) LIKE ? ESCAPE '*' OR LOWER(o.Username) LIKE ? ESCAPE '*')")
+		args = append(args, searchTerm, searchTerm, searchTerm, searchTerm)
 	}
 
 	if len(conditions) > 0 {
@@ -141,7 +150,7 @@ func (us SqlBotStore) GetAll(options *model.BotGetOptions) ([]*model.Bot, error)
 			    Bots b
 			JOIN
 			    Users u ON (u.Id = b.UserId)
-			` + additionalJoin + `
+			` + strings.Join(joins, "\n") + `
 			` + conditionsSql + `
 			ORDER BY
 			    b.CreateAt ASC,

--- a/server/channels/store/storetest/bot_store.go
+++ b/server/channels/store/storetest/bot_store.go
@@ -259,6 +259,28 @@ func testBotStoreGetAll(t *testing.T, rctx request.CTX, ss store.Store, s SqlSto
 		require.Equal(t, []*model.Bot{}, bots)
 	})
 
+	t.Run("search filters before pagination", func(t *testing.T) {
+		bots, err := ss.Bot().GetAll(&model.BotGetOptions{Page: 0, PerPage: 1, Search: "b3"})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Bot{
+			b3,
+		}, bots)
+	})
+
+	t.Run("search matches bot metadata and owner username", func(t *testing.T) {
+		bots, err := ss.Bot().GetAll(&model.BotGetOptions{Page: 0, PerPage: 10, Search: "fourth"})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Bot{
+			b4,
+		}, bots)
+
+		bots, err = ss.Bot().GetAll(&model.BotGetOptions{Page: 0, PerPage: 10, Search: deletedUser.Username})
+		require.NoError(t, err)
+		require.Equal(t, []*model.Bot{
+			ob5,
+		}, bots)
+	})
+
 	t.Run("get offset=0, limit=2, include deleted", func(t *testing.T) {
 		bots, err := ss.Bot().GetAll(&model.BotGetOptions{Page: 0, PerPage: 2, IncludeDeleted: true})
 		require.NoError(t, err)

--- a/server/public/model/bot.go
+++ b/server/public/model/bot.go
@@ -67,6 +67,7 @@ type BotGetOptions struct {
 	OwnerId        string
 	IncludeDeleted bool
 	OnlyOrphaned   bool
+	Search         string
 	Page           int
 	PerPage        int
 }

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -2097,9 +2097,27 @@ func (c *Client4) GetBotIncludeDeleted(ctx context.Context, userId string, etag 
 
 // GetBots fetches the given page of bots, excluding deleted.
 func (c *Client4) GetBots(ctx context.Context, page, perPage int, etag string) ([]*Bot, *Response, error) {
+	return c.getBots(ctx, page, perPage, false, false, "", etag)
+}
+
+// GetBotsWithSearch fetches the given page of bots matching search, excluding deleted.
+func (c *Client4) GetBotsWithSearch(ctx context.Context, page, perPage int, search string, etag string) ([]*Bot, *Response, error) {
+	return c.getBots(ctx, page, perPage, false, false, search, etag)
+}
+
+func (c *Client4) getBots(ctx context.Context, page, perPage int, includeDeleted, onlyOrphaned bool, search string, etag string) ([]*Bot, *Response, error) {
 	values := url.Values{}
 	values.Set("page", strconv.Itoa(page))
 	values.Set("per_page", strconv.Itoa(perPage))
+	if includeDeleted {
+		values.Set("include_deleted", c.boolString(true))
+	}
+	if onlyOrphaned {
+		values.Set("only_orphaned", c.boolString(true))
+	}
+	if search != "" {
+		values.Set("search", search)
+	}
 	r, err := c.doAPIGetWithQuery(ctx, c.botsRoute(), values, etag)
 	if err != nil {
 		return nil, BuildResponse(r), err
@@ -2110,30 +2128,17 @@ func (c *Client4) GetBots(ctx context.Context, page, perPage int, etag string) (
 
 // GetBotsIncludeDeleted fetches the given page of bots, including deleted.
 func (c *Client4) GetBotsIncludeDeleted(ctx context.Context, page, perPage int, etag string) ([]*Bot, *Response, error) {
-	values := url.Values{}
-	values.Set("page", strconv.Itoa(page))
-	values.Set("per_page", strconv.Itoa(perPage))
-	values.Set("include_deleted", c.boolString(true))
-	r, err := c.doAPIGetWithQuery(ctx, c.botsRoute(), values, etag)
-	if err != nil {
-		return nil, BuildResponse(r), err
-	}
-	defer closeBody(r)
-	return DecodeJSONFromResponse[BotList](r)
+	return c.getBots(ctx, page, perPage, true, false, "", etag)
+}
+
+// GetBotsIncludeDeletedWithSearch fetches the given page of bots matching search, including deleted.
+func (c *Client4) GetBotsIncludeDeletedWithSearch(ctx context.Context, page, perPage int, search string, etag string) ([]*Bot, *Response, error) {
+	return c.getBots(ctx, page, perPage, true, false, search, etag)
 }
 
 // GetBotsOrphaned fetches the given page of bots, only including orphaned bots.
 func (c *Client4) GetBotsOrphaned(ctx context.Context, page, perPage int, etag string) ([]*Bot, *Response, error) {
-	values := url.Values{}
-	values.Set("page", strconv.Itoa(page))
-	values.Set("per_page", strconv.Itoa(perPage))
-	values.Set("only_orphaned", c.boolString(true))
-	r, err := c.doAPIGetWithQuery(ctx, c.botsRoute(), values, etag)
-	if err != nil {
-		return nil, BuildResponse(r), err
-	}
-	defer closeBody(r)
-	return DecodeJSONFromResponse[BotList](r)
+	return c.getBots(ctx, page, perPage, false, true, "", etag)
 }
 
 // DisableBot disables the given bot in the system.

--- a/webapp/channels/src/components/backstage/components/backstage_list.tsx
+++ b/webapp/channels/src/components/backstage/components/backstage_list.tsx
@@ -26,6 +26,7 @@ type Props = {
     helpText?: ReactNode;
     loading: boolean;
     searchPlaceholder?: string;
+    onFilterChange?: (filter: string) => void;
     nextPage?: () => void;
     previousPage?: () => void;
     page?: number;
@@ -55,7 +56,11 @@ const BackstageList = (remainingProps: Props) => {
     const {formatMessage} = useIntl();
 
     const [filter, setFilter] = useState('');
-    const updateFilter = (e: ChangeEvent<HTMLInputElement>) => setFilter(e.target.value);
+    const updateFilter = (e: ChangeEvent<HTMLInputElement>) => {
+        const nextFilter = e.target.value;
+        setFilter(nextFilter);
+        remainingProps.onFilterChange?.(nextFilter);
+    };
     const filterLowered = filter.toLowerCase();
 
     let searchPlaceholder;

--- a/webapp/channels/src/components/integrations/bots/bots.tsx
+++ b/webapp/channels/src/components/integrations/bots/bots.tsx
@@ -58,7 +58,7 @@ type Props = {
         /**
          * Ensure we have bot accounts
          */
-        loadBots: (page?: number, perPage?: number) => Promise<ActionResult<BotType[]>>;
+        loadBots: (page?: number, perPage?: number, search?: string) => Promise<ActionResult<BotType[]>>;
 
         /**
         * Load access tokens for bot accounts
@@ -106,6 +106,8 @@ type State = {
 }
 
 export default class Bots extends React.PureComponent<Props, State> {
+    private latestSearchTerm = '';
+
     public constructor(props: Props) {
         super(props);
 
@@ -115,33 +117,43 @@ export default class Bots extends React.PureComponent<Props, State> {
     }
 
     public componentDidMount(): void {
-        this.props.actions.loadBots(
-            Constants.Integrations.START_PAGE_NUM,
-            Constants.Integrations.PAGE_SIZE,
-        ).then(
-            (result) => {
-                if (result.data) {
-                    const promises = [];
-
-                    for (const bot of result.data) {
-                        // We don't need to wait for this and we need to accept failure in the case where bot.owner_id is a plugin id
-                        this.props.actions.getUser(bot.owner_id);
-
-                        // We want to wait for these.
-                        promises.push(this.props.actions.getUser(bot.user_id));
-                        promises.push(this.props.actions.getUserAccessTokensForUser(bot.user_id));
-                    }
-
-                    Promise.all(promises).then(() => {
-                        this.setState({loading: false});
-                    });
-                }
-            },
-        );
+        this.loadBots();
         if (this.props.appsEnabled) {
             this.props.actions.fetchAppsBotIDs();
         }
     }
+
+    loadBots = (searchTerm = ''): void => {
+        this.latestSearchTerm = searchTerm;
+        this.setState({loading: true});
+        this.props.actions.loadBots(
+            Constants.Integrations.START_PAGE_NUM,
+            Constants.Integrations.PAGE_SIZE,
+            searchTerm,
+        ).then(
+            (result) => {
+                if (this.latestSearchTerm !== searchTerm) {
+                    return;
+                }
+                const promises = [];
+
+                for (const bot of result.data || []) {
+                    // We don't need to wait for this and we need to accept failure in the case where bot.owner_id is a plugin id
+                    this.props.actions.getUser(bot.owner_id);
+
+                    // We want to wait for these.
+                    promises.push(this.props.actions.getUser(bot.user_id));
+                    promises.push(this.props.actions.getUserAccessTokensForUser(bot.user_id));
+                }
+
+                Promise.all(promises).then(() => {
+                    if (this.latestSearchTerm === searchTerm) {
+                        this.setState({loading: false});
+                    }
+                });
+            },
+        );
+    };
 
     DisabledSection(props: {hasDisabled: boolean; disabledBots: JSX.Element[]; filter?: string}): JSX.Element | null {
         if (!props.hasDisabled) {
@@ -273,6 +285,7 @@ export default class Bots extends React.PureComponent<Props, State> {
                     </>
                 }
                 searchPlaceholder={Utils.localizeMessage({id: 'bots.manage.search', defaultMessage: 'Search Bot Accounts'})}
+                onFilterChange={this.loadBots}
                 loading={this.state.loading}
             >
                 {this.bots}

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/bots.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/bots.ts
@@ -41,13 +41,14 @@ export function loadBot(botUserId: string) {
     });
 }
 
-export function loadBots(page = 0, perPage = BOTS_PER_PAGE_DEFAULT) {
+export function loadBots(page = 0, perPage = BOTS_PER_PAGE_DEFAULT, search = '') {
     return bindClientFunc({
         clientFunc: Client4.getBotsIncludeDeleted,
         onSuccess: BotTypes.RECEIVED_BOT_ACCOUNTS,
         params: [
             page,
             perPage,
+            search,
         ],
     });
 }

--- a/webapp/platform/client/src/client4.test.ts
+++ b/webapp/platform/client/src/client4.test.ts
@@ -111,6 +111,26 @@ describe('Client4', () => {
         });
     });
 
+    describe('bot routes', () => {
+        let client: Client4;
+
+        beforeEach(() => {
+            client = new Client4();
+            client.setUrl('http://mattermost.example.com');
+        });
+
+        test('getBotsIncludeDeleted should include search when provided', async () => {
+            nock(client.getBaseRoute()).
+                get('/bots').
+                query({include_deleted: 'true', page: '0', per_page: '200', search: 'second bot'}).
+                reply(200, []);
+
+            const result = await client.getBotsIncludeDeleted(0, 200, 'second bot');
+
+            expect(result).toEqual([]);
+        });
+    });
+
     describe('content flagging routes', () => {
         let client: Client4;
 
@@ -312,4 +332,3 @@ describe('ClientError', () => {
         expect(error.cause).toEqual(cause);
     });
 });
-

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -4396,9 +4396,9 @@ export default class Client4 {
         );
     };
 
-    getBotsIncludeDeleted = (page = 0, perPage = PER_PAGE_DEFAULT) => {
+    getBotsIncludeDeleted = (page = 0, perPage = PER_PAGE_DEFAULT, search = '') => {
         return this.doFetch<Bot[]>(
-            `${this.getBotsRoute()}${buildQueryString({include_deleted: true, page, per_page: perPage})}`,
+            `${this.getBotsRoute()}${buildQueryString({include_deleted: true, page, per_page: perPage, search: search || undefined})}`,
             {method: 'get'},
         );
     };


### PR DESCRIPTION
#### Summary
Adds server-side search support to the bots list endpoint and wires the Bot Accounts search box to pass the search term through the web client. The SQL filter now runs before pagination, so matching bot accounts can be found even when they are beyond the capped first page of results.

Also adds coverage for bot store search pagination, API search behavior, and the web client query parameter.

Verification:
- `go test ./model -run 'TestBot|TestClient4' -count=1` from `server/public` passed.
- `GOWORK=<temp local workspace> go test ./channels/api4 -run TestGetBots -count=1` compiled, then failed at Postgres setup because `::1:5432` is not running in this environment.
- `GOWORK=<temp local workspace> go test ./channels/store/sqlstore -run 'TestSqlBotStore/TestBotStore/GetAll|TestBotStore/GetAll' -count=1` compiled, then failed at Postgres setup because `::1:5432` is not running in this environment.
- `npm test --workspace platform/client -- --runInBand -t 'bot routes'` could not run because the workspace dependencies are not installed and `jest` is unavailable.
- `git diff --check` passed.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/36872

#### Release Note
```release-note
Fixed Bot Accounts search so matching bots can be found beyond the first paginated result set.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The SQL query refactoring in `bot_store.go` that changes JOIN clause construction could introduce regressions in edge cases (e.g., orphaned bot handling). While the search parameter is optional and backward-compatible, the dynamic JOIN logic for both orphaned and search scenarios increases complexity.

**QA Recommendation:** Manual testing is recommended to verify: (1) bot search filters correctly across username/display name/description/owner fields, (2) pagination works correctly when search is applied (matching bots beyond first page can be found), (3) existing bot listing without search term works identically to before, and (4) orphaned bot handling with and without search filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->