### PR TITLE
Implement dynamic frequency for expired posts scheduler

### DIFF
--- a/server/channels/jobs/delete_expired_posts/scheduler.go
+++ b/server/channels/jobs/delete_expired_posts/scheduler.go
@@ -18,6 +18,13 @@ func MakeScheduler(jobServer *jobs.JobServer) *jobs.PeriodicScheduler {
 		return featureFlagEnabled && serviceSettingEnabled
 	}
 
-	schedFreq := time.Duration(model.SafeDereference(jobServer.Config().ServiceSettings.BurnOnReadSchedulerFrequencySeconds)) * time.Second
-	return jobs.NewPeriodicScheduler(jobServer, model.JobTypeDeleteExpiredPosts, schedFreq, isEnabled)
+	// FEATURE: Dynamic frequency interval. 
+	// Instead of a static duration, this closure fetches the latest frequency 
+	// from the config every time the scheduler evaluates its next run.
+	getSchedFreq := func(cfg *model.Config) time.Duration {
+		seconds := model.SafeDereference(cfg.ServiceSettings.BurnOnReadSchedulerFrequencySeconds)
+		return time.Duration(seconds) * time.Second
+	}
+
+	return jobs.NewDynamicPeriodicScheduler(jobServer, model.JobTypeDeleteExpiredPosts, getSchedFreq, isEnabled)
 }


### PR DESCRIPTION
Replaced static scheduler frequency with a dynamic one that fetches the latest configuration value each time the scheduler evaluates its next run.

<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
<!-- What does this PR do? Include QA steps if not covered in the ticket. -->

#### Ticket Link
<!--
Fixes: https://github.com/mattermost/mattermost/issues/XXX
Fixes: https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!-- Include screenshots or GIFs for UI changes. -->

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🔴 High

**Regression Risk:**
The PR contains a critical compilation error: the code calls `jobs.NewDynamicPeriodicScheduler()` which does not exist in the `base_schedulers.go` file. Only `NewPeriodicScheduler` and `NewDailyScheduler` functions are exported. This will cause an immediate build failure and prevent deployment. The feature referenced in the PR (dynamic frequency for expired posts scheduler) is not actually implemented—only the call site is modified without providing the underlying function implementation.

**QA Recommendation:**
Do not merge as-is. Reject the PR and require the contributor to: (1) implement the missing `NewDynamicPeriodicScheduler` function in `base_schedulers.go`, or (2) use the existing `NewPeriodicScheduler` with a callback function approach if that's supported. Code review must catch this compilation error before any testing can occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->