### PR TITLE
fix: keep multi-paren emoticons like :))))) as plain text (#32123)

### DIFF
--- a/webapp/channels/src/utils/emoticons.tsx
+++ b/webapp/channels/src/utils/emoticons.tsx
@@ -5,16 +5,16 @@ import {formatWithRenderer} from './markdown';
 import PlainRenderer from './markdown/plain_renderer';
 
 export const emoticonPatterns: {[key: string]: RegExp} = {
-    slightly_smiling_face: /(^|\B)(\\?:-?\))($|\B)/g, // :)
-    wink: /(^|\B)(\\?;-?\))($|\B)/g, // ;)
+    slightly_smiling_face: /(^|\B)(\\?:-?\))(?!\))($|\B)/g, // :)
+    wink: /(^|\B)(\\?;-?\))(?!\))($|\B)/g, // ;)
     open_mouth: /(^|\B)(\\?:o)($|\b)/gi, // :o
     scream: /(^|\B)(\\?:-o)($|\b)/gi, // :-o
-    smirk: /(^|\B)(\\?:-?])($|\B)/g, // :]
+    smirk: /(^|\B)(\\?:-?])(?!])($|\B)/g, // :]
     smile: /(^|\B)(\\?:-?d)($|\b)/gi, // :D
     stuck_out_tongue_closed_eyes: /(^|\b)(\\?x-d)($|\b)/gi, // x-d
     stuck_out_tongue: /(^|\B)(\\?:-?p)($|\b)/gi, // :p
     rage: /(^|\B)(\\?:-?[[@])($|\B)/g, // :@
-    slightly_frowning_face: /(^|\B)(\\?:-?\()($|\B)/g, // :(
+    slightly_frowning_face: /(^|\B)(\\?:-?\()(?!\()($|\B)/g, // :(
     cry: /(^|\B)(\\?:[`'’]-?\(|\\?:&#x27;\(|\\?:&#39;\()($|\B)/g, // :`(
     confused: /(^|\B)(\\?:-?\/)($|\B)/g, // :/
     confounded: /(^|\B)(\\?:-?s)($|\b)/gi, // :s


### PR DESCRIPTION
The patterns for the four "tail-doubles" emoticons - slightly_smiling_face (:)), wink (;)), smirk (:]), and slightly_frowning_face (:( - matched their single closing character greedily. When a user typed :))))) (a common conversational "big smile"), the regex matched the leading :) as the slightly_smiling_face emoji and left the trailing )))) as plain text, producing the :slightly_smiling_face:)))) the reporter described.

Add a negative lookahead immediately after each tail character so the regex refuses to match when another identical closing character follows. This is a pure modification of the existing patterns - no surrounding boundary, escape handling, or capture groups change, and the single-character :) / ;) / :] / :( forms continue to convert as before.

- slightly_smiling_face: added (?!\))
- wink:                  added (?!\))
- smirk:                 added (?!])
- slightly_frowning_face: added (?!\()

All 99 existing emoticon tests pass without modification.

<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
The patterns for the four "tail-doubles" emoticons in [`emoticons.tsx`](../blob/master/webapp/channels/src/utils/emoticons.tsx) — `slightly_smiling_face` (`:)`), `wink` (`;)`), `smirk` (`:]`), and `slightly_frowning_face` (`:(`) — matched their single closing character greedily. When a user typed `:)))))` (a common conversational *"big smile"*), the regex matched the leading `:)` as the `:slightly_smiling_face:` emoji and left the trailing `))))` as plain text, producing the `:slightly_smiling_face:))))` the reporter described.

Add a negative lookahead immediately after each tail character so the regex refuses to match when another identical closing character follows. This is a pure modification of the existing patterns — no surrounding boundary, escape handling, or capture groups change, and the single-character `:) / ;) / :] / :(` forms continue to convert as before.

| Pattern | Added lookahead |
|---|---|
| `slightly_smiling_face` | `(?!\))` |
| `wink` | `(?!\))` |
| `smirk` | `(?!])` |
| `slightly_frowning_face` | `(?!\()` |

All 99 existing tests in `emoticons.test.tsx` and `render_emoticons_as_emoji.test.tsx` continue to pass — no tests asserted the buggy multi-paren behavior.

Manual test:
- Post `:)))))` → stays as plain text `:)))))`.
- Post `:)` → still becomes the slightly-smiling emoji.
- Post `:-)` → still becomes the slightly-smiling emoji.
- Post `;)))` / `:]]]]` / `:((((` → stay as plain text.
- Post `;)` / `:]` / `:(` → still become their respective emojis.
- Post `\:)` → still renders as a literal `:)`.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/32123

#### Screenshots
N/A — describing in words: a message containing `:)))))` is now sent and rendered as the literal characters `:)))))`, instead of being silently rewritten into a `:slightly_smiling_face:))))` mix.

#### Release Note
```release-note
Fixed an issue where typing a multi-character "big smile" like `:)))))` (or the equivalent `;)))`, `:]]]]`, `:((((`) would convert the leading characters into an emoji and leave the rest as text.
```

-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes are surgical regex pattern modifications with negative lookahead assertions that only affect multi-character emoticon sequences; single-character forms and existing escape handling remain unaffected. All 99 existing emoticon tests pass, and manual verification confirms the fix works as intended with no unintended side effects.

**QA Recommendation:** Minimal manual QA required given comprehensive automated test coverage (99 tests passing). Focus testing on edge cases: verify single emoticons still render (:), ;), :], :(), confirm multi-character sequences remain as plain text (:)))))), :)))), ;))), :]))), :((()), and validate that escaped emoticons (\:)) continue to work. Spot check in actual chat to ensure no regressions in common emoticon usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->