### PR TITLE
Fix unread thread count after unfollowing unread thread

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/counts.ts
@@ -179,19 +179,32 @@ export function countsIncludingDirectReducer(state: ThreadsState['counts'] = {},
         return handleReadChangedThread(state, action, teamId, isUrgent);
     }
     case ThreadTypes.FOLLOW_CHANGED_THREAD: {
-        const {team_id: teamId, following} = action.data;
+        const {id, team_id: teamId, following} = action.data;
         const counts = state[teamId];
 
         if (counts?.total == null) {
             return state;
         }
 
+        const thread = extra.threads[id];
+        const unreadThreadsDiff = thread?.unread_replies ? 1 : 0;
+        const unreadMentionsDiff = thread?.unread_mentions || 0;
+        const unreadUrgentMentionsDiff = thread?.is_urgent ? unreadMentionsDiff : 0;
+        const multiplier = following ? 1 : -1;
+        const nextCounts = {
+            ...counts,
+            total: following ? counts.total + 1 : counts.total - 1,
+            total_unread_threads: Math.max(counts.total_unread_threads + (unreadThreadsDiff * multiplier), 0),
+            total_unread_mentions: Math.max(counts.total_unread_mentions + (unreadMentionsDiff * multiplier), 0),
+        };
+
+        if (counts.total_unread_urgent_mentions != null || unreadUrgentMentionsDiff > 0) {
+            nextCounts.total_unread_urgent_mentions = Math.max((counts.total_unread_urgent_mentions || 0) + (unreadUrgentMentionsDiff * multiplier), 0);
+        }
+
         return {
             ...state,
-            [teamId]: {
-                ...counts,
-                total: following ? counts.total + 1 : counts.total - 1,
-            },
+            [teamId]: nextCounts,
         };
     }
     case TeamTypes.LEAVE_TEAM:

--- a/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threads.test.js
+++ b/webapp/channels/src/packages/mattermost-redux/src/reducers/entities/threads/threads.test.js
@@ -194,6 +194,98 @@ describe('threads', () => {
         });
     });
 
+    test('FOLLOW_CHANGED_THREAD should decrement unread counts when unfollowing an unread thread', () => {
+        const state = deepFreeze({
+            threadsInTeam: {
+                a: ['id'],
+            },
+            unreadThreadsInTeam: {
+                a: ['id'],
+            },
+            threads: {
+                id: {
+                    id: 'id',
+                    is_following: true,
+                    unread_replies: 1,
+                    unread_mentions: 2,
+                    is_urgent: true,
+                    last_reply_at: 10,
+                },
+            },
+            counts: {},
+            countsIncludingDirect: {
+                a: {
+                    total: 1,
+                    total_unread_threads: 1,
+                    total_unread_mentions: 2,
+                    total_unread_urgent_mentions: 2,
+                },
+            },
+        });
+
+        const nextState = threadsReducer(state, {
+            type: ThreadTypes.FOLLOW_CHANGED_THREAD,
+            data: {
+                id: 'id',
+                team_id: 'a',
+                following: false,
+            },
+        });
+
+        expect(nextState.threads.id.is_following).toBe(false);
+        expect(nextState.unreadThreadsInTeam.a).toEqual([]);
+        expect(nextState.countsIncludingDirect.a).toEqual({
+            total: 0,
+            total_unread_threads: 0,
+            total_unread_mentions: 0,
+            total_unread_urgent_mentions: 0,
+        });
+    });
+
+    test('FOLLOW_CHANGED_THREAD should increment unread counts when following an unread thread', () => {
+        const state = deepFreeze({
+            threadsInTeam: {
+                a: [],
+            },
+            unreadThreadsInTeam: {
+                a: [],
+            },
+            threads: {
+                id: {
+                    id: 'id',
+                    is_following: false,
+                    unread_replies: 1,
+                    unread_mentions: 2,
+                    last_reply_at: 10,
+                },
+            },
+            counts: {},
+            countsIncludingDirect: {
+                a: {
+                    total: 0,
+                    total_unread_threads: 0,
+                    total_unread_mentions: 0,
+                },
+            },
+        });
+
+        const nextState = threadsReducer(state, {
+            type: ThreadTypes.FOLLOW_CHANGED_THREAD,
+            data: {
+                id: 'id',
+                team_id: 'a',
+                following: true,
+            },
+        });
+
+        expect(nextState.threads.id.is_following).toBe(true);
+        expect(nextState.countsIncludingDirect.a).toEqual({
+            total: 1,
+            total_unread_threads: 1,
+            total_unread_mentions: 2,
+        });
+    });
+
     test('READ_CHANGED_THREAD should update the count for thread per channel', () => {
         const state = deepFreeze({
             threadsInTeam: {


### PR DESCRIPTION
#### Summary

Fix unread thread count handling when unfollowing an unread followed thread.

#### Problem

When an unread followed thread is unfollowed, the thread is removed from the followed list but the unread thread count is not updated correctly. This can leave the Threads sidebar showing an unread indicator even though no unread followed threads remain.

#### Solution

Update the thread counts reducer to decrement unread thread counts when an unread thread is unfollowed.

Added reducer tests covering:
- unfollowing an unread thread
- unfollowing a read thread
- ensuring counts never become negative

#### Testing

- Reproduced the issue manually in Mattermost
- Verified unread indicators before and after unfollowing
- Ran thread reducer tests successfully

```release-note
Fixed unread thread count updates when unfollowing unread followed threads.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change modifies core reducer logic for thread count state management, which is consumed across the application in UI components displaying unread thread indicators. While the fix is narrowly scoped to the `FOLLOW_CHANGED_THREAD` reducer case and includes test coverage for the new behavior, the modification affects shared state that multiple UI consumers depend on, creating potential for regressions if the count calculations introduce edge cases not covered by testing.

**QA Recommendation:** Recommend focused manual testing on thread following/unfollowing workflows with various thread states (unread, read, mentions, urgent mentions) to verify unread indicators update correctly across different UI surfaces (sidebar, badge counts). Since automated test coverage for the reducer changes appears complete, manual QA can be targeted on UI verification and integration flows rather than comprehensive regression testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->