### PR TITLE
MM-69104: Elide plugin_statuses_changed payload

### DIFF
--- a/server/channels/api4/plugin_test.go
+++ b/server/channels/api4/plugin_test.go
@@ -433,12 +433,17 @@ func TestNotifyClusterPluginEvent(t *testing.T) {
 	// Successful remove
 	webSocketClient := th.CreateConnectedWebSocketClientWithClient(t, th.SystemAdminClient)
 
+	var statusesPresent bool
+	var receivedStatuses any
 	done := make(chan bool)
 	go func() {
 		for {
 			select {
 			case resp := <-webSocketClient.EventChannel:
+				// The event only signals admins to refetch statuses; it carries an empty
+				// plugin_statuses array (compatibility shim), not the full slice.
 				if resp.EventType() == model.WebsocketEventPluginStatusesChanged {
+					receivedStatuses, statusesPresent = resp.GetData()["plugin_statuses"]
 					done <- true
 					return
 				}
@@ -455,6 +460,8 @@ func TestNotifyClusterPluginEvent(t *testing.T) {
 
 	result := <-done
 	require.True(t, result, "plugin_statuses_changed websocket event was not received")
+	require.True(t, statusesPresent, "plugin_statuses field should be present")
+	assert.Empty(t, receivedStatuses, "plugin_statuses should be an empty array")
 
 	messages = testCluster.GetMessages()
 

--- a/server/channels/api4/plugin_test.go
+++ b/server/channels/api4/plugin_test.go
@@ -438,7 +438,7 @@ func TestNotifyClusterPluginEvent(t *testing.T) {
 		for {
 			select {
 			case resp := <-webSocketClient.EventChannel:
-				if resp.EventType() == model.WebsocketEventPluginStatusesChanged && len(resp.GetData()["plugin_statuses"].([]any)) == 0 {
+				if resp.EventType() == model.WebsocketEventPluginStatusesChanged {
 					done <- true
 					return
 				}

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -158,9 +158,7 @@ func (ch *Channels) syncPluginsActiveState() {
 		pluginsEnvironment.Shutdown()
 	}
 
-	if err := ch.notifyPluginStatusesChanged(); err != nil {
-		ch.srv.Log().Warn("failed to notify plugin status changed", mlog.Err(err))
-	}
+	ch.notifyPluginStatusesChanged()
 }
 
 func (a *App) NewPluginAPI(rctx request.CTX, manifest *model.Manifest) plugin.API {

--- a/server/channels/app/plugin_install.go
+++ b/server/channels/app/plugin_install.go
@@ -150,9 +150,7 @@ func (ch *Channels) installPluginFromClusterMessage(pluginID string) {
 		logger.Error("Failed notify plugin enabled", mlog.Err(err))
 	}
 
-	if err := ch.notifyPluginStatusesChanged(); err != nil {
-		logger.Error("Failed to notify plugin status changed", mlog.Err(err))
-	}
+	ch.notifyPluginStatusesChanged()
 }
 
 // removePluginFromClusterMessage is called when a peer removes a plugin, signalling all other
@@ -166,9 +164,7 @@ func (ch *Channels) removePluginFromClusterMessage(pluginID string) {
 		logger.Error("Failed to remove plugin locally", mlog.Err(err))
 	}
 
-	if err := ch.notifyPluginStatusesChanged(); err != nil {
-		logger.Error("failed to notify plugin status changed", mlog.Err(err))
-	}
+	ch.notifyPluginStatusesChanged()
 }
 
 // InstallPlugin unpacks and installs a plugin but does not enable or activate it unless the
@@ -208,9 +204,7 @@ func (ch *Channels) installPlugin(bundle, signature io.ReadSeeker, installationS
 		logger.Warn("Failed to notify plugin enabled", mlog.Err(err))
 	}
 
-	if err := ch.notifyPluginStatusesChanged(); err != nil {
-		logger.Warn("Failed to notify plugin status changed", mlog.Err(err))
-	}
+	ch.notifyPluginStatusesChanged()
 
 	return manifest, nil
 }
@@ -555,9 +549,7 @@ func (ch *Channels) RemovePlugin(id string) *model.AppError {
 		},
 	)
 
-	if err := ch.notifyPluginStatusesChanged(); err != nil {
-		logger.Warn("Failed to notify plugin status changed", mlog.Err(err))
-	}
+	ch.notifyPluginStatusesChanged()
 
 	return nil
 }

--- a/server/channels/app/plugin_statuses.go
+++ b/server/channels/app/plugin_statuses.go
@@ -93,11 +93,15 @@ func (ch *Channels) getClusterPluginStatuses() (model.PluginStatuses, *model.App
 }
 
 // notifyPluginStatusesChanged signals system admins that plugin statuses have changed without
-// carrying any payload. The full, cluster-wide status slice routinely overflows the best-effort
-// (UDP) cluster transport, so admin clients refetch it on demand instead. The signal is sent
-// reliably (TCP) and only to system admins (ContainsSensitiveData).
+// carrying the full status slice. That slice (status for every installed plugin, cluster-wide)
+// routinely overflows the best-effort (UDP) cluster transport, so admin clients refetch it on
+// demand instead. The signal is sent reliably (TCP) and only to system admins (ContainsSensitiveData).
 func (ch *Channels) notifyPluginStatusesChanged() {
 	message := model.NewWebSocketEvent(model.WebsocketEventPluginStatusesChanged, "", "", "", nil, "")
+	// Compatibility shim: some clients (e.g. the Boards/Focalboard plugin) call array methods on
+	// plugin_statuses, so include an empty (non-nil, to serialize as [] rather than null) slice
+	// rather than omitting the field. The payload is intentionally always empty.
+	message.Add("plugin_statuses", model.PluginStatuses{})
 	message.GetBroadcast().ContainsSensitiveData = true
 	message.GetBroadcast().ReliableClusterSend = true
 	ch.srv.platform.Publish(message)

--- a/server/channels/app/plugin_statuses.go
+++ b/server/channels/app/plugin_statuses.go
@@ -92,17 +92,13 @@ func (ch *Channels) getClusterPluginStatuses() (model.PluginStatuses, *model.App
 	return pluginStatuses, nil
 }
 
-func (ch *Channels) notifyPluginStatusesChanged() error {
-	pluginStatuses, err := ch.getClusterPluginStatuses()
-	if err != nil {
-		return err
-	}
-
-	// Notify any system admins.
+// notifyPluginStatusesChanged signals system admins that plugin statuses have changed without
+// carrying any payload. The full, cluster-wide status slice routinely overflows the best-effort
+// (UDP) cluster transport, so admin clients refetch it on demand instead. The signal is sent
+// reliably (TCP) and only to system admins (ContainsSensitiveData).
+func (ch *Channels) notifyPluginStatusesChanged() {
 	message := model.NewWebSocketEvent(model.WebsocketEventPluginStatusesChanged, "", "", "", nil, "")
-	message.Add("plugin_statuses", pluginStatuses)
 	message.GetBroadcast().ContainsSensitiveData = true
+	message.GetBroadcast().ReliableClusterSend = true
 	ch.srv.platform.Publish(message)
-
-	return nil
 }

--- a/webapp/channels/src/actions/websocket_actions.ts
+++ b/webapp/channels/src/actions/websocket_actions.ts
@@ -35,7 +35,6 @@ import {
     UserTypes,
     RoleTypes,
     GeneralTypes,
-    AdminTypes,
     IntegrationTypes,
     PreferenceTypes,
     AppsTypes,
@@ -615,10 +614,6 @@ export function handleEvent(msg: WebSocketMessage) {
 
     case WebSocketEvents.LicenseChanged:
         handleLicenseChanged(msg);
-        break;
-
-    case WebSocketEvents.PluginStatusesChanged:
-        handlePluginStatusesChangedEvent(msg);
         break;
 
     case WebSocketEvents.OpenDialog:
@@ -1720,10 +1715,6 @@ function handleLicenseChanged(msg: WebSocketMessages.LicenseChanged) {
 
     // Refresh server limits when license changes since limits may have changed
     dispatch(getServerLimits());
-}
-
-function handlePluginStatusesChangedEvent(msg: WebSocketMessages.PluginStatusesChanged) {
-    store.dispatch({type: AdminTypes.RECEIVED_PLUGIN_STATUSES, data: msg.data.plugin_statuses});
 }
 
 function handleOpenDialogEvent(msg: WebSocketMessages.OpenDialog) {

--- a/webapp/channels/src/components/admin_console/plugin_management/index.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_management/index.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import React from 'react';
 import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
@@ -15,6 +16,8 @@ import {
     disablePlugin,
 } from 'mattermost-redux/actions/admin';
 import {appsFeatureFlagEnabled} from 'mattermost-redux/selectors/entities/apps';
+
+import usePluginStatusesSync from 'components/common/hooks/usePluginStatusesSync';
 
 import PluginManagement from './plugin_management';
 
@@ -40,4 +43,11 @@ function mapDispatchToProps(dispatch: Dispatch) {
     };
 }
 
-export default connect(mapStateToProps, mapDispatchToProps)(PluginManagement);
+const ConnectedPluginManagement = connect(mapStateToProps, mapDispatchToProps)(PluginManagement);
+
+// Wrap the legacy class-based settings component so it can subscribe to plugin status changes
+// and refetch on demand while the page is mounted.
+export default function PluginManagementWithStatusesSync(props: React.ComponentProps<typeof ConnectedPluginManagement>) {
+    usePluginStatusesSync();
+    return <ConnectedPluginManagement {...props}/>;
+}

--- a/webapp/channels/src/components/common/hooks/usePluginStatusesSync.test.ts
+++ b/webapp/channels/src/components/common/hooks/usePluginStatusesSync.test.ts
@@ -140,4 +140,24 @@ describe('usePluginStatusesSync', () => {
 
         expect(getPluginStatuses).not.toHaveBeenCalled();
     });
+
+    test('returns the plugin statuses from the store', () => {
+        const pluginStatuses = {
+            'com.example.plugin': {
+                id: 'com.example.plugin',
+                name: 'Example',
+                description: '',
+                version: '1.0.0',
+                active: true,
+                state: 1,
+                instances: [],
+            },
+        };
+
+        const {result} = renderHookWithContext(usePluginStatusesSync, {
+            entities: {admin: {pluginStatuses}},
+        });
+
+        expect(result.current).toEqual(pluginStatuses);
+    });
 });

--- a/webapp/channels/src/components/common/hooks/usePluginStatusesSync.test.ts
+++ b/webapp/channels/src/components/common/hooks/usePluginStatusesSync.test.ts
@@ -60,7 +60,7 @@ describe('usePluginStatusesSync', () => {
     const pluginStatusesChanged = {event: WebSocketEvents.PluginStatusesChanged} as WebSocketMessage;
 
     test('dispatches getPluginStatuses after the debounce delay on a plugin_statuses_changed event', () => {
-        renderHookWithContext(() => usePluginStatusesSync());
+        renderHookWithContext(usePluginStatusesSync);
 
         act(() => {
             messageHandler(pluginStatusesChanged);
@@ -78,7 +78,7 @@ describe('usePluginStatusesSync', () => {
     });
 
     test('collapses multiple rapid events into a single refetch', () => {
-        renderHookWithContext(() => usePluginStatusesSync());
+        renderHookWithContext(usePluginStatusesSync);
 
         act(() => {
             messageHandler(pluginStatusesChanged);
@@ -110,7 +110,7 @@ describe('usePluginStatusesSync', () => {
     });
 
     test('ignores other websocket events', () => {
-        renderHookWithContext(() => usePluginStatusesSync());
+        renderHookWithContext(usePluginStatusesSync);
 
         act(() => {
             messageHandler({event: WebSocketEvents.Posted} as WebSocketMessage);
@@ -121,16 +121,14 @@ describe('usePluginStatusesSync', () => {
     });
 
     test('cleans up on unmount: removes the reconnect listener and cancels a pending refetch', () => {
-        const {unmount} = renderHookWithContext(() => usePluginStatusesSync());
+        const {unmount} = renderHookWithContext(usePluginStatusesSync);
 
         // Start a debounce window, then unmount before it elapses.
         act(() => {
             messageHandler(pluginStatusesChanged);
         });
 
-        act(() => {
-            unmount();
-        });
+        act(unmount);
 
         expect(removeReconnectListener).toHaveBeenCalledTimes(1);
         expect(removeReconnectListener).toHaveBeenCalledWith(addReconnectListener.mock.calls[0][0]);

--- a/webapp/channels/src/components/common/hooks/usePluginStatusesSync.test.ts
+++ b/webapp/channels/src/components/common/hooks/usePluginStatusesSync.test.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {act} from '@testing-library/react';
+import * as ReactRedux from 'react-redux';
+
+import type {WebSocketMessage} from '@mattermost/client';
+import {WebSocketEvents} from '@mattermost/client';
+
+import {getPluginStatuses} from 'mattermost-redux/actions/admin';
+
+import {renderHookWithContext} from 'tests/react_testing_utils';
+import * as webSocketHooks from 'utils/use_websocket/hooks';
+
+import usePluginStatusesSync from './usePluginStatusesSync';
+
+jest.mock('mattermost-redux/actions/admin', () => ({
+    ...jest.requireActual('mattermost-redux/actions/admin'),
+    getPluginStatuses: jest.fn(() => ({type: 'MOCK_GET_PLUGIN_STATUSES'})),
+}));
+
+jest.mock('utils/use_websocket/hooks', () => ({
+    useWebSocket: jest.fn(),
+    useWebSocketClient: jest.fn(),
+}));
+
+const DEBOUNCE_DELAY_MS = 500;
+
+describe('usePluginStatusesSync', () => {
+    const dispatchMock = jest.fn();
+    const addReconnectListener = jest.fn();
+    const removeReconnectListener = jest.fn();
+
+    // The handler the hook registers with useWebSocket, captured so tests can feed it messages.
+    let messageHandler: (msg: WebSocketMessage) => void;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        jest.spyOn(ReactRedux, 'useDispatch').mockReturnValue(dispatchMock);
+
+        (webSocketHooks.useWebSocket as jest.Mock).mockImplementation(({handler}) => {
+            messageHandler = handler;
+        });
+        (webSocketHooks.useWebSocketClient as jest.Mock).mockReturnValue({
+            addReconnectListener,
+            removeReconnectListener,
+        });
+    });
+
+    afterEach(() => {
+        jest.runOnlyPendingTimers();
+        jest.useRealTimers();
+        jest.restoreAllMocks();
+        (getPluginStatuses as jest.Mock).mockClear();
+        dispatchMock.mockClear();
+        addReconnectListener.mockClear();
+        removeReconnectListener.mockClear();
+    });
+
+    const pluginStatusesChanged = {event: WebSocketEvents.PluginStatusesChanged} as WebSocketMessage;
+
+    test('dispatches getPluginStatuses after the debounce delay on a plugin_statuses_changed event', () => {
+        renderHookWithContext(() => usePluginStatusesSync());
+
+        act(() => {
+            messageHandler(pluginStatusesChanged);
+        });
+
+        // Nothing dispatched until the debounce window elapses.
+        expect(getPluginStatuses).not.toHaveBeenCalled();
+
+        act(() => {
+            jest.advanceTimersByTime(DEBOUNCE_DELAY_MS);
+        });
+
+        expect(getPluginStatuses).toHaveBeenCalledTimes(1);
+        expect(dispatchMock).toHaveBeenCalledWith({type: 'MOCK_GET_PLUGIN_STATUSES'});
+    });
+
+    test('collapses multiple rapid events into a single refetch', () => {
+        renderHookWithContext(() => usePluginStatusesSync());
+
+        act(() => {
+            messageHandler(pluginStatusesChanged);
+            jest.advanceTimersByTime(100);
+            messageHandler(pluginStatusesChanged);
+            jest.advanceTimersByTime(100);
+            messageHandler(pluginStatusesChanged);
+        });
+
+        act(() => {
+            jest.advanceTimersByTime(DEBOUNCE_DELAY_MS);
+        });
+
+        expect(getPluginStatuses).toHaveBeenCalledTimes(1);
+    });
+
+    test('refetches on websocket reconnect', () => {
+        renderHookWithContext(() => usePluginStatusesSync());
+
+        expect(addReconnectListener).toHaveBeenCalledTimes(1);
+        const reconnectListener = addReconnectListener.mock.calls[0][0];
+
+        act(() => {
+            reconnectListener();
+            jest.advanceTimersByTime(DEBOUNCE_DELAY_MS);
+        });
+
+        expect(getPluginStatuses).toHaveBeenCalledTimes(1);
+    });
+
+    test('ignores other websocket events', () => {
+        renderHookWithContext(() => usePluginStatusesSync());
+
+        act(() => {
+            messageHandler({event: WebSocketEvents.Posted} as WebSocketMessage);
+            jest.advanceTimersByTime(DEBOUNCE_DELAY_MS);
+        });
+
+        expect(getPluginStatuses).not.toHaveBeenCalled();
+    });
+
+    test('cleans up on unmount: removes the reconnect listener and cancels a pending refetch', () => {
+        const {unmount} = renderHookWithContext(() => usePluginStatusesSync());
+
+        // Start a debounce window, then unmount before it elapses.
+        act(() => {
+            messageHandler(pluginStatusesChanged);
+        });
+
+        act(() => {
+            unmount();
+        });
+
+        expect(removeReconnectListener).toHaveBeenCalledTimes(1);
+        expect(removeReconnectListener).toHaveBeenCalledWith(addReconnectListener.mock.calls[0][0]);
+
+        // The pending timer was cleared, so no refetch fires after unmount.
+        act(() => {
+            jest.advanceTimersByTime(DEBOUNCE_DELAY_MS);
+        });
+
+        expect(getPluginStatuses).not.toHaveBeenCalled();
+    });
+});

--- a/webapp/channels/src/components/common/hooks/usePluginStatusesSync.ts
+++ b/webapp/channels/src/components/common/hooks/usePluginStatusesSync.ts
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import {useCallback, useEffect} from 'react';
-import {useDispatch} from 'react-redux';
+import {useDispatch, useSelector} from 'react-redux';
 
 import type {WebSocketMessage} from '@mattermost/client';
 import {WebSocketEvents} from '@mattermost/client';
@@ -12,14 +12,18 @@ import {getPluginStatuses} from 'mattermost-redux/actions/admin';
 import {useDebounce} from 'hooks/useDebounce';
 import {useWebSocket, useWebSocketClient} from 'utils/use_websocket/hooks';
 
+import type {GlobalState} from 'types/store';
+
 const DEBOUNCE_DELAY_MS = 500;
 
 /**
- * Refetches the cluster-wide plugin statuses whenever the server signals that they changed.
+ * Refetches the cluster-wide plugin statuses whenever the server signals that they changed,
+ * and returns the current statuses from the store.
  */
 export default function usePluginStatusesSync() {
     const dispatch = useDispatch();
     const wsClient = useWebSocketClient();
+    const pluginStatuses = useSelector((state: GlobalState) => state.entities.admin.pluginStatuses);
 
     const debouncedRefetch = useDebounce(() => {
         dispatch(getPluginStatuses());
@@ -39,4 +43,6 @@ export default function usePluginStatusesSync() {
             wsClient.removeReconnectListener(debouncedRefetch);
         };
     }, [wsClient, debouncedRefetch]);
+
+    return pluginStatuses;
 }

--- a/webapp/channels/src/components/common/hooks/usePluginStatusesSync.ts
+++ b/webapp/channels/src/components/common/hooks/usePluginStatusesSync.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {useCallback, useEffect, useRef} from 'react';
+import {useDispatch} from 'react-redux';
+
+import type {WebSocketMessage} from '@mattermost/client';
+import {WebSocketEvents} from '@mattermost/client';
+
+import {getPluginStatuses} from 'mattermost-redux/actions/admin';
+
+import {useWebSocket, useWebSocketClient} from 'utils/use_websocket/hooks';
+
+const DEBOUNCE_DELAY_MS = 500;
+
+/**
+ * Refetches the cluster-wide plugin statuses whenever the server signals that they changed.
+ *
+ * The plugin_statuses_changed websocket event carries no payload; it only signals admin clients
+ * to refetch on demand. Subscribing from a component means the refetch only happens while that
+ * component is mounted, and the debounce collapses bursts such as a daily restart's
+ * prepackaged-plugin reinstall. A refetch is also triggered on websocket reconnect, since any
+ * signals fired while disconnected (e.g. during an HA node restart) would otherwise be missed.
+ */
+export default function usePluginStatusesSync() {
+    const dispatch = useDispatch();
+    const wsClient = useWebSocketClient();
+    const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
+
+    useEffect(() => {
+        return () => {
+            if (debounceTimerRef.current) {
+                clearTimeout(debounceTimerRef.current);
+            }
+        };
+    }, []);
+
+    const debouncedRefetch = useCallback(() => {
+        if (debounceTimerRef.current) {
+            clearTimeout(debounceTimerRef.current);
+        }
+        debounceTimerRef.current = setTimeout(() => {
+            dispatch(getPluginStatuses());
+        }, DEBOUNCE_DELAY_MS);
+    }, [dispatch]);
+
+    const handleWebSocketMessage = useCallback((msg: WebSocketMessage) => {
+        if (msg.event === WebSocketEvents.PluginStatusesChanged) {
+            debouncedRefetch();
+        }
+    }, [debouncedRefetch]);
+
+    useWebSocket({handler: handleWebSocketMessage});
+
+    useEffect(() => {
+        wsClient.addReconnectListener(debouncedRefetch);
+        return () => {
+            wsClient.removeReconnectListener(debouncedRefetch);
+        };
+    }, [wsClient, debouncedRefetch]);
+}

--- a/webapp/channels/src/components/common/hooks/usePluginStatusesSync.ts
+++ b/webapp/channels/src/components/common/hooks/usePluginStatusesSync.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useCallback, useEffect, useRef} from 'react';
+import {useCallback, useEffect} from 'react';
 import {useDispatch} from 'react-redux';
 
 import type {WebSocketMessage} from '@mattermost/client';
@@ -9,6 +9,7 @@ import {WebSocketEvents} from '@mattermost/client';
 
 import {getPluginStatuses} from 'mattermost-redux/actions/admin';
 
+import {useDebounce} from 'hooks/useDebounce';
 import {useWebSocket, useWebSocketClient} from 'utils/use_websocket/hooks';
 
 const DEBOUNCE_DELAY_MS = 500;
@@ -25,24 +26,10 @@ const DEBOUNCE_DELAY_MS = 500;
 export default function usePluginStatusesSync() {
     const dispatch = useDispatch();
     const wsClient = useWebSocketClient();
-    const debounceTimerRef = useRef<NodeJS.Timeout | null>(null);
 
-    useEffect(() => {
-        return () => {
-            if (debounceTimerRef.current) {
-                clearTimeout(debounceTimerRef.current);
-            }
-        };
-    }, []);
-
-    const debouncedRefetch = useCallback(() => {
-        if (debounceTimerRef.current) {
-            clearTimeout(debounceTimerRef.current);
-        }
-        debounceTimerRef.current = setTimeout(() => {
-            dispatch(getPluginStatuses());
-        }, DEBOUNCE_DELAY_MS);
-    }, [dispatch]);
+    const debouncedRefetch = useDebounce(() => {
+        dispatch(getPluginStatuses());
+    }, DEBOUNCE_DELAY_MS);
 
     const handleWebSocketMessage = useCallback((msg: WebSocketMessage) => {
         if (msg.event === WebSocketEvents.PluginStatusesChanged) {

--- a/webapp/channels/src/components/common/hooks/usePluginStatusesSync.ts
+++ b/webapp/channels/src/components/common/hooks/usePluginStatusesSync.ts
@@ -16,12 +16,6 @@ const DEBOUNCE_DELAY_MS = 500;
 
 /**
  * Refetches the cluster-wide plugin statuses whenever the server signals that they changed.
- *
- * The plugin_statuses_changed websocket event carries no payload; it only signals admin clients
- * to refetch on demand. Subscribing from a component means the refetch only happens while that
- * component is mounted, and the debounce collapses bursts such as a daily restart's
- * prepackaged-plugin reinstall. A refetch is also triggered on websocket reconnect, since any
- * signals fired while disconnected (e.g. during an HA node restart) would otherwise be missed.
  */
 export default function usePluginStatusesSync() {
     const dispatch = useDispatch();

--- a/webapp/channels/src/components/plugin_marketplace/marketplace_modal.tsx
+++ b/webapp/channels/src/components/plugin_marketplace/marketplace_modal.tsx
@@ -59,10 +59,9 @@ const MarketplaceModal = () => {
     const show = useSelector((state: GlobalState) => isModalOpen(state, ModalIdentifiers.PLUGIN_MARKETPLACE));
     const listing = useSelector(getListing);
     const installedListing = useSelector(getInstalledListing);
-    const pluginStatuses = useSelector((state: GlobalState) => state.entities.admin.pluginStatuses);
 
     // Refetch plugin statuses while the modal is open whenever the server signals a change.
-    usePluginStatusesSync();
+    const pluginStatuses = usePluginStatusesSync();
     const hasFirstAdminVisitedMarketplace = useSelector(getFirstAdminVisitMarketplaceStatus);
     const isStreamlinedMarketplaceEnabled = useSelector(streamlinedMarketplaceEnabled);
     const license = useSelector(getLicense);

--- a/webapp/channels/src/components/plugin_marketplace/marketplace_modal.tsx
+++ b/webapp/channels/src/components/plugin_marketplace/marketplace_modal.tsx
@@ -24,6 +24,7 @@ import {closeModal} from 'actions/views/modals';
 import {getListing, getInstalledListing} from 'selectors/views/marketplace';
 import {isModalOpen} from 'selectors/views/modals';
 
+import usePluginStatusesSync from 'components/common/hooks/usePluginStatusesSync';
 import LoadingScreen from 'components/loading_screen';
 import Input, {SIZE} from 'components/widgets/inputs/input/input';
 
@@ -59,6 +60,9 @@ const MarketplaceModal = () => {
     const listing = useSelector(getListing);
     const installedListing = useSelector(getInstalledListing);
     const pluginStatuses = useSelector((state: GlobalState) => state.entities.admin.pluginStatuses);
+
+    // Refetch plugin statuses while the modal is open whenever the server signals a change.
+    usePluginStatusesSync();
     const hasFirstAdminVisitedMarketplace = useSelector(getFirstAdminVisitMarketplaceStatus);
     const isStreamlinedMarketplaceEnabled = useSelector(streamlinedMarketplaceEnabled);
     const license = useSelector(getLicense);

--- a/webapp/platform/client/src/websocket_messages.ts
+++ b/webapp/platform/client/src/websocket_messages.ts
@@ -10,7 +10,7 @@ import type {Draft} from '@mattermost/types/drafts';
 import type {CustomEmoji} from '@mattermost/types/emojis';
 import type {Group, GroupMember as GroupMemberType} from '@mattermost/types/groups';
 import type {OpenDialogRequest} from '@mattermost/types/integrations';
-import type {PluginManifest, PluginStatus} from '@mattermost/types/plugins';
+import type {PluginManifest} from '@mattermost/types/plugins';
 import type {Post, PostAcknowledgement as PostAcknowledgementType} from '@mattermost/types/posts';
 import type {PreferenceType} from '@mattermost/types/preferences';
 import type {PropertyField, PropertyValue} from '@mattermost/types/properties';
@@ -487,9 +487,8 @@ export type Plugin = BaseWebSocketMessage<WebSocketEvents.PluginEnabled | WebSoc
     manifest: PluginManifest;
 }>;
 
-export type PluginStatusesChanged = BaseWebSocketMessage<WebSocketEvents.PluginStatusesChanged, {
-    plugin_statuses: PluginStatus[];
-}>;
+// Carries no payload; signals admin clients to refetch the full plugin statuses on demand.
+export type PluginStatusesChanged = BaseWebSocketMessage<WebSocketEvents.PluginStatusesChanged, Record<string, never>>;
 
 export type OpenDialog = BaseWebSocketMessage<WebSocketEvents.OpenDialog, {
     dialog: JsonEncodedValue<OpenDialogRequest>;

--- a/webapp/platform/client/src/websocket_messages.ts
+++ b/webapp/platform/client/src/websocket_messages.ts
@@ -487,8 +487,12 @@ export type Plugin = BaseWebSocketMessage<WebSocketEvents.PluginEnabled | WebSoc
     manifest: PluginManifest;
 }>;
 
-// Carries no payload; signals admin clients to refetch the full plugin statuses on demand.
-export type PluginStatusesChanged = BaseWebSocketMessage<WebSocketEvents.PluginStatusesChanged, Record<string, never>>;
+// Signals admin clients to refetch the full plugin statuses on demand. plugin_statuses is always
+// an empty array: it carries no data, but is retained (rather than omitted) so clients that call
+// array methods on it don't break.
+export type PluginStatusesChanged = BaseWebSocketMessage<WebSocketEvents.PluginStatusesChanged, {
+    plugin_statuses: never[];
+}>;
 
 export type OpenDialog = BaseWebSocketMessage<WebSocketEvents.OpenDialog, {
     dialog: JsonEncodedValue<OpenDialogRequest>;


### PR DESCRIPTION
#### Summary

On Hub, an oversized `plugin_statuses_changed` message is the primary source of cluster errors -- the 30+ plugins installed exceed the UDP payload capacity and trigger an error every time a node comes online or any plugin status changes.

The event is admin-only (`ContainsSensitiveData`) and only feeds the System Console **Plugin Management** and **Marketplace** views, so rather than push the whole slice it is now published as a **payload-free signal sent reliably (TCP)** over the cluster. Those views subscribe through a small `usePluginStatusesSync` hook (built on the existing `useWebSocket`) and debounce a refetch of the full statuses from `GET /api/v4/plugins/statuses`, pulling the data on demand only while a relevant view is mounted. A refetch also runs on websocket reconnect, so signals missed during a disconnect (e.g. an HA node restart) are recovered.

For backward compatibility the event keeps a `plugin_statuses` field as an empty (non-nil) array rather than omitting it, so existing clients that call array methods on it — e.g. the Boards/Focalboard plugin's `data.plugin_statuses.find(...)` — don't break.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-69104

#### Release Note

```release-note
Reduce cluster send error logs from oversized `plugin_statuses_changed` WebSocket events.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The server-side change removes the inline plugin_statuses payload and relies on clients to refetch statuses (with debounced and reconnect-triggered refetch), which is a behavioral contract change that could break clients expecting immediate inline data and introduce timing-related issues around debounce/reconnect.  
**QA Recommendation:** Moderate manual QA: exercise System Console Plugin Management and Marketplace flows (including debounce and reconnect behavior), verify cluster broadcasts no longer produce EMSGSIZE errors for large plugin sets, and confirm compatibility with older clients that may assume payload data.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->