### PR TITLE
Fix and re-enable flaky TestCreatePostNotificationsWithCRT

### DIFF
--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -5535,6 +5535,8 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 		*cfg.ServiceSettings.CollapsedThreads = model.CollapsedThreadsDefaultOn
 	})
 
+	rpost := th.CreatePost(t)
+
 	testCases := []struct {
 		name        string
 		message     string
@@ -5599,19 +5601,12 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 		},
 	}
 
-	originalNotifyProps := model.CopyStringMap(th.BasicUser.NotifyProps)
-
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create a fresh root post per sub-test so BasicUser auto-follows as
-			// the author (CRT + ThreadAutoFollow are now on), and follower state
-			// from earlier sub-tests cannot bleed in.
-			rpost := th.CreatePost(t)
-
 			userWSClient := th.CreateConnectedWebSocketClient(t)
 
 			patch := &model.UserPatch{}
-			patch.NotifyProps = model.CopyStringMap(originalNotifyProps)
+			patch.NotifyProps = model.CopyStringMap(th.BasicUser.NotifyProps)
 			maps.Copy(patch.NotifyProps, tc.notifyProps)
 
 			// update user's notify props

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -5526,11 +5526,9 @@ func TestGetEditHistoryForPost(t *testing.T) {
 }
 
 func TestCreatePostNotificationsWithCRT(t *testing.T) {
-	t.Skip("flaky")
 	mainHelper.Parallel(t)
 
 	th := Setup(t).InitBasic(t)
-	rpost := th.CreatePost(t)
 
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.ServiceSettings.ThreadAutoFollow = true
@@ -5539,19 +5537,14 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		post        *model.Post
+		message     string
 		notifyProps model.StringMap
 		mentions    bool
 		followers   bool
 	}{
 		{
-			name: "When default is NONE, comments is NEVER, desktop threads is ALL, and has no mentions",
-			post: &model.Post{
-				ChannelId: th.BasicChannel.Id,
-				Message:   "reply",
-				UserId:    th.BasicUser2.Id,
-				RootId:    rpost.Id,
-			},
+			name:    "When default is NONE, comments is NEVER, desktop threads is ALL, and has no mentions",
+			message: "reply",
 			notifyProps: model.StringMap{
 				model.DesktopNotifyProp:        model.UserNotifyNone,
 				model.CommentsNotifyProp:       model.CommentsNotifyNever,
@@ -5561,13 +5554,8 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 			followers: false,
 		},
 		{
-			name: "When default is NONE, comments is NEVER, desktop threads is ALL, and has mentions",
-			post: &model.Post{
-				ChannelId: th.BasicChannel.Id,
-				Message:   "mention @" + th.BasicUser.Username,
-				UserId:    th.BasicUser2.Id,
-				RootId:    rpost.Id,
-			},
+			name:    "When default is NONE, comments is NEVER, desktop threads is ALL, and has mentions",
+			message: "mention @" + th.BasicUser.Username,
 			notifyProps: model.StringMap{
 				model.DesktopNotifyProp:        model.UserNotifyNone,
 				model.CommentsNotifyProp:       model.CommentsNotifyNever,
@@ -5577,13 +5565,8 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 			followers: false,
 		},
 		{
-			name: "When default is MENTION, comments is NEVER, desktop threads is ALL, and has no mentions",
-			post: &model.Post{
-				ChannelId: th.BasicChannel.Id,
-				Message:   "reply",
-				UserId:    th.BasicUser2.Id,
-				RootId:    rpost.Id,
-			},
+			name:    "When default is MENTION, comments is NEVER, desktop threads is ALL, and has no mentions",
+			message: "reply",
 			notifyProps: model.StringMap{
 				model.DesktopNotifyProp:        model.UserNotifyMention,
 				model.CommentsNotifyProp:       model.CommentsNotifyNever,
@@ -5593,13 +5576,8 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 			followers: true,
 		},
 		{
-			name: "When default is MENTION, comments is ANY, desktop threads is MENTION, and has no mentions",
-			post: &model.Post{
-				ChannelId: th.BasicChannel.Id,
-				Message:   "reply",
-				UserId:    th.BasicUser2.Id,
-				RootId:    rpost.Id,
-			},
+			name:    "When default is MENTION, comments is ANY, desktop threads is MENTION, and has no mentions",
+			message: "reply",
 			notifyProps: model.StringMap{
 				model.DesktopNotifyProp:        model.UserNotifyMention,
 				model.CommentsNotifyProp:       model.CommentsNotifyAny,
@@ -5609,13 +5587,8 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 			followers: false,
 		},
 		{
-			name: "When default is MENTION, comments is NEVER, desktop threads is MENTION, and has mentions",
-			post: &model.Post{
-				ChannelId: th.BasicChannel.Id,
-				Message:   "reply @" + th.BasicUser.Username,
-				UserId:    th.BasicUser2.Id,
-				RootId:    rpost.Id,
-			},
+			name:    "When default is MENTION, comments is NEVER, desktop threads is MENTION, and has mentions",
+			message: "reply @" + th.BasicUser.Username,
 			notifyProps: model.StringMap{
 				model.DesktopNotifyProp:        model.UserNotifyMention,
 				model.CommentsNotifyProp:       model.CommentsNotifyNever,
@@ -5626,23 +5599,37 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 		},
 	}
 
-	// reset the cache so that channel member notify props includes all users
-	th.App.Srv().Store().Channel().ClearCaches()
+	originalNotifyProps := model.CopyStringMap(th.BasicUser.NotifyProps)
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Create a fresh root post per sub-test so BasicUser auto-follows as
+			// the author (CRT + ThreadAutoFollow are now on), and follower state
+			// from earlier sub-tests cannot bleed in.
+			rpost := th.CreatePost(t)
+
 			userWSClient := th.CreateConnectedWebSocketClient(t)
 
 			patch := &model.UserPatch{}
-			patch.NotifyProps = model.CopyStringMap(th.BasicUser.NotifyProps)
+			patch.NotifyProps = model.CopyStringMap(originalNotifyProps)
 			maps.Copy(patch.NotifyProps, tc.notifyProps)
 
 			// update user's notify props
 			_, _, err := th.Client.PatchUser(context.Background(), th.BasicUser.Id, patch)
 			require.NoError(t, err)
 
+			// PatchUser updates the user entity but does not invalidate the channel
+			// member notify props cache that the notification path reads.
+			th.App.Srv().Store().Channel().ClearCaches()
+
 			// post a reply on the thread
-			_, _, appErr := th.App.CreatePostAsUser(th.Context, tc.post, th.Context.Session().Id, false)
+			reply := &model.Post{
+				ChannelId: th.BasicChannel.Id,
+				Message:   tc.message,
+				UserId:    th.BasicUser2.Id,
+				RootId:    rpost.Id,
+			}
+			_, _, appErr := th.App.CreatePostAsUser(th.Context, reply, th.Context.Session().Id, false)
 			require.Nil(t, appErr)
 
 			var caught bool
@@ -5666,6 +5653,7 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 							if ok {
 								require.EqualValues(t, "[\""+th.BasicUser.Id+"\"]", users)
 							}
+							return
 						}
 					case <-time.After(5 * time.Second):
 						return

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -5537,9 +5537,6 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 
 	rpost := th.CreatePost(t)
 
-	// reset the cache so that channel member notify props includes all users
-	th.App.Srv().Store().Channel().ClearCaches()
-
 	testCases := []struct {
 		name        string
 		post        *model.Post
@@ -5628,6 +5625,9 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 			followers: true,
 		},
 	}
+
+	// reset the cache so that channel member notify props includes all users
+	th.App.Srv().Store().Channel().ClearCaches()
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -5539,14 +5539,19 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 
 	testCases := []struct {
 		name        string
-		message     string
+		post        *model.Post
 		notifyProps model.StringMap
 		mentions    bool
 		followers   bool
 	}{
 		{
-			name:    "When default is NONE, comments is NEVER, desktop threads is ALL, and has no mentions",
-			message: "reply",
+			name: "When default is NONE, comments is NEVER, desktop threads is ALL, and has no mentions",
+			post: &model.Post{
+				ChannelId: th.BasicChannel.Id,
+				Message:   "reply",
+				UserId:    th.BasicUser2.Id,
+				RootId:    rpost.Id,
+			},
 			notifyProps: model.StringMap{
 				model.DesktopNotifyProp:        model.UserNotifyNone,
 				model.CommentsNotifyProp:       model.CommentsNotifyNever,
@@ -5556,8 +5561,13 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 			followers: false,
 		},
 		{
-			name:    "When default is NONE, comments is NEVER, desktop threads is ALL, and has mentions",
-			message: "mention @" + th.BasicUser.Username,
+			name: "When default is NONE, comments is NEVER, desktop threads is ALL, and has mentions",
+			post: &model.Post{
+				ChannelId: th.BasicChannel.Id,
+				Message:   "mention @" + th.BasicUser.Username,
+				UserId:    th.BasicUser2.Id,
+				RootId:    rpost.Id,
+			},
 			notifyProps: model.StringMap{
 				model.DesktopNotifyProp:        model.UserNotifyNone,
 				model.CommentsNotifyProp:       model.CommentsNotifyNever,
@@ -5567,8 +5577,13 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 			followers: false,
 		},
 		{
-			name:    "When default is MENTION, comments is NEVER, desktop threads is ALL, and has no mentions",
-			message: "reply",
+			name: "When default is MENTION, comments is NEVER, desktop threads is ALL, and has no mentions",
+			post: &model.Post{
+				ChannelId: th.BasicChannel.Id,
+				Message:   "reply",
+				UserId:    th.BasicUser2.Id,
+				RootId:    rpost.Id,
+			},
 			notifyProps: model.StringMap{
 				model.DesktopNotifyProp:        model.UserNotifyMention,
 				model.CommentsNotifyProp:       model.CommentsNotifyNever,
@@ -5578,8 +5593,13 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 			followers: true,
 		},
 		{
-			name:    "When default is MENTION, comments is ANY, desktop threads is MENTION, and has no mentions",
-			message: "reply",
+			name: "When default is MENTION, comments is ANY, desktop threads is MENTION, and has no mentions",
+			post: &model.Post{
+				ChannelId: th.BasicChannel.Id,
+				Message:   "reply",
+				UserId:    th.BasicUser2.Id,
+				RootId:    rpost.Id,
+			},
 			notifyProps: model.StringMap{
 				model.DesktopNotifyProp:        model.UserNotifyMention,
 				model.CommentsNotifyProp:       model.CommentsNotifyAny,
@@ -5589,8 +5609,13 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 			followers: false,
 		},
 		{
-			name:    "When default is MENTION, comments is NEVER, desktop threads is MENTION, and has mentions",
-			message: "reply @" + th.BasicUser.Username,
+			name: "When default is MENTION, comments is NEVER, desktop threads is MENTION, and has mentions",
+			post: &model.Post{
+				ChannelId: th.BasicChannel.Id,
+				Message:   "reply @" + th.BasicUser.Username,
+				UserId:    th.BasicUser2.Id,
+				RootId:    rpost.Id,
+			},
 			notifyProps: model.StringMap{
 				model.DesktopNotifyProp:        model.UserNotifyMention,
 				model.CommentsNotifyProp:       model.CommentsNotifyNever,
@@ -5618,13 +5643,7 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 			th.App.Srv().Store().Channel().ClearCaches()
 
 			// post a reply on the thread
-			reply := &model.Post{
-				ChannelId: th.BasicChannel.Id,
-				Message:   tc.message,
-				UserId:    th.BasicUser2.Id,
-				RootId:    rpost.Id,
-			}
-			_, _, appErr := th.App.CreatePostAsUser(th.Context, reply, th.Context.Session().Id, false)
+			_, _, appErr := th.App.CreatePostAsUser(th.Context, tc.post, th.Context.Session().Id, false)
 			require.Nil(t, appErr)
 
 			var caught bool

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -5537,6 +5537,9 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 
 	rpost := th.CreatePost(t)
 
+	// reset the cache so that channel member notify props includes all users
+	th.App.Srv().Store().Channel().ClearCaches()
+
 	testCases := []struct {
 		name        string
 		post        *model.Post
@@ -5638,12 +5641,8 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 			_, _, err := th.Client.PatchUser(context.Background(), th.BasicUser.Id, patch)
 			require.NoError(t, err)
 
-			// PatchUser updates the user entity but does not invalidate the channel
-			// member notify props cache that the notification path reads.
-			th.App.Srv().Store().Channel().ClearCaches()
-
 			// post a reply on the thread
-			_, _, appErr := th.App.CreatePostAsUser(th.Context, tc.post, th.Context.Session().Id, false)
+			reply, _, appErr := th.App.CreatePostAsUser(th.Context, tc.post, th.Context.Session().Id, false)
 			require.Nil(t, appErr)
 
 			var caught bool
@@ -5651,24 +5650,34 @@ func TestCreatePostNotificationsWithCRT(t *testing.T) {
 				for {
 					select {
 					case ev := <-userWSClient.EventChannel:
-						if ev.EventType() == model.WebsocketEventPosted {
-							caught = true
-							data := ev.GetData()
-
-							users, ok := data["mentions"]
-							require.Equal(t, tc.mentions, ok)
-							if ok {
-								require.EqualValues(t, "[\""+th.BasicUser.Id+"\"]", users)
-							}
-
-							users, ok = data["followers"]
-							require.Equal(t, tc.followers, ok)
-
-							if ok {
-								require.EqualValues(t, "[\""+th.BasicUser.Id+"\"]", users)
-							}
-							return
+						if ev.EventType() != model.WebsocketEventPosted {
+							continue
 						}
+						data := ev.GetData()
+						post, ok := data["post"]
+						if !ok {
+							continue
+						}
+						var evPost model.Post
+						require.NoError(t, json.Unmarshal([]byte(post.(string)), &evPost))
+						if evPost.Id != reply.Id {
+							continue
+						}
+						caught = true
+
+						users, ok := data["mentions"]
+						require.Equal(t, tc.mentions, ok)
+						if ok {
+							require.EqualValues(t, "[\""+th.BasicUser.Id+"\"]", users)
+						}
+
+						users, ok = data["followers"]
+						require.Equal(t, tc.followers, ok)
+
+						if ok {
+							require.EqualValues(t, "[\""+th.BasicUser.Id+"\"]", users)
+						}
+						return
 					case <-time.After(5 * time.Second):
 						return
 					}


### PR DESCRIPTION
#### Summary

Not a lot of details in https://mattermost.atlassian.net/browse/MM-68883, but after a static analysis, proposing:
- Create the root post after the config update so the changes to following threads take effect immediately
- Only listen for websocket events relevant to the reply post, in case parallel tests trigger issues
- `return` immediately after catching and asserting the event to speed up the test

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-68883

### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

A detailed high-level summary could not be generated for this review. Here is an overview derived from the analyzed file changes:

- **server/channels/api4/post_test.go**: ## AI-generated summary of changes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->