### PR TITLE
Prevent plugins from changing the push notification transport type

### DIFF
--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -92,6 +92,8 @@ func (a *App) sendPushNotificationSync(rctx request.CTX, post *model.Post, user 
 
 func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.PushNotification, userID string, skipSessionId string) *model.AppError {
 	rejectionReason := ""
+
+	originalTransportType := msg.Transport
 	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 		var replacementNotification *model.PushNotification
 		replacementNotification, rejectionReason = hooks.NotificationWillBePushed(msg, userID)
@@ -101,6 +103,15 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 		}
 		if replacementNotification != nil {
 			msg = replacementNotification
+
+			if msg.Transport != originalTransportType {
+				// Plugins that don't know about the updated model.PushNotification struct will incorrectly zero the Transport field,
+				// triggering a standard transport by mistake. For now, we disallow plugins touching the transport type.
+				rctx.Logger().Debug("Notification transport type changed by plugin, resetting original value", mlog.String("original_transport_type", originalTransportType), mlog.String("transport_type", msg.Transport))
+				msg.Transport = originalTransportType
+			}
+
+			rctx.Logger().Info("Notification modified by plugin.")
 		}
 		return true
 	}, plugin.NotificationWillBePushedID)
@@ -227,6 +238,8 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 				mlog.String("reason", reason),
 				mlog.String("ack_id", tmpMessage.AckId),
 				mlog.String("push_type", tmpMessage.Type),
+				mlog.String("transport", string(tmpMessage.Transport)),
+				mlog.String("sub_type", string(tmpMessage.SubType)),
 				mlog.String("user_id", session.UserId),
 				mlog.String("session_id", session.Id),
 				mlog.String("deviceId", model.RedactDeviceId(tmpMessage.DeviceId)),
@@ -239,6 +252,8 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 			mlog.String("type", model.NotificationTypePush),
 			mlog.String("ack_id", tmpMessage.AckId),
 			mlog.String("push_type", tmpMessage.Type),
+			mlog.String("transport", string(tmpMessage.Transport)),
+			mlog.String("sub_type", string(tmpMessage.SubType)),
 			mlog.String("user_id", session.UserId),
 			mlog.String("session_id", session.Id),
 			mlog.String("deviceId", model.RedactDeviceId(tmpMessage.DeviceId)),

--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -93,6 +93,23 @@ func (a *App) sendPushNotificationSync(rctx request.CTX, post *model.Post, user 
 func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.PushNotification, userID string, skipSessionId string) *model.AppError {
 	rejectionReason := ""
 
+	if msg == nil {
+		a.CountNotificationReason(model.NotificationStatusError, model.NotificationTypePush, model.NotificationReasonParseError, model.NotificationNoPlatform)
+		rctx.Logger().LogM(mlog.MlvlNotificationError, "Failed to parse push notification",
+			mlog.String("type", model.NotificationTypePush),
+			mlog.String("status", model.NotificationStatusError),
+			mlog.String("reason", model.NotificationReasonParseError),
+			mlog.String("user_id", userID),
+		)
+		return model.NewAppError(
+			"pushNotification",
+			"api.push_notifications.message.parse.app_error",
+			nil,
+			"",
+			http.StatusBadRequest,
+		)
+	}
+
 	originalTransportType := msg.Transport
 	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 		var replacementNotification *model.PushNotification
@@ -140,23 +157,6 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 			mlog.Err(appErr),
 		)
 		return appErr
-	}
-
-	if msg == nil {
-		a.CountNotificationReason(model.NotificationStatusError, model.NotificationTypePush, model.NotificationReasonParseError, model.NotificationNoPlatform)
-		rctx.Logger().LogM(mlog.MlvlNotificationError, "Failed to parse push notification",
-			mlog.String("type", model.NotificationTypePush),
-			mlog.String("status", model.NotificationStatusError),
-			mlog.String("reason", model.NotificationReasonParseError),
-			mlog.String("user_id", userID),
-		)
-		return model.NewAppError(
-			"pushNotification",
-			"api.push_notifications.message.parse.app_error",
-			nil,
-			"",
-			http.StatusBadRequest,
-		)
 	}
 
 	for _, session := range sessions {

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -1644,6 +1644,86 @@ func TestHookNotificationWillBePushed(t *testing.T) {
 	}
 }
 
+func TestHookNotificationWillBePushedTransportPreserved(t *testing.T) {
+	mainHelper.Parallel(t)
+	if testing.Short() {
+		t.Skip("skipping TestHookNotificationWillBePushedTransportPreserved test in short mode")
+	}
+
+	const (
+		standardToken = model.PushNotifyAppleReactNative + ":standardtoken"
+		voIPToken     = model.PushNotifyAppleReactNative + ":voiptoken"
+	)
+
+	// A plugin compiled against an older model.PushNotification struct can't see
+	// the Transport field, so returning a replacement notification would zero it.
+	// The server must ignore any plugin-driven change to Transport and keep the
+	// original routing (here, VoIP).
+	tests := []struct {
+		name     string
+		testCode string
+	}{
+		{
+			name: "plugin zeroing the transport keeps the original routing",
+			testCode: `notification.Transport = ""
+	return notification, ""`,
+		},
+		{
+			name: "plugin overriding the transport keeps the original routing",
+			testCode: `notification.Transport = model.PushTransportStandard
+	return notification, ""`,
+		},
+		{
+			name:     "plugin leaving the transport untouched keeps the original routing",
+			testCode: `return notification, ""`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mainHelper.Parallel(t)
+
+			th := Setup(t).InitBasic(t)
+
+			templatedPlugin := fmt.Sprintf(hookNotificationWillBePushedTmpl, tt.testCode)
+			tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{templatedPlugin}, th.App, th.NewPluginAPI)
+			defer tearDown()
+
+			handler := &testPushNotificationHandler{t: t, behavior: "simple"}
+			pushServer := httptest.NewServer(http.HandlerFunc(handler.handleReq))
+			defer pushServer.Close()
+
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				*cfg.EmailSettings.PushNotificationServer = pushServer.URL
+			})
+
+			_, err := th.App.CreateSession(th.Context, &model.Session{
+				UserId:       th.BasicUser.Id,
+				DeviceId:     standardToken,
+				VoIPDeviceId: voIPToken,
+				ExpiresAt:    model.GetMillis() + 100000,
+			})
+			require.Nil(t, err)
+
+			msg := &model.PushNotification{
+				Type:      model.PushTypeMessage,
+				SubType:   model.PushSubTypeCalls,
+				Transport: model.PushTransportVoIP,
+			}
+			appErr := th.App.sendPushNotificationToAllSessions(th.Context, msg, th.BasicUser.Id, "")
+			require.Nil(t, appErr)
+
+			require.Eventually(t, func() bool {
+				return len(handler.notifications()) == 1
+			}, 2*time.Second, 10*time.Millisecond, "expected exactly one push notification")
+
+			notifications := handler.notifications()
+			assert.Equal(t, model.PushTransportVoIP, notifications[0].Transport, "plugin must not be able to change the transport")
+			assert.Equal(t, "voiptoken", notifications[0].DeviceId, "VoIP routing must be preserved despite the plugin")
+		})
+	}
+}
+
 //go:embed test_templates/hook_email_notification_will_be_sent.tmpl
 var hookEmailNotificationWillBeSentTmpl string
 


### PR DESCRIPTION
#### Summary
The `NotificationWillBePushed` plugin hook lets a plugin return a replacement `model.PushNotification`. A plugin compiled against an older `model.PushNotification` struct can't see the newer `Transport` field, so returning a replacement notification silently zeroes it — misrouting a VoIP push (e.g. a Calls notification) as a standard chat alert.

This hardens `sendPushNotificationToAllSessions` to ignore any plugin-driven change to `Transport`, restoring the original value (with a debug log) before dispatch. It also adds `transport` and `sub_type` to the push notification debug/error logs for easier diagnosis.

Added `TestHookNotificationWillBePushedTransportPreserved`, which registers a real plugin that zeroes / overrides / leaves the transport untouched and verifies a VoIP push keeps its VoIP routing in every case.

#### Ticket Link
NONE

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change alters how plugins’ `NotificationWillBePushed` modifications to `Transport` are handled during push dispatch, which can affect user-facing notification routing across all session sends. While the fix is defensive and a dedicated test covers VoIP transport preservation, plugin behaviors beyond the tested cases could be impacted if they relied on changing `Transport`.

**QA Recommendation:** Limited manual QA is recommended despite automated coverage: verify VoIP (Calls) push routing still uses the VoIP device token and that standard chat pushes continue to deliver normally with representative plugins enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->