### PR TITLE
Prepackage mattermost-plugin-agents v2.0.4 (release-11.7)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -164,7 +164,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.0
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.9.0
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.3
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.4
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.6.0
@@ -178,7 +178,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.9.0%2Bdfb5b30-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.3%2Bcab391a-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.4%2Bf359551-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4%2B5855fe1-fips
 endif
 


### PR DESCRIPTION
#### Summary

Updates the default prepackaged [mattermost-plugin-agents](https://github.com/mattermost/mattermost-plugin-agents) artifact from **2.0.3** to **2.0.4** ([release v2.0.4](https://github.com/mattermost/mattermost-plugin-agents/releases/tag/v2.0.4)) for the `release-11.7` branch.

Both prepackaged plugin lists are updated:
- non-FIPS: `mattermost-plugin-agents-v2.0.4`
- FIPS: `mattermost-plugin-agents-v2.0.4%2Bf359551-fips`

#### Release Note

```release-note
Prepackaged the Mattermost Agents plugin at version 2.0.4 instead of 2.0.3.
```

Made with [Cursor](https://cursor.com)