### PR TITLE
MM-61199: Remove channelBookmarks feature flag

### DIFF
--- a/e2e-tests/playwright/lib/src/server/default_config.ts
+++ b/e2e-tests/playwright/lib/src/server/default_config.ts
@@ -773,7 +773,6 @@ const defaultServerConfig: AdminConfig = {
         ConsumePostHook: false,
         CloudAnnualRenewals: false,
         CloudDedicatedExportUI: false,
-        ChannelBookmarks: true,
         WebSocketEventScope: true,
         NotificationMonitoring: true,
         ExperimentalAuditSettingsSystemConsoleUI: true,

--- a/server/channels/api4/channel_bookmark.go
+++ b/server/channels/api4/channel_bookmark.go
@@ -17,13 +17,11 @@ func rejectExternallyManagedBookmarkWrite(op string) *model.AppError {
 }
 
 func (api *API) InitChannelBookmarks() {
-	if api.srv.Config().FeatureFlags.ChannelBookmarks {
-		api.BaseRoutes.ChannelBookmarks.Handle("", api.APISessionRequired(createChannelBookmark)).Methods(http.MethodPost)
-		api.BaseRoutes.ChannelBookmark.Handle("", api.APISessionRequired(updateChannelBookmark)).Methods(http.MethodPatch)
-		api.BaseRoutes.ChannelBookmark.Handle("/sort_order", api.APISessionRequired(updateChannelBookmarkSortOrder)).Methods(http.MethodPost)
-		api.BaseRoutes.ChannelBookmark.Handle("", api.APISessionRequired(deleteChannelBookmark)).Methods(http.MethodDelete)
-		api.BaseRoutes.ChannelBookmarks.Handle("", api.APISessionRequired(listChannelBookmarksForChannel)).Methods(http.MethodGet)
-	}
+	api.BaseRoutes.ChannelBookmarks.Handle("", api.APISessionRequired(createChannelBookmark)).Methods(http.MethodPost)
+	api.BaseRoutes.ChannelBookmark.Handle("", api.APISessionRequired(updateChannelBookmark)).Methods(http.MethodPatch)
+	api.BaseRoutes.ChannelBookmark.Handle("/sort_order", api.APISessionRequired(updateChannelBookmarkSortOrder)).Methods(http.MethodPost)
+	api.BaseRoutes.ChannelBookmark.Handle("", api.APISessionRequired(deleteChannelBookmark)).Methods(http.MethodDelete)
+	api.BaseRoutes.ChannelBookmarks.Handle("", api.APISessionRequired(listChannelBookmarksForChannel)).Methods(http.MethodGet)
 }
 
 func createChannelBookmark(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -57,8 +57,6 @@ type FeatureFlags struct {
 	CloudAnnualRenewals    bool
 	CloudDedicatedExportUI bool
 
-	ChannelBookmarks bool
-
 	WebSocketEventScope bool
 
 	NotificationMonitoring bool
@@ -181,7 +179,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.ConsumePostHook = false
 	f.CloudAnnualRenewals = false
 	f.CloudDedicatedExportUI = false
-	f.ChannelBookmarks = true
 	f.WebSocketEventScope = true
 	f.NotificationMonitoring = true
 	f.ExperimentalAuditSettingsSystemConsoleUI = true

--- a/webapp/channels/src/components/channel_bookmarks/utils.ts
+++ b/webapp/channels/src/components/channel_bookmarks/utils.ts
@@ -11,7 +11,7 @@ import type {GlobalState} from '@mattermost/types/store';
 import {Permissions} from 'mattermost-redux/constants';
 import {getChannelBookmarks} from 'mattermost-redux/selectors/entities/channel_bookmarks';
 import {getChannel, getMyChannelMember} from 'mattermost-redux/selectors/entities/channels';
-import {getConfig, getFeatureFlagValue, getLicense} from 'mattermost-redux/selectors/entities/general';
+import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {haveIChannelPermission} from 'mattermost-redux/selectors/entities/roles';
 import {insertWithoutDuplicates} from 'mattermost-redux/utils/array_utils';
 import {getFileDownloadUrl} from 'mattermost-redux/utils/file_utils';
@@ -118,12 +118,6 @@ export const useCanGetLinkPreviews = () => {
 };
 
 export const getIsChannelBookmarksEnabled = (state: GlobalState) => {
-    const isEnabled = getFeatureFlagValue(state, 'ChannelBookmarks') === 'true';
-
-    if (!isEnabled) {
-        return false;
-    }
-
     const license = getLicense(state);
 
     return license?.IsLicensed === 'true';


### PR DESCRIPTION
#### Summary
The Channel Bookmarks feature is GA, so this removes the `ChannelBookmarks` feature flag and makes the feature unconditionally available (still gated by license). Changes:
- Remove the `ChannelBookmarks` field and its `SetDefaults` entry from `FeatureFlags`.
- Register the channel bookmark API routes unconditionally in `InitChannelBookmarks()`.
- Drop the flag gate in the webapp `getIsChannelBookmarksEnabled` selector (license check retained).
- Remove the `ChannelBookmarks: true` entry from the Playwright E2E default `FeatureFlags`.

Behavior-preserving: the flag already defaulted to `true`, so the feature was already on for everyone. The per-handler and selector license checks are unchanged.

QA: `cd server && make check-style` (0 issues), server build clean, channel bookmark api4 integration tests pass, `cd webapp && make check-types && make check-style` clean. No remaining references to the flag in Go/TS.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-61199

#### Screenshots
N/A — no user-visible change (feature was already enabled by default).

#### Release Note
```release-note
Removed the `ChannelBookmarks` feature flag. The Channel Bookmarks feature is now always enabled (subject to licensing).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The feature flag being removed was already defaulting to `true`, so users will see no functional behavior change. However, the changes span multiple system components (Go model/config, server API route registration, TypeScript webapp utilities, and E2E test config), creating a medium blast radius. The risk is mitigated by the fact that all handler implementations and authorization logic remain unchanged—only the feature flag gate is being removed while license-based access control persists.

**QA Recommendation:** Targeted testing on channel bookmark creation, update, deletion, and listing flows is recommended to verify routes function correctly without the feature flag check. Basic smoke testing of license-gated behavior for users without bookmarks licenses should also be verified. Given that this removes an already-enabled flag and license checks remain in place, comprehensive regression testing can be limited to channel bookmark–specific flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->