### PR TITLE
[MM-69228] Default the CJKSearch feature flag to true

### DIFF
--- a/e2e-tests/playwright/lib/src/server/default_config.ts
+++ b/e2e-tests/playwright/lib/src/server/default_config.ts
@@ -787,7 +787,7 @@ const defaultServerConfig: AdminConfig = {
         EnableAIRecaps: false,
         ClassificationMarkings: true,
         IntegratedBoards: false,
-        CJKSearch: false,
+        CJKSearch: true,
         ManagedChannelCategories: false,
         MobileEphemeralMode: true,
     },

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -202,7 +202,7 @@ func (f *FeatureFlags) SetDefaults() {
 
 	f.IntegratedBoards = false
 
-	f.CJKSearch = false
+	f.CJKSearch = true
 
 	f.AggregatePluginMetrics = false
 


### PR DESCRIPTION
#### Summary
Promotes the `CJKSearch` feature flag to be enabled by default. This flag gates the LIKE-based CJK (Chinese, Japanese, Korean) search path for PostgreSQL in the post store. The Playwright e2e default config is updated to mirror the new default.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-69228

```release-note
Enabled CJK (Chinese, Japanese, Korean) search by default for PostgreSQL.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** This change enables the LIKE-based CJK search path by default for all PostgreSQL users with Chinese, Japanese, or Korean text. While the code path is well-tested with dedicated tests in `cjk_plugins.go`, enabling this previously opt-in feature by default changes the search behavior and performance characteristics for CJK queries, potentially affecting users who were relying on the full-text search approach.

**QA Recommendation:** Manual QA testing is recommended to validate CJK search behavior and performance with PostgreSQL across different CJK language variants (Chinese, Japanese, Korean). Focus testing on search result accuracy, performance under load with CJK queries, and comparison with previous full-text search behavior. Automated test coverage for CJK search paths exists and is comprehensive.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->