### PR TITLE
Fix AI sparkle indicator on consecutive agent posts

### DIFF
--- a/webapp/channels/src/components/post/post_component.test.tsx
+++ b/webapp/channels/src/components/post/post_component.test.tsx
@@ -670,7 +670,7 @@ describe('PostComponent', () => {
             expect(screen.queryByLabelText(/AI-generated|Message posted by/)).not.toBeInTheDocument();
         });
 
-        test('should not show AI-generated indicator for consecutive posts', () => {
+        test('should show AI-generated indicator for consecutive AI posts', () => {
             const props = {
                 ...baseProps,
                 post: aiGeneratedPost,
@@ -679,7 +679,7 @@ describe('PostComponent', () => {
             };
             renderWithContext(<PostComponent {...props}/>);
 
-            expect(screen.queryByLabelText(/AI-generated|Message posted by/)).not.toBeInTheDocument();
+            expect(screen.getByLabelText('Message posted by @aibot')).toBeInTheDocument();
         });
 
         test('should show AI-generated indicator in PostUserProfile for compact mode in CENTER', () => {
@@ -697,7 +697,7 @@ describe('PostComponent', () => {
             expect(indicators.length).toBe(1);
         });
 
-        test('should hide AI-generated indicator for consecutive posts in threads', () => {
+        test('should show AI-generated indicator for consecutive AI posts in threads', () => {
             const threadPost = TestHelper.getPostMock({
                 channel_id: channel.id,
                 root_id: 'root_post_id',
@@ -715,7 +715,7 @@ describe('PostComponent', () => {
             };
             renderWithContext(<PostComponent {...props}/>);
 
-            expect(screen.queryByLabelText(/AI-generated|Message posted by/)).not.toBeInTheDocument();
+            expect(screen.getByLabelText('Message posted by @aibot')).toBeInTheDocument();
         });
 
         test('should show AI-generated indicator for non-consecutive posts in threads', () => {

--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -837,8 +837,8 @@ function PostComponent(props: Props) {
                                 {priority}
                                 {burnOnReadBadge}
                                 {burnOnReadTimerChip}
-                                {((!props.compactDisplay && !(hasSameRoot(props) && props.isConsecutivePost)) || (props.compactDisplay && isRHS)) &&
-                                    PostUtils.hasAiGeneratedMetadata(post) && (
+                                {PostUtils.hasAiGeneratedMetadata(post) &&
+                                    ((!props.compactDisplay) || (props.compactDisplay && isRHS)) && (
                                     <AiGeneratedIndicator
                                         userId={post.props.ai_generated_by as string}
                                         username={post.props.ai_generated_by_username as string}

--- a/webapp/channels/src/utils/post_utils.test.tsx
+++ b/webapp/channels/src/utils/post_utils.test.tsx
@@ -1584,6 +1584,70 @@ describe('makeGetUniqueEmojiNameReactionsForPost', () => {
     });
 });
 
+describe('PostUtils.areConsecutivePostsBySameUser', () => {
+    const userId = 'user_id_1';
+    const baseTime = 1_000_000;
+
+    const makePost = (override: Partial<Post> = {}): Post => {
+        return TestHelper.getPostMock({
+            user_id: userId,
+            create_at: baseTime,
+            type: '',
+            ...override,
+        });
+    };
+
+    test('should return true for consecutive posts from the same user', () => {
+        const previousPost = makePost({create_at: baseTime});
+        const post = makePost({create_at: baseTime + 1000});
+
+        expect(PostUtils.areConsecutivePostsBySameUser(post, previousPost)).toBe(true);
+    });
+
+    test('should return false when current post is AI-generated', () => {
+        const previousPost = makePost({create_at: baseTime});
+        const post = makePost({
+            create_at: baseTime + 1000,
+            props: {
+                ai_generated_by: 'ai_user_id',
+                ai_generated_by_username: 'aibot',
+            },
+        });
+
+        expect(PostUtils.areConsecutivePostsBySameUser(post, previousPost)).toBe(false);
+    });
+
+    test('should return false when current AI post follows another AI post from the same user', () => {
+        const aiProps = {
+            ai_generated_by: 'ai_user_id',
+            ai_generated_by_username: 'aibot',
+        };
+        const previousPost = makePost({
+            create_at: baseTime,
+            props: aiProps,
+        });
+        const post = makePost({
+            create_at: baseTime + 1000,
+            props: aiProps,
+        });
+
+        expect(PostUtils.areConsecutivePostsBySameUser(post, previousPost)).toBe(false);
+    });
+
+    test('should return false when a normal post follows an AI post from the same user', () => {
+        const previousPost = makePost({
+            create_at: baseTime,
+            props: {
+                ai_generated_by: 'ai_user_id',
+                ai_generated_by_username: 'aibot',
+            },
+        });
+        const post = makePost({create_at: baseTime + 1000});
+
+        expect(PostUtils.areConsecutivePostsBySameUser(post, previousPost)).toBe(false);
+    });
+});
+
 describe('shouldShowActionsMenu', () => {
     const baseState = {
         entities: {

--- a/webapp/channels/src/utils/post_utils.ts
+++ b/webapp/channels/src/utils/post_utils.ts
@@ -674,6 +674,10 @@ export function areConsecutivePostsBySameUser(post: Post, previousPost: Post): b
         return false;
     }
 
+    if (hasAiGeneratedMetadata(post)) {
+        return false;
+    }
+
     const sameUser = post.user_id === previousPost.user_id;
     const withinTimeWindow = post.create_at - previousPost.create_at <= Posts.POST_COLLAPSE_TIMEOUT;
     const notFromWebhook = !(post.props && post.props.from_webhook) && !(previousPost.props && previousPost.props.from_webhook);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

When an agent posts multiple messages in a row, only the first message showed the AI-generated sparkle indicator. Subsequent messages were treated as consecutive posts from the same user, which collapsed the post header and hid the badge.

This change excludes AI-generated posts from consecutive-post collapsing so each agent message keeps a visible header and sparkle. The badge render condition in `PostComponent` is also simplified so the indicator always appears for AI posts in the badges area when appropriate.

<img width="484" height="307" alt="image" src="https://github.com/user-attachments/assets/3c9896fe-e730-4a6e-8e13-8a0080467066" />


#### Release Note

```release-note
Fixed an issue where the AI-generated indicator was only shown on the first message when an agent posted multiple messages in a row.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b13fbcc2-aac8-4b08-98f8-797ae0978e89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b13fbcc2-aac8-4b08-98f8-797ae0978e89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The modification to `areConsecutivePostsBySameUser()` in shared post_utils is called during post rendering logic across the application. While the change is scoped to exclude only AI-generated posts from consecutive-post collapsing, the function is part of core post display logic that affects how messages are rendered in channels and threads. Any edge cases in the `hasAiGeneratedMetadata()` check or interactions with the rendering pipeline could impact post visibility and layout for both AI and non-AI messages.

**QA Recommendation:** Manual QA should verify consecutive message display behavior focusing on: (1) All consecutive AI messages display headers and badges correctly in main chat and thread views, (2) Consecutive non-AI messages from the same user continue to collapse as expected, (3) Mixed scenarios (AI followed by non-AI and vice versa) render without layout issues. The comprehensive test suite provides good baseline coverage, but spot-checking across different post types and channel contexts is advisable given the shared nature of the affected utilities.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->