### PR TITLE
Fix CI Run mmctl tests (FIPS) / mmctl

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -323,7 +323,7 @@ jobs:
   test-mmctl-fips:
     name: Run mmctl tests (FIPS)
     # Skip FIPS testing for forks, which won't have docker login credentials.
-    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.repository.fork == false && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     needs: go
     uses: ./.github/workflows/mmctl-test-template.yml
     secrets: inherit


### PR DESCRIPTION
#### Summary
Fix for CI Run mmctl tests (FIPS) / mmctl on forks of Mattermost. The existing YAML configuration does not properly identify a fork, and attempts to use Docker but fails.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/36978

#### Screenshots
Before:
<img width="1210" height="644" alt="Screenshot from 2026-06-08 23-48-17" src="https://github.com/user-attachments/assets/42c82820-144e-4e17-abcc-68b893f9303e" />

After:
<img width="1468" height="736" alt="Screenshot from 2026-06-09 00-04-57" src="https://github.com/user-attachments/assets/2d2fed75-1f65-4e29-b173-85aacdc3ad27" />

#### Release Note
```release-note
NONE
```