### PR TITLE
Harden role validation for channel membership updates

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -1398,6 +1398,9 @@ func (a *App) updateChannelMemberRolesInternal(rctx request.CTX, channelID strin
 		}
 
 		if !role.SchemeManaged {
+			if role.BuiltIn && !model.IsChannelScopedRoleName(roleName) {
+				return nil, model.NewAppError("UpdateChannelMemberRoles", "api.channel.update_channel_member_roles.non_channel_scope.app_error", nil, "role_name="+roleName, http.StatusBadRequest)
+			}
 			// The role is not scheme-managed, so it's OK to apply it to the explicit roles field.
 			newExplicitRoles = append(newExplicitRoles, roleName)
 		} else {

--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -1753,6 +1753,61 @@ func TestUpdateChannelMemberRolesRequireUser(t *testing.T) {
 	})
 }
 
+func TestUpdateChannelMemberRolesRejectsNonChannelScopedRoles(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	setupMember := func(t *testing.T) *model.User {
+		t.Helper()
+		user := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Tester", Username: "tester" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
+		ruser, appErr := th.App.CreateUser(th.Context, &user)
+		require.Nil(t, appErr)
+
+		_, _, appErr = th.App.AddUserToTeam(th.Context, th.BasicTeam.Id, ruser.Id, "")
+		require.Nil(t, appErr)
+
+		_, appErr = th.App.AddUserToChannel(th.Context, ruser, th.BasicChannel, false)
+		require.Nil(t, appErr)
+
+		return ruser
+	}
+
+	deniedRoles := []string{
+		model.SystemManagerRoleId,
+		model.SystemUserManagerRoleId,
+		model.SystemReadOnlyAdminRoleId,
+		model.SystemAdminRoleId,
+		model.TeamAdminRoleId,
+	}
+
+	for _, deniedRole := range deniedRoles {
+		t.Run(deniedRole+" is rejected", func(t *testing.T) {
+			ruser := setupMember(t)
+
+			_, appErr := th.App.UpdateChannelMemberRoles(th.Context, th.BasicChannel.Id, ruser.Id, "channel_user channel_admin "+deniedRole)
+			require.NotNil(t, appErr)
+			require.Equal(t, "api.channel.update_channel_member_roles.non_channel_scope.app_error", appErr.Id)
+
+			member, appErr := th.App.GetChannelMember(th.Context, th.BasicChannel.Id, ruser.Id)
+			require.Nil(t, appErr)
+			require.NotContains(t, member.GetRoles(), deniedRole)
+		})
+	}
+
+	t.Run("custom roles remain allowed", func(t *testing.T) {
+		ruser := setupMember(t)
+
+		customRole := "custom" + model.NewId()
+		createdRole, appErr := th.App.CreateRole(&model.Role{Name: customRole, DisplayName: "custom", Description: "custom"})
+		require.Nil(t, appErr)
+		require.False(t, createdRole.BuiltIn)
+
+		updatedMember, appErr := th.App.UpdateChannelMemberRoles(th.Context, th.BasicChannel.Id, ruser.Id, "channel_user "+customRole)
+		require.Nil(t, appErr)
+		require.Contains(t, updatedMember.GetRoles(), customRole)
+	})
+}
+
 func TestUpdateChannelMemberAutotranslation(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -736,6 +736,10 @@
     "translation": "Invalid channel member update: A user must be a guest or a user but not both."
   },
   {
+    "id": "api.channel.update_channel_member_roles.non_channel_scope.app_error",
+    "translation": "The provided role is not a channel-scoped role and therefore cannot be applied to a Channel Member."
+  },
+  {
     "id": "api.channel.update_channel_member_roles.scheme_role.app_error",
     "translation": "The provided role is managed by a Scheme and therefore cannot be applied directly to a Channel Member."
   },

--- a/server/public/model/role.go
+++ b/server/public/model/role.go
@@ -872,6 +872,19 @@ func IsValidRoleName(roleName string) bool {
 	return true
 }
 
+// IsChannelScopedRoleName reports whether the named role is one of the built-in
+// channel-scoped roles. Team- and system-scoped built-in roles (e.g.
+// system_manager) return false so they can be rejected when assigning explicit
+// roles to a channel membership.
+func IsChannelScopedRoleName(roleName string) bool {
+	switch roleName {
+	case ChannelGuestRoleId, ChannelUserRoleId, ChannelAdminRoleId:
+		return true
+	default:
+		return false
+	}
+}
+
 func MakeDefaultRoles() map[string]*Role {
 	roles := make(map[string]*Role)
 

--- a/server/public/model/role_test.go
+++ b/server/public/model/role_test.go
@@ -558,3 +558,29 @@ func TestManageAgentPermissionsDefaultRoles(t *testing.T) {
 		})
 	}
 }
+
+func TestIsChannelScopedRoleName(t *testing.T) {
+	channelScoped := []string{
+		ChannelGuestRoleId,
+		ChannelUserRoleId,
+		ChannelAdminRoleId,
+	}
+	for _, roleName := range channelScoped {
+		assert.True(t, IsChannelScopedRoleName(roleName), "%s should be channel-scoped", roleName)
+	}
+
+	notChannelScoped := []string{
+		SystemAdminRoleId,
+		SystemManagerRoleId,
+		SystemUserManagerRoleId,
+		SystemReadOnlyAdminRoleId,
+		SystemUserRoleId,
+		TeamAdminRoleId,
+		TeamUserRoleId,
+		"custom_role",
+		"",
+	}
+	for _, roleName := range notChannelScoped {
+		assert.False(t, IsChannelScopedRoleName(roleName), "%s should not be channel-scoped", roleName)
+	}
+}


### PR DESCRIPTION
#### Summary

Tightens validation in the channel member roles update path so that the roles applied to a channel membership are restricted to channel-scoped roles. Built-in team- and system-scoped roles are no longer accepted as explicit roles on a channel member.

This adds a small `IsChannelScopedRoleName` helper in the model package and applies the check in `updateChannelMemberRolesInternal` (covering both the REST and plugin paths). Custom (non-built-in) roles continue to be accepted as before. Includes unit tests for the helper and app-level tests covering the accepted and rejected cases.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69240

#### Release Note
```release-note
Improved validation of role assignments for channel members.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** This introduces a behavioral constraint that rejects previously allowed role assignments. External plugins and integrations using the public Plugin API to assign system- or team-scoped roles to channel members will now receive errors. While the validation change is intentional and well-tested, the blast radius extends to the plugin ecosystem and any external systems integrating via the REST API.

**QA Recommendation:** Focused manual testing of plugin interactions and custom integrations that perform channel member role assignments is recommended. Specifically verify that: (1) plugins attempting to assign non-channel-scoped roles fail with the appropriate error message, (2) bulk import operations with non-channel-scoped roles are properly rejected, and (3) channel admin role assignments via REST API continue to work correctly. Full coverage of standard channel member role operations (channel_user, channel_admin, channel_guest) should be verified across REST and plugin APIs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->