### PR TITLE
[MM-69335] Strip native attributes from self-inclusion check (Phase 4)

### DIFF
--- a/server/channels/app/access_control.go
+++ b/server/channels/app/access_control.go
@@ -2300,6 +2300,10 @@ func (a *App) ValidateExpressionAgainstRequester(rctx request.CTX, expression st
 	users, _, appErr := acs.QueryUsersForExpression(rctx, expression, model.SubjectSearchOptions{
 		SubjectID: requesterID, // Only check this specific user
 		Limit:     1,           // Maximum 1 result expected
+		// Native attributes (user.email/verified/isbot/createat) describe the
+		// requester themselves, not who they can include; strip them so the
+		// self-inclusion check validates only the CPA-attribute parts.
+		ExcludeNativeAttributes: true,
 	})
 	if appErr != nil {
 		return false, appErr

--- a/server/channels/app/access_control_test.go
+++ b/server/channels/app/access_control_test.go
@@ -504,6 +504,26 @@ func TestCheckSelfInclusion(t *testing.T) {
 	})
 }
 
+func TestValidateExpressionAgainstRequesterExcludesNativeAttributes(t *testing.T) {
+	th := Setup(t).InitBasic(t)
+	requesterID := th.BasicUser.Id
+
+	mockACS := &mocks.AccessControlServiceInterface{}
+	th.App.Srv().ch.AccessControl = mockACS
+
+	// The requester query must scope to the requester AND request native-attribute
+	// stripping so only the CPA parts are validated against the saving admin.
+	mockACS.On("QueryUsersForExpression", mock.Anything, `user.isbot == false && user.attributes.team == "ops"`,
+		mock.MatchedBy(func(opts model.SubjectSearchOptions) bool {
+			return opts.SubjectID == requesterID && opts.ExcludeNativeAttributes
+		})).Return([]*model.User{{Id: requesterID}}, int64(1), nil).Once()
+
+	matches, appErr := th.App.ValidateExpressionAgainstRequester(th.Context, `user.isbot == false && user.attributes.team == "ops"`, requesterID)
+	require.Nil(t, appErr)
+	require.True(t, matches)
+	mockACS.AssertExpectations(t)
+}
+
 func TestGetChannelsForPolicy(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 
@@ -1694,7 +1714,7 @@ func TestTestExpressionWithChannelContext(t *testing.T) {
 			"QueryUsersForExpression",
 			th.Context,
 			expression,
-			model.SubjectSearchOptions{SubjectID: th.BasicUser.Id, Limit: 1},
+			model.SubjectSearchOptions{SubjectID: th.BasicUser.Id, Limit: 1, ExcludeNativeAttributes: true},
 		).Return([]*model.User{th.BasicUser}, int64(1), nil) // Admin matches
 
 		// Mock the actual search results
@@ -1729,7 +1749,7 @@ func TestTestExpressionWithChannelContext(t *testing.T) {
 			"QueryUsersForExpression",
 			th.Context,
 			expression,
-			model.SubjectSearchOptions{SubjectID: th.BasicUser.Id, Limit: 1},
+			model.SubjectSearchOptions{SubjectID: th.BasicUser.Id, Limit: 1, ExcludeNativeAttributes: true},
 		).Return([]*model.User{}, int64(0), nil) // Admin doesn't match
 
 		// Call the function
@@ -1755,7 +1775,7 @@ func TestTestExpressionWithChannelContext(t *testing.T) {
 			"QueryUsersForExpression",
 			th.Context,
 			expression,
-			model.SubjectSearchOptions{SubjectID: th.BasicUser.Id, Limit: 1},
+			model.SubjectSearchOptions{SubjectID: th.BasicUser.Id, Limit: 1, ExcludeNativeAttributes: true},
 		).Return([]*model.User{th.BasicUser}, int64(1), nil) // Admin matches
 
 		// Mock the actual search results
@@ -1791,7 +1811,7 @@ func TestTestExpressionWithChannelContext(t *testing.T) {
 			"QueryUsersForExpression",
 			th.Context,
 			expression,
-			model.SubjectSearchOptions{SubjectID: th.BasicUser.Id, Limit: 1},
+			model.SubjectSearchOptions{SubjectID: th.BasicUser.Id, Limit: 1, ExcludeNativeAttributes: true},
 		).Return([]*model.User{}, int64(0), nil) // Admin doesn't match full expression
 
 		// Call the function
@@ -1817,7 +1837,7 @@ func TestTestExpressionWithChannelContext(t *testing.T) {
 			"QueryUsersForExpression",
 			th.Context,
 			expression,
-			model.SubjectSearchOptions{SubjectID: th.BasicUser.Id, Limit: 1},
+			model.SubjectSearchOptions{SubjectID: th.BasicUser.Id, Limit: 1, ExcludeNativeAttributes: true},
 		).Return([]*model.User{th.BasicUser}, int64(1), nil) // Admin matches
 
 		// Mock the actual search results
@@ -1852,7 +1872,7 @@ func TestTestExpressionWithChannelContext(t *testing.T) {
 			"QueryUsersForExpression",
 			th.Context,
 			expression,
-			model.SubjectSearchOptions{SubjectID: th.BasicUser.Id, Limit: 1},
+			model.SubjectSearchOptions{SubjectID: th.BasicUser.Id, Limit: 1, ExcludeNativeAttributes: true},
 		).Return([]*model.User{}, int64(0), model.NewAppError("TestExpressionWithChannelContext", "app.access_control.query.app_error", nil, "validation error", http.StatusInternalServerError))
 
 		// Call the function
@@ -1881,7 +1901,7 @@ func TestValidateExpressionAgainstRequester(t *testing.T) {
 			"QueryUsersForExpression",
 			th.Context,
 			expression,
-			model.SubjectSearchOptions{SubjectID: requesterID, Limit: 1},
+			model.SubjectSearchOptions{SubjectID: requesterID, Limit: 1, ExcludeNativeAttributes: true},
 		).Return(mockUsers, int64(1), nil)
 
 		// Call the function
@@ -1906,7 +1926,7 @@ func TestValidateExpressionAgainstRequester(t *testing.T) {
 			"QueryUsersForExpression",
 			th.Context,
 			expression,
-			model.SubjectSearchOptions{SubjectID: requesterID, Limit: 1},
+			model.SubjectSearchOptions{SubjectID: requesterID, Limit: 1, ExcludeNativeAttributes: true},
 		).Return(mockUsers, int64(0), nil)
 
 		// Call the function
@@ -1931,7 +1951,7 @@ func TestValidateExpressionAgainstRequester(t *testing.T) {
 			"QueryUsersForExpression",
 			th.Context,
 			expression,
-			model.SubjectSearchOptions{SubjectID: requesterID, Limit: 1},
+			model.SubjectSearchOptions{SubjectID: requesterID, Limit: 1, ExcludeNativeAttributes: true},
 		).Return(mockUsers, int64(0), nil)
 
 		// Call the function
@@ -1955,7 +1975,7 @@ func TestValidateExpressionAgainstRequester(t *testing.T) {
 			"QueryUsersForExpression",
 			th.Context,
 			expression,
-			model.SubjectSearchOptions{SubjectID: requesterID, Limit: 1},
+			model.SubjectSearchOptions{SubjectID: requesterID, Limit: 1, ExcludeNativeAttributes: true},
 		).Return([]*model.User{}, int64(0), model.NewAppError("ValidateExpressionAgainstRequester", "app.access_control.validate_requester.app_error", nil, "expression parsing error", http.StatusInternalServerError))
 
 		// Call the function

--- a/server/public/model/access_request.go
+++ b/server/public/model/access_request.go
@@ -181,6 +181,10 @@ type SubjectSearchOptions struct {
 	// This is particularly useful for validation queries where we only need to check
 	// if a specific user matches an expression, rather than fetching all matching users
 	SubjectID string `json:"subject_id"`
+	// ExcludeNativeAttributes strips native user-attribute predicates (user.email,
+	// user.verified, user.isbot, user.createat[.youngerThanDays]) from the expression
+	// before building SQL, so self-inclusion validation checks only the CPA parts.
+	ExcludeNativeAttributes bool `json:"exclude_native_attributes,omitempty"`
 }
 
 type SubjectCursor struct {


### PR DESCRIPTION
#### Summary
Phase 4 of native user attributes in ABAC (epic [MM-69331](https://mattermost.atlassian.net/browse/MM-69331), ticket [MM-69334](https://mattermost.atlassian.net/browse/MM-69335)). Server side of a cross-repo change (enterprise PR linked below).

The self-inclusion check runs a policy's SQL against the saving admin so they can't lock themselves out. Native user attributes (`user.email`, `user.verified`, `user.isbot`, `user.createat`, `user.createat.youngerThanDays(N)`) describe the requester themselves, not who they can include, so they must not gate that requester query.

- Add `SubjectSearchOptions.ExcludeNativeAttributes bool`.
- `ValidateExpressionAgainstRequester` sets it `true`, so only the CPA parts are validated against the admin. The actual stripping happens in the enterprise PDP (`QueryUsersForExpression`).

#### Test plan
- New `TestValidateExpressionAgainstRequesterExcludesNativeAttributes` asserts the option is passed (via `mock.MatchedBy`).
- Updated existing `TestValidateExpressionAgainstRequester` / `TestExpressionWithChannelContext` mock expectations for the new option.
- `go test ./channels/app/ -run 'ValidateExpressionAgainstRequester|CheckSelfInclusion|ExpressionWithChannelContext'` green; gofmt clean.

#### Stacking
Cross-repo with enterprise. Stacked on **Phase 2** (`MM-69333`); base retargets to `master` once earlier phases merge. Requires the enterprise PR to land for the stripping to take effect.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

[MM-69331]: https://mattermost.atlassian.net/browse/MM-69331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[MM-69334]: https://mattermost.atlassian.net/browse/MM-69334?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟠 Medium

**Regression Risk:** This change is relatively localized, but it alters a shared access-control request option and the requester-validation path used during expression checks. Risk is moderate because the new flag changes evaluation behavior for native user attributes, which could affect authorization-adjacent flows if mocks, callers, or downstream PDP handling are not aligned.

**QA Recommendation:** Automated coverage is good for the updated call expectations, but a small amount of targeted manual QA is recommended around expression validation for requester self-inclusion and policies involving native user attributes.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->