### PR TITLE
[MM-69333] Native ABAC user attributes: populate runtime subject (Phase 2)

### DIFF
--- a/server/channels/app/access_control.go
+++ b/server/channels/app/access_control.go
@@ -2347,6 +2347,26 @@ func (a *App) BuildAccessControlSubject(rctx request.CTX, userID string, roles s
 		}
 	}
 
+	// Populate Mattermost-native user attributes (user.email / user.verified /
+	// user.isbot / user.createat) for runtime PDP evaluation. a.GetUser is the
+	// cached user read and already resolves IsBot via the Bots join, so this is
+	// a single (usually cache-hit) lookup per subject build.
+	user, appErr := a.GetUser(userID)
+	if appErr != nil {
+		// Fail closed: a native-attribute policy must not silently evaluate
+		// against zero-valued natives if the user read fails. The caller
+		// treats a build error as a denial (mirrors the channel-role path).
+		rctx.Logger().Warn("Failed to load user for ABAC native attributes; aborting subject build",
+			mlog.String("user_id", userID),
+			mlog.Err(appErr),
+		)
+		return nil, appErr
+	}
+	subject.Email = user.Email
+	subject.EmailVerified = user.EmailVerified
+	subject.IsBot = user.IsBot
+	subject.CreateAt = user.CreateAt
+
 	subject.Role = roles
 	subject.SetScopedRole(model.AccessControlSubjectScopeSystem, ResolveSystemRole(roles))
 	if channelID != "" {

--- a/server/channels/app/access_control_test.go
+++ b/server/channels/app/access_control_test.go
@@ -2230,6 +2230,46 @@ func TestBuildAccessControlSubjectScopedRoles(t *testing.T) {
 	})
 }
 
+func TestBuildAccessControlSubjectNativeAttributes(t *testing.T) {
+	th := Setup(t).InitBasic(t)
+
+	t.Run("populates native attributes from the user", func(t *testing.T) {
+		subject, appErr := th.App.BuildAccessControlSubject(th.Context, th.BasicUser.Id, th.BasicUser.Roles, "")
+		require.Nil(t, appErr)
+		require.NotNil(t, subject)
+		assert.Equal(t, th.BasicUser.Email, subject.Email)
+		assert.Equal(t, th.BasicUser.EmailVerified, subject.EmailVerified)
+		assert.Equal(t, th.BasicUser.CreateAt, subject.CreateAt)
+		assert.False(t, subject.IsBot)
+	})
+
+	t.Run("IsBot true for a bot user", func(t *testing.T) {
+		bot, appErr := th.App.CreateBot(th.Context, &model.Bot{
+			Username:    "nativeattrbot",
+			Description: "phase2 native attr bot",
+			OwnerId:     th.BasicUser.Id,
+		})
+		require.Nil(t, appErr)
+		t.Cleanup(func() { _ = th.App.PermanentDeleteBot(th.Context, bot.UserId) })
+
+		subject, appErr := th.App.BuildAccessControlSubject(th.Context, bot.UserId, model.SystemUserRoleId, "")
+		require.Nil(t, appErr)
+		require.NotNil(t, subject)
+		assert.True(t, subject.IsBot)
+		assert.Equal(t, bot.UserId, subject.ID)
+	})
+
+	t.Run("fails closed when the user read fails", func(t *testing.T) {
+		// A non-existent user ID takes the GetSubject not-found fallback and
+		// then fails the a.GetUser native-attribute read. The build must fail
+		// closed: return a nil subject and the AppError so callers treat it as
+		// a denial rather than evaluating against zero-valued native attributes.
+		subject, appErr := th.App.BuildAccessControlSubject(th.Context, model.NewId(), model.SystemUserRoleId, "")
+		require.NotNil(t, appErr)
+		require.Nil(t, subject)
+	})
+}
+
 func TestGetRecommendedPublicChannelsForUser(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 

--- a/server/public/model/access_request.go
+++ b/server/public/model/access_request.go
@@ -70,6 +70,16 @@ type Subject struct {
 	// in the enterprise repo) so authors cannot ship a control whose
 	// production behaviour silently diverges from the simulator preview.
 	Session map[string]any `json:"session,omitempty"`
+	// Email is the subject's email address (model.User.Email), exposed to
+	// CEL policies as user.email. Populated by BuildAccessControlSubject.
+	Email string `json:"email"`
+	// EmailVerified mirrors model.User.EmailVerified, exposed as user.verified.
+	EmailVerified bool `json:"email_verified,omitempty"`
+	// IsBot mirrors model.User.IsBot (derived from the Bots table on the
+	// cached user read), exposed as user.isbot.
+	IsBot bool `json:"is_bot,omitempty"`
+	// CreateAt mirrors model.User.CreateAt (epoch ms), exposed as user.createat.
+	CreateAt int64 `json:"create_at,omitempty"`
 }
 
 // RoleForScope returns the role assigned to this subject within the given

--- a/server/public/model/access_request.go
+++ b/server/public/model/access_request.go
@@ -72,7 +72,7 @@ type Subject struct {
 	Session map[string]any `json:"session,omitempty"`
 	// Email is the subject's email address (model.User.Email), exposed to
 	// CEL policies as user.email. Populated by BuildAccessControlSubject.
-	Email string `json:"email"`
+	Email string `json:"email,omitempty"`
 	// EmailVerified mirrors model.User.EmailVerified, exposed as user.verified.
 	EmailVerified bool `json:"email_verified,omitempty"`
 	// IsBot mirrors model.User.IsBot (derived from the Bots table on the


### PR DESCRIPTION
#### Summary

Phase 2 of native user attributes in ABAC: populate the native attributes on the access-control subject for the **per-request PDP evaluation** path (complementing the Phase 1 SQL/membership path).

- Add `Email`, `EmailVerified`, `IsBot`, `CreateAt` to `model.Subject`.
- `BuildAccessControlSubject` loads the (cached) user via `GetUser` and sets the native fields; `IsBot` comes from `model.User.IsBot` (already populated via the `Bots` LEFT JOIN). Fails closed on a user-read error, matching existing ABAC subject-build behavior.

The enterprise CEL evaluator change that reads these fields (`parseSubject`) is in a paired PR on `mattermost/enterprise` (`MM-69333`); this server PR should merge first.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-69333

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The PR introduces a behavioral contract change: `BuildAccessControlSubject` now fails closed (returns error) if `a.GetUser()` fails, whereas previously it would continue populating only role data. This could break callers that were not expecting user-read errors at the subject-building stage. The change affects 9 call sites in authorization and access control evaluation paths, including `BuildAccessControlSubjectForSession` which is part of the core PDP evaluation flow.

**QA Recommendation:** Manual testing is recommended to verify error handling behavior in edge cases (missing users, user service unavailability) and ensure that access denial is properly enforced when user data cannot be loaded. Functional testing of ABAC policies with the new native attributes (email, bot status, create date) should also be performed to ensure proper CEL evaluation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->