### PR TITLE
Add built-in health dashboard engine spike (WS1+WS2+WS3)

### DIFF
--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -383,3 +383,5 @@ channels/db/migrations/postgres/000192_add_voip_device_id_to_sessions.down.sql
 channels/db/migrations/postgres/000192_add_voip_device_id_to_sessions.up.sql
 channels/db/migrations/postgres/000193_add_property_groups_schema_version.down.sql
 channels/db/migrations/postgres/000193_add_property_groups_schema_version.up.sql
+channels/db/migrations/postgres/000194_create_health_check_findings.down.sql
+channels/db/migrations/postgres/000194_create_health_check_findings.up.sql

--- a/server/channels/db/migrations/postgres/000194_create_health_check_findings.down.sql
+++ b/server/channels/db/migrations/postgres/000194_create_health_check_findings.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS HealthCheckFindings;

--- a/server/channels/db/migrations/postgres/000194_create_health_check_findings.up.sql
+++ b/server/channels/db/migrations/postgres/000194_create_health_check_findings.up.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS HealthCheckFindings (
+    Fingerprint          VARCHAR(512)  NOT NULL,
+    RuleCode             VARCHAR(256)  NOT NULL,
+    State                VARCHAR(32)   NOT NULL DEFAULT 'unknown',
+    FirstFiredAt         BIGINT        NOT NULL DEFAULT 0,
+    LastFiredAt          BIGINT        NOT NULL DEFAULT 0,
+    ResolvedAt           BIGINT        NOT NULL DEFAULT 0,
+    ConsecutiveFailures  INTEGER       NOT NULL DEFAULT 0,
+    MutedAt              BIGINT        NOT NULL DEFAULT 0,
+    MutedByUserId        VARCHAR(26)   NOT NULL DEFAULT '',
+    UpdatedAt            BIGINT        NOT NULL DEFAULT 0,
+    CONSTRAINT pk_health_check_findings PRIMARY KEY (Fingerprint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_health_check_findings_state
+    ON HealthCheckFindings (State);
+
+CREATE INDEX IF NOT EXISTS idx_health_check_findings_muted
+    ON HealthCheckFindings (MutedAt)
+    WHERE MutedAt > 0;

--- a/server/channels/healthcheck/catalog.go
+++ b/server/channels/healthcheck/catalog.go
@@ -1,0 +1,299 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package healthcheck
+
+// BuiltinRules is the in-repo baseline rule catalog. Rules are expressed as
+// CEL expressions over the snapshot vocabulary defined in engine.go.
+//
+// Each entry is one finding code. Multi-finding Python rules are split into
+// one Rule per finding code so the state machine (WS4) can track and mute
+// them independently.
+//
+// Design note: DESIGN.md leans toward YAML for the catalog once the P2
+// remote feed lands (rules authored in a repo, CI-validated, signed). Go
+// literals are used here for the P1 baseline because they are compiled and
+// type-checked at build time (renamed model fields = compile errors in the
+// CEL env registration). The YAML-based feed loader will use the same Rule
+// struct. No migration needed at P2 — just add the loader alongside.
+//
+// Rule sourcing: each rule shows the originating Python function and finding
+// code from mattermost_healthcheck.py so diffs stay auditable.
+var BuiltinRules = []Rule{
+
+	// -----------------------------------------------------------------------
+	// check_push_notifications (bucket A — pure config)
+	// Source: check_push_notifications / PUSH_EMPTY_URL
+	// -----------------------------------------------------------------------
+	{
+		Code:       "PUSH_EMPTY_URL",
+		Severity:   SeverityCritical,
+		Volatility: VolatilityStable,
+		Surface:    SurfaceProduct,
+		Area:       "push",
+		Scope:      ScopeAll,
+		Expr:       `config.EmailSettings.SendPushNotifications && config.EmailSettings.PushNotificationServer == ""`,
+		Title:      "Push enabled but PushNotificationServer is blank",
+		Detail:     "Every push attempt will fail with 'unsupported protocol scheme'.",
+		Remediation: "Point EmailSettings.PushNotificationServer to https://push.mattermost.com " +
+			"or your self-hosted push proxy.",
+		DocsURL: "https://docs.mattermost.com/deploy/mobile-hpns.html",
+	},
+
+	// Source: check_push_notifications / PUSH_BAD_SCHEME
+	{
+		Code:       "PUSH_BAD_SCHEME",
+		Severity:   SeverityCritical,
+		Volatility: VolatilityStable,
+		Surface:    SurfaceProduct,
+		Area:       "push",
+		Scope:      ScopeAll,
+		Expr: `config.EmailSettings.SendPushNotifications` +
+			` && config.EmailSettings.PushNotificationServer != ""` +
+			` && !config.EmailSettings.PushNotificationServer.startsWith("http://")` +
+			` && !config.EmailSettings.PushNotificationServer.startsWith("https://")`,
+		Title:       "PushNotificationServer has an invalid URL scheme",
+		Detail:      "The push server URL must start with http:// or https://. Mobile users will not receive notifications.",
+		Remediation: "Prefix PushNotificationServer with https:// and verify reachability from the app node.",
+		DocsURL:     "https://docs.mattermost.com/deploy/mobile-hpns.html",
+	},
+
+	// Source: check_push_notifications / PUSH_TEST_PROXY
+	{
+		Code:       "PUSH_TEST_PROXY",
+		Severity:   SeverityWarning,
+		Volatility: VolatilityStable,
+		Surface:    SurfaceProduct,
+		Area:       "push",
+		Scope:      ScopeAll,
+		Expr:       `config.EmailSettings.SendPushNotifications && config.EmailSettings.PushNotificationServer.contains("push-test.mattermost.com")`,
+		Title:      "PushNotificationServer points at the test push proxy",
+		Detail:     "push-test.mattermost.com has no SLA or throughput guarantee and is not intended for production use.",
+		Remediation: "Switch to https://push.mattermost.com (production HPNS, included with Enterprise) " +
+			"or a self-hosted push proxy.",
+		DocsURL: "https://docs.mattermost.com/deploy/mobile-hpns.html",
+	},
+
+	// -----------------------------------------------------------------------
+	// check_ping_status (bucket B — probe.dbWrite)
+	// Source: check_ping_status / DB_HEALTHCHECK_FAIL
+	// -----------------------------------------------------------------------
+	{
+		Code:        "DB_HEALTHCHECK_FAIL",
+		Severity:    SeverityCritical,
+		Volatility:  VolatilityProbe,
+		Surface:     SurfaceProduct,
+		Area:        "database",
+		Scope:       ScopeAll,
+		Expr:        `!probe.dbWrite()`,
+		Title:       "Database health-check write is failing",
+		Detail:      "DBHealthCheckWrite/Delete failed against the primary database.",
+		Remediation: "Verify primary DB connectivity, disk space, long-running transactions, and max_connections on the DB server.",
+		DocsURL:     "https://docs.mattermost.com/install/troubleshooting.html",
+	},
+
+	// -----------------------------------------------------------------------
+	// check_site_url (bucket A — pure config)
+	// Source: check_site_url / CORE_SITE_URL_EMPTY
+	// -----------------------------------------------------------------------
+	{
+		Code:       "CORE_SITE_URL_EMPTY",
+		Severity:   SeverityCritical,
+		Volatility: VolatilityStable,
+		Surface:    SurfaceProduct,
+		Area:       "core",
+		Scope:      ScopeAll,
+		Expr:       `config.ServiceSettings.SiteURL == ""`,
+		Title:      "ServiceSettings.SiteURL is empty",
+		Detail:     "SiteURL is required for webhook URLs, OAuth callbacks, mobile push payloads, and email links. Empty = broken integrations.",
+		Remediation: "Set SiteURL to the public HTTPS URL of the server " +
+			"(e.g. https://mattermost.example.com).",
+		DocsURL: "https://docs.mattermost.com/configure/environment-configuration-settings.html#site-url",
+	},
+
+	// Source: check_site_url / CORE_SITE_URL_HTTP
+	{
+		Code:        "CORE_SITE_URL_HTTP",
+		Severity:    SeverityWarning,
+		Volatility:  VolatilityStable,
+		Surface:     SurfaceProduct,
+		Area:        "core",
+		Scope:       ScopeAll,
+		Expr:        `config.ServiceSettings.SiteURL.startsWith("http://")`,
+		Title:       "SiteURL uses http:// (not https://)",
+		Detail:      "Session cookies and auth tokens traverse cleartext when SiteURL uses http://.",
+		Remediation: "Serve Mattermost via HTTPS and update ServiceSettings.SiteURL to use https://.",
+		DocsURL:     "https://docs.mattermost.com/configure/environment-configuration-settings.html#site-url",
+	},
+
+	// -----------------------------------------------------------------------
+	// check_logging (bucket A — pure config)
+	// Source: check_logging / LOG_DEBUG_PROD
+	// -----------------------------------------------------------------------
+	{
+		Code:        "LOG_DEBUG_PROD",
+		Severity:    SeverityWarning,
+		Volatility:  VolatilityStable,
+		Surface:     SurfaceProduct,
+		Area:        "logging",
+		Scope:       ScopeAll,
+		Expr:        `config.LogSettings.FileLevel == "DEBUG"`,
+		Title:       "LogSettings.FileLevel is DEBUG",
+		Detail:      "Debug logs fill disk quickly and may leak structured payloads. Use DEBUG only while actively diagnosing an issue.",
+		Remediation: "Set LogSettings.FileLevel to INFO or WARN.",
+		DocsURL:     "https://docs.mattermost.com/configure/environment-configuration-settings.html#file-log-level",
+	},
+
+	// Source: check_logging / LOG_FILE_OFF
+	{
+		Code:        "LOG_FILE_OFF",
+		Severity:    SeverityWarning,
+		Volatility:  VolatilityStable,
+		Surface:     SurfaceProduct,
+		Area:        "logging",
+		Scope:       ScopeAll,
+		Expr:        `!config.LogSettings.EnableFile`,
+		Title:       "File logging is disabled",
+		Detail:      "LogSettings.EnableFile=false. If logs are not captured by an external collector (stdout/journald/sidecar), post-mortem support becomes nearly impossible.",
+		Remediation: "Verify logs are captured by an external collector. If not, set LogSettings.EnableFile=true and configure a rotating FileLocation.",
+		DocsURL:     "https://docs.mattermost.com/configure/environment-configuration-settings.html#enable-file",
+	},
+
+	// -----------------------------------------------------------------------
+	// check_saml (bucket A — pure config)
+	// Source: check_saml / SAML_SHA1
+	// -----------------------------------------------------------------------
+	{
+		Code:       "SAML_SHA1",
+		Severity:   SeverityCritical,
+		Volatility: VolatilityStable,
+		Surface:    SurfaceProduct,
+		Area:       "saml",
+		Scope:      ScopeAll,
+		Expr: `config.SamlSettings.Enable` +
+			` && (config.SamlSettings.SignatureAlgorithm == "RSAwithSHA1"` +
+			` || config.SamlSettings.SignatureAlgorithm == "http://www.w3.org/2000/09/xmldsig#rsa-sha1")`,
+		Title: "SAML SignatureAlgorithm is set to SHA1",
+		Detail: "Many IdPs (Okta, Azure AD, ADFS) reject SHA1-signed AuthnRequests. " +
+			"This is behind a large share of 'SAML login suddenly broken' support tickets.",
+		Remediation: "Set SamlSettings.SignatureAlgorithm to RSAwithSHA256.",
+		DocsURL:     "https://docs.mattermost.com/configure/authentication-configuration-settings.html#signature-algorithm",
+	},
+
+	// Source: check_saml / SAML_VERIFY_OFF
+	{
+		Code:        "SAML_VERIFY_OFF",
+		Severity:    SeverityCritical,
+		Volatility:  VolatilityStable,
+		Surface:     SurfaceProduct,
+		Area:        "saml",
+		Scope:       ScopeAll,
+		Expr:        `config.SamlSettings.Enable && !config.SamlSettings.Verify`,
+		Title:       "SAML assertion verification is disabled",
+		Detail:      "SamlSettings.Verify=false. IdP assertion signatures are not being validated — authentication is trusting unverified SAML responses.",
+		Remediation: "Set SamlSettings.Verify=true and install the IdP signing certificate.",
+		DocsURL:     "https://docs.mattermost.com/configure/authentication-configuration-settings.html#verify-signature",
+	},
+
+	// Source: check_saml / SAML_MISSING_IDPURL
+	{
+		Code:        "SAML_MISSING_IDPURL",
+		Severity:    SeverityCritical,
+		Volatility:  VolatilityStable,
+		Surface:     SurfaceProduct,
+		Area:        "saml",
+		Scope:       ScopeAll,
+		Expr:        `config.SamlSettings.Enable && config.SamlSettings.IdpURL == ""`,
+		Title:       "SamlSettings.IdpURL is empty",
+		Detail:      "SAML login cannot complete without the IdP SSO URL.",
+		Remediation: "Populate SamlSettings.IdpURL from your IdP metadata XML (SingleSignOnService Location).",
+		DocsURL:     "https://docs.mattermost.com/configure/authentication-configuration-settings.html#identity-provider-sso-url",
+	},
+
+	// -----------------------------------------------------------------------
+	// check_filestore (bucket A — pure config)
+	// Source: check_filestore / FS_LOCAL_UNDER_HA
+	// -----------------------------------------------------------------------
+	{
+		Code:        "FS_LOCAL_UNDER_HA",
+		Severity:    SeverityCritical,
+		Volatility:  VolatilityStable,
+		Surface:     SurfaceProduct,
+		Area:        "filestore",
+		Scope:       ScopeAll,
+		Expr:        `config.FileSettings.DriverName == "local" && config.ClusterSettings.Enable`,
+		Title:       "Local filestore is configured with HA clustering enabled",
+		Detail:      "FileSettings.DriverName=local with ClusterSettings.Enable=true. Files uploaded to one node will not be accessible from other nodes unless the directory is a shared network mount.",
+		Remediation: "Migrate to an object store (amazons3 / Azure Blob) or confirm all nodes mount the same shared POSIX directory.",
+		DocsURL:     "https://docs.mattermost.com/scale/high-availability-cluster.html",
+	},
+
+	// Source: check_filestore / FS_S3_NO_BUCKET
+	{
+		Code:        "FS_S3_NO_BUCKET",
+		Severity:    SeverityCritical,
+		Volatility:  VolatilityStable,
+		Surface:     SurfaceProduct,
+		Area:        "filestore",
+		Scope:       ScopeAll,
+		Expr:        `config.FileSettings.DriverName == "amazons3" && config.FileSettings.AmazonS3Bucket == ""`,
+		Title:       "S3 filestore driver selected but bucket name is empty",
+		Detail:      "FileSettings.AmazonS3Bucket is empty — all file uploads will fail.",
+		Remediation: "Populate FileSettings.AmazonS3Bucket, AmazonS3Region, and verify IAM credentials.",
+		DocsURL:     "https://docs.mattermost.com/configure/environment-configuration-settings.html#amazon-s3-bucket",
+	},
+
+	// -----------------------------------------------------------------------
+	// check_compliance (bucket A — pure config)
+	// Source: check_compliance / COMPLIANCE_NO_DIR
+	// -----------------------------------------------------------------------
+	{
+		Code:        "COMPLIANCE_NO_DIR",
+		Severity:    SeverityCritical,
+		Volatility:  VolatilityStable,
+		Surface:     SurfaceProduct,
+		Area:        "compliance",
+		Scope:       ScopeAll,
+		Expr:        `config.ComplianceSettings.Enable && config.ComplianceSettings.Directory == ""`,
+		Title:       "Compliance export enabled but Directory is empty",
+		Detail:      "ComplianceSettings.Directory is empty — compliance exports have nowhere to write.",
+		Remediation: "Set ComplianceSettings.Directory to a writable path on the server.",
+		DocsURL:     "https://docs.mattermost.com/comply/compliance-export.html",
+	},
+
+	// -----------------------------------------------------------------------
+	// check_data_retention (bucket A — pure config)
+	// Source: check_data_retention / RETENTION_DEPRECATED_DAYS
+	// -----------------------------------------------------------------------
+	{
+		Code:       "RETENTION_DEPRECATED_DAYS",
+		Severity:   SeverityWarning,
+		Volatility: VolatilityStable,
+		Surface:    SurfaceProduct,
+		Area:       "retention",
+		Scope:      ScopeAll,
+		Expr: `(config.DataRetentionSettings.EnableMessageDeletion || config.DataRetentionSettings.EnableFileDeletion)` +
+			` && config.DataRetentionSettings.MessageRetentionDays > 0` +
+			` && config.DataRetentionSettings.MessageRetentionHours == 0`,
+		Title:       "Data retention is using the deprecated MessageRetentionDays field",
+		Detail:      "MessageRetentionDays is deprecated; the server now prefers MessageRetentionHours. Mixed or unset values can produce surprising deletion windows.",
+		Remediation: "Migrate to DataRetentionSettings.MessageRetentionHours (set to days × 24) and leave MessageRetentionDays at its default.",
+		DocsURL:     "https://docs.mattermost.com/comply/data-retention-policy.html",
+	},
+
+	// Source: check_data_retention / RETENTION_BATCH_ZERO
+	{
+		Code:       "RETENTION_BATCH_ZERO",
+		Severity:   SeverityCritical,
+		Volatility: VolatilityStable,
+		Surface:    SurfaceProduct,
+		Area:       "retention",
+		Scope:      ScopeAll,
+		Expr: `(config.DataRetentionSettings.EnableMessageDeletion || config.DataRetentionSettings.EnableFileDeletion)` +
+			` && config.DataRetentionSettings.BatchSize == 0`,
+		Title:       "Data retention BatchSize is zero — no rows will be deleted",
+		Detail:      "DataRetentionSettings.BatchSize=0 means the retention job processes zero rows per run. All retention jobs will be no-ops.",
+		Remediation: "Set DataRetentionSettings.BatchSize to 1000 or higher (default is 3000).",
+		DocsURL:     "https://docs.mattermost.com/comply/data-retention-policy.html",
+	},
+}

--- a/server/channels/healthcheck/engine.go
+++ b/server/channels/healthcheck/engine.go
@@ -1,0 +1,203 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package healthcheck
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/ext"
+	"github.com/google/cel-go/interpreter/functions"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// buildEnv constructs the shared CEL environment for all rule evaluations.
+//
+// Accessor vocabulary registered here:
+//   - config.*  — typed view over model.Config via ext.NativeTypes.
+//     ext.NativeTypes recursively registers all nested struct types, so
+//     passing &model.Config{} is sufficient.
+//   - probe.dbWrite() — declared (no binding at env level; binding is
+//     injected per-program at Evaluate time via cel.Functions).
+//
+// Spike friction note (pointer fields):
+//
+//	model.Config uses *bool / *string fields throughout. ext.NativeTypes
+//	handles them: a nil pointer becomes the zero value (false/""), a
+//	non-nil pointer is dereferenced. Callers MUST call cfg.SetDefaults()
+//	before building the snapshot so all pointer fields are non-nil and
+//	carry the intended value rather than the zero-value fallback.
+//
+// TODO (WS1 vocabulary expansion): add license.*, version.*, stats.*,
+// jobs.*, cluster.*, plugins.*, db.*, deployment.*, search.*, env.*
+// as the corresponding snapshot sections are implemented.
+func buildEnv() (*cel.Env, error) {
+	env, err := cel.NewEnv(
+		// NativeTypes requires reflect.Type arguments (not pointer values).
+		// Passing reflect.TypeOf(model.Config{}) triggers recursive
+		// discovery of all nested struct types in the Config tree — one
+		// call suffices. Passing &model.Config{} directly causes a runtime
+		// error ("must be reflect.Type or reflect.Value").
+		ext.NativeTypes(reflect.TypeOf(model.Config{})),
+		cel.Variable("config", cel.ObjectType("model.Config")),
+
+		// probe.dbWrite() — zero-arg function returning bool.
+		// The actual implementation is injected at program-creation time
+		// (see Evaluate) via the cel.Functions ProgramOption.
+		// We use cel.Functions (deprecated for static implementations) here
+		// because our probe results are dynamic per-snapshot — the function
+		// implementation varies across evaluations. The deprecation note
+		// recommends cel.Function for compile-time-constant implementations;
+		// cel.Functions remains correct for this dynamic-injection pattern.
+		cel.Function("probe.dbWrite",
+			cel.Overload("probe_dbWrite_0", []*cel.Type{}, cel.BoolType),
+		),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("healthcheck: build CEL environment: %w", err)
+	}
+	return env, nil
+}
+
+// compiledRule pairs a [Rule] with its compiled CEL AST.
+type compiledRule struct {
+	rule Rule
+	ast  *cel.Ast
+}
+
+// Engine compiles rules once and evaluates them per-snapshot. Safe for
+// concurrent use after construction.
+type Engine struct {
+	env           *cel.Env
+	compiledRules []compiledRule
+}
+
+// NewEngine creates an Engine by compiling all rules in rules.
+// Returns an error if any rule fails compilation or references an unknown
+// accessor (static validation against the registered vocabulary).
+func NewEngine(rules []Rule) (*Engine, error) {
+	env, err := buildEnv()
+	if err != nil {
+		return nil, err
+	}
+
+	compiled := make([]compiledRule, 0, len(rules))
+	for _, r := range rules {
+		ast, issues := env.Compile(r.Expr)
+		if issues != nil && issues.Err() != nil {
+			return nil, fmt.Errorf("healthcheck: compile rule %q: %w", r.Code, issues.Err())
+		}
+		if ast.OutputType() != cel.BoolType {
+			return nil, fmt.Errorf("healthcheck: rule %q: expression must return bool, got %v", r.Code, ast.OutputType())
+		}
+		compiled = append(compiled, compiledRule{rule: r, ast: ast})
+	}
+	return &Engine{env: env, compiledRules: compiled}, nil
+}
+
+// Validate compiles all rules and returns all errors. Use in CI / tests to
+// catch authoring mistakes. Returns nil on success.
+func Validate(rules []Rule) []error {
+	env, err := buildEnv()
+	if err != nil {
+		return []error{err}
+	}
+
+	var errs []error
+	for _, r := range rules {
+		ast, issues := env.Compile(r.Expr)
+		if issues != nil && issues.Err() != nil {
+			errs = append(errs, fmt.Errorf("rule %q: %w", r.Code, issues.Err()))
+			continue
+		}
+		if ast.OutputType() != cel.BoolType {
+			errs = append(errs, fmt.Errorf("rule %q: expression must return bool, got %v", r.Code, ast.OutputType()))
+		}
+	}
+	return errs
+}
+
+// Evaluate runs all compiled rules against snap and returns the findings
+// currently firing (expression evaluated to true).
+//
+// A nil snapshot section causes rules that depend solely on that section to
+// be skipped, implementing the "unknown ≠ resolved" contract from DESIGN.md:
+// a missing section never produces a spurious resolution.
+//
+// TODO (WS4 state machine): skipped rules should produce an "unknown" state
+// record rather than being silently omitted. For P1 we skip to avoid false
+// positives.
+func (e *Engine) Evaluate(snap *Snapshot) []Finding {
+	if snap == nil {
+		return nil
+	}
+
+	cfg := snap.Config
+	if cfg == nil {
+		// Use a zero config rather than nil so typed field access in rules
+		// doesn't panic. Rules that need a populated config will simply see
+		// zero/default values and may or may not fire — acceptable for P1
+		// since the live provider always populates this section.
+		cfg = &model.Config{}
+	}
+
+	probeAvailable := snap.Probes != nil
+	probeDBWriteOK := probeAvailable && snap.Probes.DBWriteOK
+
+	// The probe.dbWrite() function implementation is injected per-program
+	// call so it captures the snapshot-specific probe result.
+	probeDBWriteImpl := &functions.Overload{
+		Operator: "probe_dbWrite_0",
+		Function: func(_ ...ref.Val) ref.Val {
+			return types.Bool(probeDBWriteOK)
+		},
+	}
+
+	var findings []Finding
+	for _, cr := range e.compiledRules {
+		// Skip probe-volatility rules when the probe section was not
+		// collected this cycle (avoids false-positive "probe failed" findings
+		// when the probe simply wasn't run).
+		if cr.rule.Volatility == VolatilityProbe && !probeAvailable {
+			continue
+		}
+
+		prg, err := e.env.Program(cr.ast,
+			cel.Functions(probeDBWriteImpl), //nolint:staticcheck // cel.Functions is the correct API for per-snapshot dynamic function injection; the deprecation applies to static compile-time implementations only
+		)
+		if err != nil {
+			// Program creation failure is a programming error. Skip rather
+			// than crash so one bad rule doesn't block the rest.
+			continue
+		}
+
+		out, _, err := prg.Eval(map[string]any{"config": cfg})
+		if err != nil {
+			// CEL evaluation errors (nil deref, type mismatch) are treated
+			// as "unknown" in P1 by silently skipping. WS4 will track these.
+			continue
+		}
+
+		firing, ok := out.Value().(bool)
+		if !ok || !firing {
+			continue
+		}
+
+		findings = append(findings, Finding{
+			Code:        cr.rule.Code,
+			RuleCode:    cr.rule.Code,
+			Severity:    cr.rule.Severity,
+			Area:        cr.rule.Area,
+			Title:       cr.rule.Title,
+			Detail:      cr.rule.Detail,
+			Remediation: cr.rule.Remediation,
+			DocsURL:     cr.rule.DocsURL,
+		})
+	}
+	return findings
+}

--- a/server/channels/healthcheck/engine.go
+++ b/server/channels/healthcheck/engine.go
@@ -122,35 +122,34 @@ func Validate(rules []Rule) []error {
 	return errs
 }
 
-// Evaluate runs all compiled rules against snap and returns the findings
-// currently firing (expression evaluated to true).
+// EvaluateAll runs all compiled rules against snap and returns one
+// [EvalOutcome] per rule. The three-valued result (firing / resolved /
+// unknown) is the input to the state-machine reconciler in WS4.
 //
-// A nil snapshot section causes rules that depend solely on that section to
-// be skipped, implementing the "unknown ≠ resolved" contract from DESIGN.md:
-// a missing section never produces a spurious resolution.
-//
-// TODO (WS4 state machine): skipped rules should produce an "unknown" state
-// record rather than being silently omitted. For P1 we skip to avoid false
-// positives.
-func (e *Engine) Evaluate(snap *Snapshot) []Finding {
+// Callers that only need currently-firing findings can use [Engine.Evaluate],
+// which wraps this and filters to FindingStateFiring.
+func (e *Engine) EvaluateAll(snap *Snapshot) []EvalOutcome {
 	if snap == nil {
-		return nil
+		// Treat a nil snapshot as unknown for every rule.
+		outcomes := make([]EvalOutcome, 0, len(e.compiledRules))
+		for _, cr := range e.compiledRules {
+			outcomes = append(outcomes, EvalOutcome{
+				RuleCode:    cr.rule.Code,
+				Fingerprint: cr.rule.Code,
+				State:       FindingStateUnknown,
+			})
+		}
+		return outcomes
 	}
 
 	cfg := snap.Config
 	if cfg == nil {
-		// Use a zero config rather than nil so typed field access in rules
-		// doesn't panic. Rules that need a populated config will simply see
-		// zero/default values and may or may not fire — acceptable for P1
-		// since the live provider always populates this section.
 		cfg = &model.Config{}
 	}
 
 	probeAvailable := snap.Probes != nil
 	probeDBWriteOK := probeAvailable && snap.Probes.DBWriteOK
 
-	// The probe.dbWrite() function implementation is injected per-program
-	// call so it captures the snapshot-specific probe result.
 	probeDBWriteImpl := &functions.Overload{
 		Operator: "probe_dbWrite_0",
 		Function: func(_ ...ref.Val) ref.Val {
@@ -158,12 +157,17 @@ func (e *Engine) Evaluate(snap *Snapshot) []Finding {
 		},
 	}
 
-	var findings []Finding
+	outcomes := make([]EvalOutcome, 0, len(e.compiledRules))
 	for _, cr := range e.compiledRules {
-		// Skip probe-volatility rules when the probe section was not
-		// collected this cycle (avoids false-positive "probe failed" findings
-		// when the probe simply wasn't run).
+		fp := cr.rule.Code // fingerprint = code for P1
+
+		// Missing section → unknown, not resolved.
 		if cr.rule.Volatility == VolatilityProbe && !probeAvailable {
+			outcomes = append(outcomes, EvalOutcome{
+				RuleCode:    cr.rule.Code,
+				Fingerprint: fp,
+				State:       FindingStateUnknown,
+			})
 			continue
 		}
 
@@ -171,33 +175,73 @@ func (e *Engine) Evaluate(snap *Snapshot) []Finding {
 			cel.Functions(probeDBWriteImpl), //nolint:staticcheck // cel.Functions is the correct API for per-snapshot dynamic function injection; the deprecation applies to static compile-time implementations only
 		)
 		if err != nil {
-			// Program creation failure is a programming error. Skip rather
-			// than crash so one bad rule doesn't block the rest.
+			outcomes = append(outcomes, EvalOutcome{
+				RuleCode:    cr.rule.Code,
+				Fingerprint: fp,
+				State:       FindingStateUnknown,
+			})
 			continue
 		}
 
 		out, _, err := prg.Eval(map[string]any{"config": cfg})
 		if err != nil {
-			// CEL evaluation errors (nil deref, type mismatch) are treated
-			// as "unknown" in P1 by silently skipping. WS4 will track these.
+			outcomes = append(outcomes, EvalOutcome{
+				RuleCode:    cr.rule.Code,
+				Fingerprint: fp,
+				State:       FindingStateUnknown,
+			})
 			continue
 		}
 
 		firing, ok := out.Value().(bool)
-		if !ok || !firing {
+		if !ok {
+			outcomes = append(outcomes, EvalOutcome{
+				RuleCode:    cr.rule.Code,
+				Fingerprint: fp,
+				State:       FindingStateUnknown,
+			})
 			continue
 		}
 
-		findings = append(findings, Finding{
-			Code:        cr.rule.Code,
-			RuleCode:    cr.rule.Code,
-			Severity:    cr.rule.Severity,
-			Area:        cr.rule.Area,
-			Title:       cr.rule.Title,
-			Detail:      cr.rule.Detail,
-			Remediation: cr.rule.Remediation,
-			DocsURL:     cr.rule.DocsURL,
-		})
+		if firing {
+			f := Finding{
+				Code:        cr.rule.Code,
+				RuleCode:    cr.rule.Code,
+				Severity:    cr.rule.Severity,
+				Area:        cr.rule.Area,
+				Title:       cr.rule.Title,
+				Detail:      cr.rule.Detail,
+				Remediation: cr.rule.Remediation,
+				DocsURL:     cr.rule.DocsURL,
+			}
+			outcomes = append(outcomes, EvalOutcome{
+				RuleCode:    cr.rule.Code,
+				Fingerprint: fp,
+				State:       FindingStateFiring,
+				Finding:     &f,
+			})
+		} else {
+			outcomes = append(outcomes, EvalOutcome{
+				RuleCode:    cr.rule.Code,
+				Fingerprint: fp,
+				State:       FindingStateResolved,
+			})
+		}
+	}
+	return outcomes
+}
+
+// Evaluate runs all compiled rules against snap and returns the findings
+// currently firing. It wraps [Engine.EvaluateAll] and filters to
+// [FindingStateFiring]. Use EvaluateAll when the state machine needs
+// three-valued outcomes.
+func (e *Engine) Evaluate(snap *Snapshot) []Finding {
+	outcomes := e.EvaluateAll(snap)
+	var findings []Finding
+	for _, o := range outcomes {
+		if o.State == FindingStateFiring && o.Finding != nil {
+			findings = append(findings, *o.Finding)
+		}
 	}
 	return findings
 }

--- a/server/channels/healthcheck/engine_test.go
+++ b/server/channels/healthcheck/engine_test.go
@@ -1,0 +1,351 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package healthcheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// ---------------------------------------------------------------------------
+// Spike exit criterion (Step 0)
+// Proves: cel-go NativeTypes over *model.Config, probe.dbWrite() custom
+// function, and matches() (regex) are all working end-to-end.
+// Two findings must be produced from a crafted snapshot.
+// ---------------------------------------------------------------------------
+
+func TestSpike_PushEmptyURL_Fires(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	// Trigger: push enabled with blank server URL.
+	*cfg.EmailSettings.SendPushNotifications = true
+	*cfg.EmailSettings.PushNotificationServer = ""
+
+	snap := &Snapshot{
+		Config: cfg,
+		Probes: &ProbeSection{DBWriteOK: true},
+	}
+
+	findings := engine.Evaluate(snap)
+	codes := findingCodes(findings)
+	assert.Contains(t, codes, "PUSH_EMPTY_URL", "PUSH_EMPTY_URL should fire when push is enabled with a blank server URL")
+}
+
+func TestSpike_ProbeDBWriteFails_Fires(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+
+	snap := &Snapshot{
+		Config: cfg,
+		// Probe reports DB write failed.
+		Probes: &ProbeSection{DBWriteOK: false},
+	}
+
+	findings := engine.Evaluate(snap)
+	codes := findingCodes(findings)
+	assert.Contains(t, codes, "DB_HEALTHCHECK_FAIL", "DB_HEALTHCHECK_FAIL should fire when probe.dbWrite() returns false")
+}
+
+// Confirm CEL's built-in matches() (regex) is available. DESIGN.md calls
+// this out as a required capability for DSN inspection rules (rules 3, 44).
+func TestSpike_CELMatchesAvailable(t *testing.T) {
+	env, err := buildEnv()
+	require.NoError(t, err)
+
+	ast, issues := env.Compile(`"http://example.com".matches("^https?://")`)
+	require.Nil(t, issues, "CEL matches() should compile without errors")
+	require.NotNil(t, ast)
+	assert.Equal(t, "bool", ast.OutputType().String(), "matches() must return bool")
+}
+
+// ---------------------------------------------------------------------------
+// Rule compilation / static validator
+// ---------------------------------------------------------------------------
+
+func TestValidate_BuiltinRules_AllCompile(t *testing.T) {
+	errs := Validate(BuiltinRules)
+	require.Empty(t, errs, "all built-in rules must compile without errors: %v", errs)
+}
+
+func TestValidate_UnknownAccessor_ReturnsError(t *testing.T) {
+	bad := []Rule{{
+		Code: "TEST_BAD",
+		Expr: `config.NonExistentField == "oops"`,
+	}}
+	errs := Validate(bad)
+	require.NotEmpty(t, errs, "referencing an unknown accessor must fail validation")
+}
+
+func TestValidate_NonBoolExpr_ReturnsError(t *testing.T) {
+	bad := []Rule{{
+		Code: "TEST_NON_BOOL",
+		Expr: `config.ServiceSettings.SiteURL`, // returns string, not bool
+	}}
+	errs := Validate(bad)
+	require.NotEmpty(t, errs, "non-bool expression must fail validation")
+}
+
+// ---------------------------------------------------------------------------
+// Per-rule unit tests (WS3)
+// ---------------------------------------------------------------------------
+
+func TestRule_PushBadScheme(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.EmailSettings.SendPushNotifications = true
+	*cfg.EmailSettings.PushNotificationServer = "push.example.com" // no scheme
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	assert.Contains(t, findingCodes(findings), "PUSH_BAD_SCHEME")
+	assert.NotContains(t, findingCodes(findings), "PUSH_EMPTY_URL")
+}
+
+func TestRule_PushTestProxy(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.EmailSettings.SendPushNotifications = true
+	*cfg.EmailSettings.PushNotificationServer = "https://push-test.mattermost.com"
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	assert.Contains(t, findingCodes(findings), "PUSH_TEST_PROXY")
+	assert.NotContains(t, findingCodes(findings), "PUSH_EMPTY_URL")
+	assert.NotContains(t, findingCodes(findings), "PUSH_BAD_SCHEME")
+}
+
+func TestRule_PushDisabled_NoFindings(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.EmailSettings.SendPushNotifications = false
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	for _, f := range findings {
+		assert.NotEqual(t, "PUSH_EMPTY_URL", f.Code)
+		assert.NotEqual(t, "PUSH_BAD_SCHEME", f.Code)
+		assert.NotEqual(t, "PUSH_TEST_PROXY", f.Code)
+	}
+}
+
+func TestRule_SiteURLEmpty(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.ServiceSettings.SiteURL = ""
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	assert.Contains(t, findingCodes(findings), "CORE_SITE_URL_EMPTY")
+}
+
+func TestRule_SiteURLHTTP(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.ServiceSettings.SiteURL = "http://mattermost.example.com"
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	codes := findingCodes(findings)
+	assert.Contains(t, codes, "CORE_SITE_URL_HTTP")
+	assert.NotContains(t, codes, "CORE_SITE_URL_EMPTY")
+}
+
+func TestRule_SiteURLHTTPS_NoFinding(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.ServiceSettings.SiteURL = "https://mattermost.example.com"
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	codes := findingCodes(findings)
+	assert.NotContains(t, codes, "CORE_SITE_URL_EMPTY")
+	assert.NotContains(t, codes, "CORE_SITE_URL_HTTP")
+}
+
+func TestRule_LogDebug(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.LogSettings.FileLevel = "DEBUG"
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	assert.Contains(t, findingCodes(findings), "LOG_DEBUG_PROD")
+}
+
+func TestRule_LogFileOff(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.LogSettings.EnableFile = false
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	assert.Contains(t, findingCodes(findings), "LOG_FILE_OFF")
+}
+
+func TestRule_SamlSHA1(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.SamlSettings.Enable = true
+	*cfg.SamlSettings.SignatureAlgorithm = "RSAwithSHA1"
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	assert.Contains(t, findingCodes(findings), "SAML_SHA1")
+}
+
+func TestRule_SamlVerifyOff(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.SamlSettings.Enable = true
+	*cfg.SamlSettings.Verify = false
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	assert.Contains(t, findingCodes(findings), "SAML_VERIFY_OFF")
+}
+
+func TestRule_SamlDisabled_NoSamlFindings(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.SamlSettings.Enable = false
+	*cfg.SamlSettings.SignatureAlgorithm = "RSAwithSHA1" // would fire if enabled
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	codes := findingCodes(findings)
+	assert.NotContains(t, codes, "SAML_SHA1")
+	assert.NotContains(t, codes, "SAML_VERIFY_OFF")
+	assert.NotContains(t, codes, "SAML_MISSING_IDPURL")
+}
+
+func TestRule_FilestoreLocalUnderHA(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.FileSettings.DriverName = "local"
+	*cfg.ClusterSettings.Enable = true
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	assert.Contains(t, findingCodes(findings), "FS_LOCAL_UNDER_HA")
+}
+
+func TestRule_FilestoreS3NoBucket(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.FileSettings.DriverName = "amazons3"
+	*cfg.FileSettings.AmazonS3Bucket = ""
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	assert.Contains(t, findingCodes(findings), "FS_S3_NO_BUCKET")
+}
+
+func TestRule_ComplianceNoDir(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.ComplianceSettings.Enable = true
+	*cfg.ComplianceSettings.Directory = ""
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	assert.Contains(t, findingCodes(findings), "COMPLIANCE_NO_DIR")
+}
+
+func TestRule_RetentionDeprecatedDays(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.DataRetentionSettings.EnableMessageDeletion = true
+	*cfg.DataRetentionSettings.MessageRetentionDays = 365
+	*cfg.DataRetentionSettings.MessageRetentionHours = 0
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	assert.Contains(t, findingCodes(findings), "RETENTION_DEPRECATED_DAYS")
+}
+
+func TestRule_RetentionBatchZero(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	*cfg.DataRetentionSettings.EnableMessageDeletion = true
+	*cfg.DataRetentionSettings.BatchSize = 0
+
+	findings := engine.Evaluate(&Snapshot{Config: cfg, Probes: &ProbeSection{DBWriteOK: true}})
+	assert.Contains(t, findingCodes(findings), "RETENTION_BATCH_ZERO")
+}
+
+// TestProbeSection_Nil_SkipsProbeRules verifies that when the probe section is
+// absent the probe-volatility rule (DB_HEALTHCHECK_FAIL) is not fired, even
+// though the implicit probe result would be false.
+func TestProbeSection_Nil_SkipsProbeRules(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+
+	snap := &Snapshot{
+		Config: cfg,
+		Probes: nil, // section not collected
+	}
+
+	findings := engine.Evaluate(snap)
+	codes := findingCodes(findings)
+	assert.NotContains(t, codes, "DB_HEALTHCHECK_FAIL",
+		"probe rules must not fire when probe section is not populated")
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func findingCodes(findings []Finding) []string {
+	codes := make([]string, 0, len(findings))
+	for _, f := range findings {
+		codes = append(codes, f.Code)
+	}
+	return codes
+}

--- a/server/channels/healthcheck/healthcheck.go
+++ b/server/channels/healthcheck/healthcheck.go
@@ -1,0 +1,116 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Package healthcheck implements the Built-in Health Dashboard rule engine
+// (WS1 + WS2 + WS3). It is intentionally self-contained so that both the
+// server runtime and mmctl can import it without pulling in app-layer state.
+//
+// The probe.* functions (e.g. probe.dbWrite()) require side-effecting calls
+// that live in the app layer. Callers supply a [ProbeProvider] interface; for
+// tests a fake implementation is sufficient.
+//
+// Out of scope for this package (later work items):
+//   - WS4 findings store / state machine (DB + migrations)
+//   - WS5 evaluation job (leader-elected periodic job)
+//   - WS6 REST API + mmctl command surface
+//   - WS7 System Console UI
+//   - P2 signed remote rule feed
+package healthcheck
+
+// Severity classifies how urgent a finding is.
+type Severity string
+
+const (
+	SeverityCritical Severity = "critical"
+	SeverityWarning  Severity = "warning"
+	SeverityInfo     Severity = "info"
+)
+
+// Volatility describes how a rule's inputs change over time, which determines
+// the debounce / hysteresis policy the findings store (WS4) will apply.
+type Volatility string
+
+const (
+	// VolatilityStable — config-derived; fires immediately, no debounce.
+	VolatilityStable Volatility = "stable"
+	// VolatilityProbe — transient/network; consecutive-failure debounce.
+	VolatilityProbe Volatility = "probe"
+	// VolatilityBoundary — threshold-crossing; separate fire/clear thresholds.
+	VolatilityBoundary Volatility = "boundary"
+	// VolatilityClusterMembership — cluster topology; debounce for deploys.
+	VolatilityClusterMembership Volatility = "cluster_membership"
+	// VolatilityFeed — depends on external feed; unknown when feed unreachable.
+	VolatilityFeed Volatility = "feed"
+)
+
+// Surface indicates whether a finding is shown in the in-product dashboard
+// ("product") or only to CSE tooling / mmctl ("internal").
+type Surface string
+
+const (
+	SurfaceProduct  Surface = "product"
+	SurfaceInternal Surface = "internal"
+)
+
+// DeploymentScope controls on which deployment types a rule fires.
+type DeploymentScope string
+
+const (
+	ScopeAll        DeploymentScope = "all"
+	ScopeOnPrem     DeploymentScope = "on_prem"
+	ScopeCloud      DeploymentScope = "cloud"
+	ScopeSelfHosted DeploymentScope = "self_hosted"
+)
+
+// Finding is a single diagnostic result produced when a rule's condition is
+// true. The engine produces one [Finding] per fired rule code.
+//
+// NOTE: WS4 will add state-machine fields (State, FirstSeenAt, LastSeenAt,
+// MutedAt, Fingerprint) around this value when persisted to the store.
+type Finding struct {
+	// Code is the stable, unique identifier for this type of finding (e.g.
+	// "PUSH_EMPTY_URL"). Used as the mute key and finding-store primary key.
+	Code string
+	// RuleCode is the rule that produced this finding (same as Code for
+	// single-finding rules; different for rules that emit multiple codes).
+	RuleCode string
+	Severity Severity
+	Area     string
+	Title    string
+	Detail   string
+	// Remediation is a plain-language fix description.
+	Remediation string
+	// DocsURL is a deep link to the relevant docs page.
+	DocsURL string
+}
+
+// Rule is a single health-check rule. Rules are compiled once and evaluated
+// per snapshot. The CEL expression must evaluate to bool; true means the
+// condition is firing.
+//
+// Design note: future P2 work will load rules from a signed remote YAML feed
+// as well as from the in-repo catalog. The in-repo catalog uses Go literals;
+// the feed path will add a YAML deserialiser. The Rule struct is the common
+// in-memory form for both.
+type Rule struct {
+	// Code is the stable, unique rule identifier.
+	Code string
+	// Expr is a CEL expression that evaluates to bool.
+	// true = finding is firing.
+	Expr string
+
+	Severity    Severity
+	Volatility  Volatility
+	Surface     Surface
+	Area        string
+	Scope       DeploymentScope
+	Title       string
+	Detail      string
+	Remediation string
+	DocsURL     string
+
+	// MinServerVersion is the minimum server version that supports all
+	// accessors this rule references. The engine skips rules that require
+	// a newer server version. Empty = no minimum.
+	MinServerVersion string
+}

--- a/server/channels/healthcheck/healthcheck.go
+++ b/server/channels/healthcheck/healthcheck.go
@@ -62,6 +62,42 @@ const (
 	ScopeSelfHosted DeploymentScope = "self_hosted"
 )
 
+// FindingState is the three-valued state of a finding, per DESIGN.md §Flapping.
+// "unknown ≠ resolved" is load-bearing: a temporarily unavailable section must
+// never produce a spurious resolution.
+type FindingState string
+
+const (
+	// FindingStateFiring — rule expression evaluated to true this cycle.
+	FindingStateFiring FindingState = "firing"
+	// FindingStateResolved — rule expression evaluated to false this cycle,
+	// and the finding had a prior firing row. Rules that never fired produce
+	// no row; this state only appears after at least one firing.
+	FindingStateResolved FindingState = "resolved"
+	// FindingStateUnknown — rule could not be evaluated this cycle (section
+	// unavailable, probe not collected, eval error). Neither firing nor
+	// resolved; the prior state is preserved in the store.
+	FindingStateUnknown FindingState = "unknown"
+)
+
+// EvalOutcome is the three-valued result of evaluating a single rule.
+// Every rule in the catalog produces one EvalOutcome per evaluation cycle;
+// [Engine.EvaluateAll] returns one per compiled rule. The reconciler (WS4)
+// consumes this to drive state-machine transitions.
+type EvalOutcome struct {
+	// RuleCode identifies the rule.
+	RuleCode string
+	// Fingerprint is the stable identity key for the findings store. For P1
+	// it is equal to RuleCode. Future rules with multiple simultaneous
+	// instances (e.g. per-plugin, per-DB-replica) will set a distinct
+	// fingerprint per instance.
+	Fingerprint string
+	// State is the outcome of this evaluation cycle.
+	State FindingState
+	// Finding is populated when State == FindingStateFiring.
+	Finding *Finding
+}
+
 // Finding is a single diagnostic result produced when a rule's condition is
 // true. The engine produces one [Finding] per fired rule code.
 //

--- a/server/channels/healthcheck/reconcile.go
+++ b/server/channels/healthcheck/reconcile.go
@@ -1,0 +1,197 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package healthcheck
+
+// FindingRecord is the persisted state of a single finding, keyed by
+// Fingerprint. It is the in-memory representation of one row in the
+// HealthCheckFindings table.
+type FindingRecord struct {
+	// Fingerprint is the stable, unique key for this finding instance.
+	// For P1 it equals the rule code. Future rules with multiple instances
+	// (per-plugin, per-replica) will set a distinct fingerprint per instance.
+	Fingerprint string
+	// RuleCode is the rule that produced this finding.
+	RuleCode string
+	// State is the current state-machine state.
+	State FindingState
+
+	// FirstFiredAt is the Unix-ms timestamp when the finding first entered
+	// the firing state.
+	FirstFiredAt int64
+	// LastFiredAt is the Unix-ms timestamp of the most recent evaluation cycle
+	// in which the rule was firing.
+	LastFiredAt int64
+	// ResolvedAt is the Unix-ms timestamp when the finding last transitioned
+	// to resolved. Zero if never resolved.
+	ResolvedAt int64
+
+	// ConsecutiveFailures counts how many consecutive evaluation cycles
+	// produced a firing outcome (for probe-class debounce).
+	// Reset to 0 on resolved. Not modified on unknown.
+	ConsecutiveFailures int
+
+	// MutedAt is the Unix-ms timestamp when the finding was muted.
+	// Zero means not muted. Mute persists across resolve→refire per decision #6.
+	MutedAt int64
+	// MutedByUserID is the user ID that muted the finding. Empty when not muted.
+	MutedByUserID string
+}
+
+// debounce thresholds per volatility class. These are the minimum number of
+// consecutive firing outcomes before a rule enters FindingStateFiring in the
+// store.
+//
+// Values are deliberately small (chosen for testability and initial
+// conservatism). The "real" per-class values are a parked build detail —
+// adjust once false-positive data from P1 soak is available.
+const (
+	debounceProbe             = 2 // probe rules fire after 2 consecutive failures
+	debounceClusterMembership = 3
+)
+
+// ReconcileResult holds the full outcome of one reconcile call.
+type ReconcileResult struct {
+	// Updated contains all records that changed state or counters this cycle.
+	Updated []FindingRecord
+	// Unchanged contains records that required no change this cycle.
+	Unchanged []FindingRecord
+}
+
+// Reconcile applies one evaluation cycle's outcomes to the prior persisted
+// state and returns updated records. It is a pure function: no I/O, no
+// time.Now(). The caller injects nowMS (Unix milliseconds) and provides the
+// prior state as a fingerprint-keyed map.
+//
+// State-machine transitions per volatility class:
+//
+//	stable:            firing → immediate FireState; false → immediate resolved.
+//	probe:             firing → increment ConsecutiveFailures; fires at ≥ debounceProbe.
+//	                   resolved → immediate resolved + reset counter.
+//	                   unknown  → counter unchanged, state unchanged.
+//	cluster_membership: same as probe with debounceClusterMembership threshold.
+//	boundary/feed:     treated as stable for now (no rules exercise them in P1).
+//	any:               unknown → state unchanged, counter unchanged.
+//
+// "Resolved only applies to fingerprints with a prior row" means: if a
+// fingerprint has no prior record and the outcome is resolved/unknown, no new
+// row is created.
+func Reconcile(
+	outcomes []EvalOutcome,
+	prior map[string]FindingRecord,
+	rules map[string]Rule,
+	nowMS int64,
+) ReconcileResult {
+	var result ReconcileResult
+
+	seen := make(map[string]struct{}, len(outcomes))
+
+	for _, o := range outcomes {
+		fp := o.Fingerprint
+		seen[fp] = struct{}{}
+
+		rule, hasRule := rules[o.RuleCode]
+		if !hasRule {
+			// Defensive: unknown rule code — treat as stable.
+			rule = Rule{Code: o.RuleCode, Volatility: VolatilityStable}
+		}
+
+		prev, hasPrev := prior[fp]
+
+		switch o.State {
+		case FindingStateUnknown:
+			// Unknown: preserve prior state and counter unchanged.
+			if hasPrev {
+				result.Unchanged = append(result.Unchanged, prev)
+			}
+			// No prior record + unknown → nothing to persist.
+
+		case FindingStateResolved:
+			if !hasPrev {
+				// Never fired, evaluates false → nothing to persist.
+				continue
+			}
+			if prev.State == FindingStateResolved {
+				// Already resolved — nothing changed.
+				result.Unchanged = append(result.Unchanged, prev)
+				continue
+			}
+			// Transition to resolved.
+			rec := prev
+			rec.State = FindingStateResolved
+			rec.ConsecutiveFailures = 0
+			rec.ResolvedAt = nowMS
+			result.Updated = append(result.Updated, rec)
+
+		case FindingStateFiring:
+			debounceThreshold := debounceForVolatility(rule.Volatility)
+
+			if !hasPrev {
+				// First-ever firing for this fingerprint.
+				consecutiveFails := 1
+				newState := FindingStateFiring
+				if debounceThreshold > 1 {
+					// Not yet at the debounce threshold; hold as unknown
+					// until the counter reaches threshold.
+					newState = FindingStateUnknown
+				}
+				rec := FindingRecord{
+					Fingerprint:         fp,
+					RuleCode:            o.RuleCode,
+					State:               newState,
+					ConsecutiveFailures: consecutiveFails,
+				}
+				if newState == FindingStateFiring {
+					rec.FirstFiredAt = nowMS
+					rec.LastFiredAt = nowMS
+				}
+				result.Updated = append(result.Updated, rec)
+				continue
+			}
+
+			// Update consecutive failures counter.
+			newFails := prev.ConsecutiveFailures + 1
+			rec := prev
+			rec.ConsecutiveFailures = newFails
+
+			if newFails >= debounceThreshold {
+				// At or above threshold — fire (or stay firing).
+				if rec.State != FindingStateFiring {
+					rec.State = FindingStateFiring
+					if rec.FirstFiredAt == 0 {
+						rec.FirstFiredAt = nowMS
+					}
+				}
+				rec.LastFiredAt = nowMS
+				result.Updated = append(result.Updated, rec)
+			} else {
+				// Below threshold — state is still unknown/pre-fire.
+				rec.State = FindingStateUnknown
+				result.Updated = append(result.Updated, rec)
+			}
+		}
+	}
+
+	// Fingerprints that had a prior row but were absent from this cycle's
+	// outcomes (rule removed from catalog, etc.): leave them unchanged.
+	for fp, rec := range prior {
+		if _, wasSeen := seen[fp]; !wasSeen {
+			result.Unchanged = append(result.Unchanged, rec)
+		}
+	}
+
+	return result
+}
+
+// debounceForVolatility returns the consecutive-failure threshold for the
+// given volatility class. Stable / boundary / feed use 1 (fire immediately).
+func debounceForVolatility(v Volatility) int {
+	switch v {
+	case VolatilityProbe:
+		return debounceProbe
+	case VolatilityClusterMembership:
+		return debounceClusterMembership
+	default:
+		return 1
+	}
+}

--- a/server/channels/healthcheck/reconcile_test.go
+++ b/server/channels/healthcheck/reconcile_test.go
@@ -1,0 +1,333 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package healthcheck
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+const testNow = int64(1_700_000_000_000) // arbitrary fixed timestamp
+
+func stableRule(code string) Rule {
+	return Rule{Code: code, Volatility: VolatilityStable}
+}
+
+func probeRule(code string) Rule {
+	return Rule{Code: code, Volatility: VolatilityProbe}
+}
+
+func rulesMap(rules ...Rule) map[string]Rule {
+	m := make(map[string]Rule, len(rules))
+	for _, r := range rules {
+		m[r.Code] = r
+	}
+	return m
+}
+
+func firingOutcome(code string) EvalOutcome {
+	f := &Finding{Code: code, RuleCode: code}
+	return EvalOutcome{RuleCode: code, Fingerprint: code, State: FindingStateFiring, Finding: f}
+}
+
+func resolvedOutcome(code string) EvalOutcome {
+	return EvalOutcome{RuleCode: code, Fingerprint: code, State: FindingStateResolved}
+}
+
+func unknownOutcome(code string) EvalOutcome {
+	return EvalOutcome{RuleCode: code, Fingerprint: code, State: FindingStateUnknown}
+}
+
+// findRecord returns the first record with the given fingerprint from a slice.
+func findRecord(records []FindingRecord, fp string) (FindingRecord, bool) {
+	for _, r := range records {
+		if r.Fingerprint == fp {
+			return r, true
+		}
+	}
+	return FindingRecord{}, false
+}
+
+// ---------------------------------------------------------------------------
+// Stable volatility class
+// ---------------------------------------------------------------------------
+
+func TestReconcile_Stable_FirstFiring(t *testing.T) {
+	outcomes := []EvalOutcome{firingOutcome("X")}
+	result := Reconcile(outcomes, nil, rulesMap(stableRule("X")), testNow)
+
+	require.Len(t, result.Updated, 1)
+	rec := result.Updated[0]
+	assert.Equal(t, "X", rec.Fingerprint)
+	assert.Equal(t, FindingStateFiring, rec.State)
+	assert.Equal(t, testNow, rec.FirstFiredAt)
+	assert.Equal(t, testNow, rec.LastFiredAt)
+	assert.Equal(t, 1, rec.ConsecutiveFailures)
+}
+
+func TestReconcile_Stable_StaysFiring(t *testing.T) {
+	prior := map[string]FindingRecord{
+		"X": {Fingerprint: "X", RuleCode: "X", State: FindingStateFiring, FirstFiredAt: testNow - 1000, LastFiredAt: testNow - 1000, ConsecutiveFailures: 1},
+	}
+	outcomes := []EvalOutcome{firingOutcome("X")}
+	result := Reconcile(outcomes, prior, rulesMap(stableRule("X")), testNow)
+
+	require.Len(t, result.Updated, 1)
+	rec := result.Updated[0]
+	assert.Equal(t, FindingStateFiring, rec.State)
+	assert.Equal(t, testNow-1000, rec.FirstFiredAt, "FirstFiredAt must not change once set")
+	assert.Equal(t, testNow, rec.LastFiredAt, "LastFiredAt updates each cycle")
+}
+
+func TestReconcile_Stable_Resolves(t *testing.T) {
+	prior := map[string]FindingRecord{
+		"X": {Fingerprint: "X", RuleCode: "X", State: FindingStateFiring, FirstFiredAt: testNow - 1000, LastFiredAt: testNow - 1000, ConsecutiveFailures: 1},
+	}
+	outcomes := []EvalOutcome{resolvedOutcome("X")}
+	result := Reconcile(outcomes, prior, rulesMap(stableRule("X")), testNow)
+
+	require.Len(t, result.Updated, 1)
+	rec := result.Updated[0]
+	assert.Equal(t, FindingStateResolved, rec.State)
+	assert.Equal(t, 0, rec.ConsecutiveFailures, "counter resets on resolve")
+	assert.Equal(t, testNow, rec.ResolvedAt)
+}
+
+func TestReconcile_Stable_ResolvedWithNoPriorRow_NoRecord(t *testing.T) {
+	// A rule that has never fired and evaluates false → no row created.
+	outcomes := []EvalOutcome{resolvedOutcome("X")}
+	result := Reconcile(outcomes, nil, rulesMap(stableRule("X")), testNow)
+
+	assert.Empty(t, result.Updated, "resolved with no prior row must not create a record")
+	assert.Empty(t, result.Unchanged)
+}
+
+func TestReconcile_Stable_AlreadyResolved_NoChange(t *testing.T) {
+	prior := map[string]FindingRecord{
+		"X": {Fingerprint: "X", RuleCode: "X", State: FindingStateResolved, ResolvedAt: testNow - 1000},
+	}
+	outcomes := []EvalOutcome{resolvedOutcome("X")}
+	result := Reconcile(outcomes, prior, rulesMap(stableRule("X")), testNow)
+
+	assert.Empty(t, result.Updated)
+	require.Len(t, result.Unchanged, 1)
+	assert.Equal(t, FindingStateResolved, result.Unchanged[0].State)
+}
+
+// ---------------------------------------------------------------------------
+// Probe volatility class (consecutive-failure debounce)
+// ---------------------------------------------------------------------------
+
+func TestReconcile_Probe_FiresBelowThreshold_Unknown(t *testing.T) {
+	// First failure: counter=1, below debounceProbe=2 → state=unknown.
+	outcomes := []EvalOutcome{firingOutcome("P")}
+	result := Reconcile(outcomes, nil, rulesMap(probeRule("P")), testNow)
+
+	require.Len(t, result.Updated, 1)
+	rec := result.Updated[0]
+	assert.Equal(t, FindingStateUnknown, rec.State, "below debounce threshold must be unknown")
+	assert.Equal(t, 1, rec.ConsecutiveFailures)
+}
+
+func TestReconcile_Probe_FiresAtThreshold(t *testing.T) {
+	// Second failure: counter reaches debounceProbe=2 → state=firing.
+	prior := map[string]FindingRecord{
+		"P": {Fingerprint: "P", RuleCode: "P", State: FindingStateUnknown, ConsecutiveFailures: 1},
+	}
+	outcomes := []EvalOutcome{firingOutcome("P")}
+	result := Reconcile(outcomes, prior, rulesMap(probeRule("P")), testNow)
+
+	require.Len(t, result.Updated, 1)
+	rec := result.Updated[0]
+	assert.Equal(t, FindingStateFiring, rec.State)
+	assert.Equal(t, 2, rec.ConsecutiveFailures)
+	assert.Equal(t, testNow, rec.FirstFiredAt)
+	assert.Equal(t, testNow, rec.LastFiredAt)
+}
+
+func TestReconcile_Probe_Unknown_CounterUnchanged(t *testing.T) {
+	// Unknown outcome during debounce: counter must NOT change.
+	prior := map[string]FindingRecord{
+		"P": {Fingerprint: "P", RuleCode: "P", State: FindingStateUnknown, ConsecutiveFailures: 1},
+	}
+	outcomes := []EvalOutcome{unknownOutcome("P")}
+	result := Reconcile(outcomes, prior, rulesMap(probeRule("P")), testNow)
+
+	assert.Empty(t, result.Updated)
+	require.Len(t, result.Unchanged, 1)
+	assert.Equal(t, 1, result.Unchanged[0].ConsecutiveFailures, "unknown must not change the counter")
+}
+
+func TestReconcile_Probe_ResolvesResetCounter(t *testing.T) {
+	prior := map[string]FindingRecord{
+		"P": {Fingerprint: "P", RuleCode: "P", State: FindingStateFiring, ConsecutiveFailures: 3, FirstFiredAt: testNow - 5000, LastFiredAt: testNow - 100},
+	}
+	outcomes := []EvalOutcome{resolvedOutcome("P")}
+	result := Reconcile(outcomes, prior, rulesMap(probeRule("P")), testNow)
+
+	require.Len(t, result.Updated, 1)
+	rec := result.Updated[0]
+	assert.Equal(t, FindingStateResolved, rec.State)
+	assert.Equal(t, 0, rec.ConsecutiveFailures, "counter resets on resolve")
+	assert.Equal(t, testNow, rec.ResolvedAt)
+}
+
+func TestReconcile_Probe_RefiresAfterResolve(t *testing.T) {
+	// After a resolve, a new run of failures must start the counter from scratch.
+	prior := map[string]FindingRecord{
+		"P": {Fingerprint: "P", RuleCode: "P", State: FindingStateResolved, ConsecutiveFailures: 0, FirstFiredAt: testNow - 5000, ResolvedAt: testNow - 100},
+	}
+	// First failure after resolve: counter becomes 1, below threshold → unknown.
+	outcomes := []EvalOutcome{firingOutcome("P")}
+	result := Reconcile(outcomes, prior, rulesMap(probeRule("P")), testNow)
+
+	require.Len(t, result.Updated, 1)
+	rec := result.Updated[0]
+	assert.Equal(t, FindingStateUnknown, rec.State)
+	assert.Equal(t, 1, rec.ConsecutiveFailures)
+}
+
+// ---------------------------------------------------------------------------
+// Unknown outcome — state preservation
+// ---------------------------------------------------------------------------
+
+func TestReconcile_Unknown_NoPrior_NoRecord(t *testing.T) {
+	// Unknown with no prior row → nothing persisted.
+	outcomes := []EvalOutcome{unknownOutcome("X")}
+	result := Reconcile(outcomes, nil, rulesMap(stableRule("X")), testNow)
+
+	assert.Empty(t, result.Updated)
+	assert.Empty(t, result.Unchanged)
+}
+
+func TestReconcile_Unknown_WithPrior_Preserved(t *testing.T) {
+	// Unknown with a prior firing row → row preserved unchanged.
+	prior := map[string]FindingRecord{
+		"X": {Fingerprint: "X", RuleCode: "X", State: FindingStateFiring, ConsecutiveFailures: 2},
+	}
+	outcomes := []EvalOutcome{unknownOutcome("X")}
+	result := Reconcile(outcomes, prior, rulesMap(stableRule("X")), testNow)
+
+	assert.Empty(t, result.Updated, "unknown must not change the record")
+	require.Len(t, result.Unchanged, 1)
+	assert.Equal(t, FindingStateFiring, result.Unchanged[0].State, "prior state must be preserved")
+}
+
+// ---------------------------------------------------------------------------
+// Mute persistence
+// ---------------------------------------------------------------------------
+
+func TestReconcile_MutePersistedAcrossResolve(t *testing.T) {
+	// Per decision #6: mute is NOT cleared when a finding resolves.
+	prior := map[string]FindingRecord{
+		"X": {Fingerprint: "X", RuleCode: "X", State: FindingStateFiring, MutedAt: testNow - 1000, MutedByUserID: "user1"},
+	}
+	outcomes := []EvalOutcome{resolvedOutcome("X")}
+	result := Reconcile(outcomes, prior, rulesMap(stableRule("X")), testNow)
+
+	require.Len(t, result.Updated, 1)
+	rec := result.Updated[0]
+	assert.Equal(t, testNow-1000, rec.MutedAt, "mute must persist through resolve")
+	assert.Equal(t, "user1", rec.MutedByUserID)
+}
+
+func TestReconcile_MutePersistedOnRefire(t *testing.T) {
+	// Muted finding re-fires (same fingerprint) → mute remains.
+	prior := map[string]FindingRecord{
+		"X": {Fingerprint: "X", RuleCode: "X", State: FindingStateResolved, MutedAt: testNow - 1000, MutedByUserID: "user1"},
+	}
+	outcomes := []EvalOutcome{firingOutcome("X")}
+	result := Reconcile(outcomes, prior, rulesMap(stableRule("X")), testNow)
+
+	require.Len(t, result.Updated, 1)
+	rec := result.Updated[0]
+	assert.Equal(t, FindingStateFiring, rec.State)
+	assert.Equal(t, testNow-1000, rec.MutedAt, "mute survives refire of same fingerprint")
+}
+
+// ---------------------------------------------------------------------------
+// Multi-rule / multi-fingerprint scenarios
+// ---------------------------------------------------------------------------
+
+func TestReconcile_MultiRule_IndependentTransitions(t *testing.T) {
+	rules := rulesMap(stableRule("A"), probeRule("B"), stableRule("C"))
+	prior := map[string]FindingRecord{
+		"A": {Fingerprint: "A", RuleCode: "A", State: FindingStateFiring, ConsecutiveFailures: 1},
+		"C": {Fingerprint: "C", RuleCode: "C", State: FindingStateFiring, ConsecutiveFailures: 1},
+	}
+	outcomes := []EvalOutcome{
+		resolvedOutcome("A"),
+		firingOutcome("B"), // new probe rule, first fire
+		firingOutcome("C"), // still firing
+	}
+
+	result := Reconcile(outcomes, prior, rules, testNow)
+
+	updated := make(map[string]FindingRecord)
+	for _, r := range result.Updated {
+		updated[r.Fingerprint] = r
+	}
+
+	// A: resolved
+	aRec, ok := updated["A"]
+	require.True(t, ok)
+	assert.Equal(t, FindingStateResolved, aRec.State)
+
+	// B: first fire, below probe threshold → unknown
+	bRec, ok := updated["B"]
+	require.True(t, ok)
+	assert.Equal(t, FindingStateUnknown, bRec.State)
+	assert.Equal(t, 1, bRec.ConsecutiveFailures)
+
+	// C: stays firing
+	cRec, ok := updated["C"]
+	require.True(t, ok)
+	assert.Equal(t, FindingStateFiring, cRec.State)
+}
+
+// ---------------------------------------------------------------------------
+// EvaluateAll integration — ensures engine and reconciler connect correctly
+// ---------------------------------------------------------------------------
+
+func TestEvaluateAll_ThreeValuedOutput(t *testing.T) {
+	engine, err := NewEngine(BuiltinRules)
+	require.NoError(t, err)
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	// Trigger one rule (PUSH_EMPTY_URL).
+	*cfg.EmailSettings.SendPushNotifications = true
+	*cfg.EmailSettings.PushNotificationServer = ""
+	// SiteURL is set by SetDefaults(), so CORE_SITE_URL_EMPTY won't fire.
+	// Probes not collected this cycle.
+	snap := &Snapshot{Config: cfg, Probes: nil}
+
+	outcomes := engine.EvaluateAll(snap)
+
+	byCode := make(map[string]EvalOutcome, len(outcomes))
+	for _, o := range outcomes {
+		byCode[o.RuleCode] = o
+	}
+
+	// PUSH_EMPTY_URL must be firing.
+	push, ok := byCode["PUSH_EMPTY_URL"]
+	require.True(t, ok)
+	assert.Equal(t, FindingStateFiring, push.State)
+	assert.NotNil(t, push.Finding)
+
+	// DB_HEALTHCHECK_FAIL is a probe rule and probe is nil → unknown.
+	probe, ok := byCode["DB_HEALTHCHECK_FAIL"]
+	require.True(t, ok)
+	assert.Equal(t, FindingStateUnknown, probe.State)
+
+	// A non-firing config rule must be resolved.
+	logDebug, ok := byCode["LOG_DEBUG_PROD"]
+	require.True(t, ok)
+	// SetDefaults sets FileLevel=INFO, so LOG_DEBUG_PROD should be resolved.
+	assert.Equal(t, FindingStateResolved, logDebug.State)
+}

--- a/server/channels/healthcheck/snapshot.go
+++ b/server/channels/healthcheck/snapshot.go
@@ -1,0 +1,57 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package healthcheck
+
+import "github.com/mattermost/mattermost/server/public/model"
+
+// Snapshot is a point-in-time view of server state consumed by the rule
+// engine. Each section is optional: a nil section means the data could not
+// be collected (e.g. the probe timed out, or the snapshot was built from a
+// support packet that predates this section). The engine exposes a nil
+// section as the CEL unknown type so rules return "unknown" rather than a
+// false "resolved".
+//
+// Design note (WS2 coordination):
+// The long-term goal is that this struct becomes the canonical schema for
+// both the live evaluation path and the support-packet zip (one snapshot,
+// two outputs — see DESIGN.md "Data model: one snapshot, two outputs"). The
+// current support_packet.go in channels/app does ad-hoc collection; that
+// refactor (typed section collectors feeding both paths) requires
+// coordination with the support-packet owners and is tracked as a follow-up.
+// For P1 the Live provider (see live.go in channels/app) reads live state
+// directly; the Packet provider is a TODO seam.
+type Snapshot struct {
+	// Config holds the sanitized server config. Nil means unavailable.
+	Config *model.Config
+
+	// Probes holds the results of live write probes. Nil means unavailable
+	// or not yet collected for this evaluation pass.
+	Probes *ProbeSection
+}
+
+// ProbeSection holds the results of live connectivity probes.
+//
+// Probes are side-effecting (they write to the DB / filestore) and should
+// not be collected on every evaluation cycle. The evaluation job (WS5) will
+// collect them on a slower sub-cadence controlled by the probe volatility
+// class.
+type ProbeSection struct {
+	// DBWriteOK is true if a test row was successfully written and deleted
+	// from the primary database. False means the write failed; a nil
+	// ProbeSection means the probe was not run in this cycle.
+	DBWriteOK bool
+}
+
+// ProbeProvider is the interface the Live snapshot provider uses to run
+// write probes. Implementations live in the app layer (channels/app) so
+// they can access the store; tests inject a fake.
+//
+// TODO (WS2 — Packet provider): add a PacketProbeProvider that returns
+// "unknown" for all probes, since a support packet captures probe results
+// at generation time rather than running them live.
+type ProbeProvider interface {
+	// DBWrite performs a health-check write+delete on the primary database
+	// and returns true if both operations succeed.
+	DBWrite() bool
+}

--- a/server/channels/healthcheck/store.go
+++ b/server/channels/healthcheck/store.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package healthcheck
+
+// FindingStore is the persistence interface for the health-check findings
+// state machine. It is defined in this package (not in channels/store) so
+// that healthcheck remains a leaf — the sqlstore implementation imports
+// healthcheck, never the reverse.
+//
+// All methods are fingerprint-keyed. A fingerprint is the stable identity of
+// a finding instance (for P1 it equals the rule code).
+type FindingStore interface {
+	// UpsertMany writes the given records to the store, inserting new rows and
+	// updating existing ones. The caller provides the complete updated state;
+	// the store sets UpdatedAt on each row.
+	UpsertMany(records []FindingRecord) error
+
+	// GetAll returns all persisted finding records.
+	GetAll() ([]FindingRecord, error)
+
+	// GetByFingerprint returns the record for a single fingerprint, or
+	// ErrNotFound if no record exists.
+	GetByFingerprint(fingerprint string) (FindingRecord, error)
+
+	// SetMute mutes the finding identified by fingerprint.
+	// mutedAt is the Unix-ms timestamp; mutedByUserID is the muting user.
+	SetMute(fingerprint string, mutedAt int64, mutedByUserID string) error
+
+	// ClearMute removes the mute on the finding identified by fingerprint.
+	ClearMute(fingerprint string) error
+
+	// GetMuted returns all muted findings ("My muted findings" view).
+	GetMuted() ([]FindingRecord, error)
+}
+
+// ErrNotFound is returned by GetByFingerprint when no record exists.
+type ErrNotFound struct{ Fingerprint string }
+
+func (e ErrNotFound) Error() string {
+	return "healthcheck: finding not found: " + e.Fingerprint
+}

--- a/server/channels/store/sqlstore/healthcheck_store.go
+++ b/server/channels/store/sqlstore/healthcheck_store.go
@@ -1,0 +1,198 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package sqlstore
+
+import (
+	"database/sql"
+
+	sq "github.com/mattermost/squirrel"
+	"github.com/pkg/errors"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/channels/healthcheck"
+)
+
+// SqlHealthCheckStore implements [healthcheck.FindingStore] against the shared
+// SqlStore. It is intentionally NOT wired into the monolithic store.Store
+// interface to avoid the store-layers regeneration ceremony (retrylayer /
+// timerlayer / opentracinglayer). The health-check evaluation job (WS5) will
+// construct it directly via NewSqlHealthCheckStore.
+type SqlHealthCheckStore struct {
+	*SqlStore
+	selectQ sq.SelectBuilder
+}
+
+// NewSqlHealthCheckStore constructs a healthcheck.FindingStore backed by the
+// provided SqlStore. The schema must already exist (applied by migration 194).
+func NewSqlHealthCheckStore(ss *SqlStore) healthcheck.FindingStore {
+	s := &SqlHealthCheckStore{SqlStore: ss}
+	s.selectQ = s.getQueryBuilder().
+		Select(
+			"Fingerprint",
+			"RuleCode",
+			"State",
+			"FirstFiredAt",
+			"LastFiredAt",
+			"ResolvedAt",
+			"ConsecutiveFailures",
+			"MutedAt",
+			"MutedByUserId",
+			"UpdatedAt",
+		).
+		From("HealthCheckFindings")
+	return s
+}
+
+// dbFinding is the database row representation. sqlx uses the db struct tags
+// to map columns.
+type dbFinding struct {
+	Fingerprint         string `db:"Fingerprint"`
+	RuleCode            string `db:"RuleCode"`
+	State               string `db:"State"`
+	FirstFiredAt        int64  `db:"FirstFiredAt"`
+	LastFiredAt         int64  `db:"LastFiredAt"`
+	ResolvedAt          int64  `db:"ResolvedAt"`
+	ConsecutiveFailures int    `db:"ConsecutiveFailures"`
+	MutedAt             int64  `db:"MutedAt"`
+	MutedByUserID       string `db:"MutedByUserId"`
+	UpdatedAt           int64  `db:"UpdatedAt"`
+}
+
+func toDBFinding(r healthcheck.FindingRecord, updatedAt int64) dbFinding {
+	return dbFinding{
+		Fingerprint:         r.Fingerprint,
+		RuleCode:            r.RuleCode,
+		State:               string(r.State),
+		FirstFiredAt:        r.FirstFiredAt,
+		LastFiredAt:         r.LastFiredAt,
+		ResolvedAt:          r.ResolvedAt,
+		ConsecutiveFailures: r.ConsecutiveFailures,
+		MutedAt:             r.MutedAt,
+		MutedByUserID:       r.MutedByUserID,
+		UpdatedAt:           updatedAt,
+	}
+}
+
+func fromDBFinding(d dbFinding) healthcheck.FindingRecord {
+	return healthcheck.FindingRecord{
+		Fingerprint:         d.Fingerprint,
+		RuleCode:            d.RuleCode,
+		State:               healthcheck.FindingState(d.State),
+		FirstFiredAt:        d.FirstFiredAt,
+		LastFiredAt:         d.LastFiredAt,
+		ResolvedAt:          d.ResolvedAt,
+		ConsecutiveFailures: d.ConsecutiveFailures,
+		MutedAt:             d.MutedAt,
+		MutedByUserID:       d.MutedByUserID,
+	}
+}
+
+func (s *SqlHealthCheckStore) UpsertMany(records []healthcheck.FindingRecord) error {
+	if len(records) == 0 {
+		return nil
+	}
+
+	now := nowMS()
+
+	for _, r := range records {
+		d := toDBFinding(r, now)
+		_, err := s.GetMaster().NamedExec(`
+			INSERT INTO HealthCheckFindings
+				(Fingerprint, RuleCode, State, FirstFiredAt, LastFiredAt, ResolvedAt,
+				 ConsecutiveFailures, MutedAt, MutedByUserId, UpdatedAt)
+			VALUES
+				(:Fingerprint, :RuleCode, :State, :FirstFiredAt, :LastFiredAt, :ResolvedAt,
+				 :ConsecutiveFailures, :MutedAt, :MutedByUserId, :UpdatedAt)
+			ON CONFLICT (Fingerprint) DO UPDATE SET
+				RuleCode             = EXCLUDED.RuleCode,
+				State                = EXCLUDED.State,
+				FirstFiredAt         = EXCLUDED.FirstFiredAt,
+				LastFiredAt          = EXCLUDED.LastFiredAt,
+				ResolvedAt           = EXCLUDED.ResolvedAt,
+				ConsecutiveFailures  = EXCLUDED.ConsecutiveFailures,
+				MutedAt              = EXCLUDED.MutedAt,
+				MutedByUserId        = EXCLUDED.MutedByUserId,
+				UpdatedAt            = EXCLUDED.UpdatedAt
+		`, &d)
+		if err != nil {
+			return errors.Wrapf(err, "healthcheck: upsert finding %q", r.Fingerprint)
+		}
+	}
+	return nil
+}
+
+func (s *SqlHealthCheckStore) GetAll() ([]healthcheck.FindingRecord, error) {
+	var rows []dbFinding
+	q, args, err := s.selectQ.ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "healthcheck: build GetAll query")
+	}
+	if err := s.GetReplica().Select(&rows, q, args...); err != nil {
+		return nil, errors.Wrap(err, "healthcheck: GetAll")
+	}
+	out := make([]healthcheck.FindingRecord, 0, len(rows))
+	for _, d := range rows {
+		out = append(out, fromDBFinding(d))
+	}
+	return out, nil
+}
+
+func (s *SqlHealthCheckStore) GetByFingerprint(fingerprint string) (healthcheck.FindingRecord, error) {
+	var d dbFinding
+	q, args, err := s.selectQ.Where(sq.Eq{"Fingerprint": fingerprint}).ToSql()
+	if err != nil {
+		return healthcheck.FindingRecord{}, errors.Wrap(err, "healthcheck: build GetByFingerprint query")
+	}
+	if err := s.GetReplica().Get(&d, q, args...); err != nil {
+		if err == sql.ErrNoRows {
+			return healthcheck.FindingRecord{}, healthcheck.ErrNotFound{Fingerprint: fingerprint}
+		}
+		return healthcheck.FindingRecord{}, errors.Wrapf(err, "healthcheck: GetByFingerprint %q", fingerprint)
+	}
+	return fromDBFinding(d), nil
+}
+
+func (s *SqlHealthCheckStore) SetMute(fingerprint string, mutedAt int64, mutedByUserID string) error {
+	_, err := s.GetMaster().Exec(
+		`UPDATE HealthCheckFindings SET MutedAt = $1, MutedByUserId = $2, UpdatedAt = $3 WHERE Fingerprint = $4`,
+		mutedAt, mutedByUserID, nowMS(), fingerprint,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "healthcheck: SetMute %q", fingerprint)
+	}
+	return nil
+}
+
+func (s *SqlHealthCheckStore) ClearMute(fingerprint string) error {
+	_, err := s.GetMaster().Exec(
+		`UPDATE HealthCheckFindings SET MutedAt = 0, MutedByUserId = '', UpdatedAt = $1 WHERE Fingerprint = $2`,
+		nowMS(), fingerprint,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "healthcheck: ClearMute %q", fingerprint)
+	}
+	return nil
+}
+
+func (s *SqlHealthCheckStore) GetMuted() ([]healthcheck.FindingRecord, error) {
+	var rows []dbFinding
+	q, args, err := s.selectQ.Where(sq.Gt{"MutedAt": 0}).ToSql()
+	if err != nil {
+		return nil, errors.Wrap(err, "healthcheck: build GetMuted query")
+	}
+	if err := s.GetReplica().Select(&rows, q, args...); err != nil {
+		return nil, errors.Wrap(err, "healthcheck: GetMuted")
+	}
+	out := make([]healthcheck.FindingRecord, 0, len(rows))
+	for _, d := range rows {
+		out = append(out, fromDBFinding(d))
+	}
+	return out, nil
+}
+
+// nowMS returns the current time as Unix milliseconds, consistent with the
+// rest of the store layer.
+func nowMS() int64 {
+	return model.GetMillis()
+}

--- a/server/go.mod
+++ b/server/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/golang-migrate/migrate/v4 v4.19.1
 	github.com/golang/freetype v0.0.0-20170609003504-e2365dfdc4a0
 	github.com/golang/mock v1.6.0
+	github.com/google/cel-go v0.28.1
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/handlers v1.5.2
 	github.com/gorilla/mux v1.8.1

--- a/server/go.sum
+++ b/server/go.sum
@@ -241,6 +241,8 @@ github.com/gomodule/redigo v2.0.0+incompatible/go.mod h1:B4C85qUVwatsJoIUNIfCRsp
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
 github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
+github.com/google/cel-go v0.28.1 h1:YWIwi77J4xIsYUwAF/iIuS6haffzIHS8yWI8glSbLWM=
+github.com/google/cel-go v0.28.1/go.mod h1:X0bD6iVNR8pkROSOoHVdgTkzmRcosof7WQqCD6wcMc8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=


### PR DESCRIPTION
## Summary

Introduces \`server/channels/healthcheck\` — the Phase 1 rule engine, typed snapshot model, and first 16 rules for the Built-in Health Dashboard. De-risking spike + thin vertical slice (WS1+WS2+WS3).

**Spike exit criteria met:** cel-go NativeTypes over \`*model.Config\`, \`probe.dbWrite()\` custom function, CEL \`matches()\` — all working. Two findings produced from crafted snapshots. 23 tests, all green.

## What's included

**WS1 — engine.go:** CEL env with typed \`config.*\` over \`model.Config\` (renamed field = compile error), \`probe.dbWrite()\` per-snapshot binding, \`Engine.Evaluate()\`, \`Validate()\` static validator.

**WS2 — snapshot.go:** Typed \`Snapshot{Config, Probes}\`, \`ProbeProvider\` interface. TODO seam for full WS2 refactor (support_packet.go coordination).

**WS3 — catalog.go:** 16 rules across 7 areas: push notifications (3), DB probe (1), site URL (2), logging (2), SAML (3), filestore (2), compliance (1), data retention (2).

## Package location

\`server/channels/healthcheck\` (main module) not \`server/public/healthcheck\`: cel-go is too heavy for the plugin-facing public module; mmctl is in the same main module; probe live impl needs app layer.

## Spike friction

\`ext.NativeTypes\` needs \`reflect.Type\` not a pointer value. \`cel.Functions\` (deprecated for static impls) is correct for per-snapshot dynamic injection. Both documented in code.

## Not in this PR

WS2 full section collectors, WS3 remaining ~47 rules, WS4 store, WS5 job, WS6 API/mmctl, WS7 UI. Branch needs MM ticket number prefix once assigned.