### PR TITLE
Update prepackaged Agents, Boards, and Playbooks plugins for release-11.9

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -165,8 +165,8 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.0
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.9.0
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.3
-PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.5
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.0
+PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0-rc1
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.6.1
 PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.4.1
@@ -179,7 +179,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.9.0%2Bdfb5b30-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.3%2Bcab391a-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.0%2B82431f9-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.5%2Bf4fc5d6-fips
 endif
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -166,7 +166,7 @@ PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.10.0-rc2
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.0
-PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0-rc1
+PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0-rc2
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.6.1
 PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.4.1
@@ -180,7 +180,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.10.0-rc2%2B30c1de8-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.0%2B82431f9-fips
-	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.5%2Bf4fc5d6-fips
+	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0-rc2%2B5880c13-fips
 endif
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)

--- a/server/Makefile
+++ b/server/Makefile
@@ -162,7 +162,7 @@ PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.5
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.1
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.2
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.0
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.9.0
+PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.10.0-rc2
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.0
@@ -178,7 +178,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.9.0%2Bdfb5b30-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.10.0-rc2%2B30c1de8-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.0%2B82431f9-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.5%2Bf4fc5d6-fips
 endif


### PR DESCRIPTION
#### Summary

Updates prepackaged plugin versions in `server/Makefile` for the 11.9 release:

- **Agents**: v2.0.3 → v2.4.0 (regular and FIPS)
- **Boards**: v9.2.5 → v9.3.0-rc2 (regular and FIPS)
- **Playbooks**: v2.9.0 → v2.10.0-rc2 (regular and FIPS)

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** These changes introduce three RC (release candidate) versions of plugins (Playbooks v2.10.0-rc2, Agents v2.4.0, and Boards v9.3.0-rc2) into the build configuration. While the Makefile modifications themselves are isolated variable updates, RC versions carry inherent instability risks compared to stable releases, requiring comprehensive testing of these pre-release plugin versions in integration scenarios.

**QA Recommendation:** Manual QA should focus on functional testing of the three updated plugins (Playbooks, Agents, and Boards) in common user workflows and cross-plugin interactions. Given the RC designation and the fact that these affect multiple user-facing features with a broad blast radius, manual verification is recommended despite automated test coverage being full. Prioritize testing FIPS-enabled builds as the PR comments indicate FIPS support was a critical constraint that was recently resolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->