### PR TITLE
fix(webapp): use standard makeGetChannel() for channel name for GM

### DIFF
--- a/webapp/channels/src/components/post/index.tsx
+++ b/webapp/channels/src/components/post/index.tsx
@@ -11,7 +11,7 @@ import type {Post} from '@mattermost/types/posts';
 
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {General, Preferences as ReduxPreferences} from 'mattermost-redux/constants';
-import {getDirectTeammate, isMyChannelAutotranslated} from 'mattermost-redux/selectors/entities/channels';
+import {getDirectTeammate, isMyChannelAutotranslated, makeGetChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getConfig, isPermissionPoliciesEnabled} from 'mattermost-redux/selectors/entities/general';
 import {getCurrentUserLocale} from 'mattermost-redux/selectors/entities/i18n';
 import {getPost, makeGetCommentCountForPost, makeIsPostCommentMention, isPostAcknowledgementsEnabled, isPostPriorityEnabled, isPostFlagged} from 'mattermost-redux/selectors/entities/posts';
@@ -101,6 +101,7 @@ function isConsecutivePost(state: GlobalState, ownProps: OwnProps, locale: strin
 function makeMapStateToProps() {
     const isPostCommentMention = makeIsPostCommentMention();
     const getReplyCount = makeGetCommentCountForPost();
+    const getChannelSelector = makeGetChannel();
 
     return function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
         let post;
@@ -124,7 +125,7 @@ function makeMapStateToProps() {
         const enableEmojiPicker = config.EnableEmojiPicker === 'true';
         const enablePostUsernameOverride = config.EnablePostUsernameOverride === 'true';
         const permissionPoliciesEnabled = isPermissionPoliciesEnabled(state);
-        const channel = state.entities.channels.channels[post.channel_id];
+        const channel = getChannelSelector(state, post.channel_id) ?? state.entities.channels.channels[post.channel_id];
         if (!channel) {
             return null;
         }


### PR DESCRIPTION
#### Summary

Use the standard `makeGetChannel()` for channel name for GM as per the user's Settings.

#### Ticket Link

- Fixes: #37089

#### Screenshots

prerequisite

<img width="700" height="306" alt="prerequisite" src="https://github.com/user-attachments/assets/3657ea31-d64c-4002-9d38-906edf6da87b" />

| | |
|-|-|
| before | <img width="500" height="268" alt="asis" src="https://github.com/user-attachments/assets/79ba886f-f755-4ef4-9c3f-c41e9ec759aa" /> |
| after | <img width="497" height="256" alt="tobe" src="https://github.com/user-attachments/assets/64aed431-8ca1-48e3-9888-85c1d22a740a" /> |

#### Release Note

```release-note
Fixed GM channel name for the search results of GM.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The modification switches the Post component to use the standard `makeGetChannel()` selector for resolving channel names instead of direct state access. While the selector is well-established and used in 28+ locations across the codebase with dedicated test coverage in `channels.test.ts`, introducing the fallback pattern `getChannelSelector(state, post.channel_id) ?? state.entities.channels.channels[post.channel_id]` creates a dual-path resolution that could behave unexpectedly if the selector returns undefined; however, the Post component is frequently rendered and any regression would affect search results and channel display across the application.

**QA Recommendation:** Manual QA testing should focus on: (1) Verifying that GM channel names in search results display correctly with all "Teammate Name Display" preference settings (Show nickname if exists, Show first and last name, Show username), (2) Testing GM channels with various member configurations and user preferences to ensure the selector correctly computes display names instead of showing only nicknames, (3) Regression testing across different message contexts (search results, threads, DMs, GMs) to ensure the fallback behavior works as expected when the selector returns undefined.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->