### PR TITLE
[MM-69336] Surface native user attributes in ABAC autocomplete (Phase 5)

### DIFF
--- a/server/channels/app/access_control.go
+++ b/server/channels/app/access_control.go
@@ -1693,6 +1693,14 @@ func (a *App) GetAccessControlFieldsAutocomplete(rctx request.CTX, after string,
 		return nil, model.NewAppError("GetAccessControlAutoComplete", "app.pap.get_access_control_auto_complete.app_error", nil, appErr.Error(), http.StatusInternalServerError)
 	}
 
+	// Native user attributes are synthetic (not persisted), so emit them once on
+	// the first page to keep the cursor-paging contract intact. The API maps an
+	// empty "after" to a 26-zero sentinel cursor (the lowest possible ID), so
+	// treat both as the first page.
+	if after == "" || after == strings.Repeat("0", 26) {
+		fields = append(model.NativeUserAttributeFields(group.ID), fields...)
+	}
+
 	return fields, nil
 }
 

--- a/server/channels/app/access_control_test.go
+++ b/server/channels/app/access_control_test.go
@@ -5345,3 +5345,58 @@ func TestBuildAccessControlSubjectTeamPath(t *testing.T) {
 		}
 	})
 }
+
+func TestGetAccessControlFieldsAutocompleteNativeAttributes(t *testing.T) {
+	th := Setup(t).InitBasic(t)
+	th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterprise))
+	defer th.App.Srv().SetLicense(nil)
+
+	rctx := request.TestContext(t)
+
+	cpaGroup, gErr := th.App.GetPropertyGroup(rctx, model.AccessControlPropertyGroupName)
+	require.Nil(t, gErr)
+
+	cpaField, cErr := th.App.CreatePropertyField(rctx, &model.PropertyField{
+		GroupID:    cpaGroup.ID,
+		Name:       celSafeName(),
+		Type:       model.PropertyFieldTypeText,
+		ObjectType: model.PropertyFieldObjectTypeUser,
+		TargetType: string(model.PropertyFieldTargetLevelSystem),
+	}, false, "")
+	require.Nil(t, cErr)
+
+	nativeNames := []string{
+		model.NativeAttributePropertyFieldEmail,
+		model.NativeAttributePropertyFieldVerified,
+		model.NativeAttributePropertyFieldIsBot,
+		model.NativeAttributePropertyFieldCreateAt,
+	}
+
+	t.Run("first page prepends native attributes", func(t *testing.T) {
+		// The API maps an empty first page to a 26-zero sentinel cursor.
+		fields, appErr := th.App.GetAccessControlFieldsAutocomplete(rctx, strings.Repeat("0", 26), 50, anonymousCallerId)
+		require.Nil(t, appErr)
+
+		seen := map[string]bool{}
+		for _, f := range fields {
+			if isNative, _ := f.Attrs[model.NativeAttributeAttrMarker].(bool); isNative {
+				seen[f.Name] = true
+			}
+		}
+		for _, name := range nativeNames {
+			assert.True(t, seen[name], "expected native attribute %q on first page", name)
+		}
+
+		require.GreaterOrEqual(t, len(fields), len(nativeNames)+1)
+		assert.Equal(t, true, fields[0].Attrs[model.NativeAttributeAttrMarker], "native attributes should precede CPA fields")
+	})
+
+	t.Run("subsequent pages omit native attributes", func(t *testing.T) {
+		fields, appErr := th.App.GetAccessControlFieldsAutocomplete(rctx, cpaField.ID, 50, anonymousCallerId)
+		require.Nil(t, appErr)
+		for _, f := range fields {
+			isNative, _ := f.Attrs[model.NativeAttributeAttrMarker].(bool)
+			assert.False(t, isNative, "native attribute %q must not repeat on later pages", f.Name)
+		}
+	})
+}

--- a/server/public/model/native_attributes.go
+++ b/server/public/model/native_attributes.go
@@ -1,0 +1,82 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+import "maps"
+
+// Native user attributes are first-class User columns exposed to ABAC policies
+// as user.<name> (in contrast to custom profile attributes, referenced as
+// user.attributes.<name>). The SQL/CEL source of truth lives in the enterprise
+// access_control package; these descriptors only drive editor autocomplete.
+const (
+	NativeAttributePropertyFieldEmail    = "email"
+	NativeAttributePropertyFieldVerified = "verified"
+	NativeAttributePropertyFieldIsBot    = "isbot"
+	NativeAttributePropertyFieldCreateAt = "createat"
+)
+
+const (
+	NativeAttributeDisplayNameEmail    = "Email"
+	NativeAttributeDisplayNameVerified = "Email verified"
+	NativeAttributeDisplayNameIsBot    = "Bot account"
+	NativeAttributeDisplayNameCreateAt = "Account created"
+)
+
+// PropertyField Attrs keys describing a synthetic native user attribute.
+const (
+	// NativeAttributeAttrMarker marks a field as a Mattermost-native user
+	// attribute (referenced as user.<name>), distinguishing it from custom
+	// profile attributes (user.attributes.<name>).
+	NativeAttributeAttrMarker = "native"
+	// NativeAttributeAttrDisplayName carries the human-readable label.
+	NativeAttributeAttrDisplayName = "display_name"
+	// NativeAttributeAttrOperators lists the visual operators an editor may
+	// offer. Values match the operator tokens defined by the enterprise visual
+	// format (e.g. "==", "youngerThanDays").
+	NativeAttributeAttrOperators = "operators"
+)
+
+func nativeAttributeField(groupID, name, displayName string, fieldType PropertyFieldType, operators []string, extraAttrs StringInterface) *PropertyField {
+	attrs := StringInterface{
+		NativeAttributeAttrMarker:      true,
+		NativeAttributeAttrDisplayName: displayName,
+		NativeAttributeAttrOperators:   operators,
+	}
+	maps.Copy(attrs, extraAttrs)
+	return &PropertyField{
+		GroupID:           groupID,
+		Name:              name,
+		Type:              fieldType,
+		ObjectType:        PropertyFieldObjectTypeUser,
+		TargetType:        string(PropertyFieldTargetLevelSystem),
+		PermissionField:   NewPointer(PermissionLevelSysadmin),
+		PermissionValues:  NewPointer(PermissionLevelSysadmin),
+		PermissionOptions: NewPointer(PermissionLevelSysadmin),
+		Attrs:             attrs,
+	}
+}
+
+// NativeUserAttributeFields returns the synthetic PropertyField descriptors for
+// the native user attributes exposed to ABAC editors. They are appended to the
+// access-control autocomplete so the table/text editors can list them alongside
+// custom profile attributes.
+func NativeUserAttributeFields(groupID string) []*PropertyField {
+	boolSelectOptions := StringInterface{
+		PropertyFieldAttributeOptions: []map[string]string{
+			{"name": "true"},
+			{"name": "false"},
+		},
+	}
+
+	return []*PropertyField{
+		nativeAttributeField(groupID, NativeAttributePropertyFieldEmail, NativeAttributeDisplayNameEmail, PropertyFieldTypeText,
+			[]string{"==", "!=", "in", "contains", "startsWith", "endsWith"}, nil),
+		nativeAttributeField(groupID, NativeAttributePropertyFieldVerified, NativeAttributeDisplayNameVerified, PropertyFieldTypeSelect,
+			[]string{"==", "!="}, boolSelectOptions),
+		nativeAttributeField(groupID, NativeAttributePropertyFieldIsBot, NativeAttributeDisplayNameIsBot, PropertyFieldTypeSelect,
+			[]string{"==", "!="}, boolSelectOptions),
+		nativeAttributeField(groupID, NativeAttributePropertyFieldCreateAt, NativeAttributeDisplayNameCreateAt, PropertyFieldTypeText,
+			[]string{"youngerThanDays"}, nil),
+	}
+}

--- a/server/public/model/native_attributes_test.go
+++ b/server/public/model/native_attributes_test.go
@@ -1,0 +1,52 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNativeUserAttributeFields(t *testing.T) {
+	fields := NativeUserAttributeFields("group-1")
+	require.Len(t, fields, 4)
+
+	byName := map[string]*PropertyField{}
+	for _, f := range fields {
+		assert.Equal(t, "group-1", f.GroupID)
+		assert.Equal(t, PropertyFieldObjectTypeUser, f.ObjectType)
+		assert.Equal(t, true, f.Attrs[NativeAttributeAttrMarker], "field %q must be marked native", f.Name)
+		assert.NotEmpty(t, f.Attrs[NativeAttributeAttrDisplayName], "field %q must carry a display name", f.Name)
+		assert.NotEmpty(t, f.Attrs[NativeAttributeAttrOperators], "field %q must advertise operators", f.Name)
+		require.NotNil(t, f.PermissionField)
+		assert.Equal(t, PermissionLevelSysadmin, *f.PermissionField)
+		byName[f.Name] = f
+	}
+
+	t.Run("email is a text field with string operators", func(t *testing.T) {
+		f := byName[NativeAttributePropertyFieldEmail]
+		require.NotNil(t, f)
+		assert.Equal(t, PropertyFieldTypeText, f.Type)
+		assert.Equal(t, []string{"==", "!=", "in", "contains", "startsWith", "endsWith"}, f.Attrs[NativeAttributeAttrOperators])
+		assert.Nil(t, f.Attrs[PropertyFieldAttributeOptions])
+	})
+
+	for _, name := range []string{NativeAttributePropertyFieldVerified, NativeAttributePropertyFieldIsBot} {
+		t.Run(name+" is a boolean select", func(t *testing.T) {
+			f := byName[name]
+			require.NotNil(t, f)
+			assert.Equal(t, PropertyFieldTypeSelect, f.Type)
+			assert.Equal(t, []string{"==", "!="}, f.Attrs[NativeAttributeAttrOperators])
+			assert.Equal(t, []map[string]string{{"name": "true"}, {"name": "false"}}, f.Attrs[PropertyFieldAttributeOptions])
+		})
+	}
+
+	t.Run("createat only offers youngerThanDays", func(t *testing.T) {
+		f := byName[NativeAttributePropertyFieldCreateAt]
+		require.NotNil(t, f)
+		assert.Equal(t, []string{"youngerThanDays"}, f.Attrs[NativeAttributeAttrOperators])
+	})
+}


### PR DESCRIPTION
#### Summary
Phase 5 of native ABAC user attributes (server side). Exposes the native user attributes to the policy editors via field autocomplete.

- Adds `model.NativeUserAttributeFields`: synthetic `PropertyField` descriptors for `email` (text), `verified`/`isbot` (boolean select reusing the session-attribute true/false options), and `createat` (advertises only the `youngerThanDays` operator).
- Each descriptor is marked native via an Attrs flag so editors build `user.<name>` instead of `user.attributes.<name>`, and carries an operator hint.
- `GetAccessControlFieldsAutocomplete` prepends the native fields on the first page only (the API maps an empty cursor to the 26-zero sentinel), keeping the cursor-paging contract intact.

The enterprise visual-format `youngerThanDays` operator lives in the stacked enterprise PR (mattermost/enterprise#2203).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69336

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Medium 🟡

**Regression Risk:** The change is isolated to ABAC autocomplete and native attribute descriptor generation, but it touches shared field/model code used by the policy editor path. The main risk is incorrect autocomplete ordering or field metadata leaking into existing pagination behavior, though the added tests reduce likelihood.

**QA Recommendation:** Light manual QA is recommended for policy editor autocomplete on first and subsequent pages to confirm native attributes appear once and preserve paging behavior.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->