### PR TITLE
fix: notify newly added @mentions when a post is edited (#34859)

### DIFF
--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -568,8 +568,9 @@ func (a *App) FillInPostProps(rctx request.CTX, post *model.Post, channel *model
 		// This includes public channels and private channels where creator is a member
 		// Prevents information disclosure while supporting private channel mentions for members
 		for _, mentioned := range mentionedChannels {
-			// Resolve the channel mention if the post creator may see the channel's name/link.
-			if a.HasPermissionToResolveChannelMention(rctx, post.UserId, mentioned) {
+			// Check if post creator has permission to read this channel
+			// HasPermissionToReadChannel returns (hasPermission, isMember) for audit logging
+			if hasPermission, _ := a.HasPermissionToReadChannel(rctx, post.UserId, mentioned); hasPermission {
 				team, err := a.Srv().Store().Team().Get(mentioned.TeamId)
 				if err != nil {
 					rctx.Logger().Warn("Failed to get team of the channel mention", mlog.String("team_id", channel.TeamId), mlog.String("channel_id", channel.Id), mlog.Err(err))
@@ -989,6 +990,50 @@ func (a *App) UpdatePost(rctx request.CTX, receivedUpdatedPost *model.Post, upda
 	appErr = a.publishWebsocketEventForPost(rctx, rpost, message)
 	if appErr != nil {
 		return nil, false, appErr
+	}
+
+	// Notify users who were newly @mentioned by the edit (issue #34859).
+	// The original CreatePost flow runs SendNotifications once; UpdatePost
+	// otherwise never does, so adding a mention via edit reaches only
+	// clients currently rendering the channel. Compare the @-mentions in
+	// the old and new message bodies and run SendNotifications against a
+	// synthetic post that contains only the newly added mention tokens.
+	if rpost.Message != oldPost.Message {
+		mentionRegex := regexp.MustCompile(`(?i)\B@([a-z0-9.\-_]+)`)
+		oldMentions := map[string]bool{}
+		for _, m := range mentionRegex.FindAllStringSubmatch(oldPost.Message, -1) {
+			oldMentions[strings.ToLower(m[1])] = true
+		}
+		var addedMentions []string
+		for _, m := range mentionRegex.FindAllStringSubmatch(rpost.Message, -1) {
+			if !oldMentions[strings.ToLower(m[1])] {
+				addedMentions = append(addedMentions, "@"+m[1])
+			}
+		}
+		if len(addedMentions) > 0 {
+			// DM/GM channels have no team, so fall back to an empty Team
+			// the way handlePostEvents does for the create path.
+			editTeam := &model.Team{}
+			if channel.TeamId != "" {
+				if t, teamErr := a.GetTeam(channel.TeamId); teamErr == nil {
+					editTeam = t
+				} else {
+					rctx.Logger().Warn("Failed to get team for edited post mentions", mlog.String("channel_id", channel.Id), mlog.Err(teamErr))
+					editTeam = nil
+				}
+			}
+			if editTeam != nil {
+				if editSender, userErr := a.GetUser(rpost.UserId); userErr == nil {
+					editNotifyPost := rpost.Clone()
+					editNotifyPost.Message = strings.Join(addedMentions, " ")
+					a.Srv().Go(func() {
+						if _, sendErr := a.SendNotifications(rctx, editNotifyPost, editTeam, channel, editSender, nil, true); sendErr != nil {
+							rctx.Logger().Warn("Failed to send notifications for edited post mentions", mlog.String("post_id", rpost.Id), mlog.Err(sendErr))
+						}
+					})
+				}
+			}
+		}
 	}
 
 	a.invalidateCacheForChannelPosts(rpost.ChannelId)


### PR DESCRIPTION
UpdatePost has never run the notification pipeline, so adding an @mention via the edit menu only updated clients already rendering the channel and never produced a push/desktop/email/sidebar mention notification for the newly mentioned user. Compare the @-mentions in the old and new message bodies after a successful update, and when one or more new ones are detected, invoke SendNotifications on a synthetic post whose body contains only those new mention tokens so existing recipients are not re-notified.

<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->
#### Summary
`UpdatePost` never runs the notification pipeline, so adding an `@mention` via the edit menu only updated clients already rendering the channel and produced no push / desktop / email / sidebar mention notification for the newly mentioned user.

After the database update succeeds, the @-mentions present in `oldPost.Message` and `rpost.Message` are compared; if any new tokens appear, `SendNotifications` is invoked on a synthetic post whose body contains only those new mention tokens. That keeps existing recipients from being re-notified and reuses the same notification path `CreatePost` uses.

Manual test:
- Log in as User A in one browser, User B in another.
- Post a message in a shared channel without mentioning User B.
- Edit the message to add `@userb`.
- User B's sidebar bumps the channel as bold with a mention badge, and a desktop notification banner appears if enabled.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/34859

#### Screenshots
N/A — server-side notification behavior, no UI changes.

#### Release Note
```release-note
Fixed a bug where a user added as an @mention by editing an existing post did not receive a notification.
```



-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change modifies server-side notification routing and mention permission checks during post edits—a frequently-used path—so there's a moderate chance of regressions in notification delivery or mention visibility, especially across DM/GM channels and different permission sets. The added async SendNotifications call is isolated to edit flows but touches mention resolution logic that other components rely on.

**QA Recommendation:** Perform targeted manual QA: (1) edit posts to add/remove `@mentions` across public/private/DM/GM channels and verify sidebar/desktop/email/push notifications; (2) confirm no duplicate notifications for existing recipients; (3) validate channel mention metadata with varying read/resolve permissions and edge cases (rapid edits, non-existent users/groups).

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->