### PR TITLE
MM-69213: Validate Azure storage account names and use httpservice for custom endpoints

### DIFF
--- a/server/channels/app/file.go
+++ b/server/channels/app/file.go
@@ -161,10 +161,11 @@ func (a *App) TestFileStoreConnectionWithConfig(cfg *model.FileSettings) *model.
 	var err error
 	complianceEnabled := license != nil && *license.Features.Compliance
 	allowInsecure := insecure != nil && *insecure
+	allowedUntrustedInternalConnections := model.SafeDereference(a.Config().ServiceSettings.AllowedUntrustedInternalConnections)
 	if a.UseExportFileStore() {
-		backend, err = filestore.NewFileBackend(filestore.NewExportFileBackendSettingsFromConfig(cfg, complianceEnabled && license.IsCloud(), allowInsecure))
+		backend, err = filestore.NewFileBackend(filestore.NewExportFileBackendSettingsFromConfig(cfg, complianceEnabled && license.IsCloud(), allowInsecure, allowedUntrustedInternalConnections))
 	} else {
-		backend, err = filestore.NewFileBackend(filestore.NewFileBackendSettingsFromConfig(cfg, complianceEnabled, allowInsecure))
+		backend, err = filestore.NewFileBackend(filestore.NewFileBackendSettingsFromConfig(cfg, complianceEnabled, allowInsecure, allowedUntrustedInternalConnections))
 	}
 	if err != nil {
 		return model.NewAppError("FileAttachmentBackend", "api.file.no_driver.app_error", nil, "", http.StatusInternalServerError).Wrap(err)

--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -379,7 +379,8 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 	// Step 9: Initialize filestore
 	if ps.filestore == nil {
 		insecure := ps.Config().ServiceSettings.EnableInsecureOutgoingConnections
-		backend, err2 := filestore.NewFileBackend(filestore.NewFileBackendSettingsFromConfig(&ps.Config().FileSettings, license != nil && *license.Features.Compliance, insecure != nil && *insecure))
+		allowedUntrustedInternalConnections := model.SafeDereference(ps.Config().ServiceSettings.AllowedUntrustedInternalConnections)
+		backend, err2 := filestore.NewFileBackend(filestore.NewFileBackendSettingsFromConfig(&ps.Config().FileSettings, license != nil && *license.Features.Compliance, insecure != nil && *insecure, allowedUntrustedInternalConnections))
 		if err2 != nil {
 			return nil, fmt.Errorf("failed to initialize filebackend: %w", err2)
 		}
@@ -391,7 +392,8 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 		ps.exportFilestore = ps.filestore
 		if *ps.Config().FileSettings.DedicatedExportStore {
 			mlog.Info("Setting up dedicated export filestore", mlog.String("driver_name", *ps.Config().FileSettings.ExportDriverName))
-			backend, errFileBack := filestore.NewExportFileBackend(filestore.NewExportFileBackendSettingsFromConfig(&ps.Config().FileSettings, license != nil && *license.Features.Compliance, false))
+			allowedUntrustedInternalConnections := model.SafeDereference(ps.Config().ServiceSettings.AllowedUntrustedInternalConnections)
+			backend, errFileBack := filestore.NewExportFileBackend(filestore.NewExportFileBackendSettingsFromConfig(&ps.Config().FileSettings, license != nil && *license.Features.Compliance, false, allowedUntrustedInternalConnections))
 			if errFileBack != nil {
 				return nil, fmt.Errorf("failed to initialize export filebackend: %w", errFileBack)
 			}

--- a/server/channels/app/users/profile_picture.go
+++ b/server/channels/app/users/profile_picture.go
@@ -61,7 +61,8 @@ func (us *UserService) GetProfileImage(user *model.User) ([]byte, bool, error) {
 func (us *UserService) FileBackend() (filestore.FileBackend, error) {
 	license := us.license()
 	insecure := us.config().ServiceSettings.EnableInsecureOutgoingConnections
-	backend, err := filestore.NewFileBackend(filestore.NewFileBackendSettingsFromConfig(&us.config().FileSettings, license != nil && *license.Features.Compliance, insecure != nil && *insecure))
+	allowedUntrustedInternalConnections := model.SafeDereference(us.config().ServiceSettings.AllowedUntrustedInternalConnections)
+	backend, err := filestore.NewFileBackend(filestore.NewFileBackendSettingsFromConfig(&us.config().FileSettings, license != nil && *license.Features.Compliance, insecure != nil && *insecure, allowedUntrustedInternalConnections))
 	if err != nil {
 		return nil, err
 	}

--- a/server/enterprise/message_export/shared/shared.go
+++ b/server/enterprise/message_export/shared/shared.go
@@ -564,10 +564,11 @@ func GetBatchPath(exportDir string, prevPostUpdateAt int64, lastPostUpdateAt int
 func GetExportBackend(rctx request.CTX, config *model.Config) (filestore.FileBackend, error) {
 	insecure := config.ServiceSettings.EnableInsecureOutgoingConnections
 	skipVerify := insecure != nil && *insecure
+	allowedUntrustedInternalConnections := model.SafeDereference(config.ServiceSettings.AllowedUntrustedInternalConnections)
 
 	if config.FileSettings.DedicatedExportStore != nil && *config.FileSettings.DedicatedExportStore {
 		rctx.Logger().Debug("Worker: using dedicated export filestore", mlog.String("driver_name", *config.FileSettings.ExportDriverName))
-		backend, errFileBack := filestore.NewExportFileBackend(filestore.NewExportFileBackendSettingsFromConfig(&config.FileSettings, true, skipVerify))
+		backend, errFileBack := filestore.NewExportFileBackend(filestore.NewExportFileBackendSettingsFromConfig(&config.FileSettings, true, skipVerify, allowedUntrustedInternalConnections))
 		if errFileBack != nil {
 			return nil, errFileBack
 		}
@@ -575,7 +576,7 @@ func GetExportBackend(rctx request.CTX, config *model.Config) (filestore.FileBac
 		return backend, nil
 	}
 
-	backend, err := filestore.NewFileBackend(filestore.NewFileBackendSettingsFromConfig(&config.FileSettings, true, skipVerify))
+	backend, err := filestore.NewFileBackend(filestore.NewFileBackendSettingsFromConfig(&config.FileSettings, true, skipVerify, allowedUntrustedInternalConnections))
 	if err != nil {
 		return nil, err
 	}
@@ -587,8 +588,9 @@ func GetExportBackend(rctx request.CTX, config *model.Config) (filestore.FileBac
 // where the export will be created.
 func GetFileAttachmentBackend(rctx request.CTX, config *model.Config) (filestore.FileBackend, error) {
 	insecure := config.ServiceSettings.EnableInsecureOutgoingConnections
+	allowedUntrustedInternalConnections := model.SafeDereference(config.ServiceSettings.AllowedUntrustedInternalConnections)
 
-	backend, err := filestore.NewFileBackend(filestore.NewFileBackendSettingsFromConfig(&config.FileSettings, true, insecure != nil && *insecure))
+	backend, err := filestore.NewFileBackend(filestore.NewFileBackendSettingsFromConfig(&config.FileSettings, true, insecure != nil && *insecure, allowedUntrustedInternalConnections))
 	if err != nil {
 		return nil, err
 	}

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -11447,6 +11447,10 @@
     "translation": "{{.Setting}} must be set when the corresponding AzureCloud value is 'custom'."
   },
   {
+    "id": "model.config.is_valid.azure_storage_account.app_error",
+    "translation": "Invalid value {{.Value}} for {{.Setting}}. The Azure storage account name must be 3 to 24 characters long and contain only lowercase letters and numbers."
+  },
+  {
     "id": "model.config.is_valid.azure_timeout.app_error",
     "translation": "Invalid timeout value {{.Value}}. Should be a positive number."
   },

--- a/server/platform/shared/filestore/azurestore.go
+++ b/server/platform/shared/filestore/azurestore.go
@@ -29,6 +29,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/service"
 	"github.com/google/uuid"
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/httpservice"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
@@ -75,23 +76,7 @@ func NewAzureFileBackend(settings FileBackendSettings) (*AzureFileBackend, error
 		return nil, err
 	}
 
-	var clientOptions *azblob.ClientOptions
-	if settings.SkipVerify {
-		// Mirror the S3 backend: when the admin opts into skipping TLS
-		// verification, plumb a custom transport into the SDK so the toggle
-		// actually takes effect for Azure too.
-		clientOptions = &azblob.ClientOptions{
-			ClientOptions: azcore.ClientOptions{
-				Transport: &http.Client{
-					Transport: &http.Transport{
-						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
-					},
-				},
-			},
-		}
-	}
-
-	client, sharedKey, err := newAzureClient(settings, serviceURL, clientOptions)
+	client, sharedKey, err := newAzureClient(settings, serviceURL, buildAzureClientOptions(settings))
 	if err != nil {
 		return nil, err
 	}
@@ -160,6 +145,38 @@ func newAzureClient(settings FileBackendSettings, serviceURL string, clientOptio
 	default:
 		return nil, nil, fmt.Errorf("unknown azure auth mode %q", settings.AzureAuthMode)
 	}
+}
+
+// buildAzureClientOptions selects the HTTP transport for the Azure SDK. The
+// custom cloud routes requests through httpservice's transport, honoring
+// AllowedUntrustedInternalConnections. The commercial and government clouds use
+// a fixed Azure host (which may resolve to a private address under Private
+// Link), so they keep the SDK default transport and only override it to honor
+// SkipVerify, mirroring the S3 backend.
+func buildAzureClientOptions(settings FileBackendSettings) *azblob.ClientOptions {
+	if settings.AzureCloud == model.AzureCloudCustom {
+		return &azblob.ClientOptions{
+			ClientOptions: azcore.ClientOptions{
+				Transport: &http.Client{
+					Transport: httpservice.NewTransportForInternalConnections(settings.SkipVerify, settings.AllowedUntrustedInternalConnections),
+				},
+			},
+		}
+	}
+
+	if settings.SkipVerify {
+		return &azblob.ClientOptions{
+			ClientOptions: azcore.ClientOptions{
+				Transport: &http.Client{
+					Transport: &http.Transport{
+						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+					},
+				},
+			},
+		}
+	}
+
+	return nil
 }
 
 // buildAzureServiceURL renders the Blob service URL that the SDK signs

--- a/server/platform/shared/filestore/azurestore.go
+++ b/server/platform/shared/filestore/azurestore.go
@@ -181,8 +181,14 @@ func newAzureClient(settings FileBackendSettings, serviceURL string, clientOptio
 func buildAzureServiceURL(cloud, scheme, account, endpoint string) (string, error) {
 	switch cloud {
 	case model.AzureCloudCommercial, "":
+		if !model.IsValidAzureStorageAccountName(account) {
+			return "", fmt.Errorf("invalid azure storage account name %q", account)
+		}
 		return fmt.Sprintf("%s://%s.blob.core.windows.net/", scheme, account), nil
 	case model.AzureCloudGovernment:
+		if !model.IsValidAzureStorageAccountName(account) {
+			return "", fmt.Errorf("invalid azure storage account name %q", account)
+		}
 		return fmt.Sprintf("%s://%s.blob.core.usgovcloudapi.net/", scheme, account), nil
 	case model.AzureCloudCustom:
 		if endpoint == "" {

--- a/server/platform/shared/filestore/azurestore_test.go
+++ b/server/platform/shared/filestore/azurestore_test.go
@@ -251,14 +251,16 @@ func azuriteSettings(t *testing.T) FileBackendSettings {
 		port = "10000"
 	}
 	return FileBackendSettings{
-		DriverName:                      driverAzure,
-		AzureStorageAccount:             azuriteWellKnownAccount,
-		AzureAuthMode:                   model.AzureAuthModeSharedKey,
-		AzureAccessKey:                  azuriteWellKnownKey,
-		AzureContainer:                  "mattermost-test",
-		AzureCloud:                      model.AzureCloudCustom,
-		AzureEndpoint:                   "http://" + net.JoinHostPort(host, port) + "/" + azuriteWellKnownAccount + "/",
-		AzureRequestTimeoutMilliseconds: 30000,
+		DriverName:          driverAzure,
+		AzureStorageAccount: azuriteWellKnownAccount,
+		AzureAuthMode:       model.AzureAuthModeSharedKey,
+		AzureAccessKey:      azuriteWellKnownKey,
+		AzureContainer:      "mattermost-test",
+		AzureCloud:          model.AzureCloudCustom,
+		AzureEndpoint:       "http://" + net.JoinHostPort(host, port) + "/" + azuriteWellKnownAccount + "/",
+		// The emulator runs on an internal address, so its host must be allowed.
+		AllowedUntrustedInternalConnections: host,
+		AzureRequestTimeoutMilliseconds:     30000,
 	}
 }
 

--- a/server/platform/shared/filestore/azurestore_test.go
+++ b/server/platform/shared/filestore/azurestore_test.go
@@ -27,6 +27,7 @@ func TestBuildAzureServiceURL(t *testing.T) {
 		name     string
 		cloud    string
 		scheme   string
+		account  string // defaults to the package-level account const when empty
 		endpoint string
 		expected string
 		wantErr  bool
@@ -36,6 +37,27 @@ func TestBuildAzureServiceURL(t *testing.T) {
 			cloud:    model.AzureCloudCommercial,
 			scheme:   "https",
 			expected: "https://acmemattermost.blob.core.windows.net/",
+		},
+		{
+			name:    "commercial cloud rejects an account name with a hash character",
+			cloud:   model.AzureCloudCommercial,
+			scheme:  "https",
+			account: "account#",
+			wantErr: true,
+		},
+		{
+			name:    "commercial cloud rejects an account name with a slash character",
+			cloud:   model.AzureCloudCommercial,
+			scheme:  "https",
+			account: "account/",
+			wantErr: true,
+		},
+		{
+			name:    "government cloud rejects a malformed account name",
+			cloud:   model.AzureCloudGovernment,
+			scheme:  "https",
+			account: "account#",
+			wantErr: true,
 		},
 		{
 			name:     "empty cloud falls back to commercial for legacy configs",
@@ -107,7 +129,11 @@ func TestBuildAzureServiceURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := buildAzureServiceURL(tt.cloud, tt.scheme, account, tt.endpoint)
+			acct := account
+			if tt.account != "" {
+				acct = tt.account
+			}
+			got, err := buildAzureServiceURL(tt.cloud, tt.scheme, acct, tt.endpoint)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/server/platform/shared/filestore/filesstore.go
+++ b/server/platform/shared/filestore/filesstore.go
@@ -76,9 +76,13 @@ type FileBackendSettings struct {
 	AzureSSL                           bool
 	AzureRequestTimeoutMilliseconds    int64
 	AzurePresignExpiresSeconds         int64
+	// AllowedUntrustedInternalConnections carries the value of the
+	// ServiceSettings.AllowedUntrustedInternalConnections config setting, used
+	// by the Azure custom-cloud backend.
+	AllowedUntrustedInternalConnections string
 }
 
-func NewFileBackendSettingsFromConfig(fileSettings *model.FileSettings, enableComplianceFeature bool, skipVerify bool) FileBackendSettings {
+func NewFileBackendSettingsFromConfig(fileSettings *model.FileSettings, enableComplianceFeature bool, skipVerify bool, allowedUntrustedInternalConnections string) FileBackendSettings {
 	if *fileSettings.DriverName == model.ImageDriverLocal {
 		return FileBackendSettings{
 			DriverName: *fileSettings.DriverName,
@@ -87,17 +91,18 @@ func NewFileBackendSettingsFromConfig(fileSettings *model.FileSettings, enableCo
 	}
 	if *fileSettings.DriverName == model.ImageDriverAzure {
 		return FileBackendSettings{
-			DriverName:                      *fileSettings.DriverName,
-			AzureStorageAccount:             *fileSettings.AzureStorageAccount,
-			AzureAuthMode:                   *fileSettings.AzureAuthMode,
-			AzureAccessKey:                  *fileSettings.AzureAccessKey,
-			AzureContainer:                  *fileSettings.AzureContainer,
-			AzurePathPrefix:                 *fileSettings.AzurePathPrefix,
-			AzureCloud:                      *fileSettings.AzureCloud,
-			AzureEndpoint:                   *fileSettings.AzureEndpoint,
-			AzureSSL:                        fileSettings.AzureSSL == nil || *fileSettings.AzureSSL,
-			AzureRequestTimeoutMilliseconds: *fileSettings.AzureRequestTimeoutMilliseconds,
-			SkipVerify:                      skipVerify,
+			DriverName:                          *fileSettings.DriverName,
+			AzureStorageAccount:                 *fileSettings.AzureStorageAccount,
+			AzureAuthMode:                       *fileSettings.AzureAuthMode,
+			AzureAccessKey:                      *fileSettings.AzureAccessKey,
+			AzureContainer:                      *fileSettings.AzureContainer,
+			AzurePathPrefix:                     *fileSettings.AzurePathPrefix,
+			AzureCloud:                          *fileSettings.AzureCloud,
+			AzureEndpoint:                       *fileSettings.AzureEndpoint,
+			AzureSSL:                            fileSettings.AzureSSL == nil || *fileSettings.AzureSSL,
+			AzureRequestTimeoutMilliseconds:     *fileSettings.AzureRequestTimeoutMilliseconds,
+			SkipVerify:                          skipVerify,
+			AllowedUntrustedInternalConnections: allowedUntrustedInternalConnections,
 		}
 	}
 	return FileBackendSettings{
@@ -119,7 +124,7 @@ func NewFileBackendSettingsFromConfig(fileSettings *model.FileSettings, enableCo
 	}
 }
 
-func NewExportFileBackendSettingsFromConfig(fileSettings *model.FileSettings, enableComplianceFeature bool, skipVerify bool) FileBackendSettings {
+func NewExportFileBackendSettingsFromConfig(fileSettings *model.FileSettings, enableComplianceFeature bool, skipVerify bool, allowedUntrustedInternalConnections string) FileBackendSettings {
 	if *fileSettings.ExportDriverName == model.ImageDriverLocal {
 		return FileBackendSettings{
 			DriverName: *fileSettings.ExportDriverName,
@@ -128,18 +133,19 @@ func NewExportFileBackendSettingsFromConfig(fileSettings *model.FileSettings, en
 	}
 	if *fileSettings.ExportDriverName == model.ImageDriverAzure {
 		return FileBackendSettings{
-			DriverName:                      *fileSettings.ExportDriverName,
-			AzureStorageAccount:             *fileSettings.ExportAzureStorageAccount,
-			AzureAuthMode:                   *fileSettings.ExportAzureAuthMode,
-			AzureAccessKey:                  *fileSettings.ExportAzureAccessKey,
-			AzureContainer:                  *fileSettings.ExportAzureContainer,
-			AzurePathPrefix:                 *fileSettings.ExportAzurePathPrefix,
-			AzureCloud:                      *fileSettings.ExportAzureCloud,
-			AzureEndpoint:                   *fileSettings.ExportAzureEndpoint,
-			AzureSSL:                        fileSettings.ExportAzureSSL == nil || *fileSettings.ExportAzureSSL,
-			AzureRequestTimeoutMilliseconds: *fileSettings.ExportAzureRequestTimeoutMilliseconds,
-			AzurePresignExpiresSeconds:      *fileSettings.ExportAzurePresignExpiresSeconds,
-			SkipVerify:                      skipVerify,
+			DriverName:                          *fileSettings.ExportDriverName,
+			AzureStorageAccount:                 *fileSettings.ExportAzureStorageAccount,
+			AzureAuthMode:                       *fileSettings.ExportAzureAuthMode,
+			AzureAccessKey:                      *fileSettings.ExportAzureAccessKey,
+			AzureContainer:                      *fileSettings.ExportAzureContainer,
+			AzurePathPrefix:                     *fileSettings.ExportAzurePathPrefix,
+			AzureCloud:                          *fileSettings.ExportAzureCloud,
+			AzureEndpoint:                       *fileSettings.ExportAzureEndpoint,
+			AzureSSL:                            fileSettings.ExportAzureSSL == nil || *fileSettings.ExportAzureSSL,
+			AzureRequestTimeoutMilliseconds:     *fileSettings.ExportAzureRequestTimeoutMilliseconds,
+			AzurePresignExpiresSeconds:          *fileSettings.ExportAzurePresignExpiresSeconds,
+			SkipVerify:                          skipVerify,
+			AllowedUntrustedInternalConnections: allowedUntrustedInternalConnections,
 		}
 	}
 	return FileBackendSettings{

--- a/server/platform/shared/filestore/filesstore_test.go
+++ b/server/platform/shared/filestore/filesstore_test.go
@@ -932,7 +932,7 @@ func TestNewExportFileBackendSettingsFromConfig(t *testing.T) {
 		actual := NewExportFileBackendSettingsFromConfig(&model.FileSettings{
 			ExportDriverName: new(driverLocal),
 			ExportDirectory:  new("directory"),
-		}, enableComplianceFeature, skipVerify)
+		}, enableComplianceFeature, skipVerify, "")
 
 		require.Equal(t, expected, actual)
 	})
@@ -976,7 +976,7 @@ func TestNewExportFileBackendSettingsFromConfig(t *testing.T) {
 			ExportAmazonS3PresignExpiresSeconds:      new(int64(60000)),
 			ExportAmazonS3UploadPartSizeBytes:        model.NewPointer(int64(model.FileSettingsDefaultS3ExportUploadPartSizeBytes)),
 			ExportAmazonS3StorageClass:               new(""),
-		}, enableComplianceFeature, skipVerify)
+		}, enableComplianceFeature, skipVerify, "")
 
 		require.Equal(t, expected, actual)
 	})
@@ -986,17 +986,18 @@ func TestNewExportFileBackendSettingsFromConfig(t *testing.T) {
 		enableComplianceFeature := false
 
 		expected := FileBackendSettings{
-			DriverName:                      driverAzure,
-			AzureStorageAccount:             "anaccount",
-			AzureAuthMode:                   model.AzureAuthModeSharedKey,
-			AzureAccessKey:                  "akey",
-			AzureContainer:                  "acontainer",
-			AzurePathPrefix:                 "prefix",
-			AzureCloud:                      model.AzureCloudCommercial,
-			AzureEndpoint:                   "",
-			AzureSSL:                        true,
-			AzureRequestTimeoutMilliseconds: 30000,
-			AzurePresignExpiresSeconds:      21600,
+			DriverName:                          driverAzure,
+			AzureStorageAccount:                 "anaccount",
+			AzureAuthMode:                       model.AzureAuthModeSharedKey,
+			AzureAccessKey:                      "akey",
+			AzureContainer:                      "acontainer",
+			AzurePathPrefix:                     "prefix",
+			AzureCloud:                          model.AzureCloudCommercial,
+			AzureEndpoint:                       "",
+			AzureSSL:                            true,
+			AzureRequestTimeoutMilliseconds:     30000,
+			AzurePresignExpiresSeconds:          21600,
+			AllowedUntrustedInternalConnections: "10.0.0.0/8 internal.example.com",
 		}
 
 		actual := NewExportFileBackendSettingsFromConfig(&model.FileSettings{
@@ -1011,7 +1012,7 @@ func TestNewExportFileBackendSettingsFromConfig(t *testing.T) {
 			ExportAzureSSL:                        new(true),
 			ExportAzureRequestTimeoutMilliseconds: new(int64(30000)),
 			ExportAzurePresignExpiresSeconds:      new(int64(21600)),
-		}, enableComplianceFeature, skipVerify)
+		}, enableComplianceFeature, skipVerify, "10.0.0.0/8 internal.example.com")
 
 		require.Equal(t, expected, actual)
 	})
@@ -1056,7 +1057,7 @@ func TestNewExportFileBackendSettingsFromConfig(t *testing.T) {
 			ExportAmazonS3PresignExpiresSeconds:      new(int64(60000)),
 			ExportAmazonS3UploadPartSizeBytes:        model.NewPointer(int64(model.FileSettingsDefaultS3ExportUploadPartSizeBytes)),
 			ExportAmazonS3StorageClass:               new(""),
-		}, enableComplianceFeature, skipVerify)
+		}, enableComplianceFeature, skipVerify, "")
 
 		require.Equal(t, expected, actual)
 	})

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -4594,6 +4594,15 @@ func (s *SqlSettings) isValid() *AppError {
 	return nil
 }
 
+// See https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview#storage-account-name
+var azureStorageAccountNameRegex = regexp.MustCompile(`^[a-z0-9]{3,24}$`)
+
+// IsValidAzureStorageAccountName reports whether name matches Azure's storage
+// account name format: 3 to 24 lowercase letters and digits.
+func IsValidAzureStorageAccountName(name string) bool {
+	return azureStorageAccountNameRegex.MatchString(name)
+}
+
 func (s *FileSettings) isValid() *AppError {
 	if *s.MaxFileSize <= 0 {
 		return NewAppError("Config.IsValid", "model.config.is_valid.max_file_size.app_error", nil, "", http.StatusBadRequest)
@@ -4636,14 +4645,22 @@ func (s *FileSettings) isValid() *AppError {
 		return NewAppError("Config.IsValid", "model.config.is_valid.azure_auth_mode.app_error", map[string]any{"Value": *s.AzureAuthMode}, "", http.StatusBadRequest)
 	}
 
+	// Empty cloud is treated as commercial for configs that pre-date the field,
+	// matching buildAzureServiceURL.
 	switch *s.AzureCloud {
-	case AzureCloudCommercial, AzureCloudGovernment, AzureCloudCustom:
+	case AzureCloudCommercial, AzureCloudGovernment, AzureCloudCustom, "":
 	default:
 		return NewAppError("Config.IsValid", "model.config.is_valid.azure_cloud.app_error", map[string]any{"Setting": "FileSettings.AzureCloud", "Value": *s.AzureCloud}, "", http.StatusBadRequest)
 	}
 
 	if *s.AzureCloud == AzureCloudCustom && *s.AzureEndpoint == "" {
 		return NewAppError("Config.IsValid", "model.config.is_valid.azure_custom_endpoint.app_error", map[string]any{"Setting": "FileSettings.AzureEndpoint"}, "", http.StatusBadRequest)
+	}
+
+	// For managed clouds the account name forms the service hostname and must
+	// match Azure's format; custom mode uses AzureEndpoint instead.
+	if *s.DriverName == ImageDriverAzure && *s.AzureCloud != AzureCloudCustom && !IsValidAzureStorageAccountName(*s.AzureStorageAccount) {
+		return NewAppError("Config.IsValid", "model.config.is_valid.azure_storage_account.app_error", map[string]any{"Setting": "FileSettings.AzureStorageAccount", "Value": *s.AzureStorageAccount}, "", http.StatusBadRequest)
 	}
 
 	if *s.AmazonS3StorageClass != "" && !slices.Contains([]string{StorageClassStandard, StorageClassReducedRedundancy, StorageClassStandardIA, StorageClassOnezoneIA, StorageClassIntelligentTiering, StorageClassGlacier, StorageClassDeepArchive, StorageClassOutposts, StorageClassGlacierIR, StorageClassSnow, StorageClassExpressOnezone}, *s.AmazonS3StorageClass) {
@@ -4675,13 +4692,17 @@ func (s *FileSettings) isValid() *AppError {
 	}
 
 	switch *s.ExportAzureCloud {
-	case AzureCloudCommercial, AzureCloudGovernment, AzureCloudCustom:
+	case AzureCloudCommercial, AzureCloudGovernment, AzureCloudCustom, "":
 	default:
 		return NewAppError("Config.IsValid", "model.config.is_valid.azure_cloud.app_error", map[string]any{"Setting": "FileSettings.ExportAzureCloud", "Value": *s.ExportAzureCloud}, "", http.StatusBadRequest)
 	}
 
 	if *s.ExportAzureCloud == AzureCloudCustom && *s.ExportAzureEndpoint == "" {
 		return NewAppError("Config.IsValid", "model.config.is_valid.azure_custom_endpoint.app_error", map[string]any{"Setting": "FileSettings.ExportAzureEndpoint"}, "", http.StatusBadRequest)
+	}
+
+	if *s.ExportDriverName == ImageDriverAzure && *s.ExportAzureCloud != AzureCloudCustom && !IsValidAzureStorageAccountName(*s.ExportAzureStorageAccount) {
+		return NewAppError("Config.IsValid", "model.config.is_valid.azure_storage_account.app_error", map[string]any{"Setting": "FileSettings.ExportAzureStorageAccount", "Value": *s.ExportAzureStorageAccount}, "", http.StatusBadRequest)
 	}
 
 	if strings.TrimSpace(*s.ExportAmazonS3PathPrefix) != *s.ExportAmazonS3PathPrefix {

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -495,6 +495,110 @@ func TestFileSettingsAzureCloudValidation(t *testing.T) {
 	})
 }
 
+func TestFileSettingsAzureStorageAccountValidation(t *testing.T) {
+	// Managed clouds put the account name in the service hostname, so it must
+	// match Azure's documented format.
+	type accessors struct {
+		driver  func(*Config, *string)
+		cloud   func(*Config, *string)
+		account func(*Config, *string)
+	}
+	variants := []struct {
+		name string
+		accessors
+	}{
+		{
+			"upload",
+			accessors{
+				func(cfg *Config, v *string) { cfg.FileSettings.DriverName = v },
+				func(cfg *Config, v *string) { cfg.FileSettings.AzureCloud = v },
+				func(cfg *Config, v *string) { cfg.FileSettings.AzureStorageAccount = v },
+			},
+		},
+		{
+			"export",
+			accessors{
+				func(cfg *Config, v *string) { cfg.FileSettings.ExportDriverName = v },
+				func(cfg *Config, v *string) { cfg.FileSettings.ExportAzureCloud = v },
+				func(cfg *Config, v *string) { cfg.FileSettings.ExportAzureStorageAccount = v },
+			},
+		},
+	}
+
+	for _, variant := range variants {
+		t.Run(variant.name, func(t *testing.T) {
+			t.Run("malformed account name is rejected for commercial cloud", func(t *testing.T) {
+				for _, bad := range []string{"", "ab", strings.Repeat("a", 25), "WithUppercase", "with-dash", "with.dot", "with/slash", "with#hash"} {
+					cfg := &Config{}
+					cfg.SetDefaults()
+					variant.driver(cfg, NewPointer(ImageDriverAzure))
+					variant.cloud(cfg, NewPointer(AzureCloudCommercial))
+					variant.account(cfg, NewPointer(bad))
+
+					err := cfg.FileSettings.isValid()
+					require.NotNil(t, err, "expected %q to be rejected", bad)
+					assert.Equal(t, "model.config.is_valid.azure_storage_account.app_error", err.Id)
+				}
+			})
+
+			t.Run("valid account name passes for managed clouds", func(t *testing.T) {
+				// Empty cloud is treated as commercial, so it is validated too.
+				for _, cloud := range []string{AzureCloudCommercial, AzureCloudGovernment, ""} {
+					cfg := &Config{}
+					cfg.SetDefaults()
+					variant.driver(cfg, NewPointer(ImageDriverAzure))
+					variant.cloud(cfg, NewPointer(cloud))
+					variant.account(cfg, NewPointer("acmemattermost"))
+
+					err := cfg.FileSettings.isValid()
+					require.Nil(t, err)
+				}
+			})
+
+			t.Run("malformed account name is rejected for empty (commercial) cloud", func(t *testing.T) {
+				cfg := &Config{}
+				cfg.SetDefaults()
+				variant.driver(cfg, NewPointer(ImageDriverAzure))
+				variant.cloud(cfg, NewPointer(""))
+				variant.account(cfg, NewPointer("with#hash"))
+
+				err := cfg.FileSettings.isValid()
+				require.NotNil(t, err)
+				assert.Equal(t, "model.config.is_valid.azure_storage_account.app_error", err.Id)
+			})
+
+			t.Run("custom cloud skips account name validation", func(t *testing.T) {
+				cfg := &Config{}
+				cfg.SetDefaults()
+				variant.driver(cfg, NewPointer(ImageDriverAzure))
+				variant.cloud(cfg, NewPointer(AzureCloudCustom))
+				variant.account(cfg, NewPointer("with#hash"))
+				// Custom mode derives the host from the endpoint, not the account.
+				if variant.name == "upload" {
+					cfg.FileSettings.AzureEndpoint = NewPointer("https://blob.example.com/")
+				} else {
+					cfg.FileSettings.ExportAzureEndpoint = NewPointer("https://blob.example.com/")
+				}
+
+				err := cfg.FileSettings.isValid()
+				require.Nil(t, err)
+			})
+
+			t.Run("non-azure driver skips account name validation", func(t *testing.T) {
+				cfg := &Config{}
+				cfg.SetDefaults()
+				// DriverName stays at its default (local); the malformed Azure
+				// account name must not block an unrelated driver's config.
+				variant.cloud(cfg, NewPointer(AzureCloudCommercial))
+				variant.account(cfg, NewPointer("with#hash"))
+
+				err := cfg.FileSettings.isValid()
+				require.Nil(t, err)
+			})
+		})
+	}
+}
+
 func TestFileSettingsAzurePathPrefixTraversal(t *testing.T) {
 	cases := []struct {
 		name         string

--- a/server/public/shared/httpservice/client_test.go
+++ b/server/public/shared/httpservice/client_test.go
@@ -95,6 +95,39 @@ func TestHTTPClient(t *testing.T) {
 	})
 }
 
+func TestNewTransportForInternalConnections(t *testing.T) {
+	// httptest servers listen on a loopback address, which is a reserved range.
+	mockHTTP := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockHTTP.Close()
+
+	u, err := url.Parse(mockHTTP.URL)
+	require.NoError(t, err)
+	host := u.Hostname()
+
+	t.Run("blocks reserved IP ranges when the allowlist is empty", func(t *testing.T) {
+		c := NewHTTPClient(NewTransportForInternalConnections(false, ""))
+		_, err := c.Get(mockHTTP.URL)
+		require.IsType(t, &url.Error{}, err)
+		require.Contains(t, err.(*url.Error).Err.Error(), "address forbidden")
+	})
+
+	t.Run("allows a host named in the allowlist", func(t *testing.T) {
+		c := NewHTTPClient(NewTransportForInternalConnections(false, host))
+		resp, err := c.Get(mockHTTP.URL)
+		require.NoError(t, err)
+		resp.Body.Close()
+	})
+
+	t.Run("allows a CIDR range named in the allowlist", func(t *testing.T) {
+		c := NewHTTPClient(NewTransportForInternalConnections(false, "127.0.0.0/8 ::1/128"))
+		resp, err := c.Get(mockHTTP.URL)
+		require.NoError(t, err)
+		resp.Body.Close()
+	})
+}
+
 func TestHTTPClientWithProxy(t *testing.T) {
 	proxy := createProxyServer()
 	defer proxy.Close()

--- a/server/public/shared/httpservice/httpservice.go
+++ b/server/public/shared/httpservice/httpservice.go
@@ -71,6 +71,58 @@ func (h *HTTPServiceImpl) MakeClient(trustURLs bool) *http.Client {
 	}
 }
 
+// isAllowedInternalHost reports whether host appears verbatim in a
+// space/comma-separated AllowedUntrustedInternalConnections value.
+func isAllowedInternalHost(host, allowedUntrustedInternalConnections string) bool {
+	return slices.Contains(strings.FieldsFunc(allowedUntrustedInternalConnections, splitFields), host)
+}
+
+// checkInternalIP returns nil if ip may be dialed, or an error if it is a
+// reserved-range or self-assigned IP not covered by a CIDR entry in the
+// space/comma-separated AllowedUntrustedInternalConnections value.
+func checkInternalIP(ip net.IP, allowedUntrustedInternalConnections string) error {
+	reservedIP := IsReservedIP(ip)
+
+	ownIP, err := IsOwnIP(ip)
+	if err != nil {
+		// If there is an error getting the self-assigned IPs, default to the secure option
+		return fmt.Errorf("unable to determine if IP is own IP: %w", err)
+	}
+
+	// If it's not a reserved IP and it's not self-assigned IP, accept the IP
+	if !reservedIP && !ownIP {
+		return nil
+	}
+
+	// Otherwise it needs to be explicitly added to AllowedUntrustedInternalConnections
+	for _, allowed := range strings.FieldsFunc(allowedUntrustedInternalConnections, splitFields) {
+		if _, ipRange, err := net.ParseCIDR(allowed); err == nil && ipRange.Contains(ip) {
+			return nil
+		}
+	}
+
+	if reservedIP {
+		return fmt.Errorf("IP %s is in a reserved range and not in AllowedUntrustedInternalConnections", ip)
+	}
+	return fmt.Errorf("IP %s is a self-assigned IP and not in AllowedUntrustedInternalConnections", ip)
+}
+
+// NewTransportForInternalConnections returns a transport that applies the same
+// AllowedUntrustedInternalConnections filtering as MakeTransport, but takes the
+// allowlist as a static value instead of reading it from a config service. It is
+// for callers that have the allowlist string but not an HTTPService.
+func NewTransportForInternalConnections(insecure bool, allowedUntrustedInternalConnections string) *MattermostTransport {
+	allowHost := func(host string) bool {
+		return isAllowedInternalHost(host, allowedUntrustedInternalConnections)
+	}
+
+	allowIP := func(ip net.IP) error {
+		return checkInternalIP(ip, allowedUntrustedInternalConnections)
+	}
+
+	return NewTransport(insecure, allowHost, allowIP)
+}
+
 func (h *HTTPServiceImpl) MakeTransport(trustURLs bool) *MattermostTransport {
 	insecure := h.configService.Config().ServiceSettings.EnableInsecureOutgoingConnections != nil && *h.configService.Config().ServiceSettings.EnableInsecureOutgoingConnections
 
@@ -78,38 +130,14 @@ func (h *HTTPServiceImpl) MakeTransport(trustURLs bool) *MattermostTransport {
 		return NewTransport(insecure, nil, nil)
 	}
 
+	// The allowlist is read inside the closures so a long-lived client picks up
+	// config changes on each dial.
 	allowHost := func(host string) bool {
-		if h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections == nil {
-			return false
-		}
-		return slices.Contains(strings.FieldsFunc(*h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections, splitFields), host)
+		return isAllowedInternalHost(host, model.SafeDereference(h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections))
 	}
 
 	allowIP := func(ip net.IP) error {
-		reservedIP := IsReservedIP(ip)
-
-		ownIP, err := IsOwnIP(ip)
-		if err != nil {
-			// If there is an error getting the self-assigned IPs, default to the secure option
-			return fmt.Errorf("unable to determine if IP is own IP: %w", err)
-		}
-
-		// If it's not a reserved IP and it's not self-assigned IP, accept the IP
-		if !reservedIP && !ownIP {
-			return nil
-		}
-
-		// In the case it's the self-assigned IP, enforce that it needs to be explicitly added to the AllowedUntrustedInternalConnections
-		for _, allowed := range strings.FieldsFunc(model.SafeDereference(h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections), splitFields) {
-			if _, ipRange, err := net.ParseCIDR(allowed); err == nil && ipRange.Contains(ip) {
-				return nil
-			}
-		}
-
-		if reservedIP {
-			return fmt.Errorf("IP %s is in a reserved range and not in AllowedUntrustedInternalConnections", ip)
-		}
-		return fmt.Errorf("IP %s is a self-assigned IP and not in AllowedUntrustedInternalConnections", ip)
+		return checkInternalIP(ip, model.SafeDereference(h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections))
 	}
 
 	return NewTransport(insecure, allowHost, allowIP)


### PR DESCRIPTION
#### Summary

Two changes to the Azure Blob Storage file backend.

First, the storage account name is now validated against Azure's documented format (3 to 24 lowercase letters and digits) for the commercial and government clouds, both in config validation and when building the service URL. An empty `AzureCloud` is treated as commercial, matching the URL builder.

Second, requests for the custom cloud now go through the shared `httpservice` transport instead of the Azure SDK default, so they honor `ServiceSettings.AllowedUntrustedInternalConnections` like other outbound connections. The commercial and government clouds keep the SDK default transport. This keeps two scenarios working: the Azurite emulator used by the test suite, whose host is added to the allowlist, and Private Link deployments in production, where the standard Azure host resolves to a private address.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-69213

#### Release Note

```release-note
Added validation of the Azure file storage account name and routed Azure custom-endpoint requests through the standard outbound HTTP transport.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes modify public function signatures in shared utilities (`NewFileBackendSettingsFromConfig` and `NewExportFileBackendSettingsFromConfig`) by adding a required parameter, requiring updates across four call sites. Azure storage account name validation could reject existing configurations with previously-accepted invalid names, creating a potential breaking change for deployments not using commercial or government clouds.

**QA Recommendation:** Recommend focused manual testing on: (1) Azure storage backend initialization with existing configurations to verify no unexpected validation failures; (2) custom Azure endpoint routing through httpservice to confirm proper allowlist enforcement; (3) Azurite test scenario compatibility. Automated coverage appears comprehensive for validation logic and transport behavior, so manual QA should target integration scenarios and backwards-compatibility edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->