### PR TITLE
Prepackage mattermost-plugin-agents v2.0.5 (release-11.8)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -165,7 +165,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.0
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.9.1
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.4
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.5
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.6.1
@@ -179,7 +179,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.9.1%2B885dcf9-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.4%2Bf359551-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.5%2B4ad0d7d-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4%2B5855fe1-fips
 endif
 


### PR DESCRIPTION
#### Summary

Updates the default prepackaged [mattermost-plugin-agents](https://github.com/mattermost/mattermost-plugin-agents) artifact from **2.0.4** to **2.0.5** ([release v2.0.5](https://github.com/mattermost/mattermost-plugin-agents/releases/tag/v2.0.5)) for the `release-11.8` branch.

Both prepackaged plugin lists are updated:
- non-FIPS: `mattermost-plugin-agents-v2.0.5`
- FIPS: `mattermost-plugin-agents-v2.0.5%2B4ad0d7d-fips`

#### Release Note

```release-note
Prepackaged the Mattermost Agents plugin at version 2.0.5 instead of 2.0.4.
```

Made with [Cursor](https://cursor.com)