### PR TITLE
Add transport/sub_type to push notification logs and metrics

### DIFF
--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -221,12 +221,14 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 				reason = model.NotificationReasonPushProxyRemoveDevice
 			}
 			a.CountNotificationReason(model.NotificationStatusError, model.NotificationTypePush, reason, tmpMessage.Platform)
-			rctx.Logger().LogM(mlog.MlvlNotificationError, "Failed to send to push proxy",
+			rctx.Logger().Debug("Failed to send to push proxy",
 				mlog.String("type", model.NotificationTypePush),
 				mlog.String("status", model.NotificationStatusNotSent),
 				mlog.String("reason", reason),
 				mlog.String("ack_id", tmpMessage.AckId),
 				mlog.String("push_type", tmpMessage.Type),
+				mlog.String("transport", string(tmpMessage.Transport)),
+				mlog.String("sub_type", string(tmpMessage.SubType)),
 				mlog.String("user_id", session.UserId),
 				mlog.String("session_id", session.Id),
 				mlog.String("deviceId", model.RedactDeviceId(tmpMessage.DeviceId)),
@@ -235,10 +237,12 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 			continue
 		}
 
-		rctx.Logger().LogM(mlog.MlvlNotificationTrace, "Notification sent to push proxy",
+		rctx.Logger().Debug("Notification sent to push proxy",
 			mlog.String("type", model.NotificationTypePush),
 			mlog.String("ack_id", tmpMessage.AckId),
 			mlog.String("push_type", tmpMessage.Type),
+			mlog.String("transport", string(tmpMessage.Transport)),
+			mlog.String("sub_type", string(tmpMessage.SubType)),
 			mlog.String("user_id", session.UserId),
 			mlog.String("session_id", session.Id),
 			mlog.String("deviceId", model.RedactDeviceId(tmpMessage.DeviceId)),


### PR DESCRIPTION
#### Summary

Surfaces the push notification `transport` (standard vs `voip`) and `sub_type` (e.g. `calls`) dimensions so VoIP/call pushes can be distinguished from regular message pushes in observability.

**Logging** — adds `transport` and `sub_type` fields to the push-proxy send-path log statements in `sendPushNotificationToAllSessions` (`Notification sent to push proxy` and `Failed to send to push proxy`). These fields already existed on the `PushNotification` payload but weren't logged.

**Metrics** — adds a `transport` label to the `mattermost_notifications_*` counters (`total`, `total_ack`, `success`, `error`, `not_sent`, `unsupported`), threaded through the `IncrementNotification*Counter` metrics interface and the `CountNotification`/`CountNotificationReason`/`CountNotificationAck` app helpers. This mirrors the push-proxy's own `service_*` counters, which already carry a `transport` label, so the two sides can now be correlated on standard-vs-VoIP traffic.

The real transport value is threaded through on the server send path (`notification_push.go`, `expirynotify.go`); all other call sites — email, websocket, and the ack handler — pass `standard`, since the `PushNotificationAck` payload carries no transport and those notification types have no transport concept.

#### Release Note
```release-note
Added a `transport` label to the `mattermost_notifications_*` Prometheus metrics, distinguishing standard push notifications from VoIP (`voip`) notifications.
```