### PR TITLE
Downgrade missing-profile thread notification from error to debug

### DIFF
--- a/server/channels/app/notification.go
+++ b/server/channels/app/notification.go
@@ -755,7 +755,7 @@ func (a *App) SendNotifications(rctx request.CTX, post *model.Post, team *model.
 				// bot, they've been deactivated, or they've left the channel (MM-36769). None can
 				// receive the notification, so record it as not sent rather than an error.
 				a.CountNotificationReason(model.NotificationStatusNotSent, model.NotificationTypeWebsocket, model.NotificationReasonMissingProfile, model.NotificationNoPlatform)
-				rctx.Logger().LogM(mlog.MlvlNotificationWarn, "Missing profile",
+				rctx.Logger().LogM(mlog.MlvlNotificationDebug, "Missing profile",
 					mlog.String("type", model.NotificationTypeWebsocket),
 					mlog.String("post_id", post.Id),
 					mlog.String("status", model.NotificationStatusNotSent),

--- a/server/channels/app/notification.go
+++ b/server/channels/app/notification.go
@@ -750,22 +750,19 @@ func (a *App) SendNotifications(rctx request.CTX, post *model.Post, team *model.
 	// If this is a reply in a thread, notify participants
 	if isCRTAllowed && post.RootId != "" {
 		for uid := range followers {
-			// A user following a thread but had left the channel won't get a notification
-			// https://mattermost.atlassian.net/browse/MM-36769
 			if profileMap[uid] == nil {
-				// This also sometimes happens when bots, which will never show up in the map, reply to threads
-				// Their own post goes through this and they get "notified", which we don't need to count as an error if they can't
-				if uid != post.UserId {
-					a.CountNotificationReason(model.NotificationStatusError, model.NotificationTypeWebsocket, model.NotificationReasonMissingProfile, model.NotificationNoPlatform)
-					rctx.Logger().LogM(mlog.MlvlNotificationError, "Missing profile",
-						mlog.String("type", model.NotificationTypeWebsocket),
-						mlog.String("post_id", post.Id),
-						mlog.String("status", model.NotificationStatusError),
-						mlog.String("reason", model.NotificationReasonMissingProfile),
-						mlog.String("sender_id", sender.Id),
-						mlog.String("receiver_id", uid),
-					)
-				}
+				// A follower can be absent from the profile map for several valid reasons: they're a
+				// bot, they've been deactivated, or they've left the channel (MM-36769). None can
+				// receive the notification, so record it as not sent rather than an error.
+				a.CountNotificationReason(model.NotificationStatusNotSent, model.NotificationTypeWebsocket, model.NotificationReasonMissingProfile, model.NotificationNoPlatform)
+				rctx.Logger().LogM(mlog.MlvlNotificationWarn, "Missing profile",
+					mlog.String("type", model.NotificationTypeWebsocket),
+					mlog.String("post_id", post.Id),
+					mlog.String("status", model.NotificationStatusNotSent),
+					mlog.String("reason", model.NotificationReasonMissingProfile),
+					mlog.String("sender_id", sender.Id),
+					mlog.String("receiver_id", uid),
+				)
 				continue
 			}
 			if a.IsCRTEnabledForUser(rctx, uid) {


### PR DESCRIPTION
#### Summary

There are various good reasons why the profile map is missing an entry:
* User left the channel (previous handling)
* User is a bot
* User has been deactivated

A more thoughtful analysis of `notifications.go` could probably surface a solution that addresses the root cause and moves us away from this giant monolith, but that's not in scope right now. Since we're already spamming these ERRORs and ignoring them, let's just downgrade to a warning and continue to kick the can down the road on deciphering `notifications.go`.

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** This change only modifies log level and metric categorization for a specific edge case (missing user profiles in CRT thread notifications), with no behavioral changes to the notification delivery logic. The code correctly handles the condition by skipping notification delivery, and the log level adjustment appropriately reflects that missing profiles are legitimate scenarios (users left channel, deactivated, or bots) rather than errors. No untested code paths are affected, and this is an isolated change within a single module.

**QA Recommendation:** Minimal manual QA required. Automated test coverage should validate that CRT thread notifications continue to function correctly for users with valid profiles. The change is low-risk since it's purely a logging/metrics adjustment with no functional impact, and automated testing can confirm the notification delivery behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->