### PR TITLE
Reserve image attachment height during thumbnail checks

### DIFF
--- a/webapp/channels/src/components/single_image_view/single_image_view.test.tsx
+++ b/webapp/channels/src/components/single_image_view/single_image_view.test.tsx
@@ -5,7 +5,8 @@ import React from 'react';
 
 import SingleImageView from 'components/single_image_view/single_image_view';
 
-import {fireEvent, renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
+import {fireEvent, renderWithContext, screen, userEvent, waitFor, act} from 'tests/react_testing_utils';
+import {HttpHeaders} from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
 
 describe('components/SingleImageView', () => {
@@ -38,6 +39,78 @@ describe('components/SingleImageView', () => {
         enablePublicLink: false,
         isFileRejected: false,
     };
+
+    test('should reserve image space without loading preview while thumbnail check is pending', async () => {
+        let resolveFetch: (response: Response) => void;
+        mockFetch.mockImplementationOnce(() => new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+        }));
+
+        const {container} = renderWithContext(
+            <SingleImageView {...baseProps}/>,
+        );
+
+        const svgElement = container.querySelector('.image-loading__container > svg');
+        expect(svgElement).toBeInTheDocument();
+        expect(svgElement?.getAttribute('viewBox')).toEqual('0 0 350 200');
+        expect(container.querySelector('img')).not.toBeInTheDocument();
+        expect(container.querySelector('.file-preview__button')).not.toBeInTheDocument();
+
+        await act(async () => {
+            resolveFetch!({
+                status: 200,
+                headers: new Headers(),
+            } as Response);
+        });
+
+        await waitFor(() => {
+            expect(container.querySelector('img')).toBeInTheDocument();
+        });
+    });
+
+    test('should collapse placeholder to filename when thumbnail check is rejected by plugin', async () => {
+        let resolveFetch: (response: Response) => void;
+        mockFetch.mockImplementationOnce(() => new Promise<Response>((resolve) => {
+            resolveFetch = resolve;
+        }));
+
+        const {container} = renderWithContext(
+            <SingleImageView {...baseProps}/>,
+        );
+
+        expect(container.querySelector('.image-loading__container > svg')).toBeInTheDocument();
+        expect(container.querySelector('img')).not.toBeInTheDocument();
+
+        await act(async () => {
+            resolveFetch!({
+                status: 403,
+                headers: new Headers({
+                    [HttpHeaders.REJECT_REASON]: 'plugin_rejected',
+                }),
+            } as Response);
+        });
+
+        await waitFor(() => {
+            expect(container.querySelector('.image-name')?.textContent).toEqual(baseProps.fileInfo.name);
+        });
+        expect(container.querySelector('.image-loading__container')).not.toBeInTheDocument();
+        expect(container.querySelector('img')).not.toBeInTheDocument();
+    });
+
+    test('should keep rejected files collapsed without reserving image space', () => {
+        mockFetch.mockImplementationOnce(() => new Promise<Response>(() => {}));
+
+        const {container} = renderWithContext(
+            <SingleImageView
+                {...baseProps}
+                isFileRejected={true}
+            />,
+        );
+
+        expect(container.querySelector('.image-name')?.textContent).toEqual(baseProps.fileInfo.name);
+        expect(container.querySelector('.image-loading__container')).not.toBeInTheDocument();
+        expect(container.querySelector('img')).not.toBeInTheDocument();
+    });
 
     test('should match snapshot', async () => {
         const {container} = renderWithContext(

--- a/webapp/channels/src/components/single_image_view/single_image_view.tsx
+++ b/webapp/channels/src/components/single_image_view/single_image_view.tsx
@@ -57,7 +57,7 @@ export default class SingleImageView extends React.PureComponent<Props, State> {
                 width: props.fileInfo?.width || 0,
                 height: props.fileInfo?.height || 0,
             },
-            thumbnailCheckComplete: false,
+            thumbnailCheckComplete: !props.fileInfo?.has_preview_image,
             thumbnailRejected: false,
         };
     }
@@ -164,23 +164,10 @@ export default class SingleImageView extends React.PureComponent<Props, State> {
             return <></>;
         }
 
-        // If thumbnail check not complete yet, don't render the preview
-        // This prevents flashing the image before we know if it should be hidden
-        if (!thumbnailCheckComplete) {
-            return (
-                <div className={classNames('file-view--single')}>
-                    <div className='file__image'>
-                        <div className='image-header'>
-                            <div className='image-name'>{fileInfo.name}</div>
-                        </div>
-                    </div>
-                </div>
-            );
-        }
-
         // If thumbnail was rejected, treat this file as rejected
         // Show it collapsed with file icon instead of inline preview
-        const effectivelyRejected = this.props.isFileRejected || thumbnailRejected;
+        const thumbnailRejectedByPlugin = thumbnailCheckComplete && thumbnailRejected;
+        const effectivelyRejected = this.props.isFileRejected || thumbnailRejectedByPlugin;
         if (effectivelyRejected) {
             // Don't show inline preview - return minimal view
             // User can still click to attempt opening in modal (which will be controlled by preview rejection)
@@ -203,6 +190,7 @@ export default class SingleImageView extends React.PureComponent<Props, State> {
         const {has_preview_image: hasPreviewImage, id} = fileInfo;
         const fileURL = getFileUrl(id);
         const previewURL = hasPreviewImage ? getFilePreviewUrl(id) : fileURL;
+        const renderPlaceholderOnly = !thumbnailCheckComplete;
 
         const previewHeight = fileInfo.height;
         const previewWidth = fileInfo.width;
@@ -323,6 +311,7 @@ export default class SingleImageView extends React.PureComponent<Props, State> {
                                     fileURL={fileURL}
                                     onImageLoaded={this.imageLoaded}
                                     showLoader={this.props.isEmbedVisible}
+                                    renderPlaceholderOnly={renderPlaceholderOnly}
                                     handleSmallImageContainer={true}
                                     enablePublicLink={this.props.enablePublicLink}
                                     getFilePublicLink={this.getFilePublicLink}

--- a/webapp/channels/src/components/size_aware_image.test.tsx
+++ b/webapp/channels/src/components/size_aware_image.test.tsx
@@ -79,6 +79,28 @@ describe('components/SizeAwareImage', () => {
         expect(container).toMatchSnapshot();
     });
 
+    test('should reserve a placeholder without rendering image content when renderPlaceholderOnly is true', () => {
+        const props = {
+            ...baseProps,
+            showLoader: true,
+            renderPlaceholderOnly: true,
+            fileInfo: TestHelper.getFileInfoMock({
+                ...baseProps.fileInfo,
+                mime_type: 'mime_type',
+                mini_preview: 'mini_preview',
+            }),
+        };
+
+        const {container} = renderWithContext(<SizeAwareImage {...props}/>, state);
+
+        const svgElement = container.querySelector('.image-loading__container > svg');
+        expect(svgElement).not.toBeNull();
+        expect(svgElement?.getAttribute('viewBox')).toEqual('0 0 300 200');
+        expect(container.querySelector('img')).toBeNull();
+        expect(container.querySelector('.file__image-loading')).toBeNull();
+        expect(container.querySelector('.file-preview__button')).toBeNull();
+    });
+
     test('should render a mini preview when showLoader is true and preview is set', () => {
         const props = {
             ...baseProps,

--- a/webapp/channels/src/components/size_aware_image.tsx
+++ b/webapp/channels/src/components/size_aware_image.tsx
@@ -55,6 +55,11 @@ export type Props = WrappedComponentProps & {
     showLoader?: boolean;
 
     /*
+    * Keeps the dimension placeholder mounted without rendering image content
+    */
+    renderPlaceholderOnly?: boolean;
+
+    /*
     * A callback that is called as soon as the image component has a height value
     */
     onImageLoaded?: ({height, width}: {height: number; width: number}) => void;
@@ -186,7 +191,9 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
     };
 
     renderImageLoaderIfNeeded = () => {
-        if (!this.state.loaded && this.props.showLoader && !this.state.error) {
+        const renderPlaceholderOnly = this.props.renderPlaceholderOnly ?? false;
+
+        if (!renderPlaceholderOnly && !this.state.loaded && this.props.showLoader && !this.state.error) {
             return (
                 <div style={{position: 'absolute', top: '50%', transform: 'translate(-50%, -50%)', left: '50%'}}>
                     <LoadingImagePreview
@@ -218,6 +225,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
         Reflect.deleteProperty(props, 'hideUtilities');
         Reflect.deleteProperty(props, 'getFilePublicLink');
         Reflect.deleteProperty(props, 'isFileRejected');
+        Reflect.deleteProperty(props, 'renderPlaceholderOnly');
         Reflect.deleteProperty(props, 'intl');
 
         let ariaLabelImage = intl.formatMessage({id: 'file_attachment.thumbnail', defaultMessage: 'file thumbnail'});
@@ -400,6 +408,7 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
             dimensions,
             fileInfo,
         } = this.props;
+        const renderPlaceholderOnly = this.props.renderPlaceholderOnly ?? false;
 
         let ariaLabelImage = this.props.intl.formatMessage({id: 'file_attachment.thumbnail', defaultMessage: 'file thumbnail'});
         if (fileInfo) {
@@ -408,13 +417,15 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
 
         let fallback;
 
-        if (this.dimensionsAvailable(dimensions) && !this.state.loaded) {
+        if (this.dimensionsAvailable(dimensions) && (!this.state.loaded || renderPlaceholderOnly)) {
             const ratio = (dimensions?.height ?? 0) > MAX_IMAGE_HEIGHT ? MAX_IMAGE_HEIGHT / (dimensions?.height ?? 1) : 1;
             const height = (dimensions?.height ?? 0) * ratio;
             const width = (dimensions?.width ?? 0) * ratio;
 
-            // Don't show mini preview (blurred thumbnail) if the file is rejected
-            const miniPreview = this.props.isFileRejected ? null : getFileMiniPreviewUrl(fileInfo);
+            // Placeholder-only mode reserves layout without rendering image-derived content;
+            // rejected files should also avoid preview content.
+            const shouldShowMiniPreview = !renderPlaceholderOnly && !this.props.isFileRejected;
+            const miniPreview = shouldShowMiniPreview ? getFileMiniPreviewUrl(fileInfo) : null;
 
             if (miniPreview) {
                 fallback = (
@@ -449,17 +460,19 @@ export class SizeAwareImage extends React.PureComponent<Props, State> {
             }
         }
 
-        const shouldShowImg = !this.dimensionsAvailable(dimensions) || this.state.loaded;
+        const shouldShowImg = !renderPlaceholderOnly && (!this.dimensionsAvailable(dimensions) || this.state.loaded);
 
         return (
             <>
                 {fallback}
-                <div
-                    className='file-preview__button'
-                    style={{display: shouldShowImg ? 'inline-block' : 'none'}}
-                >
-                    {this.renderImageWithContainerIfNeeded()}
-                </div>
+                {!renderPlaceholderOnly && (
+                    <div
+                        className='file-preview__button'
+                        style={{display: shouldShowImg ? 'inline-block' : 'none'}}
+                    >
+                        {this.renderImageWithContainerIfNeeded()}
+                    </div>
+                )}
             </>
         );
     };


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
Delay rendering single image content until the thumbnail availability check finishes, while still reserving the final image dimensions up front. This prevents media-heavy channels from shifting message row heights when SizeAwareImage mounts after the plugin thumbnail check completes, which can move scroll position in permalink views and while loading older posts.

Add a renderPlaceholderOnly mode to SizeAwareImage so callers can mount the same dimension placeholder without rendering the real image, mini preview, loader, or preview controls. Use that mode in SingleImageView while the thumbnail HEAD request is pending. Once the check succeeds, render the image normally. If the thumbnail is rejected by a plugin, keep the existing collapsed filename behavior unchanged.

Also cover the pending, accepted, plugin-rejected, and already-rejected paths with focused tests.

#### Ticket Link
<!--
Fixes: https://github.com/mattermost/mattermost/issues/XXX
Fixes: https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
Before:
<img width="1892" height="1108" alt="Before" src="https://github.com/user-attachments/assets/5ee76dd0-dd19-4dc4-be86-71dc79bf558e" />
After:
<img width="1898" height="1108" alt="After" src="https://github.com/user-attachments/assets/f19680e8-af75-4acb-b09d-e654e329e50c" />


#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note

```
-->
```release-note
Fixes the issue of the wrong scroll position in the permalink view of channels with images
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes introduce a new optional prop to `SizeAwareImage`, a shared component used in 5 different places (file_attachment_list, markdown_image, message_attachment, post_image, and single_image_view). While the prop is backward compatible and optional, the modification to image rendering logic and conditional placeholder-only behavior could have subtle side effects across these different usage contexts, particularly regarding layout and dimension handling.

**QA Recommendation:** Manual QA testing should focus on image rendering across all affected components (especially message attachments and post images) to verify no layout shifts or scroll position anomalies are introduced. Verify permalink view scroll behavior with media-heavy channels. Existing automated test coverage is comprehensive (600+ lines of test and snapshot code), but cross-component integration testing is recommended to ensure the changes don't cause unintended side effects in other image rendering contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->