### PR TITLE
[MM-69183] Gate expensive user/guest count queries behind admin check in getServerLimits

### DIFF
--- a/server/channels/api4/limits.go
+++ b/server/channels/api4/limits.go
@@ -19,7 +19,10 @@ func (api *API) InitLimits() {
 func getServerLimits(c *Context, w http.ResponseWriter, r *http.Request) {
 	isAdmin := c.IsSystemAdmin() && c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionSysconsoleReadUserManagementUsers)
 
-	serverLimits, err := c.App.GetServerLimits()
+	// Only admins receive (and need) the user/guest counts, so only compute them for
+	// admins. This keeps the expensive count queries off the per-login/per-refresh hot
+	// path that non-admin clients hit via loadMe()/loadConfigAndMe().
+	serverLimits, err := c.App.GetServerLimits(isAdmin)
 	if err != nil {
 		c.Err = err
 		return

--- a/server/channels/app/limits.go
+++ b/server/channels/app/limits.go
@@ -14,7 +14,14 @@ const (
 	maxUsersHardLimit = 250
 )
 
-func (a *App) GetServerLimits() (*model.ServerLimits, *model.AppError) {
+// GetServerLimits returns the server's seat/post-history limits. The license-derived
+// limit fields and post-history fields are always computed (they are cheap and needed
+// by all users). The active user and single-channel guest counts are only computed when
+// includeUserCounts is true, because those queries are expensive and the counts are only
+// consumed by admin-gated UI and internal seat-limit checks. Callers that do not need the
+// counts (e.g. non-admin API requests) should pass false to keep the expensive queries off
+// the hot path.
+func (a *App) GetServerLimits(includeUserCounts bool) (*model.ServerLimits, *model.AppError) {
 	limits := &model.ServerLimits{}
 	license := a.License()
 
@@ -45,6 +52,12 @@ func (a *App) GetServerLimits() (*model.ServerLimits, *model.AppError) {
 			return nil, appErr
 		}
 		limits.LastAccessiblePostTime = lastAccessibleTime
+	}
+
+	// The user/guest count queries are expensive (the single-channel guest count is a
+	// full ChannelMembers scan). Only run them when the caller actually needs the counts.
+	if !includeUserCounts {
+		return limits, nil
 	}
 
 	activeUserCount, appErr := a.Srv().Store().User().Count(model.UserCountOptions{})
@@ -99,7 +112,7 @@ func (a *App) GetPostHistoryLimit() int64 {
 }
 
 func (a *App) isAtUserLimit() (bool, *model.AppError) {
-	userLimits, appErr := a.GetServerLimits()
+	userLimits, appErr := a.GetServerLimits(true)
 	if appErr != nil {
 		return false, appErr
 	}

--- a/server/channels/app/limits_test.go
+++ b/server/channels/app/limits_test.go
@@ -22,7 +22,7 @@ func TestGetServerLimits(t *testing.T) {
 
 		th.App.Srv().SetLicense(nil)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		// InitBasic creates 3 users by default
@@ -31,25 +31,45 @@ func TestGetServerLimits(t *testing.T) {
 		require.Equal(t, int64(250), serverLimits.MaxUsersHardLimit)
 	})
 
+	t.Run("user counts are skipped when includeUserCounts is false", func(t *testing.T) {
+		th := Setup(t).InitBasic(t)
+
+		th.App.Srv().SetLicense(nil)
+
+		// With counts included we get the real active user count (InitBasic creates 3 users).
+		withCounts, appErr := th.App.GetServerLimits(true)
+		require.Nil(t, appErr)
+		require.Equal(t, int64(3), withCounts.ActiveUserCount)
+
+		// Without counts the expensive count queries are skipped, so the count is zero even
+		// though users exist. The cheap license-derived limits are still returned.
+		withoutCounts, appErr := th.App.GetServerLimits(false)
+		require.Nil(t, appErr)
+		require.Equal(t, int64(0), withoutCounts.ActiveUserCount)
+		require.Equal(t, int64(0), withoutCounts.SingleChannelGuestCount)
+		require.Equal(t, int64(200), withoutCounts.MaxUsersLimit)
+		require.Equal(t, int64(250), withoutCounts.MaxUsersHardLimit)
+	})
+
 	t.Run("user count should increase on creating new user and decrease on permanently deleting", func(t *testing.T) {
 		th := Setup(t).InitBasic(t)
 
 		th.App.Srv().SetLicense(nil)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(3), serverLimits.ActiveUserCount)
 
 		// now we create a new user
 		newUser := th.CreateUser(t)
 
-		serverLimits, appErr = th.App.GetServerLimits()
+		serverLimits, appErr = th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(4), serverLimits.ActiveUserCount)
 
 		// now we'll delete the user
 		_ = th.App.PermanentDeleteUser(th.Context, newUser)
-		serverLimits, appErr = th.App.GetServerLimits()
+		serverLimits, appErr = th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(3), serverLimits.ActiveUserCount)
 	})
@@ -59,20 +79,20 @@ func TestGetServerLimits(t *testing.T) {
 
 		th.App.Srv().SetLicense(nil)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(3), serverLimits.ActiveUserCount)
 
 		// now we create a new user
 		newGuestUser := th.CreateGuest(t)
 
-		serverLimits, appErr = th.App.GetServerLimits()
+		serverLimits, appErr = th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(4), serverLimits.ActiveUserCount)
 
 		// now we'll delete the user
 		_ = th.App.PermanentDeleteUser(th.Context, newGuestUser)
-		serverLimits, appErr = th.App.GetServerLimits()
+		serverLimits, appErr = th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(3), serverLimits.ActiveUserCount)
 	})
@@ -82,21 +102,21 @@ func TestGetServerLimits(t *testing.T) {
 
 		th.App.Srv().SetLicense(nil)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(3), serverLimits.ActiveUserCount)
 
 		// now we create a new user
 		newUser := th.CreateUser(t)
 
-		serverLimits, appErr = th.App.GetServerLimits()
+		serverLimits, appErr = th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(4), serverLimits.ActiveUserCount)
 
 		// now we'll delete the user
 		_, appErr = th.App.UpdateActive(th.Context, newUser, false)
 		require.Nil(t, appErr)
-		serverLimits, appErr = th.App.GetServerLimits()
+		serverLimits, appErr = th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(3), serverLimits.ActiveUserCount)
 	})
@@ -106,21 +126,21 @@ func TestGetServerLimits(t *testing.T) {
 
 		th.App.Srv().SetLicense(nil)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(3), serverLimits.ActiveUserCount)
 
 		// now we create a new user
 		newGuestUser := th.CreateGuest(t)
 
-		serverLimits, appErr = th.App.GetServerLimits()
+		serverLimits, appErr = th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(4), serverLimits.ActiveUserCount)
 
 		// now we'll delete the user
 		_, appErr = th.App.UpdateActive(th.Context, newGuestUser, false)
 		require.Nil(t, appErr)
-		serverLimits, appErr = th.App.GetServerLimits()
+		serverLimits, appErr = th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(3), serverLimits.ActiveUserCount)
 	})
@@ -130,20 +150,20 @@ func TestGetServerLimits(t *testing.T) {
 
 		th.App.Srv().SetLicense(nil)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(3), serverLimits.ActiveUserCount)
 
 		// now we create a new bot
 		newBot := th.CreateBot(t)
 
-		serverLimits, appErr = th.App.GetServerLimits()
+		serverLimits, appErr = th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(3), serverLimits.ActiveUserCount)
 
 		// now we'll delete the bot
 		_ = th.App.PermanentDeleteBot(th.Context, newBot.UserId)
-		serverLimits, appErr = th.App.GetServerLimits()
+		serverLimits, appErr = th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 		require.Equal(t, int64(3), serverLimits.ActiveUserCount)
 	})
@@ -155,7 +175,7 @@ func TestGetServerLimits(t *testing.T) {
 		license.IsSeatCountEnforced = false
 		th.App.Srv().SetLicense(license)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		require.Greater(t, serverLimits.ActiveUserCount, int64(0))
@@ -174,7 +194,7 @@ func TestGetServerLimits(t *testing.T) {
 		license.ExtraUsers = &extraUsers
 		th.App.Srv().SetLicense(license)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		// InitBasic creates 3 users by default
@@ -193,7 +213,7 @@ func TestGetServerLimits(t *testing.T) {
 		license.ExtraUsers = nil // Not configured
 		th.App.Srv().SetLicense(license)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		// InitBasic creates 3 users by default
@@ -213,7 +233,7 @@ func TestGetServerLimits(t *testing.T) {
 		license.ExtraUsers = &extraUsers
 		th.App.Srv().SetLicense(license)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		// InitBasic creates 3 users by default
@@ -230,7 +250,7 @@ func TestGetServerLimits(t *testing.T) {
 		license.Features.Users = nil
 		th.App.Srv().SetLicense(license)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		require.Greater(t, serverLimits.ActiveUserCount, int64(0))
@@ -247,7 +267,7 @@ func TestGetServerLimits(t *testing.T) {
 		license.Features.Users = &userLimit
 		th.App.Srv().SetLicense(license)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		require.Greater(t, serverLimits.ActiveUserCount, int64(0))
@@ -510,7 +530,7 @@ func TestExtraUsersBehavior(t *testing.T) {
 				license.ExtraUsers = tt.extraUsers
 				th.App.Srv().SetLicense(license)
 
-				serverLimits, appErr := th.App.GetServerLimits()
+				serverLimits, appErr := th.App.GetServerLimits(true)
 				require.Nil(t, appErr)
 
 				require.Equal(t, tt.expectedBaseLimit, serverLimits.MaxUsersLimit)
@@ -524,7 +544,7 @@ func TestExtraUsersBehavior(t *testing.T) {
 
 		th.App.Srv().SetLicense(nil)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		// Unlicensed servers use hard-coded limits without extra users
@@ -541,7 +561,7 @@ func TestGetServerLimitsWithPostHistory(t *testing.T) {
 
 		th.App.Srv().SetLicense(nil)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		// Unlicensed servers should have no post history limits
@@ -556,7 +576,7 @@ func TestGetServerLimitsWithPostHistory(t *testing.T) {
 		license.Limits = nil // No limits configured
 		th.App.Srv().SetLicense(license)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		// Should have no post history limits when Limits is nil
@@ -573,7 +593,7 @@ func TestGetServerLimitsWithPostHistory(t *testing.T) {
 		}
 		th.App.Srv().SetLicense(license)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		// Should have no post history limits when PostHistory is 0
@@ -606,7 +626,7 @@ func TestGetServerLimitsWithPostHistory(t *testing.T) {
 		}
 		th.App.Srv().SetLicense(license)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		// Should have proper post history limits set
@@ -637,7 +657,7 @@ func TestGetServerLimitsWithPostHistory(t *testing.T) {
 		}
 		th.App.Srv().SetLicense(license)
 
-		_, appErr := th.App.GetServerLimits()
+		_, appErr := th.App.GetServerLimits(true)
 		require.NotNil(t, appErr)
 		require.Contains(t, appErr.Message, "Unable to find the system variable")
 	})
@@ -664,7 +684,7 @@ func TestGetServerLimitsWithPostHistory(t *testing.T) {
 		}
 		th.App.Srv().SetLicense(license)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		// Should have post history limit set but LastAccessiblePostTime should be 0 (all posts accessible)
@@ -745,7 +765,7 @@ func TestGetServerLimitsWithSingleChannelGuests(t *testing.T) {
 		th.LinkUserToTeam(t, guest, th.BasicTeam)
 		th.AddUserToChannel(t, guest, th.BasicChannel)
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		require.Greater(t, serverLimits.SingleChannelGuestCount, int64(0))
@@ -761,7 +781,7 @@ func TestGetServerLimitsWithSingleChannelGuests(t *testing.T) {
 
 		th.App.UpdateConfig(func(cfg *model.Config) { *cfg.GuestAccountsSettings.Enable = true })
 
-		serverLimits, appErr := th.App.GetServerLimits()
+		serverLimits, appErr := th.App.GetServerLimits(true)
 		require.Nil(t, appErr)
 
 		require.Equal(t, int64(0), serverLimits.SingleChannelGuestCount)

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -408,7 +408,7 @@ func (a *App) createUserOrGuest(rctx request.CTX, user *model.User, guest bool) 
 		}, plugin.UserHasBeenCreatedID)
 	})
 
-	userLimits, limitErr := a.GetServerLimits()
+	userLimits, limitErr := a.GetServerLimits(true)
 	if limitErr != nil {
 		// we don't want to break the create user flow just because of this.
 		// So, we log the error, not return
@@ -1243,7 +1243,7 @@ func (a *App) UpdateActive(rctx request.CTX, user *model.User, active bool) (*mo
 	}
 
 	if active {
-		userLimits, appErr := a.GetServerLimits()
+		userLimits, appErr := a.GetServerLimits(true)
 		if appErr != nil {
 			rctx.Logger().Error("Error fetching user limits in UpdateActive", mlog.Err(appErr))
 		} else {


### PR DESCRIPTION
#### Summary

The `GET /api/v4/limits/server` endpoint computed expensive user/guest count queries for _every_ user on login and app refresh, even though non-admin users never receive (or need) those counts. The handler `getServerLimits` (`server/channels/api4/limits.go`) called `App.GetServerLimits()` unconditionally and then stripped the count fields out of the response for non-admins.

That meant `GetServerLimits()` always ran:
* `User().Count(...)` — active user count
* `User().AnalyticsGetSingleChannelGuestCount()` — a full `ChannelMembers` scan with an unindexable `Roles ILIKE '%system_guest%'` predicate

The web app dispatches this endpoint for all users from `loadMe()` (login) and `loadConfigAndMe()` (full page load / refresh), so on a large deployment the full-scan query landed on a high-frequency hot path and contributed to repeated DB CPU spikes — only for the result to be discarded for non-admins.

This PR adds an `includeUserCounts bool` parameter to `App.GetServerLimits`. The cheap license-derived limit fields plus `PostHistoryLimit`/`LastAccessiblePostTime` are always computed (all users need them for the message-history banner). The expensive `User().Count` and `AnalyticsGetSingleChannelGuestCount` queries now only run when `includeUserCounts` is true.

* The api4 handler passes the existing admin check, so the counts are computed only for system admins. Non-admins still receive zeros for the count fields (the existing strip block keeps the license-derived `MaxUsersLimit`/`MaxUsersHardLimit` hidden too), so the response contract is unchanged.
* Internal callers that genuinely need the counts (`isAtUserLimit`, user creation in `createUserOrGuest`, and `UpdateActive`) pass `true`.

This is "Fix 1" from the ticket. Follow-ups (caching the counts with a short TTL, and rewriting `AnalyticsGetSingleChannelGuestCount` to avoid the leading-wildcard `ILIKE`) are tracked separately.

More context: https://hub.mattermost.com/private-core/pl/rtc71bsjp3yhmprmifzpf335dw

##### QA steps
1. As a non-admin user, load the app / refresh and confirm `GET /api/v4/limits/server` returns the post-history fields with zeroed count fields (unchanged from before).
2. As a system admin, confirm the endpoint still returns `activeUserCount`, `singleChannelGuestCount`, and the seat limits.
3. Confirm user creation/activation seat-limit warnings still fire when the active user count exceeds the configured limit.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-69183

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change modifies an exported method signature (`GetServerLimits()` → `GetServerLimits(includeUserCounts bool)`), which is a breaking change for external callers. However, all internal call sites within `server/channels` have been systematically updated (API handler, `isAtUserLimit()`, user creation/activation). The API endpoint's behavioral contract is preserved—non-admin responses maintain the same structure with zeroed count fields while retaining post-history limit information. No external consumers beyond the client model wrapper were found.

**QA Recommendation:** Standard manual QA to verify: (1) non-admin users see zeroed seat/guest counts but retain post-history limits in `/api/v4/limits/server` responses; (2) admin users receive full counts via the same endpoint; (3) user creation/activation still properly enforces seat limits; (4) expensive count queries are avoided on the non-admin hot path (login/refresh flows). Automated test coverage is comprehensive across both `GetServerLimits(true)` and `GetServerLimits(false)` scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->