### PR TITLE
chore(e2e): backport openldap retry logic to release-11.6 (#36054)

### DIFF
--- a/e2e-tests/.ci/server.start.sh
+++ b/e2e-tests/.ci/server.start.sh
@@ -10,7 +10,72 @@ mme2e_wait_image "$SERVER_IMAGE" 4 30
 # Launch mattermost-server, and wait for it to be healthy
 mme2e_log "Starting E2E containers"
 ${MME2E_DC_SERVER} create
-${MME2E_DC_SERVER} up -d --remove-orphans
+
+# `docker compose up -d` returns non-zero the moment any depended container
+# exits during startup, which masks openldap's own `restart: always` policy.
+# On a small fraction of ubuntu-24.04 runners the osixia/openldap:1.4.0 image
+# exits 1 on first boot (suspected init-script race under runner load). Retry
+# the `up` a bounded number of times, force-recreating openldap between tries
+# so its first-boot bootstrap re-runs cleanly, and dump rich diagnostics on
+# every failure so future CI failures contain the actual data we need to
+# permanently root-cause this. The diagnostics directory is also uploaded as
+# a workflow artifact (see e2e-tests-*-template.yml `ci/upload-docker-diagnostics`).
+DIAG_DIR="${PWD}/../docker-diagnostics"
+mkdir -p "$DIAG_DIR"
+
+dump_openldap_diagnostics() {
+  local label="$1"
+  local out="$DIAG_DIR/${label}"
+  mkdir -p "$out"
+  mme2e_log "[diagnostics:${label}] capturing openldap state to $out"
+
+  # Container-level state (exit code, OOMKilled, error string, restart count)
+  docker inspect mmserver-openldap-1 >"$out/openldap.inspect.json" 2>&1 || true
+  ${MME2E_DC_SERVER} ps -a >"$out/compose.ps.txt" 2>&1 || true
+  ${MME2E_DC_SERVER} logs --no-log-prefix -- openldap >"$out/openldap.log" 2>&1 || true
+
+  # Merged compose config — confirms which security_opt / cap_add / image is actually applied
+  ${MME2E_DC_SERVER} config >"$out/compose.config.yml" 2>&1 || true
+
+  # Host-level state useful for OOM / AppArmor diagnosis
+  uname -a >"$out/host.uname.txt" 2>&1 || true
+  free -m >"$out/host.free.txt" 2>&1 || true
+  df -h >"$out/host.df.txt" 2>&1 || true
+  docker version >"$out/docker.version.txt" 2>&1 || true
+  docker info >"$out/docker.info.txt" 2>&1 || true
+  docker compose version >"$out/compose.version.txt" 2>&1 || true
+  cat /proc/sys/kernel/apparmor_restrict_unprivileged_userns >"$out/host.apparmor_userns.txt" 2>&1 || true
+  # AppArmor denials and OOM kills land in dmesg — grep them out (needs sudo on GH runners).
+  sudo dmesg | tail -200 >"$out/host.dmesg.tail.txt" 2>&1 || true
+  sudo dmesg | grep -iE 'apparmor|denied|oom|killed|openldap|slapd' >"$out/host.dmesg.relevant.txt" 2>&1 || true
+
+  # Echo the most useful slice straight to the workflow log so it shows up
+  # in the GH Actions UI without needing to download the artifact.
+  mme2e_log "----- openldap inspect (exit/oom/error) -----"
+  docker inspect mmserver-openldap-1 \
+    --format 'ExitCode={{.State.ExitCode}} OOMKilled={{.State.OOMKilled}} Error={{.State.Error}} Restarts={{.RestartCount}} Status={{.State.Status}}' \
+    2>&1 || true
+  mme2e_log "----- openldap log (last 100) -----"
+  ${MME2E_DC_SERVER} logs --no-log-prefix --tail=100 -- openldap 2>&1 || true
+  mme2e_log "----- relevant dmesg -----"
+  sudo dmesg | grep -iE 'apparmor|denied|oom|killed|openldap|slapd' | tail -40 2>&1 || true
+  mme2e_log "----- end diagnostics:${label} -----"
+}
+
+UP_ATTEMPTS=3
+for attempt in $(seq 1 $UP_ATTEMPTS); do
+  if ${MME2E_DC_SERVER} up -d --remove-orphans; then
+    break
+  fi
+  dump_openldap_diagnostics "up-attempt-${attempt}"
+  if [ "$attempt" -eq "$UP_ATTEMPTS" ]; then
+    mme2e_log "compose up failed after ${UP_ATTEMPTS} attempts; aborting"
+    exit 1
+  fi
+  # Force-recreate openldap so its first-boot init re-runs from a clean state
+  ${MME2E_DC_SERVER} rm -fsv openldap || true
+  sleep 5
+done
 
 # Postgres check
 if ! mme2e_wait_command_success "${MME2E_DC_SERVER} exec -T -- postgres pg_isready -h localhost" "Waiting for postgres to accept connections" "30" "5"; then

--- a/e2e-tests/playwright/specs/functional/channels/autotranslation/autotranslation.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/autotranslation/autotranslation.spec.ts
@@ -171,7 +171,7 @@ test(
     },
 );
 
-test(
+test.fixme(
     'only new messages are translated after enable; old messages unchanged',
     {
         tag: ['@autotranslation'],
@@ -351,7 +351,7 @@ test(
     },
 );
 
-test(
+test.fixme(
     'auto-translation is ON by default for new channel members',
     {
         tag: ['@autotranslation'],
@@ -458,7 +458,7 @@ test(
     },
 );
 
-test(
+test.fixme(
     'disabling for self reverts translated messages to original',
     {
         tag: ['@autotranslation'],
@@ -536,7 +536,7 @@ test(
     },
 );
 
-test(
+test.fixme(
     'messages only translate when source differs from user language',
     {
         tag: ['@autotranslation'],
@@ -639,7 +639,7 @@ test(
     },
 );
 
-test(
+test.fixme(
     'message indicator only on actually translated message',
     {
         tag: ['@autotranslation'],


### PR DESCRIPTION
#### Summary

Backport of two fixes to `release-11.6`:

**1. openldap retry logic** (`e2e-tests/.ci/server.start.sh`) — from PR #36054

`osixia/openldap:1.4.0` intermittently exits 1 on first boot on ubuntu-24.04 runners due to an init-script race condition, even after the AppArmor user-namespace restriction is disabled by `runner-prep-openldap`. Without a retry loop, the entire CI job fails immediately with no recovery:

\`\`\`
Container mmserver-openldap-1  Error   ← crashes 2 sec after start
dependency failed to start: container mmserver-openldap-1 exited (1)
make: *** [Makefile:16: start-server] Error 1
\`\`\`

Adds `dump_openldap_diagnostics()` and a `UP_ATTEMPTS=3` retry loop that force-recreates openldap between tries so its first-boot init re-runs from a clean state.

**2. Mark flaky autotranslation tests as `test.fixme()`** (`autotranslation.spec.ts`) — from PRs #36492/#36550

The mock LibreTranslate server on `release-11.6` is missing `targets` in its `/languages` response and form-encoded body parsing in `/translate`, causing the server to never trigger translation. These 5 tests consistently fail as a result:

- only new messages are translated after enable; old messages unchanged
- auto-translation is ON by default for new channel members
- disabling for self reverts translated messages to original
- messages only translate when source differs from user language
- message indicator only on actually translated message

On master these are already `test.fixme()`. This backport applies the same annotation to unblock CI while the mock server issue is addressed separately.

**Confirmed missing from:** release-11.7, release-11.6, release-11.5, release-10.11 (release-11.8 already has it)

#### Release Note
```release-note
NONE
```