### PR TITLE
update Calls to v1.12.0

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -158,7 +158,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.5
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.12.0
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.1
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.2
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.0


### PR DESCRIPTION
#### Summary
- Update prepackaged Calls to v1.12.0

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-68811


#### Release Note
```release-note
Mattermost Calls was updated to v1.12.0, supporting video 1:1 calls as an experimental feature
```

Calls v1.12.0 https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v1.12.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Isolated single-file change to plugin version in Makefile with no modifications to core server logic, shared utilities, or critical paths. Plugin version updates carry minimal regression risk when the plugin maintains backward compatibility.

**QA Recommendation:** Standard smoke testing on prepackaged plugin deployment sufficient. No extensive manual QA needed given the isolated nature of the change and the plugin's external maintenance. Verify plugin loads correctly in test environment.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->