### PR TITLE
Seed display names for session attribute fields

### DIFF
--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -10732,7 +10732,7 @@ func TestGetSessionAttributesManifest(t *testing.T) {
 			}
 		}
 		require.NotNil(t, hardwareEntry)
-		require.Equal(t, "Hardware ID", hardwareEntry.DisplayName)
+		require.Equal(t, model.SessionAttributesDisplayNameHardwareID, hardwareEntry.DisplayName)
 	})
 }
 

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -10693,6 +10693,47 @@ func TestGetSessionAttributesManifest(t *testing.T) {
 		CheckOKStatus(t, resp)
 		require.Empty(t, manifest)
 	})
+
+	t.Run("enabled field carries its seeded display name", func(t *testing.T) {
+		const desktopUserAgent = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_12_6) AppleWebKit/537.36 (KHTML, like Gecko) Mattermost/3.7.1 Chrome/56.0.2924.87 Electron/1.6.11 Safari/537.36"
+
+		group, appErr := th.App.GetPropertyGroup(th.Context, model.SessionAttributesPropertyGroupName)
+		require.Nil(t, appErr)
+		fields, appErr := th.App.SearchPropertyFields(th.Context, group.ID, model.PropertyFieldSearchOpts{PerPage: 100})
+		require.Nil(t, appErr)
+
+		var hardwareField *model.PropertyField
+		for _, field := range fields {
+			if field.Name == model.SessionAttributesPropertyFieldHardwareID {
+				hardwareField = field
+				break
+			}
+		}
+		require.NotNil(t, hardwareField)
+		if hardwareField.Attrs == nil {
+			hardwareField.Attrs = model.StringInterface{}
+		}
+		hardwareField.Attrs["enabled"] = true
+		_, _, appErr = th.App.UpdatePropertyFields(th.Context, group.ID, []*model.PropertyField{hardwareField}, true, "")
+		require.Nil(t, appErr)
+
+		th.Client.HTTPHeader = map[string]string{"User-Agent": desktopUserAgent}
+		defer func() { th.Client.HTTPHeader = nil }()
+
+		manifest, resp, err := th.Client.GetSessionAttributesManifest(context.Background())
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		var hardwareEntry *model.SessionAttributeManifestEntry
+		for _, entry := range manifest {
+			if entry.Name == model.SessionAttributesPropertyFieldHardwareID {
+				hardwareEntry = entry
+				break
+			}
+		}
+		require.NotNil(t, hardwareEntry)
+		require.Equal(t, "Hardware ID", hardwareEntry.DisplayName)
+	})
 }
 
 // setSessionAttributeDeviceID configures the test client to send a desktop

--- a/server/channels/app/migrations.go
+++ b/server/channels/app/migrations.go
@@ -892,6 +892,7 @@ func (s *Server) seedSessionAttributeFields(groupID string) error {
 		if current, ok := existingByName[expected.Name]; ok {
 			current.Type = expected.Type
 			current.Attrs["platforms"] = expected.Attrs["platforms"]
+			current.Attrs[model.SAAttrDisplayName] = expected.Attrs[model.SAAttrDisplayName]
 			current.ObjectType = expected.ObjectType
 			current.TargetType = expected.TargetType
 			current.Protected = expected.Protected

--- a/server/channels/app/migrations_test.go
+++ b/server/channels/app/migrations_test.go
@@ -387,6 +387,7 @@ func TestDoSetupSessionAttributesProperties(t *testing.T) {
 			require.NotNil(t, field.PermissionValues)
 			require.Equal(t, model.PermissionLevelSysadmin, *field.PermissionValues, "field %q permission_values", field.Name)
 			require.Equal(t, false, field.Attrs["enabled"], "field %q must seed disabled", field.Name)
+			require.NotEmpty(t, field.Attrs[model.SAAttrDisplayName], "field %q must seed a display name", field.Name)
 		}
 
 		ipField := fieldsByName[model.SessionAttributesPropertyFieldIPAddress]
@@ -401,6 +402,7 @@ func TestDoSetupSessionAttributesProperties(t *testing.T) {
 		// The typed attrs must survive the DB round trip so the app reads back what it seeded.
 		saField, err := model.SAFieldFromPropertyField(networkField)
 		require.NoError(t, err)
+		require.Equal(t, "Network interface type", saField.Attrs.DisplayName)
 		require.Equal(t, model.SessionAttributeDefaultTTLNetworkIdentity, saField.Attrs.TTLSeconds)
 		require.Equal(t, model.SessionAttributeDefaultGraceNetworkIdentity, saField.Attrs.GracePeriodSeconds)
 		require.ElementsMatch(t,

--- a/server/channels/app/migrations_test.go
+++ b/server/channels/app/migrations_test.go
@@ -402,7 +402,7 @@ func TestDoSetupSessionAttributesProperties(t *testing.T) {
 		// The typed attrs must survive the DB round trip so the app reads back what it seeded.
 		saField, err := model.SAFieldFromPropertyField(networkField)
 		require.NoError(t, err)
-		require.Equal(t, "Network interface type", saField.Attrs.DisplayName)
+		require.Equal(t, model.SessionAttributesDisplayNameNetworkInterfaceType, saField.Attrs.DisplayName)
 		require.Equal(t, model.SessionAttributeDefaultTTLNetworkIdentity, saField.Attrs.TTLSeconds)
 		require.Equal(t, model.SessionAttributeDefaultGraceNetworkIdentity, saField.Attrs.GracePeriodSeconds)
 		require.ElementsMatch(t,

--- a/server/public/model/session_attributes.go
+++ b/server/public/model/session_attributes.go
@@ -184,8 +184,9 @@ func sessionAttributeFieldAttrs(platforms []string, ttl, grace int) StringInterf
 	}
 }
 
-func sessionAttributeField(groupID, name string, fieldType PropertyFieldType, platforms []string, ttl, grace int, extraAttrs StringInterface) *PropertyField {
+func sessionAttributeField(groupID, name, displayName string, fieldType PropertyFieldType, platforms []string, ttl, grace int, extraAttrs StringInterface) *PropertyField {
 	attrs := sessionAttributeFieldAttrs(platforms, ttl, grace)
+	attrs[SAAttrDisplayName] = displayName
 	maps.Copy(attrs, extraAttrs)
 	return &PropertyField{
 		GroupID:           groupID,
@@ -217,9 +218,9 @@ func SessionAttributeSystemFields(groupID string) []*PropertyField {
 	}
 
 	return []*PropertyField{
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldIPAddress, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientIPAddress, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldNetworkInterfaceType, PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, StringInterface{
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldIPAddress, "IP address", PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientIPAddress, "Client IP address", PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldNetworkInterfaceType, "Network interface type", PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, StringInterface{
 			PropertyFieldAttributeOptions: []map[string]string{
 				{"name": "wifi"},
 				{"name": "ethernet"},
@@ -229,23 +230,23 @@ func SessionAttributeSystemFields(groupID string) []*PropertyField {
 				{"name": "other"},
 			},
 		}),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldVPNActive, PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, boolSelectOptions),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldSSID, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldVPNActive, "VPN active", PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, boolSelectOptions),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldSSID, "SSID", PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
 
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldMDMEnrolled, PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, boolSelectOptions),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldJailbreakDetected, PropertyFieldTypeSelect, mobileOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, boolSelectOptions),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldOSPlatform, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldOSVersion, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientVersion, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldMDMEnrolled, "MDM enrolled", PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, boolSelectOptions),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldJailbreakDetected, "Jailbreak detected", PropertyFieldTypeSelect, mobileOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, boolSelectOptions),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldOSPlatform, "OS platform", PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldOSVersion, "OS version", PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientVersion, "Client version", PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
 
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentPlatform, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentOS, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentBrowserName, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentBrowserVersion, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldTLSDDeviceID, PropertyFieldTypeText, desktopBrowser, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientDeviceID, PropertyFieldTypeText, mobileOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldHardwareID, PropertyFieldTypeText, desktopOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldServerFQDN, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientFQDN, PropertyFieldTypeText, desktopOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentPlatform, "User agent platform", PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentOS, "User agent OS", PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentBrowserName, "User agent browser name", PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentBrowserVersion, "User agent browser version", PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldTLSDDeviceID, "TLS device ID", PropertyFieldTypeText, desktopBrowser, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientDeviceID, "Device ID", PropertyFieldTypeText, mobileOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldHardwareID, "Hardware ID", PropertyFieldTypeText, desktopOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldServerFQDN, "Server FQDN", PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientFQDN, "Client FQDN", PropertyFieldTypeText, desktopOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
 	}
 }

--- a/server/public/model/session_attributes.go
+++ b/server/public/model/session_attributes.go
@@ -41,6 +41,28 @@ const (
 )
 
 const (
+	SessionAttributesDisplayNameClientIPAddress         = "Client IP address"
+	SessionAttributesDisplayNameNetworkInterfaceType    = "Network interface type"
+	SessionAttributesDisplayNameVPNActive               = "VPN active"
+	SessionAttributesDisplayNameSSID                    = "SSID"
+	SessionAttributesDisplayNameTLSDDeviceID            = "TLS device ID"
+	SessionAttributesDisplayNameClientDeviceID          = "Device ID"
+	SessionAttributesDisplayNameMDMEnrolled             = "MDM enrolled"
+	SessionAttributesDisplayNameHardwareID              = "Hardware ID"
+	SessionAttributesDisplayNameOSPlatform              = "OS platform"
+	SessionAttributesDisplayNameOSVersion               = "OS version"
+	SessionAttributesDisplayNameClientVersion           = "Client version"
+	SessionAttributesDisplayNameJailbreakDetected       = "Jailbreak detected"
+	SessionAttributesDisplayNameServerFQDN              = "Server FQDN"
+	SessionAttributesDisplayNameClientFQDN              = "Client FQDN"
+	SessionAttributesDisplayNameUserAgentPlatform       = "User agent platform"
+	SessionAttributesDisplayNameUserAgentOS             = "User agent OS"
+	SessionAttributesDisplayNameUserAgentBrowserName    = "User agent browser name"
+	SessionAttributesDisplayNameUserAgentBrowserVersion = "User agent browser version"
+	SessionAttributesDisplayNameIPAddress               = "IP address"
+)
+
+const (
 	SAAttrEnabled            = "enabled"
 	SAAttrPlatforms          = "platforms"
 	SAAttrTTLSeconds         = "ttl_seconds"
@@ -218,9 +240,9 @@ func SessionAttributeSystemFields(groupID string) []*PropertyField {
 	}
 
 	return []*PropertyField{
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldIPAddress, "IP address", PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientIPAddress, "Client IP address", PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldNetworkInterfaceType, "Network interface type", PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, StringInterface{
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldIPAddress, SessionAttributesDisplayNameIPAddress, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientIPAddress, SessionAttributesDisplayNameClientIPAddress, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldNetworkInterfaceType, SessionAttributesDisplayNameNetworkInterfaceType, PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, StringInterface{
 			PropertyFieldAttributeOptions: []map[string]string{
 				{"name": "wifi"},
 				{"name": "ethernet"},
@@ -230,23 +252,23 @@ func SessionAttributeSystemFields(groupID string) []*PropertyField {
 				{"name": "other"},
 			},
 		}),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldVPNActive, "VPN active", PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, boolSelectOptions),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldSSID, "SSID", PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldVPNActive, SessionAttributesDisplayNameVPNActive, PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, boolSelectOptions),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldSSID, SessionAttributesDisplayNameSSID, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLNetworkIdentity, SessionAttributeDefaultGraceNetworkIdentity, nil),
 
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldMDMEnrolled, "MDM enrolled", PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, boolSelectOptions),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldJailbreakDetected, "Jailbreak detected", PropertyFieldTypeSelect, mobileOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, boolSelectOptions),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldOSPlatform, "OS platform", PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldOSVersion, "OS version", PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientVersion, "Client version", PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldMDMEnrolled, SessionAttributesDisplayNameMDMEnrolled, PropertyFieldTypeSelect, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, boolSelectOptions),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldJailbreakDetected, SessionAttributesDisplayNameJailbreakDetected, PropertyFieldTypeSelect, mobileOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, boolSelectOptions),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldOSPlatform, SessionAttributesDisplayNameOSPlatform, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldOSVersion, SessionAttributesDisplayNameOSVersion, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientVersion, SessionAttributesDisplayNameClientVersion, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLPosture, SessionAttributeDefaultGracePosture, nil),
 
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentPlatform, "User agent platform", PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentOS, "User agent OS", PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentBrowserName, "User agent browser name", PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentBrowserVersion, "User agent browser version", PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldTLSDDeviceID, "TLS device ID", PropertyFieldTypeText, desktopBrowser, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientDeviceID, "Device ID", PropertyFieldTypeText, mobileOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldHardwareID, "Hardware ID", PropertyFieldTypeText, desktopOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldServerFQDN, "Server FQDN", PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
-		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientFQDN, "Client FQDN", PropertyFieldTypeText, desktopOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentPlatform, SessionAttributesDisplayNameUserAgentPlatform, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentOS, SessionAttributesDisplayNameUserAgentOS, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentBrowserName, SessionAttributesDisplayNameUserAgentBrowserName, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldUserAgentBrowserVersion, SessionAttributesDisplayNameUserAgentBrowserVersion, PropertyFieldTypeText, allPlatforms, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldTLSDDeviceID, SessionAttributesDisplayNameTLSDDeviceID, PropertyFieldTypeText, desktopBrowser, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientDeviceID, SessionAttributesDisplayNameClientDeviceID, PropertyFieldTypeText, mobileOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldHardwareID, SessionAttributesDisplayNameHardwareID, PropertyFieldTypeText, desktopOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldServerFQDN, SessionAttributesDisplayNameServerFQDN, PropertyFieldTypeText, clientsOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
+		sessionAttributeField(groupID, SessionAttributesPropertyFieldClientFQDN, SessionAttributesDisplayNameClientFQDN, PropertyFieldTypeText, desktopOnly, SessionAttributeDefaultTTLIdentity, SessionAttributeDefaultGraceIdentity, nil),
 	}
 }

--- a/server/public/model/session_attributes_test.go
+++ b/server/public/model/session_attributes_test.go
@@ -46,17 +46,17 @@ func TestSessionAttributeSystemFieldsDisplayNames(t *testing.T) {
 	}
 
 	expected := map[string]string{
-		SessionAttributesPropertyFieldClientIPAddress:      "Client IP address",
-		SessionAttributesPropertyFieldNetworkInterfaceType: "Network interface type",
-		SessionAttributesPropertyFieldVPNActive:            "VPN active",
-		SessionAttributesPropertyFieldSSID:                 "SSID",
-		SessionAttributesPropertyFieldClientDeviceID:       "Device ID",
-		SessionAttributesPropertyFieldHardwareID:           "Hardware ID",
-		SessionAttributesPropertyFieldMDMEnrolled:          "MDM enrolled",
-		SessionAttributesPropertyFieldClientVersion:        "Client version",
-		SessionAttributesPropertyFieldOSPlatform:           "OS platform",
-		SessionAttributesPropertyFieldOSVersion:            "OS version",
-		SessionAttributesPropertyFieldJailbreakDetected:    "Jailbreak detected",
+		SessionAttributesPropertyFieldClientIPAddress:      SessionAttributesDisplayNameClientIPAddress,
+		SessionAttributesPropertyFieldNetworkInterfaceType: SessionAttributesDisplayNameNetworkInterfaceType,
+		SessionAttributesPropertyFieldVPNActive:            SessionAttributesDisplayNameVPNActive,
+		SessionAttributesPropertyFieldSSID:                 SessionAttributesDisplayNameSSID,
+		SessionAttributesPropertyFieldClientDeviceID:       SessionAttributesDisplayNameClientDeviceID,
+		SessionAttributesPropertyFieldHardwareID:           SessionAttributesDisplayNameHardwareID,
+		SessionAttributesPropertyFieldMDMEnrolled:          SessionAttributesDisplayNameMDMEnrolled,
+		SessionAttributesPropertyFieldClientVersion:        SessionAttributesDisplayNameClientVersion,
+		SessionAttributesPropertyFieldOSPlatform:           SessionAttributesDisplayNameOSPlatform,
+		SessionAttributesPropertyFieldOSVersion:            SessionAttributesDisplayNameOSVersion,
+		SessionAttributesPropertyFieldJailbreakDetected:    SessionAttributesDisplayNameJailbreakDetected,
 	}
 	for name, displayName := range expected {
 		assert.Equal(t, displayName, displayNamesByName[name], "display name for %q", name)

--- a/server/public/model/session_attributes_test.go
+++ b/server/public/model/session_attributes_test.go
@@ -33,6 +33,36 @@ func TestSAFieldFromPropertyField(t *testing.T) {
 	assert.Equal(t, "VPN Active", saField.Attrs.DisplayName)
 }
 
+func TestSessionAttributeSystemFieldsDisplayNames(t *testing.T) {
+	fields := SessionAttributeSystemFields("group-id")
+	require.NotEmpty(t, fields)
+
+	displayNamesByName := make(map[string]string, len(fields))
+	for _, field := range fields {
+		saField, err := SAFieldFromPropertyField(field)
+		require.NoError(t, err)
+		require.NotEmpty(t, saField.Attrs.DisplayName, "field %q must have a display name", field.Name)
+		displayNamesByName[field.Name] = saField.Attrs.DisplayName
+	}
+
+	expected := map[string]string{
+		SessionAttributesPropertyFieldClientIPAddress:      "Client IP address",
+		SessionAttributesPropertyFieldNetworkInterfaceType: "Network interface type",
+		SessionAttributesPropertyFieldVPNActive:            "VPN active",
+		SessionAttributesPropertyFieldSSID:                 "SSID",
+		SessionAttributesPropertyFieldClientDeviceID:       "Device ID",
+		SessionAttributesPropertyFieldHardwareID:           "Hardware ID",
+		SessionAttributesPropertyFieldMDMEnrolled:          "MDM enrolled",
+		SessionAttributesPropertyFieldClientVersion:        "Client version",
+		SessionAttributesPropertyFieldOSPlatform:           "OS platform",
+		SessionAttributesPropertyFieldOSVersion:            "OS version",
+		SessionAttributesPropertyFieldJailbreakDetected:    "Jailbreak detected",
+	}
+	for name, displayName := range expected {
+		assert.Equal(t, displayName, displayNamesByName[name], "display name for %q", name)
+	}
+}
+
 func TestSAFieldEnabledForPlatform(t *testing.T) {
 	field := &PropertyField{
 		Name: SessionAttributesPropertyFieldVPNActive,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

PR #36934 seeded the `session_attributes` property group with a list of pre-defined session attributes but did not set a `display_name` for them, so the manifest API and Admin Console had no human-readable label per attribute.

The manifest already returned `DisplayName` from the field attrs, so seeding the value is sufficient for it to flow through to `GET /users/sessions/attributes/manifest`.

QA steps:
- Fresh install: every seeded `session_attributes` field has a non-empty `display_name`.
- Enable a field and call the manifest endpoint; the entry carries the seeded display name.

#### Ticket Link

Part of webapp implementation of Session Attributes: https://mattermost.atlassian.net/browse/MM-68650

#### Release Note
```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3dc59b8e-80ac-4979-acb0-c148071feda3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3dc59b8e-80ac-4979-acb0-c148071feda3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes are purely additive metadata seeding—populating missing `display_name` attributes on session attribute fields. The migration logic is idempotent, safely updating existing fields with only a new attribute value without altering field structure or behavior. No authentication, authorization, or core business logic is modified; the manifest endpoint behavior is unchanged since it already returned DisplayName from field attrs.

**QA Recommendation:** Minimal manual QA is sufficient. Automated test coverage is comprehensive (fresh install and upgrade path tested, display name assertions added, manifest endpoint validation included). The documented QA steps (fresh install verification and manifest endpoint call) provide sufficient validation for this metadata-only change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->