### PR TITLE
Stop shared channel sync error spam for deleted remote clusters

### DIFF
--- a/server/channels/store/sqlstore/shared_channel_store.go
+++ b/server/channels/store/sqlstore/shared_channel_store.go
@@ -759,12 +759,14 @@ func (s SqlSharedChannelStore) GetSingleUser(userID string, channelID string, re
 	return &scu, nil
 }
 
-// GetUsersForUser fetches all shared channel user records based on userID.
+// GetUsersForUser fetches all shared channel user records based on userID,
+// excluding rows whose remote cluster has been deleted or no longer exists.
 func (s SqlSharedChannelStore) GetUsersForUser(userID string) ([]*model.SharedChannelUser, error) {
 	squery, args, err := s.getQueryBuilder().
-		Select(sharedChannelUserFields("")...).
-		From("SharedChannelUsers").
-		Where(sq.Eq{"SharedChannelUsers.UserId": userID}).
+		Select(sharedChannelUserFields("scu")...).
+		From("SharedChannelUsers AS scu").
+		Where(sq.Eq{"scu.UserId": userID}).
+		Where("EXISTS (SELECT 1 FROM RemoteClusters rc WHERE rc.RemoteId = scu.RemoteId AND rc.DeleteAt = 0)").
 		ToSql()
 
 	if err != nil {

--- a/server/channels/store/storetest/shared_channel_store.go
+++ b/server/channels/store/storetest/shared_channel_store.go
@@ -1297,11 +1297,22 @@ func testGetSingleSharedChannelUser(t *testing.T, rctx request.CTX, ss store.Sto
 }
 
 func testGetSharedChannelUser(t *testing.T, rctx request.CTX, ss store.Store) {
+	// GetUsersForUser only returns rows whose remote cluster still exists and
+	// is not deleted, so point the rows at a live remote.
+	liveRemote := &model.RemoteCluster{
+		RemoteId:  model.NewId(),
+		SiteURL:   "http://example.com",
+		CreatorId: model.NewId(),
+		Name:      "live-remote",
+	}
+	_, err := ss.RemoteCluster().Save(liveRemote)
+	require.NoError(t, err, "couldn't save remote cluster", err)
+
 	userId := model.NewId()
 	for range 10 {
 		scUser := &model.SharedChannelUser{
 			UserId:    userId,
-			RemoteId:  model.NewId(),
+			RemoteId:  liveRemote.RemoteId,
 			ChannelId: model.NewId(),
 		}
 		_, err := ss.SharedChannel().SaveUser(scUser)
@@ -1320,6 +1331,53 @@ func testGetSharedChannelUser(t *testing.T, rctx request.CTX, ss store.Store) {
 		scus, err := ss.SharedChannel().GetUsersForUser(model.NewId())
 		require.NoError(t, err, "should not error when not found")
 		require.Empty(t, scus, "should be empty")
+	})
+
+	t.Run("Excludes rows for deleted or missing remote clusters", func(t *testing.T) {
+		deletedRemote := &model.RemoteCluster{
+			RemoteId:  model.NewId(),
+			SiteURL:   "http://example.com",
+			CreatorId: model.NewId(),
+			Name:      "deleted-remote",
+		}
+		_, err := ss.RemoteCluster().Save(deletedRemote)
+		require.NoError(t, err)
+
+		mixedUserId := model.NewId()
+		// Two rows for the live remote: these should be returned.
+		for range 2 {
+			_, err = ss.SharedChannel().SaveUser(&model.SharedChannelUser{
+				UserId:    mixedUserId,
+				RemoteId:  liveRemote.RemoteId,
+				ChannelId: model.NewId(),
+			})
+			require.NoError(t, err)
+		}
+		// One row for a soft-deleted remote: should be excluded.
+		_, err = ss.SharedChannel().SaveUser(&model.SharedChannelUser{
+			UserId:    mixedUserId,
+			RemoteId:  deletedRemote.RemoteId,
+			ChannelId: model.NewId(),
+		})
+		require.NoError(t, err)
+		// One row for a remote that never existed: should be excluded.
+		_, err = ss.SharedChannel().SaveUser(&model.SharedChannelUser{
+			UserId:    mixedUserId,
+			RemoteId:  model.NewId(),
+			ChannelId: model.NewId(),
+		})
+		require.NoError(t, err)
+
+		deleted, err := ss.RemoteCluster().Delete(deletedRemote.RemoteId)
+		require.NoError(t, err)
+		require.True(t, deleted)
+
+		scus, err := ss.SharedChannel().GetUsersForUser(mixedUserId)
+		require.NoError(t, err)
+		require.Len(t, scus, 2, "should only return rows pointing at the live remote")
+		for _, scu := range scus {
+			require.Equal(t, liveRemote.RemoteId, scu.RemoteId)
+		}
 	})
 }
 

--- a/server/platform/services/sharedchannel/sync_send.go
+++ b/server/platform/services/sharedchannel/sync_send.go
@@ -5,6 +5,8 @@ package sharedchannel
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"slices"
 	"time"
@@ -430,6 +432,16 @@ func (scs *Service) processTask(task syncTask) error {
 	} else {
 		rc, err := scs.server.GetStore().RemoteCluster().Get(task.remoteID, false)
 		if err != nil {
+			// The remote cluster has been deleted or no longer exists; there is
+			// nothing to sync, so drop the task rather than retrying and logging
+			// an error on every change for the orphaned reference.
+			if errors.Is(err, sql.ErrNoRows) {
+				scs.server.Log().Warn("Skipping sync for deleted remote cluster",
+					mlog.String("channelId", task.channelID),
+					mlog.String("remoteId", task.remoteID),
+				)
+				return nil
+			}
 			return err
 		}
 		if !rc.IsOnline() {

--- a/server/platform/services/sharedchannel/sync_send_test.go
+++ b/server/platform/services/sharedchannel/sync_send_test.go
@@ -4,9 +4,14 @@
 package sharedchannel
 
 import (
+	"database/sql"
+	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,6 +21,51 @@ func newTestService() *Service {
 		changeSignal: make(chan struct{}, 1),
 		tasks:        make(map[string]syncTask),
 	}
+}
+
+func TestProcessTask_RemoteClusterLookup(t *testing.T) {
+	newServiceWithRemoteGet := func(t *testing.T, remoteID string, rc *model.RemoteCluster, getErr error) *Service {
+		t.Helper()
+
+		mockRemoteClusterStore := &mocks.RemoteClusterStore{}
+		mockRemoteClusterStore.On("Get", remoteID, false).Return(rc, getErr)
+
+		mockStore := &mocks.Store{}
+		mockStore.On("RemoteCluster").Return(mockRemoteClusterStore)
+
+		mockServer := &MockServerIface{}
+		mockServer.On("GetStore").Return(mockStore)
+		mockServer.On("Log").Return(mlog.CreateConsoleTestLogger(t))
+
+		return &Service{
+			server:       mockServer,
+			changeSignal: make(chan struct{}, 1),
+			tasks:        make(map[string]syncTask),
+		}
+	}
+
+	t.Run("deleted or missing remote is skipped without error or retry", func(t *testing.T) {
+		remoteID := model.NewId()
+		// Mirror how the store wraps the not-found case.
+		notFound := fmt.Errorf("failed to find RemoteCluster: %w", sql.ErrNoRows)
+		scs := newServiceWithRemoteGet(t, remoteID, nil, notFound)
+
+		err := scs.processTask(newSyncTask("channel-1", "", remoteID, nil, nil))
+
+		require.NoError(t, err, "a deleted remote should be skipped, not surfaced as an error")
+		assert.Empty(t, scs.tasks, "the task should not be re-enqueued for retry")
+	})
+
+	t.Run("transient error is propagated for retry", func(t *testing.T) {
+		remoteID := model.NewId()
+		dbErr := errors.New("write tcp: connection reset by peer")
+		scs := newServiceWithRemoteGet(t, remoteID, nil, dbErr)
+
+		err := scs.processTask(newSyncTask("channel-1", "", remoteID, nil, nil))
+
+		require.Error(t, err, "a transient lookup error must still be returned so the task retries")
+		assert.ErrorContains(t, err, "connection reset by peer")
+	})
 }
 
 func TestAddTask_OriginRemoteIDMerge(t *testing.T) {


### PR DESCRIPTION
#### Summary
Change `SqlSharedChannelStore.GetUsersForUser` to skip users whose remotes don't exist or have been soft-deleted. This prevents `NotifyUserProfileChanged` and `NotifyUserStatusChanged` from queuing tasks that will inevitably fail without the corresponding remote.

If a task does happen to get queued up for which the remote is missing, handle the `ErrNotFound` discretely, log as a warning, and don't requeue the task.

This is all to reduce the secondary driver of ERROR log spam in production:
<img width="1720" height="444" alt="CleanShot 2026-06-04 at 14 23 19@2x" src="https://github.com/user-attachments/assets/291809f7-0f91-4f7e-8f9b-1f05e9828547" />

Fixes: https://mattermost.atlassian.net/browse/MM-69103

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes add defensive filtering and error handling without modifying existing functionality or contracts. The GetUsersForUser query adds an EXISTS condition to exclude deleted/missing remotes, and processTask distinguishes between transient and permanent (deleted remote) errors—both are additive safety measures rather than behavioral reversals.

**QA Recommendation:** Minimal manual QA required. Focus should be on shared channel sync scenarios with deleted or recently removed remote clusters to verify error logs are reduced. Automated test coverage is comprehensive, including edge cases for missing/deleted remotes and transient errors. Standard regression testing for shared channel functionality is sufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->