### PR TITLE
[MM-69054] Fix Permission Policy tab failing to load for channel admins when no policy exists

### DIFF
--- a/server/channels/api4/access_control_test.go
+++ b/server/channels/api4/access_control_test.go
@@ -537,6 +537,75 @@ func TestGetAccessControlPolicy(t *testing.T) {
 		CheckForbiddenStatus(t, resp)
 	})
 
+	t.Run("GetAccessControlPolicy with channel admin when no policy exists returns 404 not 403", func(t *testing.T) {
+		// Regression test for MM-69054: a channel admin opening the
+		// Permissions Policy tab before any policy has been created must
+		// receive a clean 404 (handled by the UI as "first-time create")
+		// rather than a misleading 403. Authorization for a channel policy
+		// must not hinge on the policy record already existing.
+		ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
+		require.True(t, ok, "SetLicense should return true")
+
+		th.AddPermissionToRole(t, model.PermissionManageChannelAccessRules.Id, model.ChannelAdminRoleId)
+
+		privateChannel := th.CreatePrivateChannel(t)
+		channelAdmin := th.CreateUser(t)
+		th.LinkUserToTeam(t, channelAdmin, th.BasicTeam)
+		th.AddUserToChannel(t, channelAdmin, privateChannel)
+		th.MakeUserChannelAdmin(t, channelAdmin, privateChannel)
+		channelAdminClient := th.CreateClient()
+		_, _, err := channelAdminClient.Login(context.Background(), channelAdmin.Email, channelAdmin.Password)
+		require.NoError(t, err)
+
+		// No policy exists yet for this channel.
+		notFound := model.NewAppError("GetPolicy", "app.access_control.not_found.app_error", nil, "", http.StatusNotFound)
+		mockAccessControlService := &mocks.AccessControlServiceInterface{}
+		th.App.Srv().Channels().AccessControl = mockAccessControlService
+		mockAccessControlService.On("GetPolicy", mock.AnythingOfType("*request.Context"), privateChannel.Id).Return(nil, notFound)
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
+		})
+
+		_, resp, err := channelAdminClient.GetAccessControlPolicy(context.Background(), privateChannel.Id)
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+	})
+
+	t.Run("GetAccessControlPolicy with channel admin of another channel when no policy exists returns 403", func(t *testing.T) {
+		// Counterpart to the regression test above: the missing-policy
+		// fallback must only admit admins of the requested channel. A
+		// channel admin asking for an unrelated channel's (missing) policy
+		// must still be denied with 403.
+		ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
+		require.True(t, ok, "SetLicense should return true")
+
+		th.AddPermissionToRole(t, model.PermissionManageChannelAccessRules.Id, model.ChannelAdminRoleId)
+
+		ownedChannel := th.CreatePrivateChannel(t)
+		otherChannel := th.CreatePrivateChannel(t)
+		channelAdmin := th.CreateUser(t)
+		th.LinkUserToTeam(t, channelAdmin, th.BasicTeam)
+		th.AddUserToChannel(t, channelAdmin, ownedChannel)
+		th.MakeUserChannelAdmin(t, channelAdmin, ownedChannel)
+		channelAdminClient := th.CreateClient()
+		_, _, err := channelAdminClient.Login(context.Background(), channelAdmin.Email, channelAdmin.Password)
+		require.NoError(t, err)
+
+		notFound := model.NewAppError("GetPolicy", "app.access_control.not_found.app_error", nil, "", http.StatusNotFound)
+		mockAccessControlService := &mocks.AccessControlServiceInterface{}
+		th.App.Srv().Channels().AccessControl = mockAccessControlService
+		mockAccessControlService.On("GetPolicy", mock.AnythingOfType("*request.Context"), otherChannel.Id).Return(nil, notFound)
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
+		})
+
+		_, resp, err := channelAdminClient.GetAccessControlPolicy(context.Background(), otherChannel.Id)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
 	th.TestForSystemAdminAndLocal(t, func(t *testing.T, client *model.Client4) {
 		ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		require.True(t, ok, "SetLicense should return true")

--- a/server/channels/app/access_control.go
+++ b/server/channels/app/access_control.go
@@ -1987,6 +1987,18 @@ func (a *App) ValidateAccessControlPolicyPermissionWithOptions(rctx request.CTX,
 	// Get the policy to determine its type
 	policy, appErr := a.GetAccessControlPolicy(rctx, policyID)
 	if appErr != nil {
+		// Authorization must not hinge on the policy already existing. A
+		// channel policy uses its channel's ID as the policy ID, so when the
+		// record is missing (e.g. a channel admin opening the Permissions
+		// Policy tab before any policy has been created) fall back to a direct
+		// channel-permission check. An authorized channel admin is then
+		// allowed through so the caller's own lookup surfaces a clean 404
+		// ("first-time create") instead of a misleading 403.
+		if appErr.StatusCode == http.StatusNotFound {
+			if channelErr := a.ValidateChannelAccessControlPermission(rctx, userID, policyID); channelErr == nil {
+				return nil
+			}
+		}
 		return appErr
 	}
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Channel admins with the `Manage Channel Access Control Policy` permission saw **"Failed to load this channel's permission policy"** on the Permissions Policy tab in Channel Settings whenever the channel had no access control policy yet. System admins were unaffected.

Root cause: `ValidateAccessControlPolicyPermissionWithOptions` fetches the policy to determine its type *before* checking channel-level permission. When no policy exists, that lookup returns `404`, which the `getAccessControlPolicy` handler converts into a `403 Forbidden` (the team-admin fallback doesn't apply with no `team_id`). The frontend only treats a `404` as the legitimate "first-time create / empty editor" path, so the `403` surfaced as a hard load error. System admins skip the validation block entirely and receive the raw `404`, which the UI handles gracefully — hence they were unaffected, and creating a Membership Policy first was a workaround.

Fix: authorization for a channel policy must not depend on the policy already existing. When the policy lookup returns `404`, fall back to a direct channel-permission check (channel policies use the channel ID as the policy ID). An authorized channel admin is then allowed through, so the operation's own lookup surfaces a clean `404` and the UI shows the empty, editable editor. Because the fix lives in the shared helper, the read, delete, and activate paths now behave consistently for channel admins.

QA steps:
1. Enable the Resource Level Permission Policies feature flags.
2. Grant channel admins `Manage Channel Access Control Policy` in the System Scheme.
3. As a channel admin, open Channel Settings → Permissions Policy on a channel with **no** Membership/access policy.
4. The empty Permissions Policy editor loads (no error banner).

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-69054

#### Release Note
```release-note
Fixed an issue where channel admins saw "Failed to load this channel's permission policy" on the Permissions Policy tab when the channel had no access control policy configured.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b837bc80-6395-4a84-b0bd-8d4579fe6419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b837bc80-6395-4a84-b0bd-8d4579fe6419"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change modifies the authorization fallback path in `ValidateAccessControlPolicyPermissionWithOptions`, a shared helper function used across multiple API endpoints for access control policy operations (read, delete, activate). While the logic is narrowly scoped to only apply when policies don't exist (404) and for channel-scoped operations, any modification to permission validation introduces the risk of unintended authorization side effects across all non-system-admin operations using this function.

**QA Recommendation:** Manual QA should focus on end-to-end verification of the fix scenario with different user roles (channel admin, team admin, system admin, non-admin) accessing non-existent channel policies to confirm the empty editor loads without error banners. Additionally, verify that existing policies continue to work for all user roles and that non-channel-scoped policies maintain their current authorization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->