### PR TITLE
Keep plugin post action menus open when hovering away

### DIFF
--- a/webapp/channels/src/components/post/post_options.test.tsx
+++ b/webapp/channels/src/components/post/post_options.test.tsx
@@ -8,9 +8,11 @@ import type {SystemEmoji} from '@mattermost/types/emojis';
 import {Permissions} from 'mattermost-redux/constants';
 
 import {testPluginComponentErrorHandling} from 'tests/helpers/plugin_error_handling';
-import {renderWithContext, screen} from 'tests/react_testing_utils';
+import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
 import {Locations} from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
+
+import type {PostActionComponent} from 'types/store/plugins';
 
 import PostOptions from './post_options';
 
@@ -135,5 +137,41 @@ describe('PostOptions - quick reaction count (MM-68681)', () => {
                 pluginActions={[pluginComponent]}
             />,
         );
+    });
+
+    test('keeps plugin action visible when its menu is open and hover ends', async () => {
+        const PluginAction = ({handleDropdownOpened}: {handleDropdownOpened?: (open: boolean) => void}) => (
+            <button onClick={() => handleDropdownOpened?.(true)}>
+                {'AI Actions'}
+            </button>
+        );
+        const pluginAction: PostActionComponent = {
+            id: 'ai-actions',
+            pluginId: 'mattermost-ai',
+            component: PluginAction,
+        };
+
+        const {rerender} = renderWithContext(
+            <PostOptions
+                {...baseProps}
+                hover={true}
+                pluginActions={[pluginAction]}
+            />,
+            baseState,
+        );
+
+        expect(screen.getByRole('button', {name: 'AI Actions'})).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('button', {name: 'AI Actions'}));
+
+        rerender(
+            <PostOptions
+                {...baseProps}
+                hover={false}
+                pluginActions={[pluginAction]}
+            />,
+        );
+
+        expect(screen.getByRole('button', {name: 'AI Actions'})).toBeInTheDocument();
     });
 });

--- a/webapp/channels/src/components/post/post_options.test.tsx
+++ b/webapp/channels/src/components/post/post_options.test.tsx
@@ -138,7 +138,6 @@ describe('PostOptions - quick reaction count (MM-68681)', () => {
             />,
         );
     });
-
 });
 
 describe('PostOptions - plugin post actions (MM-68323)', () => {

--- a/webapp/channels/src/components/post/post_options.test.tsx
+++ b/webapp/channels/src/components/post/post_options.test.tsx
@@ -139,6 +139,9 @@ describe('PostOptions - quick reaction count (MM-68681)', () => {
         );
     });
 
+});
+
+describe('PostOptions - plugin post actions (MM-68323)', () => {
     test('keeps plugin action visible when its menu is open and hover ends', async () => {
         const PluginAction = ({handleDropdownOpened}: {handleDropdownOpened?: (open: boolean) => void}) => (
             <button onClick={() => handleDropdownOpened?.(true)}>

--- a/webapp/channels/src/components/post/post_options.tsx
+++ b/webapp/channels/src/components/post/post_options.tsx
@@ -67,6 +67,7 @@ const PostOptions = (props: Props): JSX.Element => {
     const [showEmojiPicker, setShowEmojiPicker] = useState(false);
     const [showDotMenu, setShowDotMenu] = useState(false);
     const [showActionsMenu, setShowActionsMenu] = useState(false);
+    const [showPluginMenu, setShowPluginMenu] = useState(false);
 
     const toggleEmojiPicker = useCallback((show: boolean) => {
         setShowEmojiPicker(show);
@@ -121,8 +122,13 @@ const PostOptions = (props: Props): JSX.Element => {
         props.handleDropdownOpened!(open);
     };
 
+    const handlePluginMenuOpened = (open: boolean) => {
+        setShowPluginMenu(open);
+        props.handleDropdownOpened!(open);
+    };
+
     const isPostDeleted = post && post.state === Posts.POST_DELETED;
-    const hoverLocal = props.hover || showEmojiPicker || showDotMenu || showActionsMenu;
+    const hoverLocal = props.hover || showEmojiPicker || showDotMenu || showActionsMenu || showPluginMenu;
     const isBurnOnReadPost = props.isBurnOnReadPost || false;
     const showCommentIcon = !isBurnOnReadPost && (isFromAutoResponder || (!systemMessage && (isMobileView ||
             hoverLocal || (!post.root_id && Boolean(props.hasReplies)) ||
@@ -221,6 +227,7 @@ const PostOptions = (props: Props): JSX.Element => {
                             <PluggableErrorBoundary pluginId={item.pluginId}>
                                 <Component
                                     post={props.post}
+                                    handleDropdownOpened={handlePluginMenuOpened}
                                 />
                             </PluggableErrorBoundary>
                         </li>

--- a/webapp/channels/src/types/store/plugins.ts
+++ b/webapp/channels/src/types/store/plugins.ts
@@ -367,6 +367,7 @@ export type SearchButtonsComponent = PluginComponent & {
 export type PostActionComponent = PluginComponent & {
     component: React.ComponentType<{
         post: Post;
+        handleDropdownOpened?: (open: boolean) => void;
     }>;
 };
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Keeps plugin post action menus mounted after hover ends by passing plugin post actions the same dropdown-open lifecycle callback used by core post menus.

Companion Agents plugin PR: https://github.com/mattermost/mattermost-plugin-agents/pull/811

QA: Opened the Agents plugin AI Actions menu on one post, hovered another post, and confirmed the menu stayed open.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-68323

#### Screenshots
<a href="https://cursor.com/agents/bc-896f105e-4916-4a0f-9678-f15d18b05d3b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fagents_plugin_menu_hover_persistence_clean_demo.mp4"><img src="https://cursor.com/artifacts/c/art-784b4386-82d3-472e-8342-9370d1bea887" alt="agents_plugin_menu_hover_persistence_clean_demo.mp4" /></a>

![Agents menu stays open while hovering another post](https://cursor.com/artifacts/c/art-1bc23c59-822d-461b-9fb9-e496281d1746)

#### Release Note
```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-896f105e-4916-4a0f-9678-f15d18b05d3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-896f105e-4916-4a0f-9678-f15d18b05d3b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change adjusts hover/dropdown lifecycle in PostOptions and adds an optional callback to plugin post action props; it's localized to post action UI but may affect plugins or edge cases relying on previous hover behavior, so regressions are possible though limited in scope.  
**QA Recommendation:** Perform focused manual QA on plugin post actions and core post menus: verify plugin dropdowns remain mounted when opened after hover leaves, ensure menus close on outside click/expected dismissals, and test interactions with multiple plugin actions to detect state conflicts.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->