### PR TITLE
fix the mocks and the store layer function declarations ordering

### DIFF
--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -383,3 +383,5 @@ channels/db/migrations/postgres/000192_add_voip_device_id_to_sessions.down.sql
 channels/db/migrations/postgres/000192_add_voip_device_id_to_sessions.up.sql
 channels/db/migrations/postgres/000193_add_property_groups_schema_version.down.sql
 channels/db/migrations/postgres/000193_add_property_groups_schema_version.up.sql
+channels/db/migrations/postgres/000194_add_type_id_index_to_access_control_policies.down.sql
+channels/db/migrations/postgres/000194_add_type_id_index_to_access_control_policies.up.sql

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -843,11 +843,11 @@ func (s *RetryLayerAttributesStore) GetChannelMembersToRemove(rctx request.CTX, 
 
 }
 
-func (s *RetryLayerAttributesStore) GetTeamMembersToRemove(rctx request.CTX, teamID string, opts model.SubjectSearchOptions) ([]*model.TeamMember, error) {
+func (s *RetryLayerAttributesStore) GetSubject(rctx request.CTX, ID string, groupID string) (*model.Subject, error) {
 
 	tries := 0
 	for {
-		result, err := s.AttributesStore.GetTeamMembersToRemove(rctx, teamID, opts)
+		result, err := s.AttributesStore.GetSubject(rctx, ID, groupID)
 		if err == nil {
 			return result, nil
 		}
@@ -864,11 +864,11 @@ func (s *RetryLayerAttributesStore) GetTeamMembersToRemove(rctx request.CTX, tea
 
 }
 
-func (s *RetryLayerAttributesStore) GetSubject(rctx request.CTX, ID string, groupID string) (*model.Subject, error) {
+func (s *RetryLayerAttributesStore) GetTeamMembersToRemove(rctx request.CTX, teamID string, opts model.SubjectSearchOptions) ([]*model.TeamMember, error) {
 
 	tries := 0
 	for {
-		result, err := s.AttributesStore.GetSubject(rctx, ID, groupID)
+		result, err := s.AttributesStore.GetTeamMembersToRemove(rctx, teamID, opts)
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/storetest/mocks/AttributesStore.go
+++ b/server/channels/store/storetest/mocks/AttributesStore.go
@@ -45,36 +45,6 @@ func (_m *AttributesStore) GetChannelMembersToRemove(rctx request.CTX, channelID
 	return r0, r1
 }
 
-// GetTeamMembersToRemove provides a mock function with given fields: rctx, teamID, opts
-func (_m *AttributesStore) GetTeamMembersToRemove(rctx request.CTX, teamID string, opts model.SubjectSearchOptions) ([]*model.TeamMember, error) {
-	ret := _m.Called(rctx, teamID, opts)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetTeamMembersToRemove")
-	}
-
-	var r0 []*model.TeamMember
-	var r1 error
-	if rf, ok := ret.Get(0).(func(request.CTX, string, model.SubjectSearchOptions) ([]*model.TeamMember, error)); ok {
-		return rf(rctx, teamID, opts)
-	}
-	if rf, ok := ret.Get(0).(func(request.CTX, string, model.SubjectSearchOptions) []*model.TeamMember); ok {
-		r0 = rf(rctx, teamID, opts)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*model.TeamMember)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(request.CTX, string, model.SubjectSearchOptions) error); ok {
-		r1 = rf(rctx, teamID, opts)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
 // GetSubject provides a mock function with given fields: rctx, ID, groupID
 func (_m *AttributesStore) GetSubject(rctx request.CTX, ID string, groupID string) (*model.Subject, error) {
 	ret := _m.Called(rctx, ID, groupID)
@@ -98,6 +68,36 @@ func (_m *AttributesStore) GetSubject(rctx request.CTX, ID string, groupID strin
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, string) error); ok {
 		r1 = rf(rctx, ID, groupID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetTeamMembersToRemove provides a mock function with given fields: rctx, teamID, opts
+func (_m *AttributesStore) GetTeamMembersToRemove(rctx request.CTX, teamID string, opts model.SubjectSearchOptions) ([]*model.TeamMember, error) {
+	ret := _m.Called(rctx, teamID, opts)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTeamMembersToRemove")
+	}
+
+	var r0 []*model.TeamMember
+	var r1 error
+	if rf, ok := ret.Get(0).(func(request.CTX, string, model.SubjectSearchOptions) ([]*model.TeamMember, error)); ok {
+		return rf(rctx, teamID, opts)
+	}
+	if rf, ok := ret.Get(0).(func(request.CTX, string, model.SubjectSearchOptions) []*model.TeamMember); ok {
+		r0 = rf(rctx, teamID, opts)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.TeamMember)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(request.CTX, string, model.SubjectSearchOptions) error); ok {
+		r1 = rf(rctx, teamID, opts)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -781,22 +781,6 @@ func (s *TimerLayerAttributesStore) GetChannelMembersToRemove(rctx request.CTX, 
 	return result, err
 }
 
-func (s *TimerLayerAttributesStore) GetTeamMembersToRemove(rctx request.CTX, teamID string, opts model.SubjectSearchOptions) ([]*model.TeamMember, error) {
-	start := time.Now()
-
-	result, err := s.AttributesStore.GetTeamMembersToRemove(rctx, teamID, opts)
-
-	elapsed := float64(time.Since(start)) / float64(time.Second)
-	if s.Root.Metrics != nil {
-		success := "false"
-		if err == nil {
-			success = "true"
-		}
-		s.Root.Metrics.ObserveStoreMethodDuration("AttributesStore.GetTeamMembersToRemove", success, elapsed)
-	}
-	return result, err
-}
-
 func (s *TimerLayerAttributesStore) GetSubject(rctx request.CTX, ID string, groupID string) (*model.Subject, error) {
 	start := time.Now()
 
@@ -809,6 +793,22 @@ func (s *TimerLayerAttributesStore) GetSubject(rctx request.CTX, ID string, grou
 			success = "true"
 		}
 		s.Root.Metrics.ObserveStoreMethodDuration("AttributesStore.GetSubject", success, elapsed)
+	}
+	return result, err
+}
+
+func (s *TimerLayerAttributesStore) GetTeamMembersToRemove(rctx request.CTX, teamID string, opts model.SubjectSearchOptions) ([]*model.TeamMember, error) {
+	start := time.Now()
+
+	result, err := s.AttributesStore.GetTeamMembersToRemove(rctx, teamID, opts)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("AttributesStore.GetTeamMembersToRemove", success, elapsed)
 	}
 	return result, err
 }

--- a/server/einterfaces/mocks/AccessControlServiceInterface.go
+++ b/server/einterfaces/mocks/AccessControlServiceInterface.go
@@ -161,38 +161,6 @@ func (_m *AccessControlServiceInterface) GetChannelMembersToRemove(rctx request.
 	return r0, r1
 }
 
-// GetTeamMembersToRemove provides a mock function with given fields: rctx, teamID
-func (_m *AccessControlServiceInterface) GetTeamMembersToRemove(rctx request.CTX, teamID string) ([]*model.TeamMember, *model.AppError) {
-	ret := _m.Called(rctx, teamID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetTeamMembersToRemove")
-	}
-
-	var r0 []*model.TeamMember
-	var r1 *model.AppError
-	if rf, ok := ret.Get(0).(func(request.CTX, string) ([]*model.TeamMember, *model.AppError)); ok {
-		return rf(rctx, teamID)
-	}
-	if rf, ok := ret.Get(0).(func(request.CTX, string) []*model.TeamMember); ok {
-		r0 = rf(rctx, teamID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*model.TeamMember)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(request.CTX, string) *model.AppError); ok {
-		r1 = rf(rctx, teamID)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*model.AppError)
-		}
-	}
-
-	return r0, r1
-}
-
 // GetPoliciesForFieldIDs provides a mock function with given fields: rctx, fieldIDs
 func (_m *AccessControlServiceInterface) GetPoliciesForFieldIDs(rctx request.CTX, fieldIDs []string) ([]*model.AccessControlPolicy, *model.AppError) {
 	ret := _m.Called(rctx, fieldIDs)
@@ -280,6 +248,38 @@ func (_m *AccessControlServiceInterface) GetPolicyRuleAttributes(rctx request.CT
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, string) *model.AppError); ok {
 		r1 = rf(rctx, policyID, action)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
+// GetTeamMembersToRemove provides a mock function with given fields: rctx, teamID
+func (_m *AccessControlServiceInterface) GetTeamMembersToRemove(rctx request.CTX, teamID string) ([]*model.TeamMember, *model.AppError) {
+	ret := _m.Called(rctx, teamID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTeamMembersToRemove")
+	}
+
+	var r0 []*model.TeamMember
+	var r1 *model.AppError
+	if rf, ok := ret.Get(0).(func(request.CTX, string) ([]*model.TeamMember, *model.AppError)); ok {
+		return rf(rctx, teamID)
+	}
+	if rf, ok := ret.Get(0).(func(request.CTX, string) []*model.TeamMember); ok {
+		r0 = rf(rctx, teamID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.TeamMember)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(request.CTX, string) *model.AppError); ok {
+		r1 = rf(rctx, teamID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)

--- a/server/einterfaces/mocks/PolicyAdministrationPointInterface.go
+++ b/server/einterfaces/mocks/PolicyAdministrationPointInterface.go
@@ -131,38 +131,6 @@ func (_m *PolicyAdministrationPointInterface) GetChannelMembersToRemove(rctx req
 	return r0, r1
 }
 
-// GetTeamMembersToRemove provides a mock function with given fields: rctx, teamID
-func (_m *PolicyAdministrationPointInterface) GetTeamMembersToRemove(rctx request.CTX, teamID string) ([]*model.TeamMember, *model.AppError) {
-	ret := _m.Called(rctx, teamID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetTeamMembersToRemove")
-	}
-
-	var r0 []*model.TeamMember
-	var r1 *model.AppError
-	if rf, ok := ret.Get(0).(func(request.CTX, string) ([]*model.TeamMember, *model.AppError)); ok {
-		return rf(rctx, teamID)
-	}
-	if rf, ok := ret.Get(0).(func(request.CTX, string) []*model.TeamMember); ok {
-		r0 = rf(rctx, teamID)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*model.TeamMember)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(request.CTX, string) *model.AppError); ok {
-		r1 = rf(rctx, teamID)
-	} else {
-		if ret.Get(1) != nil {
-			r1 = ret.Get(1).(*model.AppError)
-		}
-	}
-
-	return r0, r1
-}
-
 // GetPoliciesForFieldIDs provides a mock function with given fields: rctx, fieldIDs
 func (_m *PolicyAdministrationPointInterface) GetPoliciesForFieldIDs(rctx request.CTX, fieldIDs []string) ([]*model.AccessControlPolicy, *model.AppError) {
 	ret := _m.Called(rctx, fieldIDs)
@@ -250,6 +218,38 @@ func (_m *PolicyAdministrationPointInterface) GetPolicyRuleAttributes(rctx reque
 
 	if rf, ok := ret.Get(1).(func(request.CTX, string, string) *model.AppError); ok {
 		r1 = rf(rctx, policyID, action)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
+// GetTeamMembersToRemove provides a mock function with given fields: rctx, teamID
+func (_m *PolicyAdministrationPointInterface) GetTeamMembersToRemove(rctx request.CTX, teamID string) ([]*model.TeamMember, *model.AppError) {
+	ret := _m.Called(rctx, teamID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTeamMembersToRemove")
+	}
+
+	var r0 []*model.TeamMember
+	var r1 *model.AppError
+	if rf, ok := ret.Get(0).(func(request.CTX, string) ([]*model.TeamMember, *model.AppError)); ok {
+		return rf(rctx, teamID)
+	}
+	if rf, ok := ret.Get(0).(func(request.CTX, string) []*model.TeamMember); ok {
+		r0 = rf(rctx, teamID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.TeamMember)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(request.CTX, string) *model.AppError); ok {
+		r1 = rf(rctx, teamID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).(*model.AppError)


### PR DESCRIPTION
#### Summary
Fixes method ordering in auto-generated mock and store layer files (retrylayer, timerlayer, and mockery mocks) to match alphabetical order required by the code generators, resolving CI build failures.

#### Ticket Link
n/a

#### Screenshots
n/a


#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** These changes are limited to reordering methods in autogenerated mocks and store-layer wrappers and adding a synchronized migration entry; no logic, signatures, or public APIs were altered, so the likelihood of regressions is minimal.

**QA Recommendation:** Minimal manual QA recommended — rely on CI build and automated tests to validate code generation and migration application.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->