### PR TITLE
Fix: Improve emoji searching in emoji picker to include blank spaces (#19792)

### DIFF
--- a/webapp/channels/src/components/emoji_picker/utils/index.ts
+++ b/webapp/channels/src/components/emoji_picker/utils/index.ts
@@ -59,11 +59,13 @@ function isEmojiIdEqual(firstEmoji: Emoji, secondEmoji: Emoji): boolean {
 }
 
 export function getFilteredEmojis(allEmojis: Record<string, Emoji>, filter: string, recentEmojisString: string[], userSkinTone: string): Emoji[] {
+    const normalizedFilter = filter.toLowerCase().replace(/ /g, '_');
+
     const filteredEmojisWithRecent = Object.values(allEmojis).filter((emoji) => {
         const aliases = isSystemEmoji(emoji) ? emoji.short_names : [emoji.name];
 
         for (let i = 0; i < aliases.length; i++) {
-            if (aliases[i].toLowerCase().includes(filter.toLowerCase())) {
+            if (aliases[i].toLowerCase().includes(normalizedFilter)) {
                 return true;
             }
         }
@@ -79,7 +81,7 @@ export function getFilteredEmojis(allEmojis: Record<string, Emoji>, filter: stri
     });
 
     const sortedRecentEmojis = filteredRecentEmojis.sort((firstEmoji, secondEmoji) =>
-        compareEmojis(firstEmoji, secondEmoji, filter),
+        compareEmojis(firstEmoji, secondEmoji, normalizedFilter),
     );
 
     // Seprate out recent emojis from the rest of the emoji result
@@ -88,7 +90,7 @@ export function getFilteredEmojis(allEmojis: Record<string, Emoji>, filter: stri
     });
 
     const sortedFiltertedEmojisMinusRecent = filtertedEmojisMinusRecent.sort((firstEmoji, secondEmoji) =>
-        compareEmojis(firstEmoji, secondEmoji, filter),
+        compareEmojis(firstEmoji, secondEmoji, normalizedFilter),
     );
 
     const filteredEmojis = [...sortedRecentEmojis, ...sortedFiltertedEmojisMinusRecent];


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
<!-- What does this PR do? Include QA steps if not covered in the ticket. -->
This PR updates the `getFilteredEmojis` utility in the webapp to replace spaces with underscores inside the search query. This ensures that users can naturally search for emojis with spaces (e.g. typing "umbrella with rain drops" instead of "umbrella_with_rain_drops") and still get the expected results in the picker.

#### Ticket Link
<!--
Fixes: https://github.com/mattermost/mattermost/issues/19792
Fixes: https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes: https://github.com/mattermost/mattermost/issues/19792
Fixes: https://mattermost.atlassian.net/browse/MM-42492

#### Screenshots
<!-- Include screenshots or GIFs for UI changes. -->
*(No visual UI change, just functional search behavior change)*

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Improved emoji search in the emoji picker to handle queries containing blank spaces.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Low. The change is backward compatible; filters without spaces behave identically to before. The function has comprehensive test coverage (8 tests) for existing functionality including case-insensitivity, multiple matches, skin tones, and recent emojis. However, there is no explicit test case for the new space-to-underscore normalization feature (e.g., "umbrella with rain drops" → "umbrella_with_rain_drops").

**QA Recommendation:** Manual testing is recommended. Verify that space-separated search queries (e.g., "umbrella with rain drops") correctly match and return the intended underscored emojis (e.g., `:umbrella_with_rain_drops:`), and confirm that result sorting behavior is consistent when using space vs. underscore variants.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->