### PR TITLE
fix: render hashtags that start with a digit, e.g. #12345test (#33406)

### DIFF
--- a/server/public/model/utils.go
+++ b/server/public/model/utils.go
@@ -741,7 +741,7 @@ func Etag(parts ...any) string {
 }
 
 var (
-	validHashtag = regexp.MustCompile(`^(#\pL[\pL\d\-_.]*[\pL\d])$`)
+	validHashtag = regexp.MustCompile(`^(#[\pL\d][\pL\d\-_.]*[\pL\d])$`)
 	puncStart    = regexp.MustCompile(`^[^\pL\d\s#]+`)
 	hashtagStart = regexp.MustCompile(`^#{2,}`)
 	puncEnd      = regexp.MustCompile(`[^\pL\d\s]+$`)

--- a/server/public/model/utils_test.go
+++ b/server/public/model/utils_test.go
@@ -466,7 +466,7 @@ var hashtags = map[string]string{
 	"#test":           "#test",
 	"test":            "",
 	"#test123":        "#test123",
-	"#123test123":     "",
+	"#123test123":     "#123test123",
 	"#test-test":      "#test-test",
 	"#test?":          "#test",
 	"hi #there":       "#there",

--- a/server/tests/test-hashtags.md
+++ b/server/tests/test-hashtags.md
@@ -6,6 +6,7 @@ Hashtags in Mattermosts should render as specified below.
 
 #testing
 #testing123
+#123test
 #test-test
 #test_test
 #test! (punctuation should be excluded from linking)
@@ -14,7 +15,6 @@ Hashtags in Mattermosts should render as specified below.
 
 #### These strings should not auto-link:
 
-#123test
 #?test
 #-test
 

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -761,7 +761,7 @@ export function highlightWithoutNotificationKeywords(
     return output;
 }
 
-const hashtagRegex = /(^|\W)(#\p{L}[\p{L}\d\-_.]*[\p{L}\d])/gu;
+const hashtagRegex = /(^|\W)(#[\p{L}\d][\p{L}\d\-_.]*[\p{L}\d])/gu;
 
 function autolinkHashtags(
     text: string,

--- a/webapp/channels/src/utils/text_formatting_hashtags.test.ts
+++ b/webapp/channels/src/utils/text_formatting_hashtags.test.ts
@@ -15,15 +15,19 @@ describe('TextFormatting.Hashtags with default setting', () => {
         expect(TextFormatting.formatText('#ab', {}, emojiMap).trim()).toBe(
             '<p>#ab</p>',
         );
-
-        expect(TextFormatting.formatText('#123test', {}, emojiMap).trim()).toBe(
-            '<p>#123test</p>',
-        );
     });
 
     it('Hashtags', () => {
         expect(TextFormatting.formatText('#test', {}, emojiMap).trim()).toBe(
             "<p><a class='mention-link' href='#' data-hashtag='#test'>#test</a></p>",
+        );
+
+        // issue #33406: number-first hashtags (like #123test) must render as
+        // hashtags. The regression locked this case in as plain text via the
+        // hashtagRegex requiring \p{L} (letter) immediately after #. The fix
+        // widened that to [\p{L}\d].
+        expect(TextFormatting.formatText('#123test', {}, emojiMap).trim()).toBe(
+            "<p><a class='mention-link' href='#' data-hashtag='#123test'>#123test</a></p>",
         );
 
         expect(TextFormatting.formatText('#test123', {}, emojiMap).trim()).toBe(


### PR DESCRIPTION
The hashtagRegex requires the character right after `#` to be a Unicode letter (\p{L}), so #12345test and other number-first hashtags rendered as plain text instead of clickable hashtag links — a regression from prior versions. The reporter expected `#12345test` to render as a hashtag as before.

Widen the second character class from `\p{L}` to `[\p{L}\d]` so the post-`#` character can be a letter OR a digit. The middle and trailing classes already accepted digits, so this restores symmetric handling without altering any other rule:
- middle: `[\p{L}\d\-_.]*` (unchanged)
- end: `[\p{L}\d]` (unchanged)

The minimumHashtagLength check at line 803 still rejects hashtags shorter than 3 characters after `#` (so `#12` and `#ab` remain plain text), and the leading-non-word-character requirement (`^|\W`) is preserved, so this change does not introduce any accidental new matches.

Also moves the existing `#123test` test assertion from the "Not hashtags" describe block (where it was locking in the buggy behavior) into the "Hashtags" describe block with the correct expected hashtag-link output. The other two "Not hashtags" assertions (`# hashtag` -> heading, `#ab` -> too short) stay unchanged.

<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
`hashtagRegex` in [`text_formatting.tsx`](../blob/master/webapp/channels/src/utils/text_formatting.tsx) required the character right after `#` to be a Unicode letter (`\p{L}`), so `#12345test` and other number-first hashtags rendered as plain text instead of clickable links — a regression from prior versions. The reporter expected `#12345test` to render as a hashtag as before.

The fix widens the second character class from `\p{L}` to `[\p{L}\d]` so the post-`#` character can be a letter OR a digit. The middle (`[\p{L}\d\-_.]*`) and trailing (`[\p{L}\d]`) classes already accepted digits, so this restores symmetric handling without altering any other rule.

The `minimumHashtagLength` check (default 3) still rejects hashtags shorter than 3 characters after `#`, so `#12` and `#ab` remain plain text and the existing `#ab` assertion in the "Not hashtags" test is unchanged.

Also moves the existing `#123test` test assertion from the "Not hashtags" describe block (which was locking in the buggy behavior) into the "Hashtags" block with the correct expected output.

Manual test:
- Post `#12345test` in a channel → renders as a clickable hashtag.
- Post `#12345` → renders as a clickable hashtag.
- Post `#test` → still renders as a clickable hashtag.
- Post `#ab` → still renders as plain text (below `minimumHashtagLength`).
- Post `# hashtag` → still renders as an `<h1>` heading.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/33406

#### Screenshots
N/A — describing in words: a message containing `#12345test` now displays it as a highlighted hashtag link rather than as plain unstyled text.

#### Release Note
```release-note
Fixed an issue where hashtags that begin with a digit (e.g. `#12345test`) rendered as plain text instead of as clickable hashtag links.
```

-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** Moderate — the change relaxes hashtag parsing rules in both client and server codepaths that influence rendering and search; tests were updated but wider consumers of hashtag parsing may be affected.  
**QA Recommendation:** Run focused manual QA for hashtag-related flows (message rendering, search/results, channel mentions, edge cases like punctuation and short tags) in addition to existing automated tests.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->