### PR TITLE
Fixes for the session attributes manifest

### DIFF
--- a/server/channels/app/migrations.go
+++ b/server/channels/app/migrations.go
@@ -50,7 +50,6 @@ const (
 	contentFlaggingPropertySubTypeTimestamp = "timestamp"
 
 	boardsPropertySetupDoneKey     = "boards_property_setup_done"
-	sessionAttributesSetupDoneKey  = "session_attributes_setup_done"
 	boardsPropertyMigrationVersion = "v1"
 )
 
@@ -892,7 +891,7 @@ func (s *Server) seedSessionAttributeFields(groupID string) error {
 	for _, expected := range model.SessionAttributeSystemFields(groupID) {
 		if current, ok := existingByName[expected.Name]; ok {
 			current.Type = expected.Type
-			current.Attrs = expected.Attrs
+			current.Attrs["platforms"] = expected.Attrs["platforms"]
 			current.ObjectType = expected.ObjectType
 			current.TargetType = expected.TargetType
 			current.Protected = expected.Protected
@@ -926,15 +925,6 @@ func (s *Server) seedSessionAttributeFields(groupID string) error {
 }
 
 func (s *Server) doSetupSessionAttributesProperties() error {
-	var nfErr *store.ErrNotFound
-	data, err := s.Store().System().GetByName(sessionAttributesSetupDoneKey)
-	if err != nil && !errors.As(err, &nfErr) {
-		return fmt.Errorf("could not query session attributes migration: %w", err)
-	}
-	if data != nil {
-		return nil
-	}
-
 	group, err := s.propertyService.Group(model.SessionAttributesPropertyGroupName)
 	if err != nil {
 		return fmt.Errorf("failed to look up session attributes property group: %w", err)
@@ -942,10 +932,6 @@ func (s *Server) doSetupSessionAttributesProperties() error {
 
 	if err := s.seedSessionAttributeFields(group.ID); err != nil {
 		return fmt.Errorf("failed to seed session attribute fields: %w", err)
-	}
-
-	if err := s.Store().System().SaveOrUpdate(&model.System{Name: sessionAttributesSetupDoneKey, Value: "true"}); err != nil {
-		return fmt.Errorf("failed to save session attributes setup done flag: %w", err)
 	}
 
 	return nil

--- a/server/channels/app/migrations_test.go
+++ b/server/channels/app/migrations_test.go
@@ -363,7 +363,7 @@ func TestCPADisplayNameBackfill_BackfillsProtectedSourceOnlyField(t *testing.T) 
 func TestDoSetupSessionAttributesProperties(t *testing.T) {
 	expectedFieldCount := len(model.SessionAttributeSystemFields("group-id"))
 
-	t.Run("fresh install seeds the group, fields, and done marker", func(t *testing.T) {
+	t.Run("fresh install seeds the group and fields", func(t *testing.T) {
 		th := Setup(t)
 
 		group, appErr := th.App.GetPropertyGroup(th.Context, model.SessionAttributesPropertyGroupName)
@@ -404,16 +404,12 @@ func TestDoSetupSessionAttributesProperties(t *testing.T) {
 		require.Equal(t, model.SessionAttributeDefaultTTLNetworkIdentity, saField.Attrs.TTLSeconds)
 		require.Equal(t, model.SessionAttributeDefaultGraceNetworkIdentity, saField.Attrs.GracePeriodSeconds)
 		require.ElementsMatch(t,
-			[]string{model.SessionAttributePlatformDesktop, model.SessionAttributePlatformMobile, model.SessionAttributePlatformBrowser},
+			[]string{model.SessionAttributePlatformDesktop, model.SessionAttributePlatformMobile},
 			saField.Attrs.Platforms,
 		)
-
-		data, sysErr := th.Store.System().GetByName(sessionAttributesSetupDoneKey)
-		require.NoError(t, sysErr)
-		require.Equal(t, "true", data.Value)
 	})
 
-	t.Run("re-running after clearing the marker is idempotent", func(t *testing.T) {
+	t.Run("re-running is idempotent", func(t *testing.T) {
 		th := Setup(t)
 
 		group, appErr := th.App.GetPropertyGroup(th.Context, model.SessionAttributesPropertyGroupName)
@@ -423,31 +419,20 @@ func TestDoSetupSessionAttributesProperties(t *testing.T) {
 		require.Nil(t, appErr)
 		require.Len(t, before, expectedFieldCount)
 
-		_, err := th.Store.System().PermanentDeleteByName(sessionAttributesSetupDoneKey)
-		require.NoError(t, err)
-
-		err = th.Server.doSetupSessionAttributesProperties()
+		err := th.Server.doSetupSessionAttributesProperties()
 		require.NoError(t, err)
 
 		after, appErr := th.App.SearchPropertyFields(th.Context, group.ID, model.PropertyFieldSearchOpts{PerPage: 100})
 		require.Nil(t, appErr)
 		require.Len(t, after, expectedFieldCount, "re-running must not create duplicate fields")
-
-		data, sysErr := th.Store.System().GetByName(sessionAttributesSetupDoneKey)
-		require.NoError(t, sysErr)
-		require.Equal(t, "true", data.Value)
 	})
 
 	t.Run("concurrent runs tolerate update conflicts", func(t *testing.T) {
 		th := Setup(t)
 
-		// Fields already exist from Setup. Clearing the marker forces every
-		// goroutine into the seed body and onto the update path, racing on the
-		// same UpdateAt timestamps. Only one wins; the rest must tolerate the
-		// resulting ErrConflict rather than failing.
-		_, err := th.Store.System().PermanentDeleteByName(sessionAttributesSetupDoneKey)
-		require.NoError(t, err)
-
+		// Fields already exist from Setup. Every goroutine runs the seed body
+		// and races on the same UpdateAt timestamps. Only one wins; the rest
+		// must tolerate the resulting ErrConflict rather than failing.
 		const runners = 5
 		errs := make([]error, runners)
 		var wg sync.WaitGroup

--- a/server/channels/app/session_attributes.go
+++ b/server/channels/app/session_attributes.go
@@ -249,6 +249,9 @@ func (a *App) GetSessionAttributesManifest(rctx request.CTX, r *http.Request) ([
 		if err != nil || !saField.EnabledForPlatform(platform) {
 			continue
 		}
+		if _, isDerived := model.SessionAttributesRequestDerivedFieldNames[field.Name]; isDerived {
+			continue
+		}
 		manifest = append(manifest, &model.SessionAttributeManifestEntry{
 			Name:               field.Name,
 			Type:               string(field.Type),

--- a/server/channels/app/session_attributes_test.go
+++ b/server/channels/app/session_attributes_test.go
@@ -303,7 +303,7 @@ func TestProcessSessionAttributesRequest(t *testing.T) {
 		require.Nil(t, appErr)
 		rctx := th.Context.WithSession(session)
 
-		r := newSessionAttributesRequest(t, testUserAgentChrome, "192.0.2.10:1234")
+		r := newSessionAttributesRequest(t, testUserAgentDesktop, "192.0.2.10:1234")
 		r.Header.Set(model.SessionAttributeHeaderClientAttributes, encodeClientSessionAttributesHeader(t, map[string]any{
 			model.SessionAttributesPropertyFieldNetworkInterfaceType: "not-a-valid-option",
 			model.SessionAttributesPropertyFieldOSPlatform:           "linux",

--- a/server/channels/testlib/store.go
+++ b/server/channels/testlib/store.go
@@ -195,6 +195,7 @@ func GetMockStoreForSetupFunctions() *mocks.Store {
 	propertyFieldStore.On("SearchPropertyFields", mock.Anything).Return([]*model.PropertyField{}, nil)
 	propertyFieldStore.On("CreatePropertyField", mock.Anything).Return(&model.PropertyField{}, nil)
 	propertyFieldStore.On("Create", mock.AnythingOfType("*model.PropertyField")).Return(&model.PropertyField{}, nil)
+	propertyFieldStore.On("CheckPropertyNameConflict", mock.AnythingOfType("*model.PropertyField"), mock.Anything).Return(model.PropertyFieldTargetLevel(""), nil)
 
 	managedCategoryField := &model.PropertyField{ID: model.NewId(), GroupID: managedCategoryGroup.ID, Name: model.ManagedCategoryPropertyFieldName}
 	propertyFieldStore.On("GetFieldByName", mock.Anything, managedCategoryGroup.ID, "", model.ManagedCategoryPropertyFieldName).Return(managedCategoryField, nil)

--- a/server/public/model/session_attributes.go
+++ b/server/public/model/session_attributes.go
@@ -204,6 +204,7 @@ func sessionAttributeField(groupID, name string, fieldType PropertyFieldType, pl
 // SessionAttributeSystemFields returns the built-in session attribute schema fields.
 func SessionAttributeSystemFields(groupID string) []*PropertyField {
 	allPlatforms := []string{SessionAttributePlatformDesktop, SessionAttributePlatformMobile, SessionAttributePlatformBrowser}
+	clientsOnly := []string{SessionAttributePlatformDesktop, SessionAttributePlatformMobile}
 	desktopBrowser := []string{SessionAttributePlatformDesktop, SessionAttributePlatformBrowser}
 	desktopOnly := []string{SessionAttributePlatformDesktop}
 	mobileOnly := []string{SessionAttributePlatformMobile}
@@ -217,8 +218,8 @@ func SessionAttributeSystemFields(groupID string) []*PropertyField {
 
 	return []*PropertyField{
 		sessionAttributeField(groupID, SessionAttributesPropertyFieldIPAddress, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientIPAddress, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldNetworkInterfaceType, PropertyFieldTypeSelect, allPlatforms, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, StringInterface{
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientIPAddress, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldNetworkInterfaceType, PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, StringInterface{
 			PropertyFieldAttributeOptions: []map[string]string{
 				{"name": "wifi"},
 				{"name": "ethernet"},
@@ -228,14 +229,14 @@ func SessionAttributeSystemFields(groupID string) []*PropertyField {
 				{"name": "other"},
 			},
 		}),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldVPNActive, PropertyFieldTypeSelect, allPlatforms, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, boolSelectOptions),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldSSID, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldVPNActive, PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, boolSelectOptions),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldSSID, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
 
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldMDMEnrolled, PropertyFieldTypeSelect, allPlatforms, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, boolSelectOptions),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldMDMEnrolled, PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, boolSelectOptions),
 		sessionAttributeField(groupID, SessionAttributesPropertyFieldJailbreakDetected, PropertyFieldTypeSelect, mobileOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, boolSelectOptions),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldOSPlatform, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldOSVersion, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientVersion, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldOSPlatform, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldOSVersion, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientVersion, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
 
 		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentPlatform, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
 		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentOS, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
@@ -244,7 +245,7 @@ func SessionAttributeSystemFields(groupID string) []*PropertyField {
 		sessionAttributeField(groupID, SessionAttributesPropertyFieldTLSDDeviceID, PropertyFieldTypeText, desktopBrowser, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
 		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientDeviceID, PropertyFieldTypeText, mobileOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
 		sessionAttributeField(groupID, SessionAttributesPropertyFieldHardwareID, PropertyFieldTypeText, desktopOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldServerFQDN, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldServerFQDN, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
 		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientFQDN, PropertyFieldTypeText, desktopOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
 	}
 }


### PR DESCRIPTION
#### Summary
The session attributes manifest sent to clients included request-derived fields (computed server-side from the request) and several attributes that only apply to native clients, causing clients to be prompted for data they can't or shouldn't provide.

This PR filters request-derived fields out of `GetSessionAttributesManifest`, scopes the network, posture, and identity attributes that only make sense on native clients to desktop/mobile (removing browser), and makes `doSetupSessionAttributesProperties` always run its idempotent seed instead of gating on a done-marker, updating only the `platforms` attribute on existing fields.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** Changes affect session attribute manifests, platform scoping, and migration seeding: GetSessionAttributesManifest now excludes request-derived fields and several attributes are restricted to desktop/mobile, while the migration now always seeds and only updates platforms for existing fields—these alter runtime manifest contents and persistent field metadata and may break clients or integrations relying on previous manifest contents; additionally, the new manifest filter currently has no unit-test coverage.  
**QA Recommendation:** Run focused QA validating manifest outputs from browser, desktop, and mobile clients, verify idempotent migration behavior on existing databases (including concurrent runs), and add unit tests ensuring request-derived fields are excluded and platform scoping is correct before merge.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->