### PR TITLE
Skip docs impact review when Docs/Not Needed label is present

### DIFF
--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -13,35 +13,16 @@ concurrency:
 permissions: {}
 
 jobs:
-  check-docs-not-needed:
-    if: github.event.pull_request.draft == false && !startsWith(github.event.pull_request.user.login, 'unified-ci-app')
-    runs-on: ubuntu-24.04
-    permissions:
-      issues: read
-      pull-requests: read
-    outputs:
-      skip: ${{ steps.check.outputs.skip }}
-    steps:
-      - name: Check Docs/Not Needed label
-        id: check
-        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
-        with:
-          script: |
-            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.payload.pull_request.number,
-            });
-            core.setOutput('skip', labels.some(l => l.name === 'Docs/Not Needed') ? 'true' : 'false');
-
   docs-impact-review:
+    if: |
+      github.event.pull_request.draft == false
+      && !startsWith(github.event.pull_request.user.login, 'unified-ci-app')
+      && !contains(github.event.pull_request.labels.*.name, 'Docs/Not Needed')
     permissions:
       contents: read
       pull-requests: write
       issues: write
       id-token: write
-    needs: check-docs-not-needed
-    if: needs.check-docs-not-needed.outputs.skip != 'true'
     runs-on: ubuntu-24.04
     env:
       HAS_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}

--- a/.github/workflows/docs-impact-review.yml
+++ b/.github/workflows/docs-impact-review.yml
@@ -13,13 +13,35 @@ concurrency:
 permissions: {}
 
 jobs:
+  check-docs-not-needed:
+    if: github.event.pull_request.draft == false && !startsWith(github.event.pull_request.user.login, 'unified-ci-app')
+    runs-on: ubuntu-24.04
+    permissions:
+      issues: read
+      pull-requests: read
+    outputs:
+      skip: ${{ steps.check.outputs.skip }}
+    steps:
+      - name: Check Docs/Not Needed label
+        id: check
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
+        with:
+          script: |
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+            });
+            core.setOutput('skip', labels.some(l => l.name === 'Docs/Not Needed') ? 'true' : 'false');
+
   docs-impact-review:
     permissions:
       contents: read
       pull-requests: write
       issues: write
       id-token: write
-    if: github.event.pull_request.draft == false && !startsWith(github.event.pull_request.user.login, 'unified-ci-app')
+    needs: check-docs-not-needed
+    if: needs.check-docs-not-needed.outputs.skip != 'true'
     runs-on: ubuntu-24.04
     env:
       HAS_ANTHROPIC_KEY: ${{ secrets.ANTHROPIC_API_KEY != '' }}


### PR DESCRIPTION
#### Summary

Adds a `check-docs-not-needed` gate job to the documentation impact review workflow. When a PR has the `Docs/Not Needed` label, the Claude analysis is skipped so maintainers can opt out without the workflow re-adding `Docs/Needed` on subsequent CI runs.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The changes introduce a new conditional check for the `Docs/Not Needed` label that gates the analysis job, but this is a reversible, maintainer-controlled feature. The conditional logic is straightforward (check label presence) with no side effects; if the label is applied incorrectly, removing it re-enables analysis on the next CI run.

**QA Recommendation:** Manual QA is minimal. Verify that: (1) PRs without the label continue to trigger documentation analysis as expected, (2) PRs with the `Docs/Not Needed` label correctly skip analysis, and (3) the label can be toggled to control analysis re-runs. Automated testing of workflow conditionals is inherently limited, but the logic is simple and low-risk.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->