### PR TITLE
fix: normalize spaces to underscores in emoji picker search

### DIFF
--- a/webapp/channels/src/components/emoji_picker/utils/index.ts
+++ b/webapp/channels/src/components/emoji_picker/utils/index.ts
@@ -59,11 +59,15 @@ function isEmojiIdEqual(firstEmoji: Emoji, secondEmoji: Emoji): boolean {
 }
 
 export function getFilteredEmojis(allEmojis: Record<string, Emoji>, filter: string, recentEmojisString: string[], userSkinTone: string): Emoji[] {
+    // Normalize filter: replace spaces with underscores to match emoji aliases
+    // e.g. "umbrella with rain drops" -> "umbrella_with_rain_drops"
+    const normalizedFilter = filter.toLowerCase().replace(/\s+/g, '_');
+
     const filteredEmojisWithRecent = Object.values(allEmojis).filter((emoji) => {
         const aliases = isSystemEmoji(emoji) ? emoji.short_names : [emoji.name];
 
         for (let i = 0; i < aliases.length; i++) {
-            if (aliases[i].toLowerCase().includes(filter.toLowerCase())) {
+            if (aliases[i].toLowerCase().includes(normalizedFilter)) {
                 return true;
             }
         }
@@ -79,7 +83,7 @@ export function getFilteredEmojis(allEmojis: Record<string, Emoji>, filter: stri
     });
 
     const sortedRecentEmojis = filteredRecentEmojis.sort((firstEmoji, secondEmoji) =>
-        compareEmojis(firstEmoji, secondEmoji, filter),
+        compareEmojis(firstEmoji, secondEmoji, normalizedFilter),
     );
 
     // Seprate out recent emojis from the rest of the emoji result
@@ -88,7 +92,7 @@ export function getFilteredEmojis(allEmojis: Record<string, Emoji>, filter: stri
     });
 
     const sortedFiltertedEmojisMinusRecent = filtertedEmojisMinusRecent.sort((firstEmoji, secondEmoji) =>
-        compareEmojis(firstEmoji, secondEmoji, filter),
+        compareEmojis(firstEmoji, secondEmoji, normalizedFilter),
     );
 
     const filteredEmojis = [...sortedRecentEmojis, ...sortedFiltertedEmojisMinusRecent];

--- a/webapp/channels/src/components/emoji_picker/utils/index.ts
+++ b/webapp/channels/src/components/emoji_picker/utils/index.ts
@@ -59,9 +59,10 @@ function isEmojiIdEqual(firstEmoji: Emoji, secondEmoji: Emoji): boolean {
 }
 
 export function getFilteredEmojis(allEmojis: Record<string, Emoji>, filter: string, recentEmojisString: string[], userSkinTone: string): Emoji[] {
-    // Normalize filter: replace spaces with underscores to match emoji aliases
+    // Normalize filter: trim and replace spaces with underscores to match emoji aliases
     // e.g. "umbrella with rain drops" -> "umbrella_with_rain_drops"
-    const normalizedFilter = filter.toLowerCase().replace(/\s+/g, '_');
+    // Trim first so whitespace-only queries don't normalize to "_"
+    const normalizedFilter = filter.trim().toLowerCase().replace(/\s+/g, '_');
 
     const filteredEmojisWithRecent = Object.values(allEmojis).filter((emoji) => {
         const aliases = isSystemEmoji(emoji) ? emoji.short_names : [emoji.name];


### PR DESCRIPTION
## Summary
Emoji picker search now normalizes spaces to underscores before matching against emoji aliases.

Previously, searching for "umbrella with rain drops" returned no results because emoji aliases use underscores (e.g. `umbrella_with_rain_drops`). Now both "umbrella with rain drops" and "umbrella_with_rain_drops" produce the same results.

Resolves #19792

## Changes
- `emoji_picker/utils/index.ts`: Added `replace(/\s+/g, '_')` normalization to the filter in `getFilteredEmojis`. The normalized filter is used for both matching and sorting.

## Release Notes
```release-note
Emoji picker search now matches emojis when typing spaces instead of underscores (e.g. searching "umbrella with rain drops" now finds the matching emoji).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is confined to the emoji picker’s client-side filtering/sorting utility and only normalizes the user’s search string (trim + whitespace-to-underscore) before matching aliases and ranking results. Blast radius is limited to emoji search behavior, with reduced risk of unintended matches for whitespace-only inputs.

**QA Recommendation:** Minimal manual QA: confirm that searches using spaces vs underscores return identical results (including `:umbrella_with_rain_drops:`), verify whitespace-only queries return no unintended matches, and spot-check sorting/ranking when multiple emojis match.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->