### PR TITLE
[MM-69119] MBE Phase 12e: createButtonText for registerChannelTypeOption

### DIFF
--- a/webapp/channels/src/components/new_channel_modal/new_channel_modal.test.tsx
+++ b/webapp/channels/src/components/new_channel_modal/new_channel_modal.test.tsx
@@ -555,11 +555,12 @@ describe('components/new_channel_modal - plugin channel-type options', () => {
         group_constrained: false,
     };
 
-    function stateWithOption(overrides: {isAvailable?: () => boolean; onCreate?: jest.Mock; extraContent?: React.ComponentType<any>} = {}): DeepPartial<GlobalState> {
+    function stateWithOption(overrides: {isAvailable?: () => boolean; onCreate?: jest.Mock; extraContent?: React.ComponentType<any>; createButtonText?: React.ReactNode} = {}): DeepPartial<GlobalState> {
         const {
             isAvailable = () => true,
             onCreate = jest.fn().mockResolvedValue({status: 'created', channel: mockChannel}),
             extraContent,
+            createButtonText,
         } = overrides;
 
         return {
@@ -577,6 +578,7 @@ describe('components/new_channel_modal - plugin channel-type options', () => {
                             isAvailable,
                             onCreate,
                             extraContent,
+                            createButtonText,
                         },
                     ],
                 },
@@ -605,6 +607,26 @@ describe('components/new_channel_modal - plugin channel-type options', () => {
         await userEvent.click(pluginButton);
 
         expect(pluginButton.closest('button')).toHaveClass('selected');
+    });
+
+    test('confirm button label - falls back to "Create channel" when the selected option supplies no createButtonText', async () => {
+        renderWithContext(<NewChannelModal/>, stateWithOption());
+
+        await userEvent.click(screen.getByText('Plugin Channel'));
+
+        expect(screen.getByRole('button', {name: /create channel/i})).toBeInTheDocument();
+    });
+
+    test('confirm button label - uses the selected option createButtonText when supplied', async () => {
+        renderWithContext(<NewChannelModal/>, stateWithOption({createButtonText: 'Next'}));
+
+        // Before selecting the plugin option, the default built-in label is shown.
+        expect(screen.getByRole('button', {name: /create channel/i})).toBeInTheDocument();
+
+        await userEvent.click(screen.getByText('Plugin Channel'));
+
+        expect(screen.getByRole('button', {name: 'Next'})).toBeInTheDocument();
+        expect(screen.queryByRole('button', {name: /create channel/i})).not.toBeInTheDocument();
     });
 
     test('isAvailable gating - unavailable option renders only Public and Private', () => {

--- a/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
+++ b/webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx
@@ -432,7 +432,7 @@ const NewChannelModal = () => {
         <LoadingSpinner
             text={formatMessage({id: 'channel_modal.creating', defaultMessage: 'Creating...'})}
         />
-    ) : formatMessage({id: 'channel_modal.createNew', defaultMessage: 'Create channel'});
+    ) : (activePluginOption?.createButtonText ?? formatMessage({id: 'channel_modal.createNew', defaultMessage: 'Create channel'}));
 
     return (
         <GenericModal

--- a/webapp/channels/src/plugins/registry.ts
+++ b/webapp/channels/src/plugins/registry.ts
@@ -1333,6 +1333,7 @@ export default class PluginRegistry {
         'isAvailable',
         'extraContent',
         'onCreate',
+        'createButtonText',
     ], ({
         label,
         description,
@@ -1340,6 +1341,7 @@ export default class PluginRegistry {
         isAvailable,
         extraContent,
         onCreate,
+        createButtonText,
     }: {
         label: ReactResolvable;
         description: ReactResolvable;
@@ -1347,6 +1349,7 @@ export default class PluginRegistry {
         isAvailable: ChannelTypeOptionComponent['isAvailable'];
         extraContent?: ChannelTypeOptionComponent['extraContent'];
         onCreate: ChannelTypeOptionComponent['onCreate'];
+        createButtonText?: ReactResolvable;
     }) => {
         const id = generateId();
         dispatchPluginComponentWithData('ChannelTypeOption', {
@@ -1358,6 +1361,7 @@ export default class PluginRegistry {
             isAvailable,
             extraContent,
             onCreate,
+            createButtonText: createButtonText ? resolveReactElement(createButtonText) : undefined,
         });
 
         return id;

--- a/webapp/channels/src/plugins/registry.ts
+++ b/webapp/channels/src/plugins/registry.ts
@@ -1361,7 +1361,7 @@ export default class PluginRegistry {
             isAvailable,
             extraContent,
             onCreate,
-            createButtonText: createButtonText ? resolveReactElement(createButtonText) : undefined,
+            createButtonText: createButtonText === undefined ? undefined : resolveReactElement(createButtonText),
         });
 
         return id;

--- a/webapp/channels/src/types/store/plugins.ts
+++ b/webapp/channels/src/types/store/plugins.ts
@@ -461,6 +461,7 @@ export type ChannelTypeOptionComponent = PluginComponent & {
     label: PluggableText;
     description: PluggableText;
     icon: React.ReactNode;
+    createButtonText?: PluggableText;
 
     /** Called with the full Redux state so plugins can read their own plugin-scoped state. */
     isAvailable: (state: GlobalState) => boolean;


### PR DESCRIPTION
#### Summary

A small, generic webapp-registry addition that the MBE plugin's new multi-step Create Channel flow needs — useful beyond MBE. `registerChannelTypeOption` gains an optional `createButtonText` so a plugin-supplied channel type can relabel the modal's confirm button (MBE uses it to show "Next" and defer into a second step). Omitting the field is fully backward compatible.

Companion plugin PR: https://github.com/mattermost/message-based-encryption/pull/19

#### Tips for reviewing (suggested order)

1. **`webapp/channels/src/types/store/plugins.ts`** — the contract: the optional `createButtonText` field on `ChannelTypeOptionComponent`. Additive.
2. **`webapp/channels/src/plugins/registry.ts`** — `createButtonText` threaded through `registerChannelTypeOption`'s `reArg`/`resolveReactElement` path.
3. **`webapp/channels/src/components/new_channel_modal/new_channel_modal.tsx`** — the only host behavior change: the confirm button prefers the active plugin option's `createButtonText`, falling back to "Create channel" (so omitting the field is fully backward compatible).

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-69119

#### Release Note

```release-note
Phase 12e of the mbe-tech-preview.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** This is an additive, backward-compatible option that preserves default behavior when `createButtonText` is not provided. Risk is limited to UI text rendering in the Create Channel modal, with no changes to auth, persistence, or channel creation logic.

**QA Recommendation:** Light manual QA to verify the Create Channel modal confirm button shows (1) the default “Create channel” when no `createButtonText` is supplied, and (2) the custom text (e.g., “Next”) when it is. Also confirm the loading/submitting state keeps the existing “Creating...” behavior.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->