### PR TITLE
Add showPopout opt-out to plugin RHS registerRightHandSidebarComponent

### DIFF
--- a/webapp/channels/src/plugins/registry.ts
+++ b/webapp/channels/src/plugins/registry.ts
@@ -1095,6 +1095,7 @@ export default class PluginRegistry {
      * Accepts the following:
      * - component - A react component to display in the Right-Hand Sidebar.
      * - title - A string or JSX element to display as a title for the RHS.
+     * - showPopout - Optional boolean (default: true). Set to false to hide the "Open in new window" button in the RHS header.
      * Returns:
      * - id: a unique identifier
      * - showRHSPlugin: the action to dispatch that will open the RHS.
@@ -1104,12 +1105,15 @@ export default class PluginRegistry {
     registerRightHandSidebarComponent = reArg([
         'component',
         'title',
+        'showPopout',
     ], ({
         component,
         title,
+        showPopout = true,
     }: {
         component: RightHandSidebarComponent['component'];
         title: ReactResolvable;
+        showPopout?: boolean;
     }) => {
         const id = generateId();
 
@@ -1118,6 +1122,7 @@ export default class PluginRegistry {
             pluginId: this.id,
             component,
             title: resolveReactElement(title),
+            showPopout,
         });
 
         return {id, showRHSPlugin: showRHSPlugin(id), hideRHSPlugin: hideRHSPlugin(id), toggleRHSPlugin: toggleRHSPlugin(id)};

--- a/webapp/channels/src/plugins/rhs_plugin/index.ts
+++ b/webapp/channels/src/plugins/rhs_plugin/index.ts
@@ -21,6 +21,7 @@ function mapStateToProps(state: GlobalState) {
         pluggableId,
         title: pluginTitle,
         pluginId,
+        showPopout: pluginComponent?.showPopout ?? true,
     };
 }
 

--- a/webapp/channels/src/plugins/rhs_plugin/rhs_plugin.test.tsx
+++ b/webapp/channels/src/plugins/rhs_plugin/rhs_plugin.test.tsx
@@ -1,0 +1,145 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import type {DeepPartial} from '@mattermost/types/utilities';
+
+import {renderWithContext, screen} from 'tests/react_testing_utils';
+
+import type {GlobalState} from 'types/store';
+
+import ConnectedRhsPlugin from '.';
+import RhsPlugin from './rhs_plugin';
+
+jest.mock('components/search_results_header', () => ({
+    __esModule: true,
+    default: ({children, newWindowHandler}: {children: React.ReactNode; newWindowHandler?: () => void}) => (
+        <div
+            data-testid='search-results-header'
+            data-has-window-handler={newWindowHandler !== undefined ? 'true' : 'false'}
+        >
+            {children}
+        </div>
+    ),
+}));
+
+jest.mock('plugins/pluggable', () => ({
+    __esModule: true,
+    default: () => <div data-testid='pluggable' />,
+}));
+
+jest.mock('utils/popouts/popout_windows', () => ({
+    popoutRhsPlugin: jest.fn(),
+}));
+
+const baseState: DeepPartial<GlobalState> = {
+    entities: {
+        general: {config: {}},
+        teams: {
+            currentTeamId: 'team-id',
+            teams: {'team-id': {id: 'team-id', name: 'test-team'}},
+        },
+        channels: {
+            currentChannelId: 'channel-id',
+            channels: {'channel-id': {id: 'channel-id', name: 'test-channel'}},
+        },
+        preferences: {myPreferences: {}},
+    },
+    plugins: {
+        plugins: {'plugin-id': {name: 'Test Plugin'}},
+        components: {
+            RightHandSidebarComponent: [],
+        },
+    },
+    views: {
+        rhs: {pluggableId: ''},
+    },
+};
+
+describe('RhsPlugin', () => {
+    describe('component', () => {
+        it('passes newWindowHandler to SearchResultsHeader when showPopout is true', () => {
+            renderWithContext(
+                <RhsPlugin
+                    showPluggable={true}
+                    pluggableId='pluggable-id'
+                    title='Test Title'
+                    pluginId='plugin-id'
+                    showPopout={true}
+                />,
+                baseState,
+            );
+
+            expect(screen.getByTestId('search-results-header')).toHaveAttribute('data-has-window-handler', 'true');
+        });
+
+        it('passes undefined for newWindowHandler to SearchResultsHeader when showPopout is false', () => {
+            renderWithContext(
+                <RhsPlugin
+                    showPluggable={true}
+                    pluggableId='pluggable-id'
+                    title='Test Title'
+                    pluginId='plugin-id'
+                    showPopout={false}
+                />,
+                baseState,
+            );
+
+            expect(screen.getByTestId('search-results-header')).toHaveAttribute('data-has-window-handler', 'false');
+        });
+
+        it('defaults showPopout to true when the prop is omitted', () => {
+            renderWithContext(
+                <RhsPlugin
+                    showPluggable={true}
+                    pluggableId='pluggable-id'
+                    title='Test Title'
+                    pluginId='plugin-id'
+                />,
+                baseState,
+            );
+
+            expect(screen.getByTestId('search-results-header')).toHaveAttribute('data-has-window-handler', 'true');
+        });
+    });
+
+    describe('mapStateToProps', () => {
+        const pluggableId = 'pluggable-id';
+
+        function stateWithRegisteredComponent(showPopout?: boolean): DeepPartial<GlobalState> {
+            const component: Record<string, unknown> = {
+                id: pluggableId,
+                pluginId: 'plugin-id',
+                title: 'Test Title',
+            };
+            if (showPopout !== undefined) {
+                component.showPopout = showPopout;
+            }
+            return {
+                ...baseState,
+                plugins: {
+                    ...baseState.plugins,
+                    components: {
+                        RightHandSidebarComponent: [component as any],
+                    },
+                },
+                views: {
+                    rhs: {pluggableId},
+                },
+            };
+        }
+
+        it('defaults showPopout to true when component showPopout field is undefined', () => {
+            renderWithContext(<ConnectedRhsPlugin />, stateWithRegisteredComponent(undefined));
+
+            expect(screen.getByTestId('search-results-header')).toHaveAttribute('data-has-window-handler', 'true');
+        });
+
+        it('passes showPopout: false through to hide the popout button', () => {
+            renderWithContext(<ConnectedRhsPlugin />, stateWithRegisteredComponent(false));
+
+            expect(screen.getByTestId('search-results-header')).toHaveAttribute('data-has-window-handler', 'false');
+        });
+    });
+});

--- a/webapp/channels/src/plugins/rhs_plugin/rhs_plugin.test.tsx
+++ b/webapp/channels/src/plugins/rhs_plugin/rhs_plugin.test.tsx
@@ -9,15 +9,16 @@ import {renderWithContext, screen} from 'tests/react_testing_utils';
 
 import type {GlobalState} from 'types/store';
 
-import ConnectedRhsPlugin from '.';
 import RhsPlugin from './rhs_plugin';
+
+import ConnectedRhsPlugin from '.';
 
 jest.mock('components/search_results_header', () => ({
     __esModule: true,
     default: ({children, newWindowHandler}: {children: React.ReactNode; newWindowHandler?: () => void}) => (
         <div
             data-testid='search-results-header'
-            data-has-window-handler={newWindowHandler !== undefined ? 'true' : 'false'}
+            data-has-window-handler={newWindowHandler === undefined ? 'false' : 'true'}
         >
             {children}
         </div>
@@ -26,7 +27,7 @@ jest.mock('components/search_results_header', () => ({
 
 jest.mock('plugins/pluggable', () => ({
     __esModule: true,
-    default: () => <div data-testid='pluggable' />,
+    default: () => <div data-testid='pluggable'/>,
 }));
 
 jest.mock('utils/popouts/popout_windows', () => ({
@@ -131,13 +132,13 @@ describe('RhsPlugin', () => {
         }
 
         it('defaults showPopout to true when component showPopout field is undefined', () => {
-            renderWithContext(<ConnectedRhsPlugin />, stateWithRegisteredComponent(undefined));
+            renderWithContext(<ConnectedRhsPlugin/>, stateWithRegisteredComponent(undefined));
 
             expect(screen.getByTestId('search-results-header')).toHaveAttribute('data-has-window-handler', 'true');
         });
 
         it('passes showPopout: false through to hide the popout button', () => {
-            renderWithContext(<ConnectedRhsPlugin />, stateWithRegisteredComponent(false));
+            renderWithContext(<ConnectedRhsPlugin/>, stateWithRegisteredComponent(false));
 
             expect(screen.getByTestId('search-results-header')).toHaveAttribute('data-has-window-handler', 'false');
         });

--- a/webapp/channels/src/plugins/rhs_plugin/rhs_plugin.tsx
+++ b/webapp/channels/src/plugins/rhs_plugin/rhs_plugin.tsx
@@ -21,9 +21,10 @@ export type Props = {
     pluggableId: string;
     title: React.ReactNode;
     pluginId?: string;
+    showPopout?: boolean;
 };
 
-const RhsPlugin = ({showPluggable, pluggableId, title, pluginId}: Props) => {
+const RhsPlugin = ({showPluggable, pluggableId, title, pluginId, showPopout = true}: Props) => {
     const intl = useIntl();
     const currentTeam = useSelector(getCurrentTeam);
     const currentChannel = useSelector(getCurrentChannel);
@@ -51,7 +52,7 @@ const RhsPlugin = ({showPluggable, pluggableId, title, pluginId}: Props) => {
             id='rhsContainer'
             className='sidebar-right__body'
         >
-            <SearchResultsHeader newWindowHandler={newWindowHandler}>
+            <SearchResultsHeader newWindowHandler={showPopout ? newWindowHandler : undefined}>
                 {title}
             </SearchResultsHeader>
             {

--- a/webapp/channels/src/types/store/plugins.ts
+++ b/webapp/channels/src/types/store/plugins.ts
@@ -350,6 +350,7 @@ export type PostDropdownMenuItemComponent = PluginComponent & {
 export type RightHandSidebarComponent = PluginComponent & {
     title: PluggableText;
     component: React.ComponentType<BasePluggableProps>;
+    showPopout?: boolean;
 };
 
 export type SearchHintsComponent = PluginComponent & {


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary

Adds an optional `showPopout` flag (default: `true`) to `registerRightHandSidebarComponent` in the webapp plugin registry so plugins can opt out of showing the "Open in new window" popout button in the RHS header.

**Changes:**
- `RightHandSidebarComponent` type gains `showPopout?: boolean`
- `registerRightHandSidebarComponent` accepts `showPopout` (defaults to `true`) and stores it in Redux
- `rhs_plugin/index.ts` reads the flag from the matched component (`?? true` guard for safety)
- `RhsPlugin` conditionally passes `newWindowHandler` to `SearchResultsHeader` only when `showPopout` is `true`

**Usage:**
```js
registry.registerRightHandSidebarComponent({
    component: MyComponent,
    title: 'My Panel',
    showPopout: false, // hides the "Open in new window" button
});
```

**Regression notes:** Existing plugins and all non-plugin RHS states (search, mentions, pinned, flagged, etc.) are completely unaffected — the flag defaults to `true` and the search RHS is rendered by a separate, untouched code path.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69391

#### Screenshots
**RHS new window popout disabled:** 

<img width="559" height="482" alt="Screenshot 2026-06-19 at 5 02 10 PM" src="https://github.com/user-attachments/assets/b0cadcc4-ae57-4893-9c2d-b2662cd1d752" />

**RHS new window popout enabled (default behavior):**

<img width="573" height="498" alt="Screenshot 2026-06-20 at 7 14 59 PM" src="https://github.com/user-attachments/assets/de9d26e3-16bf-476f-aaa7-a29fa29236ee" />


#### Release Note
```release-note
Plugin registry's `registerRightHandSidebarComponent` now accepts an optional `showPopout` boolean (default `true`) to hide the "Open in new window" button from the plugin RHS header.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** This is a backward-compatible feature addition with proper defensive defaults. All four modified files use sensible defaults (`showPopout` defaults to `true`, nullish coalescing operator `?? true`), ensuring existing plugin behavior is entirely preserved. The changes are isolated to the plugin registry and RHS subsystem with no impact on authentication, data persistence, or core business logic.

**QA Recommendation:** Manual QA can be minimal. Focus on verifying that existing RHS plugins without the `showPopout` parameter continue to show the "Open in new window" button, and that plugins explicitly setting `showPopout: false` correctly hide the button. Automated tests should sufficiently cover the optional parameter handling, defaults, and conditional logic.
  
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->