### PR TITLE
docs: fix outdated Mattermost Omnibus link in README (#34277)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Table of contents
 Other install guides:
 
 - [Deploy Mattermost on Docker](https://docs.mattermost.com/install/install-docker.html)
-- [Mattermost Omnibus](https://docs.mattermost.com/install/installing-mattermost-omnibus.html)
+- [Deploy Mattermost on Linux](https://docs.mattermost.com/deployment-guide/server/deploy-linux.html)
 - [Install Mattermost from Tar](https://docs.mattermost.com/install/install-tar.html)
 - [Ubuntu 20.04 LTS](https://docs.mattermost.com/install/installing-ubuntu-2004-LTS.html)
 - [Kubernetes](https://docs.mattermost.com/install/install-kubernetes.html)


### PR DESCRIPTION
The "Mattermost Omnibus" entry in the README's "Other install guides" section pointed to an installation guide that no longer exists. The page silently redirects to a generic "Deploy Mattermost on Linux" guide, leaving readers confused. Replace the line with a correct entry pointing directly at that Linux deployment guide.

<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
The "Mattermost Omnibus" entry in the README's "Other install guides" section points to `https://docs.mattermost.com/install/installing-mattermost-omnibus.html`, which silently redirects to `https://docs.mattermost.com/deployment-guide/server/deploy-linux.html` — a generic "Deploy Mattermost on Linux" guide that doesn't mention Omnibus. Since Mattermost Omnibus has been retired and the page no longer exists, replaced the line with a correct entry pointing directly at the Linux deployment guide.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/34277

#### Screenshots
N/A — single-line README change.

#### Release Note
```release-note
NONE
```

-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** No regression risk. This is a documentation-only change affecting a single line in README.md (replacing one URL with another). No code, configurations, or behavior are modified.

**QA Recommendation:** No manual QA required. This change is purely informational (README link update) with no functional code changes or behavioral impact. Verification that the link renders correctly in the README is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->