### PR TITLE
[MM-68856] Respect default agent and persist last-selected agent in the agent selector

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/rewrite_menu.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/rewrite_menu.tsx
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import React from 'react';
 import type {MessageDescriptor} from 'react-intl';
 import {defineMessage, FormattedMessage, useIntl} from 'react-intl';
+import {useSelector} from 'react-redux';
 
 import {
     AiSummarizeIcon,
@@ -18,6 +19,8 @@ import {
 } from '@mattermost/compass-icons/components';
 import {Button} from '@mattermost/shared/components/button';
 import type {Agent} from '@mattermost/types/agents';
+
+import {getDefaultAgent} from 'mattermost-redux/selectors/entities/agents';
 
 import AgentDropdown from 'components/common/agents/agent_dropdown';
 import * as Menu from 'components/menu';
@@ -108,6 +111,7 @@ export default function RewriteMenu({
     customPromptRef,
 }: RewriteMenuProps) {
     const {formatMessage} = useIntl();
+    const defaultAgent = useSelector(getDefaultAgent);
 
     const showMenuItem = !isProcessing && draftMessage.trim();
 
@@ -146,6 +150,7 @@ export default function RewriteMenu({
                             selectedBotId={selectedAgentId}
                             onBotSelect={setSelectedAgentId}
                             bots={agents}
+                            defaultBotId={defaultAgent?.id}
                             disabled={isProcessing}
                             showLabel={true}
                         />
@@ -330,6 +335,7 @@ export function RewriteSubMenuHeader({
     customPromptRef,
 }: RewriteSubMenuHeaderProps) {
     const {formatMessage} = useIntl();
+    const defaultAgent = useSelector(getDefaultAgent);
 
     let placeholderText = formatMessage({
         id: 'texteditor.rewrite.prompt',
@@ -364,6 +370,7 @@ export function RewriteSubMenuHeader({
                     selectedBotId={selectedAgentId}
                     onBotSelect={setSelectedAgentId}
                     bots={agents}
+                    defaultBotId={defaultAgent?.id}
                     disabled={isProcessing}
                     showLabel={true}
                 />

--- a/webapp/channels/src/components/advanced_text_editor/use_rewrite.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_rewrite.test.tsx
@@ -7,11 +7,13 @@ import type {Agent} from '@mattermost/types/agents';
 import type {DeepPartial} from '@mattermost/types/utilities';
 
 import {getAgents as getAgentsAction} from 'mattermost-redux/actions/agents';
+import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {Client4} from 'mattermost-redux/client';
 
 import type TextboxClass from 'components/textbox/textbox';
 
-import {renderHookWithContext, waitFor} from 'tests/react_testing_utils';
+import {act, renderHookWithContext, waitFor} from 'tests/react_testing_utils';
+import {Preferences} from 'utils/constants';
 
 import type {GlobalState} from 'types/store';
 import type {PostDraft} from 'types/store/draft';
@@ -23,11 +25,17 @@ jest.mock('mattermost-redux/actions/agents', () => ({
     getAgents: jest.fn(() => ({type: 'GET_AGENTS'})),
 }));
 
+jest.mock('mattermost-redux/actions/preferences', () => ({
+    savePreferences: jest.fn(() => ({type: 'SAVE_PREFERENCES'})),
+}));
+
 jest.mock('mattermost-redux/client', () => ({
     Client4: {
         getAIRewrittenMessage: jest.fn(),
     },
 }));
+
+const CURRENT_USER_ID = 'current_user_id';
 
 describe('useRewrite', () => {
     const mockAgents: Agent[] = [
@@ -94,17 +102,33 @@ describe('useRewrite', () => {
         document.body.innerHTML = '';
     });
 
-    function getBaseState(): DeepPartial<GlobalState> {
+    function getBaseState(agents: Agent[] = mockAgents, selectedAgentPref?: string): DeepPartial<GlobalState> {
+        const myPreferences: Record<string, {category: string; name: string; user_id: string; value: string}> = {};
+        if (selectedAgentPref) {
+            myPreferences[`${Preferences.CATEGORY_AGENTS}--${Preferences.SELECTED_AGENT}`] = {
+                category: Preferences.CATEGORY_AGENTS,
+                name: Preferences.SELECTED_AGENT,
+                user_id: CURRENT_USER_ID,
+                value: selectedAgentPref,
+            };
+        }
+
         return {
             entities: {
                 agents: {
-                    agents: mockAgents,
+                    agents,
+                },
+                users: {
+                    currentUserId: CURRENT_USER_ID,
+                },
+                preferences: {
+                    myPreferences,
                 },
             },
         };
     }
 
-    function renderHookWithProps(draft: PostDraft = mockDraft, overrides?: Partial<typeof mockDraft>) {
+    function renderHookWithProps(draft: PostDraft = mockDraft, overrides?: Partial<typeof mockDraft>, state: DeepPartial<GlobalState> = getBaseState()) {
         return renderHookWithContext(
             () => useRewrite(
                 {...draft, ...overrides},
@@ -113,7 +137,7 @@ describe('useRewrite', () => {
                 mockFocusTextbox,
                 mockSetServerError,
             ),
-            getBaseState(),
+            state,
         );
     }
 
@@ -123,10 +147,66 @@ describe('useRewrite', () => {
             expect(getAgentsAction).toHaveBeenCalledTimes(1);
         });
 
-        it('should set default selected agent when agents are available', () => {
+        it('should fall back to the first agent when there is no preference or default', () => {
             const {result} = renderHookWithProps();
             const props = result.current.rewriteMenuProps;
             expect(props.selectedAgentId).toBe('agent1');
+        });
+
+        it('should select the system default agent when no preference is set', () => {
+            const agentsWithDefault: Agent[] = [
+                mockAgents[0],
+                {...mockAgents[1], is_default: true},
+            ];
+            const {result} = renderHookWithProps(mockDraft, undefined, getBaseState(agentsWithDefault));
+            const props = result.current.rewriteMenuProps;
+            expect(props.selectedAgentId).toBe('agent2');
+        });
+
+        it('should restore the saved preference agent over the default', () => {
+            const agentsWithDefault: Agent[] = [
+                {...mockAgents[0], is_default: true},
+                mockAgents[1],
+            ];
+            const {result} = renderHookWithProps(mockDraft, undefined, getBaseState(agentsWithDefault, 'agent2'));
+            const props = result.current.rewriteMenuProps;
+            expect(props.selectedAgentId).toBe('agent2');
+        });
+
+        it('should ignore a saved preference that is no longer available', () => {
+            const agentsWithDefault: Agent[] = [
+                mockAgents[0],
+                {...mockAgents[1], is_default: true},
+            ];
+            const {result} = renderHookWithProps(mockDraft, undefined, getBaseState(agentsWithDefault, 'missing_agent'));
+            const props = result.current.rewriteMenuProps;
+            expect(props.selectedAgentId).toBe('agent2');
+        });
+
+        it('should fall back to the first agent when the saved preference is stale and there is no default', () => {
+            const {result} = renderHookWithProps(mockDraft, undefined, getBaseState(mockAgents, 'missing_agent'));
+            const props = result.current.rewriteMenuProps;
+            expect(props.selectedAgentId).toBe('agent1');
+        });
+
+        it('should not persist a preference during auto-resolution', () => {
+            renderHookWithProps();
+            expect(savePreferences).not.toHaveBeenCalled();
+        });
+
+        it('should persist the preference on an explicit selection', () => {
+            const {result} = renderHookWithProps();
+
+            act(() => {
+                result.current.rewriteMenuProps.setSelectedAgentId('agent2');
+            });
+
+            expect(savePreferences).toHaveBeenCalledWith(CURRENT_USER_ID, [{
+                category: Preferences.CATEGORY_AGENTS,
+                name: Preferences.SELECTED_AGENT,
+                user_id: CURRENT_USER_ID,
+                value: 'agent2',
+            }]);
         });
     });
 

--- a/webapp/channels/src/components/advanced_text_editor/use_rewrite.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_rewrite.tsx
@@ -11,6 +11,7 @@ import {getAgents as getAgentsAction} from 'mattermost-redux/actions/agents';
 import {Client4} from 'mattermost-redux/client';
 import {getAgents} from 'mattermost-redux/selectors/entities/agents';
 
+import {useSelectedAgent} from 'components/common/agents';
 import type TextboxClass from 'components/textbox/textbox';
 
 import type {PostDraft} from 'types/store/draft';
@@ -28,9 +29,9 @@ const useRewrite = (
 ) => {
     const dispatch = useDispatch();
     const agents = useSelector(getAgents);
+    const [selectedAgentId, setSelectedAgentId] = useSelectedAgent(agents);
 
     const [prompt, setPrompt] = useState('');
-    const [selectedAgentId, setSelectedAgentId] = useState<string>('');
 
     const [isProcessing, setIsProcessing] = useState(false);
     const [isMenuOpen, setIsMenuOpen] = useState(false);
@@ -139,12 +140,6 @@ const useRewrite = (
     useEffect(() => {
         dispatch(getAgentsAction());
     }, [dispatch]);
-
-    useEffect(() => {
-        if (agents && agents.length > 0 && !selectedAgentId) {
-            setSelectedAgentId(agents[0].id);
-        }
-    }, [agents, selectedAgentId]);
 
     useEffect(() => {
         if (isMenuOpen && !draft.message.trim()) {

--- a/webapp/channels/src/components/common/agents/index.ts
+++ b/webapp/channels/src/components/common/agents/index.ts
@@ -2,3 +2,4 @@
 // See LICENSE.txt for license information.
 
 export {default as AgentDropdown} from './agent_dropdown';
+export {default as useSelectedAgent} from './use_selected_agent';

--- a/webapp/channels/src/components/common/agents/use_selected_agent.ts
+++ b/webapp/channels/src/components/common/agents/use_selected_agent.ts
@@ -1,0 +1,50 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {useCallback, useMemo} from 'react';
+import {useDispatch, useSelector} from 'react-redux';
+
+import type {Agent} from '@mattermost/types/agents';
+import type {PreferenceType} from '@mattermost/types/preferences';
+
+import {savePreferences} from 'mattermost-redux/actions/preferences';
+import {getDefaultAgent} from 'mattermost-redux/selectors/entities/agents';
+import {getCurrentUserId} from 'mattermost-redux/selectors/entities/common';
+import {get as getPreference} from 'mattermost-redux/selectors/entities/preferences';
+import type {ActionResult} from 'mattermost-redux/types/actions';
+
+import {Preferences} from 'utils/constants';
+
+import type {GlobalState} from 'types/store';
+
+// Resolves the active agent (precedence: saved preference -> default agent -> first)
+// and returns a setter that persists the choice. Persists only on explicit selection.
+export default function useSelectedAgent(agents: Agent[]): [string, (agentId: string) => Promise<ActionResult>] {
+    const dispatch = useDispatch();
+
+    const userId = useSelector(getCurrentUserId);
+    const preferredAgentId = useSelector((state: GlobalState) => getPreference(state, Preferences.CATEGORY_AGENTS, Preferences.SELECTED_AGENT));
+    const defaultAgent = useSelector(getDefaultAgent);
+
+    const selectedAgentId = useMemo(() => {
+        if (preferredAgentId && agents.some((agent) => agent.id === preferredAgentId)) {
+            return preferredAgentId;
+        }
+        if (defaultAgent && agents.some((agent) => agent.id === defaultAgent.id)) {
+            return defaultAgent.id;
+        }
+        return agents.length > 0 ? agents[0].id : '';
+    }, [agents, preferredAgentId, defaultAgent]);
+
+    const setSelectedAgent = useCallback((agentId: string) => {
+        const preference: PreferenceType = {
+            category: Preferences.CATEGORY_AGENTS,
+            name: Preferences.SELECTED_AGENT,
+            user_id: userId,
+            value: agentId,
+        };
+        return dispatch(savePreferences(userId, [preference]));
+    }, [dispatch, userId]);
+
+    return useMemo(() => ([selectedAgentId, setSelectedAgent]), [selectedAgentId, setSelectedAgent]);
+}

--- a/webapp/channels/src/components/create_recap_modal/create_recap_modal.test.tsx
+++ b/webapp/channels/src/components/create_recap_modal/create_recap_modal.test.tsx
@@ -4,8 +4,10 @@
 import React from 'react';
 
 import {getAgents} from 'mattermost-redux/actions/agents';
+import {savePreferences} from 'mattermost-redux/actions/preferences';
 
 import {renderWithContext, screen, userEvent, waitFor, waitForElementToBeRemoved} from 'tests/react_testing_utils';
+import {Preferences} from 'utils/constants';
 
 import CreateRecapModal from './create_recap_modal';
 
@@ -15,6 +17,11 @@ jest.mock('mattermost-redux/actions/recaps', () => ({
 
 jest.mock('mattermost-redux/actions/agents', () => ({
     getAgents: jest.fn(() => ({type: 'GET_AGENTS'})),
+}));
+
+// Persist the selection straight into the store so the resolved agent updates without a network call.
+jest.mock('mattermost-redux/actions/preferences', () => ({
+    savePreferences: jest.fn((userId, preferences) => ({type: 'RECEIVED_PREFERENCES', data: preferences})),
 }));
 
 jest.mock('react-router-dom', () => ({
@@ -39,6 +46,7 @@ describe('CreateRecapModal', () => {
             username: 'copilot',
             service_id: 'copilot-service',
             service_type: 'copilot',
+            is_default: true,
         },
         {
             id: 'openai-bot',
@@ -315,6 +323,30 @@ describe('CreateRecapModal', () => {
         await userEvent.click(channelCheckbox);
 
         await waitFor(() => expect(nextButton).not.toBeDisabled());
+    });
+
+    test('should persist the selected agent as a preference when the user picks a bot', async () => {
+        renderWithContext(<CreateRecapModal {...defaultProps}/>, initialState);
+
+        await waitFor(() => {
+            const dropdownButton = screen.getByLabelText('Agent selector');
+            expect(dropdownButton).toHaveTextContent('Copilot');
+        });
+
+        const dropdownButton = screen.getByLabelText('Agent selector');
+        await userEvent.click(dropdownButton);
+
+        const openAIOption = screen.getByText('OpenAI');
+        await userEvent.click(openAIOption);
+
+        await waitForElementToBeRemoved(() => screen.queryByText('CHOOSE A BOT'));
+
+        expect(savePreferences).toHaveBeenCalledWith('user1', [{
+            category: Preferences.CATEGORY_AGENTS,
+            name: Preferences.SELECTED_AGENT,
+            user_id: 'user1',
+            value: 'openai-bot',
+        }]);
     });
 
     test('should maintain selected bot across step navigation', async () => {

--- a/webapp/channels/src/components/create_recap_modal/create_recap_modal.tsx
+++ b/webapp/channels/src/components/create_recap_modal/create_recap_modal.tsx
@@ -13,11 +13,11 @@ import type {Channel} from '@mattermost/types/channels';
 
 import {getAgents} from 'mattermost-redux/actions/agents';
 import {createRecap} from 'mattermost-redux/actions/recaps';
-import {getAgents as getAgentsSelector} from 'mattermost-redux/selectors/entities/agents';
+import {getAgents as getAgentsSelector, getDefaultAgent} from 'mattermost-redux/selectors/entities/agents';
 import {getMyChannels, getUnreadChannelIds} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
-import {AgentDropdown} from 'components/common/agents';
+import {AgentDropdown, useSelectedAgent} from 'components/common/agents';
 import PaginationDots from 'components/common/pagination_dots';
 
 import ChannelSelector from './channel_selector';
@@ -41,12 +41,13 @@ const CreateRecapModal = ({onExited}: Props) => {
     const myChannels = useSelector(getMyChannels);
     const unreadChannelIds = useSelector(getUnreadChannelIds);
     const agents = useSelector(getAgentsSelector);
+    const defaultAgent = useSelector(getDefaultAgent);
+    const [selectedBotId, setSelectedBotId] = useSelectedAgent(agents);
 
     const [currentStep, setCurrentStep] = useState(1);
     const [recapName, setRecapName] = useState('');
     const [recapType, setRecapType] = useState<RecapType | null>(null);
     const [selectedChannelIds, setSelectedChannelIds] = useState<string[]>([]);
-    const [selectedBotId, setSelectedBotId] = useState<string>('');
     const [isAgentMenuOpen, setIsAgentMenuOpen] = useState(false);
     const [isSubmitting, setIsSubmitting] = useState(false);
     const [error, setError] = useState<string | null>(null);
@@ -55,13 +56,6 @@ const CreateRecapModal = ({onExited}: Props) => {
     useEffect(() => {
         dispatch(getAgents());
     }, [dispatch]);
-
-    // Set default bot when agents are loaded
-    useEffect(() => {
-        if (agents.length > 0 && !selectedBotId) {
-            setSelectedBotId(agents[0].id);
-        }
-    }, [agents, selectedBotId]);
 
     // Get unread channels
     const unreadChannels = myChannels.filter((channel: Channel) =>
@@ -180,7 +174,7 @@ const CreateRecapModal = ({onExited}: Props) => {
 
     const handleBotSelect = useCallback((botId: string) => {
         setSelectedBotId(botId);
-    }, []);
+    }, [setSelectedBotId]);
 
     const handleAgentMenuToggle = useCallback((isOpen: boolean) => {
         setIsAgentMenuOpen(isOpen);
@@ -195,7 +189,7 @@ const CreateRecapModal = ({onExited}: Props) => {
                     selectedBotId={selectedBotId}
                     onBotSelect={handleBotSelect}
                     bots={agents}
-                    defaultBotId={agents.length > 0 ? agents[0].id : undefined}
+                    defaultBotId={defaultAgent?.id}
                     disabled={isSubmitting}
                     onMenuToggle={handleAgentMenuToggle}
                 />

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -118,6 +118,8 @@ export const Preferences = {
     ADMIN_CLOUD_UPGRADE_PANEL: 'admin_cloud_upgrade_panel',
     CATEGORY_EMOJI: 'emoji',
     EMOJI_SKINTONE: 'emoji_skintone',
+    CATEGORY_AGENTS: 'agents',
+    SELECTED_AGENT: 'selected_agent',
     ONE_CLICK_REACTIONS_ENABLED: 'one_click_reactions_enabled',
     ONE_CLICK_REACTIONS_ENABLED_DEFAULT: 'true',
     CLOUD_TRIAL_END_BANNER: 'cloud_trial_end_banner',


### PR DESCRIPTION
#### Summary
The agent selector in the rewrite menu and the create-recap modal defaulted to the alphabetically-first agent and ignored the system-wide default agent (`is_default`). This PR fixes that bug and adds a persistence enhancement so the selector remembers your last-selected agent.

A new `useSelectedAgent` hook centralizes the resolution logic with the precedence: saved preference -> system default (`is_default`) -> first agent. The selected agent is persisted only on an explicit user selection, via a shared core preference (category `agents`, name `selected_agent`, value = agent id).

This is 1 of 3 coordinated PRs sharing the same `agents/selected_agent` preference contract across the web app, the Agents plugin, and mobile:
- mattermost (webapp) — this PR
- mattermost-plugin-agents
- mattermost-mobile

Related PRs: see linked PRs.

### Related PRs
Coordinated change for MM-68856 (the agent selector is duplicated across these repos):
- Webapp: mattermost/mattermost#37017 (this PR)
- Plugin: mattermost/mattermost-plugin-agents#827
- Mobile: mattermost/mattermost-mobile#9829
- Jira: https://mattermost.atlassian.net/browse/MM-68856

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68856

#### Test plan
- Unit tests (all green):
  - `use_rewrite` — 14 tests
  - `create_recap_modal` — 16 tests
- Manual browser QA:
  - Configured default agent `matty` is respected over the alphabetically-first agent `aira`.
  - The "(default)" label renders on the configured default agent.
  - Last-selected agent persists across a page refresh.
  - No `localStorage` writes occur (persistence flows through the server-backed preference).

#### Release Note
```release-note
The agent selector now respects the configured default agent and remembers your last-selected agent.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The PR introduces new preference persistence logic for agent selection across two components (`useRewrite` and `CreateRecapModal`) with centralized state via the new `useSelectedAgent` hook. While the changes are well-isolated and test coverage is comprehensive (30 new tests), the hook adds Redux dispatch calls for preference persistence that must synchronize correctly with the server. The cross-system coordination contract (`agents/selected_agent` preference) spans webapp, plugin, and mobile—if not consistently implemented across all systems, agents may fail to persist their last-selected state.

**QA Recommendation:** Moderate manual QA recommended despite full automated test coverage. Verify the precedence logic for agent selection (saved preference → system default → first agent) works correctly across different agent configurations, confirm the "(default)" label renders correctly on the configured default agent, test last-selected agent persistence across page refreshes and logout/login scenarios, and validate that no localStorage writes occur (persistence is server-backed only). Cross-system preference sync should be validated with the agents plugin if available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
