### PR TITLE
fix: load katex mhchem extension so chemistry macros render (#34109)

### DIFF
--- a/webapp/channels/src/components/latex_block/latex_block.tsx
+++ b/webapp/channels/src/components/latex_block/latex_block.tsx
@@ -21,7 +21,14 @@ const LatexBlock = ({
     const [katex, setKatex] = useState<Katex | undefined>();
 
     useEffect(() => {
-        import('katex').then((katex) => {
+        // issue #34109: load the mhchem extension alongside KaTeX so chemistry
+        // macros like \ce and \pu register on the same module instance the
+        // renderer uses. Without this, `$$\ce{H2O}$$` falls back to KaTeX's
+        // unknown-command path and renders \ce in red with H2O as plain math.
+        Promise.all([
+            import('katex'),
+            import('katex/contrib/mhchem'),
+        ]).then(([katex]) => {
             setKatex(katex.default);
         });
     }, []);

--- a/webapp/channels/src/components/latex_inline/latex_inline.tsx
+++ b/webapp/channels/src/components/latex_inline/latex_inline.tsx
@@ -16,7 +16,14 @@ const LatexInline = ({content, enableInlineLatex}: Props) => {
     const [katex, setKatex] = useState<Katex | undefined>(undefined);
 
     useEffect(() => {
-        import('katex').then((katexModule) => {
+        // issue #34109: load the mhchem extension alongside KaTeX so chemistry
+        // macros like \ce and \pu register on the same module instance the
+        // renderer uses. Without this, `$\ce{H2O}$` falls back to KaTeX's
+        // unknown-command path and renders \ce in red with H2O as plain math.
+        Promise.all([
+            import('katex'),
+            import('katex/contrib/mhchem'),
+        ]).then(([katexModule]) => {
             setKatex(katexModule.default);
         });
     }, []);


### PR DESCRIPTION
`$\ce{H2O}$` and other mhchem chemistry expressions could not render. The reporter added mhchem.min.js via a <script> tag in root.html, but that approach cannot reach Mattermost's KaTeX: LatexInline / LatexBlock load KaTeX through a webpack dynamic import, so the renderer's KaTeX is module-scoped and never exposed on window. The standalone mhchem.min.js patches a different (global / orphan) KaTeX, leaving the renderer's KaTeX unaware of \ce. KaTeX then falls back to its unknown-command path (throwOnError: false), emitting \ce in red and rendering H2O as plain math.

Import katex/contrib/mhchem alongside katex in both LatexInline and LatexBlock so the mhchem side-effect registers \ce and \pu on the same module instance the renderer actually uses. Use Promise.all to await both imports before setting katex into state, preventing a first-render race where the component would otherwise render before mhchem finished registering its macros.

- katex/contrib/mhchem already ships with katex@0.16.21 in node_modules; no package.json change needed.
- Behavior of the existing katex import and setKatex call is preserved; mhchem is loaded in parallel and the state setter only fires after both promises resolve.

<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
`$\ce{H2O}$` and other mhchem chemistry expressions could not render. The reporter added `mhchem.min.js` via a `<script>` tag in `root.html`, but that approach cannot reach Mattermost's KaTeX: [`LatexInline`](../blob/master/webapp/channels/src/components/latex_inline/latex_inline.tsx) and [`LatexBlock`](../blob/master/webapp/channels/src/components/latex_block/latex_block.tsx) load KaTeX through a webpack dynamic import, so the renderer's KaTeX is module-scoped and never exposed on `window`. The standalone `mhchem.min.js` patches a different (global / orphan) KaTeX, leaving the renderer's KaTeX unaware of `\ce`. KaTeX then falls back to its unknown-command path (`throwOnError: false`), emitting `\ce` in red and rendering `H2O` as plain math.

Import `katex/contrib/mhchem` alongside `katex` in both `LatexInline` and `LatexBlock` so the mhchem side-effect registers `\ce` and `\pu` on the same module instance the renderer actually uses. Use `Promise.all` to await both imports before setting `katex` into state — that prevents a first-render race where the component would otherwise render before mhchem finished registering its macros.

- `katex/contrib/mhchem` already ships with `katex@0.16.21` in `node_modules`; no `package.json` change is needed.
- The existing `import('katex')` / `setKatex(...)` behavior is preserved; mhchem is loaded in parallel and the state setter only fires after both promises resolve.
- The script-tag workaround in `root.html` from the bug report becomes unnecessary.

Manual test:
- Post `$\ce{H2O}$` in a channel → renders as H₂O with chemistry-style subscript and upright element letters, instead of red `\ce` + italic H2O.
- Post `$$\ce{H+ + OH- -> H2O}$$` → renders as a proper chemistry equation with a reaction arrow.
- Post `$\pu{12 J s}$` → renders as `12 J s` with mhchem unit spacing.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/34109

#### Screenshots
N/A — describing in words: the rendered output changes from a red `\ce` followed by an italic `H2O` to a proper H₂O chemistry formula.

#### Release Note
```release-note
Fixed an issue where the KaTeX mhchem chemistry macros (`\ce`, `\pu`) did not render in Mattermost messages.
```

<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes are isolated to two rendering components (LatexInline and LatexBlock) with only additive logic—Promise.all-wrapped imports of mhchem alongside katex—and no modifications to existing rendering or error-handling paths. The pattern ensures both modules load before state update, maintaining consistency with prior behavior.

**QA Recommendation:** Minimal manual QA required beyond automated testing. Focus verification on chemistry expression rendering (`$\ce{H2O}$`, `$\pu{12 J s}$`) in both inline and block contexts, standard LaTeX math unchanged, and error handling preserved when KaTeX load fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->