### PR TITLE
MM-69444 Harden permissions on scheduled post update

### DIFF
--- a/server/channels/api4/scheduled_post.go
+++ b/server/channels/api4/scheduled_post.go
@@ -207,16 +207,20 @@ func updateScheduledPost(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if len(scheduledPost.FileIds) > 0 {
-		originalPost, err := existingScheduledPost.ToPost()
-		if err != nil {
-			c.Err = model.NewAppError("updateScheduledPost", "app.update_scheduled_post.convert_to_post.error", nil, "", http.StatusInternalServerError).Wrap(err)
-			return
-		}
-		checkUploadFilePermissionForNewFiles(c, scheduledPost.FileIds, originalPost)
-		if c.Err != nil {
-			return
-		}
+	originalPost, err := existingScheduledPost.ToPost()
+	if err != nil {
+		c.Err = model.NewAppError("updateScheduledPost", "app.update_scheduled_post.convert_to_post.error", nil, "", http.StatusInternalServerError).Wrap(err)
+		return
+	}
+
+	checkUploadFilePermissionForNewFiles(c, scheduledPost.FileIds, originalPost)
+	if c.Err != nil {
+		return
+	}
+
+	checkEditFileAttachmentPermission(c, scheduledPost.FileIds, originalPost)
+	if c.Err != nil {
+		return
 	}
 
 	scheduledPostChecks("Api4.updateScheduledPost", c, &scheduledPost)

--- a/server/channels/api4/scheduled_post_test.go
+++ b/server/channels/api4/scheduled_post_test.go
@@ -5,9 +5,11 @@ package api4
 
 import (
 	"context"
+	"net/http"
 	"testing"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/channels/utils/testutils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -52,6 +54,120 @@ func TestUpdateScheduledPost(t *testing.T) {
 		require.NotNil(t, fetchedPost)
 		require.Equal(t, originalMessage, fetchedPost.Message)
 		require.Equal(t, originalScheduledAt, fetchedPost.ScheduledAt)
+	})
+
+	t.Run("should prevent swapping attachments when edit_file_attachment permission is revoked", func(t *testing.T) {
+		th.LoginBasic(t)
+
+		data, err := testutils.ReadTestFile("test.png")
+		require.NoError(t, err)
+
+		fileA, _, err := th.Client.UploadFile(context.Background(), data, th.BasicChannel.Id, "test.png")
+		require.NoError(t, err)
+		fileB, _, err := th.Client.UploadFile(context.Background(), data, th.BasicChannel.Id, "test.png")
+		require.NoError(t, err)
+
+		scheduledPost := &model.ScheduledPost{
+			Draft: model.Draft{
+				CreateAt:  model.GetMillis(),
+				UserId:    th.BasicUser.Id,
+				ChannelId: th.BasicChannel.Id,
+				Message:   "this is a scheduled post",
+				FileIds:   model.StringArray{fileA.FileInfos[0].Id},
+			},
+			ScheduledAt: model.GetMillis() + 100000,
+		}
+		createdScheduledPost, _, err := th.Client.CreateScheduledPost(context.Background(), scheduledPost)
+		require.NoError(t, err)
+		require.NotNil(t, createdScheduledPost)
+
+		th.RemovePermissionFromRole(t, model.PermissionEditFileAttachment.Id, model.ChannelUserRoleId)
+		defer th.AddPermissionToRole(t, model.PermissionEditFileAttachment.Id, model.ChannelUserRoleId)
+
+		createdScheduledPost.FileIds = model.StringArray{fileB.FileInfos[0].Id}
+
+		_, resp, err := th.Client.UpdateScheduledPost(context.Background(), createdScheduledPost)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+
+		fetchedPost, err := th.App.Srv().Store().ScheduledPost().Get(createdScheduledPost.Id)
+		require.NoError(t, err)
+		require.NotNil(t, fetchedPost)
+		require.Equal(t, model.StringArray{fileA.FileInfos[0].Id}, fetchedPost.FileIds)
+	})
+
+	t.Run("should prevent removing attachments when edit_file_attachment permission is revoked", func(t *testing.T) {
+		th.LoginBasic(t)
+
+		data, err := testutils.ReadTestFile("test.png")
+		require.NoError(t, err)
+
+		fileA, _, err := th.Client.UploadFile(context.Background(), data, th.BasicChannel.Id, "test.png")
+		require.NoError(t, err)
+
+		scheduledPost := &model.ScheduledPost{
+			Draft: model.Draft{
+				CreateAt:  model.GetMillis(),
+				UserId:    th.BasicUser.Id,
+				ChannelId: th.BasicChannel.Id,
+				Message:   "this is a scheduled post",
+				FileIds:   model.StringArray{fileA.FileInfos[0].Id},
+			},
+			ScheduledAt: model.GetMillis() + 100000,
+		}
+		createdScheduledPost, _, err := th.Client.CreateScheduledPost(context.Background(), scheduledPost)
+		require.NoError(t, err)
+		require.NotNil(t, createdScheduledPost)
+
+		th.RemovePermissionFromRole(t, model.PermissionEditFileAttachment.Id, model.ChannelUserRoleId)
+		defer th.AddPermissionToRole(t, model.PermissionEditFileAttachment.Id, model.ChannelUserRoleId)
+
+		createdScheduledPost.FileIds = model.StringArray{}
+
+		_, resp, err := th.Client.UpdateScheduledPost(context.Background(), createdScheduledPost)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+
+		fetchedPost, err := th.App.Srv().Store().ScheduledPost().Get(createdScheduledPost.Id)
+		require.NoError(t, err)
+		require.NotNil(t, fetchedPost)
+		require.Equal(t, model.StringArray{fileA.FileInfos[0].Id}, fetchedPost.FileIds)
+	})
+
+	t.Run("should allow updating message with unchanged attachments when edit_file_attachment permission is revoked", func(t *testing.T) {
+		th.LoginBasic(t)
+
+		data, err := testutils.ReadTestFile("test.png")
+		require.NoError(t, err)
+
+		fileA, _, err := th.Client.UploadFile(context.Background(), data, th.BasicChannel.Id, "test.png")
+		require.NoError(t, err)
+
+		scheduledPost := &model.ScheduledPost{
+			Draft: model.Draft{
+				CreateAt:  model.GetMillis(),
+				UserId:    th.BasicUser.Id,
+				ChannelId: th.BasicChannel.Id,
+				Message:   "this is a scheduled post",
+				FileIds:   model.StringArray{fileA.FileInfos[0].Id},
+			},
+			ScheduledAt: model.GetMillis() + 100000,
+		}
+		createdScheduledPost, _, err := th.Client.CreateScheduledPost(context.Background(), scheduledPost)
+		require.NoError(t, err)
+		require.NotNil(t, createdScheduledPost)
+
+		th.RemovePermissionFromRole(t, model.PermissionEditFileAttachment.Id, model.ChannelUserRoleId)
+		defer th.AddPermissionToRole(t, model.PermissionEditFileAttachment.Id, model.ChannelUserRoleId)
+
+		createdScheduledPost.Message = "Updated message only"
+
+		updatedScheduledPost, resp, err := th.Client.UpdateScheduledPost(context.Background(), createdScheduledPost)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		require.NotNil(t, updatedScheduledPost)
+		require.Equal(t, "Updated message only", updatedScheduledPost.Message)
+		require.Equal(t, model.StringArray{fileA.FileInfos[0].Id}, updatedScheduledPost.FileIds)
 	})
 }
 


### PR DESCRIPTION
#### Summary

Add additional permission checks for the the scheduled-post update endpoint (`PUT /api/v4/posts/schedule/{id}`) to mirror regular post edit endpoints (`updatePost` / `patchPost`) .


#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-69444

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Low likelihood of breaking existing behavior since the permission check gracefully exits early when file IDs remain unchanged, matching the proven pattern already used in regular post endpoints (`updatePost` and `patchPost`). The change is isolated to the scheduled post update endpoint with no side effects propagating to unrelated systems.

**QA Recommendation:** Manual QA focused on permission enforcement workflows is recommended. Specifically test: (1) scheduled post file attachment modifications with/without the `edit_file_attachment` permission, (2) message-only updates with unchanged attachments, and (3) attachment add/swap/remove scenarios. Automated test coverage is comprehensive with new subtests validating all three scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->