### PR TITLE
Allows saving a managed field linked to LDAP/SAML and disables the managed switch

### DIFF
--- a/server/public/model/custom_profile_attributes.go
+++ b/server/public/model/custom_profile_attributes.go
@@ -214,12 +214,6 @@ func (c *CPAField) SanitizeAndValidate() *AppError {
 		c.Attrs.SAML = ""
 	}
 
-	// Clear sync properties if managed is set (mutual exclusivity)
-	if c.IsAdminManaged() {
-		c.Attrs.LDAP = ""
-		c.Attrs.SAML = ""
-	}
-
 	switch c.Type {
 	case PropertyFieldTypeText:
 		if valueType := strings.TrimSpace(c.Attrs.ValueType); valueType != "" {

--- a/server/public/model/custom_profile_attributes_test.go
+++ b/server/public/model/custom_profile_attributes_test.go
@@ -829,7 +829,7 @@ func TestCPAField_SanitizeAndValidate(t *testing.T) {
 				errorId:     "app.custom_profile_attributes.sanitize_and_validate.app_error",
 			},
 			{
-				name: "managed field should clear LDAP sync properties",
+				name: "admin-managed text field preserves LDAP and SAML sync properties",
 				field: &CPAField{
 					PropertyField: PropertyField{
 						Type: PropertyFieldTypeText,
@@ -844,27 +844,27 @@ func TestCPAField_SanitizeAndValidate(t *testing.T) {
 				expectedAttrs: CPAAttrs{
 					Visibility: CustomProfileAttributesVisibilityDefault,
 					Managed:    "admin",
-					LDAP:       "", // Should be cleared
-					SAML:       "", // Should be cleared
+					LDAP:       "ldap_attribute", // preserved: managed no longer strips the link
+					SAML:       "saml_attribute",
 				},
 			},
 			{
-				name: "managed field should clear sync properties even when field supports syncing",
+				name: "admin-managed SAML-only text field preserves the link",
 				field: &CPAField{
 					PropertyField: PropertyField{
 						Type: PropertyFieldTypeText, // Text fields support syncing
 					},
 					Attrs: CPAAttrs{
 						Managed: "admin",
-						LDAP:    "ldap_attribute",
+						SAML:    "saml_attribute",
 					},
 				},
 				expectError: false,
 				expectedAttrs: CPAAttrs{
 					Visibility: CustomProfileAttributesVisibilityDefault,
 					Managed:    "admin",
-					LDAP:       "", // Should be cleared due to mutual exclusivity
-					SAML:       "",
+					LDAP:       "",
+					SAML:       "saml_attribute", // preserved
 				},
 			},
 		}

--- a/webapp/channels/src/components/admin_console/system_properties/user_properties_dot_menu.test.tsx
+++ b/webapp/channels/src/components/admin_console/system_properties/user_properties_dot_menu.test.tsx
@@ -8,7 +8,7 @@ import type {UserPropertyField} from '@mattermost/types/properties';
 
 import ModalController from 'components/modal_controller';
 
-import {renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
+import {renderWithContext, screen, userEvent, waitFor, within} from 'tests/react_testing_utils';
 
 import DotMenu from './user_properties_dot_menu';
 
@@ -175,6 +175,155 @@ describe('UserPropertyDotMenu', () => {
 
         // Verify the SAML link text shows the edit option
         expect(screen.getByText('Edit SAML link')).toBeInTheDocument();
+    });
+
+    it('sets ldap from the modal without adding managed to an unmanaged field', async () => {
+        renderComponent();
+
+        const menuButton = screen.getByTestId(`user-property-field_dotmenu-${baseField.id}`);
+        await userEvent.click(menuButton);
+        await userEvent.click(screen.getByText('Link attribute to AD/LDAP'));
+
+        await userEvent.type(await screen.findByRole('textbox'), 'employeeID');
+        await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        expect(updateField).toHaveBeenCalledWith({
+            ...baseField,
+            type: 'text',
+            attrs: {
+                ...baseField.attrs,
+                ldap: 'employeeID',
+            },
+        });
+    });
+
+    it('sets ldap from the modal without changing managed on an admin-managed field', async () => {
+        const adminManagedField: UserPropertyField = {
+            ...baseField,
+            id: 'admin-managed-ldap-modal',
+            attrs: {
+                ...baseField.attrs,
+                managed: 'admin',
+            },
+        };
+
+        renderComponent(adminManagedField);
+
+        const menuButton = screen.getByTestId(`user-property-field_dotmenu-${adminManagedField.id}`);
+        await userEvent.click(menuButton);
+        await userEvent.click(screen.getByText('Link attribute to AD/LDAP'));
+
+        await userEvent.type(await screen.findByRole('textbox'), 'employeeID');
+        await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        expect(updateField).toHaveBeenCalledWith({
+            ...adminManagedField,
+            type: 'text',
+            attrs: {
+                ...adminManagedField.attrs,
+                ldap: 'employeeID',
+            },
+        });
+    });
+
+    it('keeps the "Editable by users" toggle enabled for an admin-managed field that is not synced', async () => {
+        const adminManagedField: UserPropertyField = {
+            ...baseField,
+            id: 'admin-managed-unsynced',
+            attrs: {
+                ...baseField.attrs,
+                managed: 'admin',
+            },
+        };
+
+        renderComponent(adminManagedField);
+
+        await userEvent.click(screen.getByTestId(`user-property-field_dotmenu-${adminManagedField.id}`));
+
+        const editableItem = screen.getByRole('menuitemcheckbox', {name: /Editable by users/});
+        expect(editableItem).toHaveAttribute('aria-checked', 'false');
+        expect(within(editableItem).getByRole('button')).toBeEnabled();
+        expect(screen.queryByText('Synced attributes are managed by AD/LDAP or SAML')).not.toBeInTheDocument();
+    });
+
+    it('disables the "Editable by users" toggle and reports it off when the field is synced via LDAP', async () => {
+        const ldapSyncedField: UserPropertyField = {
+            ...baseField,
+            id: 'ldap-synced-field',
+            attrs: {
+                ...baseField.attrs,
+                ldap: 'employeeID',
+            },
+        };
+
+        renderComponent(ldapSyncedField);
+
+        await userEvent.click(screen.getByTestId(`user-property-field_dotmenu-${ldapSyncedField.id}`));
+
+        const editableItem = screen.getByRole('menuitemcheckbox', {name: /Editable by users/});
+        expect(editableItem).toHaveAttribute('aria-checked', 'false');
+        expect(within(editableItem).getByRole('button')).toBeDisabled();
+        expect(screen.getByText('Synced attributes are managed by AD/LDAP or SAML')).toBeInTheDocument();
+    });
+
+    it('does not update a synced field when clicking the "Editable by users" toggle', async () => {
+        const ldapSyncedField: UserPropertyField = {
+            ...baseField,
+            id: 'ldap-synced-toggle-click',
+            attrs: {
+                ...baseField.attrs,
+                ldap: 'employeeID',
+            },
+        };
+
+        renderComponent(ldapSyncedField);
+
+        await userEvent.click(screen.getByTestId(`user-property-field_dotmenu-${ldapSyncedField.id}`));
+
+        const editableItem = screen.getByRole('menuitemcheckbox', {name: /Editable by users/});
+        editableItem.click();
+
+        expect(updateField).not.toHaveBeenCalled();
+    });
+
+    it('disables the "Editable by users" toggle when the field is synced via SAML', async () => {
+        const samlSyncedField: UserPropertyField = {
+            ...baseField,
+            id: 'saml-synced-field',
+            attrs: {
+                ...baseField.attrs,
+                saml: 'position',
+            },
+        };
+
+        renderComponent(samlSyncedField);
+
+        await userEvent.click(screen.getByTestId(`user-property-field_dotmenu-${samlSyncedField.id}`));
+
+        const editableItem = screen.getByRole('menuitemcheckbox', {name: /Editable by users/});
+        expect(editableItem).toHaveAttribute('aria-checked', 'false');
+        expect(within(editableItem).getByRole('button')).toBeDisabled();
+        expect(screen.getByText('Synced attributes are managed by AD/LDAP or SAML')).toBeInTheDocument();
+    });
+
+    it('disables the "Editable by users" toggle when the field is both admin-managed and synced', async () => {
+        const adminManagedSyncedField: UserPropertyField = {
+            ...baseField,
+            id: 'admin-managed-synced-field',
+            attrs: {
+                ...baseField.attrs,
+                managed: 'admin',
+                ldap: 'employeeID',
+            },
+        };
+
+        renderComponent(adminManagedSyncedField);
+
+        await userEvent.click(screen.getByTestId(`user-property-field_dotmenu-${adminManagedSyncedField.id}`));
+
+        const editableItem = screen.getByRole('menuitemcheckbox', {name: /Editable by users/});
+        expect(within(editableItem).getByRole('button')).toBeDisabled();
+        expect(screen.getByText('Synced attributes are managed by AD/LDAP or SAML')).toBeInTheDocument();
     });
 
     it('handles field duplication', async () => {

--- a/webapp/channels/src/components/admin_console/system_properties/user_properties_dot_menu.tsx
+++ b/webapp/channels/src/components/admin_console/system_properties/user_properties_dot_menu.tsx
@@ -120,6 +120,9 @@ const DotMenu = ({
 
     const isProtected = Boolean(field.attrs?.protected);
 
+    const isSynced = Boolean(field.attrs.ldap || field.attrs.saml);
+    const isEditableByUsers = !isSynced && field.attrs.managed !== 'admin';
+
     const handleDuplicate = () => {
         const name = formatMessage({
             id: 'admin.system_properties.user_properties.dotmenu.duplicate.name_copy',
@@ -143,6 +146,10 @@ const DotMenu = ({
     };
 
     const handleEditableByUsersToggle = () => {
+        if (isSynced) {
+            return;
+        }
+
         const newAttrs = {...field.attrs};
 
         if (field.attrs.managed === 'admin') {
@@ -277,10 +284,26 @@ const DotMenu = ({
             <Menu.Item
                 id={`${menuId}_editable-by-users`}
                 role='menuitemcheckbox'
-                aria-checked={field.attrs.managed !== 'admin'}
+                disabled={isSynced}
+                aria-checked={isEditableByUsers}
                 onClick={handleEditableByUsersToggle}
                 leadingElement={<PencilOutlineIcon size={18}/>}
-                labels={(
+                labels={isSynced ? (
+                    <>
+                        <span>
+                            <FormattedMessage
+                                id='admin.system_properties.user_properties.dotmenu.editable_by_users.label'
+                                defaultMessage='Editable by users'
+                            />
+                        </span>
+                        <span>
+                            <FormattedMessage
+                                id='admin.system_properties.user_properties.dotmenu.editable_by_users.synced_help'
+                                defaultMessage='Synced attributes are managed by AD/LDAP or SAML'
+                            />
+                        </span>
+                    </>
+                ) : (
                     <FormattedMessage
                         id='admin.system_properties.user_properties.dotmenu.editable_by_users.label'
                         defaultMessage='Editable by users'
@@ -289,9 +312,9 @@ const DotMenu = ({
                 trailingElements={(
                     <Toggle
                         size='btn-sm'
-                        disabled={false}
+                        disabled={isSynced}
                         onToggle={handleEditableByUsersToggle}
-                        toggled={field.attrs.managed !== 'admin'}
+                        toggled={isEditableByUsers}
                         toggleClassName='btn-toggle-primary'
                         tabIndex={-1}
                     />

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -3082,6 +3082,7 @@
   "admin.system_properties.user_properties.dotmenu.duplicate.label": "Duplicate attribute",
   "admin.system_properties.user_properties.dotmenu.duplicate.name_copy": "{fieldName} (copy)",
   "admin.system_properties.user_properties.dotmenu.editable_by_users.label": "Editable by users",
+  "admin.system_properties.user_properties.dotmenu.editable_by_users.synced_help": "Synced attributes are managed by AD/LDAP or SAML",
   "admin.system_properties.user_properties.dotmenu.saml.edit_link.label": "Edit SAML link",
   "admin.system_properties.user_properties.dotmenu.saml.link_property.label": "Link attribute to SAML",
   "admin.system_properties.user_properties.dotmenu.saml.modal.helpText": "The attribute in the SAML server used to sync as a custom attribute in user's profile in Mattermost.",


### PR DESCRIPTION
#### Summary
Storing a managed field with a LDAP/SAML link was removing the link attributes. These changes avoid that cleanup, allowing for a managed field to be stored while linked, and port the frontend changes from https://github.com/mattermost/mattermost/pull/37018 to disable the `editable by users` option when a field is linked.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69387

#### Release Note
```release-note
User Attributes can now be synced with AD/LDAP or SAML whether they are user-editable or admin-managed. When an attribute is synced, the "Editable by users" toggle is disabled; remove the link to change it again.
```
