### PR TITLE
[MM-69366] Scope property field lookups by object type

### DIFF
--- a/server/channels/app/access_control.go
+++ b/server/channels/app/access_control.go
@@ -754,7 +754,8 @@ func (a *App) protectedCPAFieldNamesForCaller(rctx request.CTX) (map[string]stru
 	}
 
 	propertyFields, appErr := a.SearchPropertyFields(rctx, group.ID, model.PropertyFieldSearchOpts{
-		PerPage: model.AccessControlGroupFieldLimit + 5,
+		ObjectTypes: []string{model.PropertyFieldObjectTypeUser},
+		PerPage:     model.AccessControlGroupFieldLimit + 5,
 	})
 	if appErr != nil {
 		return nil, appErr
@@ -1658,7 +1659,7 @@ func (a *App) GetAccessControlPolicyAttributes(rctx request.CTX, channelID strin
 	for fieldName := range attributes {
 		// Read directly from the store so this security filter sees the raw
 		// access_mode, unaffected by property read hooks for the request caller.
-		field, fieldErr := a.Srv().Store().PropertyField().GetFieldByName(rctx.Context(), cpaGroup.ID, "", fieldName)
+		field, fieldErr := a.Srv().Store().PropertyField().GetFieldByNameForObjectType(rctx.Context(), cpaGroup.ID, "", model.PropertyFieldObjectTypeUser, fieldName)
 		if fieldErr != nil {
 			delete(attributes, fieldName)
 			continue

--- a/server/channels/app/access_control_masking.go
+++ b/server/channels/app/access_control_masking.go
@@ -66,7 +66,9 @@ func (a *App) fetchConditionFields(rctx request.CTX, conditions []model.Conditio
 
 	fields := make(map[string]*model.PropertyField, len(seen))
 	for name := range seen {
-		field, appErr := a.GetPropertyFieldByName(rctx, cpaGroupID, "", name)
+		// Scope to user CPA fields so a name shared across object types in this
+		// group resolves deterministically.
+		field, appErr := a.GetPropertyFieldByNameForObjectType(rctx, cpaGroupID, "", model.PropertyFieldObjectTypeUser, name)
 		if appErr != nil {
 			rctx.Logger().Warn("Failed to look up field for masking, failing closed",
 				mlog.String("field_name", name),
@@ -107,7 +109,9 @@ func (r *appMaskingResolver) Resolve(fieldName string) (*model.MaskingFieldInfo,
 	if info, ok := r.cache[fieldName]; ok {
 		return info, nil
 	}
-	field, appErr := r.app.GetPropertyFieldByName(r.rctxWithCaller, r.cpaGroupID, "", fieldName)
+	// Scope to user CPA fields so a name shared across object types in this
+	// group resolves deterministically.
+	field, appErr := r.app.GetPropertyFieldByNameForObjectType(r.rctxWithCaller, r.cpaGroupID, "", model.PropertyFieldObjectTypeUser, fieldName)
 	if appErr != nil {
 		return nil, appErr
 	}

--- a/server/channels/app/board.go
+++ b/server/channels/app/board.go
@@ -30,12 +30,12 @@ func (a *App) CreateBoardChannel(rctx request.CTX, channel *model.Channel) (*mod
 		return nil, model.NewAppError("CreateBoardChannel", "app.channel.create_board_channel.internal_error", nil, "boards property group not found", http.StatusInternalServerError).Wrap(appErr)
 	}
 
-	assigneeField, appErr := a.GetPropertyFieldByName(rctx, boardsGroup.ID, "", model.BoardsPropertyFieldAssignee)
+	assigneeField, appErr := a.GetPropertyFieldByNameForObjectType(rctx, boardsGroup.ID, "", model.PropertyFieldObjectTypePost, model.BoardsPropertyFieldAssignee)
 	if appErr != nil {
 		return nil, model.NewAppError("CreateBoardChannel", "app.channel.create_board_channel.internal_error", nil, "assignee property field not found", http.StatusInternalServerError).Wrap(appErr)
 	}
 
-	statusField, appErr := a.GetPropertyFieldByName(rctx, boardsGroup.ID, "", model.BoardsPropertyFieldStatus)
+	statusField, appErr := a.GetPropertyFieldByNameForObjectType(rctx, boardsGroup.ID, "", model.PropertyFieldObjectTypePost, model.BoardsPropertyFieldStatus)
 	if appErr != nil {
 		return nil, model.NewAppError("CreateBoardChannel", "app.channel.create_board_channel.internal_error", nil, "status property field not found", http.StatusInternalServerError).Wrap(appErr)
 	}

--- a/server/channels/app/content_flagging.go
+++ b/server/channels/app/content_flagging.go
@@ -253,7 +253,9 @@ func (a *App) GetPostContentFlaggingPropertyValue(postId, propertyFieldName stri
 		return nil, model.NewAppError("GetPostContentFlaggingPropertyValue", "app.data_spillage.get_group.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	statusPropertyField, appErr := a.GetPropertyFieldByName(nil, groupId, "", propertyFieldName)
+	// Content flagging fields carry no object type, so the empty object type is
+	// their exact scope.
+	statusPropertyField, appErr := a.GetPropertyFieldByNameForObjectType(nil, groupId, "", "", propertyFieldName)
 	if appErr != nil {
 		return nil, model.NewAppError("GetPostContentFlaggingPropertyValue", "app.data_spillage.get_status_property.app_error", nil, "", http.StatusInternalServerError).Wrap(appErr)
 	}

--- a/server/channels/app/migrations.go
+++ b/server/channels/app/migrations.go
@@ -746,7 +746,7 @@ func (s *Server) doSetupContentFlaggingProperties() error {
 			// Another server may have won the race and created this field
 			// concurrently (e.g. parallel tests sharing a database pool).
 			// Tolerate that but propagate any other error.
-			if _, retryErr := s.propertyService.GetPropertyFieldByName(nil, group.ID, "", property.Name); retryErr != nil {
+			if _, retryErr := s.propertyService.GetPropertyFieldByNameForObjectType(nil, group.ID, "", property.ObjectType, property.Name); retryErr != nil {
 				return fmt.Errorf("failed to create content flagging property: %q, error: %w", property.Name, err)
 			}
 		}
@@ -847,7 +847,7 @@ func (s *Server) doSetupBoardsProperties() error {
 			// Another server may have won the race and created this field
 			// concurrently (e.g. parallel tests sharing a database pool).
 			// Tolerate that but propagate any other error.
-			if _, retryErr := s.propertyService.GetPropertyFieldByName(nil, group.ID, "", property.Name); retryErr != nil {
+			if _, retryErr := s.propertyService.GetPropertyFieldByNameForObjectType(nil, group.ID, "", property.ObjectType, property.Name); retryErr != nil {
 				return fmt.Errorf("failed to create boards property: %q, error: %w", property.Name, err)
 			}
 		}
@@ -907,7 +907,7 @@ func (s *Server) seedSessionAttributeFields(groupID string) error {
 
 	for _, field := range fieldsToCreate {
 		if _, err := s.propertyService.CreatePropertyField(nil, field); err != nil {
-			if _, retryErr := s.propertyService.GetPropertyFieldByName(nil, groupID, "", field.Name); retryErr != nil {
+			if _, retryErr := s.propertyService.GetPropertyFieldByNameForObjectType(nil, groupID, "", field.ObjectType, field.Name); retryErr != nil {
 				return fmt.Errorf("failed to create session attribute field: %q, error: %w", field.Name, err)
 			}
 		}
@@ -966,7 +966,7 @@ func (s *Server) doSetupManagedCategoryProperties() error {
 		return fmt.Errorf("failed to register managed category group: %w", err)
 	}
 
-	_, err = s.propertyService.GetPropertyFieldByName(nil, group.ID, "", model.ManagedCategoryPropertyFieldName)
+	_, err = s.propertyService.GetPropertyFieldByNameForObjectType(nil, group.ID, "", model.PropertyValueTargetTypeChannel, model.ManagedCategoryPropertyFieldName)
 	if err != nil {
 		field := &model.PropertyField{
 			GroupID:           group.ID,
@@ -982,7 +982,7 @@ func (s *Server) doSetupManagedCategoryProperties() error {
 		}
 
 		if _, err := s.propertyService.CreatePropertyField(nil, field); err != nil {
-			if _, retryErr := s.propertyService.GetPropertyFieldByName(nil, group.ID, "", model.ManagedCategoryPropertyFieldName); retryErr != nil {
+			if _, retryErr := s.propertyService.GetPropertyFieldByNameForObjectType(nil, group.ID, "", field.ObjectType, model.ManagedCategoryPropertyFieldName); retryErr != nil {
 				return fmt.Errorf("failed to create managed category field: %w", err)
 			}
 		}
@@ -1038,7 +1038,7 @@ func (s *Server) cacheManagedCategoryIDs() error {
 		return fmt.Errorf("failed to get managed category group: %w", err)
 	}
 
-	field, err := s.propertyService.GetPropertyFieldByName(nil, group.ID, "", model.ManagedCategoryPropertyFieldName)
+	field, err := s.propertyService.GetPropertyFieldByNameForObjectType(nil, group.ID, "", model.PropertyValueTargetTypeChannel, model.ManagedCategoryPropertyFieldName)
 	if err != nil {
 		return fmt.Errorf("failed to get managed category field: %w", err)
 	}

--- a/server/channels/app/properties/property_field.go
+++ b/server/channels/app/properties/property_field.go
@@ -196,6 +196,10 @@ func (ps *PropertyService) getPropertyFieldByName(groupID, targetID, name string
 	return ps.fieldStore.GetFieldByName(context.Background(), groupID, targetID, name)
 }
 
+func (ps *PropertyService) getPropertyFieldByNameForObjectType(groupID, targetID, objectType, name string) (*model.PropertyField, error) {
+	return ps.fieldStore.GetFieldByNameForObjectType(context.Background(), groupID, targetID, objectType, name)
+}
+
 func (ps *PropertyService) countActivePropertyFieldsForGroup(groupID string) (int64, error) {
 	return ps.fieldStore.CountForGroup(groupID, false)
 }
@@ -496,10 +500,23 @@ func (ps *PropertyService) GetPropertyFieldsForGroup(rctx request.CTX, groupID s
 	return ps.runPostGetPropertyFields(rctx, fields)
 }
 
+// GetPropertyFieldByName looks up a field by name within a group and target.
+//
+// Deprecated: name is not unique within a group when fields of different object
+// types share a name. Use GetPropertyFieldByNameForObjectType to disambiguate.
 func (ps *PropertyService) GetPropertyFieldByName(rctx request.CTX, groupID, targetID, name string) (*model.PropertyField, error) {
 	field, err := ps.getPropertyFieldByName(groupID, targetID, name)
 	if err != nil {
 		return nil, fmt.Errorf("GetPropertyFieldByName: %w", err)
+	}
+
+	return ps.runPostGetPropertyField(rctx, field)
+}
+
+func (ps *PropertyService) GetPropertyFieldByNameForObjectType(rctx request.CTX, groupID, targetID, objectType, name string) (*model.PropertyField, error) {
+	field, err := ps.getPropertyFieldByNameForObjectType(groupID, targetID, objectType, name)
+	if err != nil {
+		return nil, fmt.Errorf("GetPropertyFieldByNameForObjectType: %w", err)
 	}
 
 	return ps.runPostGetPropertyField(rctx, field)

--- a/server/channels/app/property_field.go
+++ b/server/channels/app/property_field.go
@@ -158,6 +158,10 @@ func (a *App) GetPropertyFields(rctx request.CTX, groupID string, ids []string) 
 }
 
 // GetPropertyFieldByName retrieves a property field by name within a group and target.
+//
+// Deprecated: name is not unique within a group when fields of different object
+// types share a name. Use GetPropertyFieldByNameForObjectType to scope the
+// lookup to a single object type and get a deterministic result.
 func (a *App) GetPropertyFieldByName(rctx request.CTX, groupID, targetID, name string) (*model.PropertyField, *model.AppError) {
 	field, err := a.Srv().propertyService.GetPropertyFieldByName(rctx, groupID, targetID, name)
 	if err != nil {
@@ -165,6 +169,21 @@ func (a *App) GetPropertyFieldByName(rctx request.CTX, groupID, targetID, name s
 			return nil, appErr
 		}
 		return nil, model.NewAppError("GetPropertyFieldByName", "app.property_field.get_by_name.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	return field, nil
+}
+
+// GetPropertyFieldByNameForObjectType retrieves a property field by name within
+// a group and target, scoped to a single object type. Prefer this over
+// GetPropertyFieldByName when a name may be shared across object types within a
+// group (e.g. the access_control "classification" fields).
+func (a *App) GetPropertyFieldByNameForObjectType(rctx request.CTX, groupID, targetID, objectType, name string) (*model.PropertyField, *model.AppError) {
+	field, err := a.Srv().propertyService.GetPropertyFieldByNameForObjectType(rctx, groupID, targetID, objectType, name)
+	if err != nil {
+		if appErr := mapPropertyServiceError("GetPropertyFieldByNameForObjectType", err); appErr != nil {
+			return nil, appErr
+		}
+		return nil, model.NewAppError("GetPropertyFieldByNameForObjectType", "app.property_field.get_by_name.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 	return field, nil
 }

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -10509,6 +10509,27 @@ func (s *RetryLayerPropertyFieldStore) GetFieldByName(ctx context.Context, group
 
 }
 
+func (s *RetryLayerPropertyFieldStore) GetFieldByNameForObjectType(ctx context.Context, groupID string, targetID string, objectType string, name string) (*model.PropertyField, error) {
+
+	tries := 0
+	for {
+		result, err := s.PropertyFieldStore.GetFieldByNameForObjectType(ctx, groupID, targetID, objectType, name)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerPropertyFieldStore) GetForGroup(ctx context.Context, groupID string) ([]*model.PropertyField, error) {
 
 	tries := 0

--- a/server/channels/store/sqlstore/property_field_store.go
+++ b/server/channels/store/sqlstore/property_field_store.go
@@ -76,13 +76,36 @@ func (s *SqlPropertyFieldStore) Get(ctx context.Context, groupID, id string) (*m
 	return &field, nil
 }
 
+// GetFieldByName retrieves a single property field by group, target, and name,
+// matching any object type.
+//
+// Deprecated: a (groupID, targetID, name) tuple is not unique when fields of
+// different object types share a name within a group, in which case this
+// returns an arbitrary match (the query has no ORDER BY/LIMIT). Use
+// GetFieldByNameForObjectType for a deterministic result. Retained because it
+// is exposed on the (stable) plugin API.
 func (s *SqlPropertyFieldStore) GetFieldByName(ctx context.Context, groupID, targetID, name string) (*model.PropertyField, error) {
-	builder := s.tableSelectQuery.
+	return s.getFieldByName(ctx, s.fieldByNameQuery(groupID, targetID, name), name)
+}
+
+// GetFieldByNameForObjectType retrieves a single property field by group,
+// target, object type, and name. objectType is matched exactly — including the
+// empty string, which is itself a valid object type, not a match-any wildcard —
+// so together with the typed unique index the result is deterministic.
+func (s *SqlPropertyFieldStore) GetFieldByNameForObjectType(ctx context.Context, groupID, targetID, objectType, name string) (*model.PropertyField, error) {
+	builder := s.fieldByNameQuery(groupID, targetID, name).Where(sq.Eq{"ObjectType": objectType})
+	return s.getFieldByName(ctx, builder, name)
+}
+
+func (s *SqlPropertyFieldStore) fieldByNameQuery(groupID, targetID, name string) sq.SelectBuilder {
+	return s.tableSelectQuery.
 		Where(sq.Eq{"GroupID": groupID}).
 		Where(sq.Eq{"TargetID": targetID}).
 		Where(sq.Eq{"Name": name}).
 		Where(sq.Eq{"DeleteAt": 0})
+}
 
+func (s *SqlPropertyFieldStore) getFieldByName(ctx context.Context, builder sq.SelectBuilder, name string) (*model.PropertyField, error) {
 	var field model.PropertyField
 	if err := s.DBXFromContext(ctx).GetBuilder(&field, builder); err != nil {
 		if errors.Is(err, sql.ErrNoRows) {

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -1177,6 +1177,7 @@ type PropertyFieldStore interface {
 	Get(ctx context.Context, groupID, id string) (*model.PropertyField, error)
 	GetMany(ctx context.Context, groupID string, ids []string) ([]*model.PropertyField, error)
 	GetFieldByName(ctx context.Context, groupID, targetID, name string) (*model.PropertyField, error)
+	GetFieldByNameForObjectType(ctx context.Context, groupID, targetID, objectType, name string) (*model.PropertyField, error)
 	GetForGroup(ctx context.Context, groupID string) ([]*model.PropertyField, error)
 	CountForGroup(groupID string, includeDeleted bool) (int64, error)
 	CountForGroupObjectType(groupID, objectType string, includeDeleted bool) (int64, error)

--- a/server/channels/store/storetest/mocks/PropertyFieldStore.go
+++ b/server/channels/store/storetest/mocks/PropertyFieldStore.go
@@ -264,6 +264,36 @@ func (_m *PropertyFieldStore) GetFieldByName(ctx context.Context, groupID string
 	return r0, r1
 }
 
+// GetFieldByNameForObjectType provides a mock function with given fields: ctx, groupID, targetID, objectType, name
+func (_m *PropertyFieldStore) GetFieldByNameForObjectType(ctx context.Context, groupID string, targetID string, objectType string, name string) (*model.PropertyField, error) {
+	ret := _m.Called(ctx, groupID, targetID, objectType, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetFieldByNameForObjectType")
+	}
+
+	var r0 *model.PropertyField
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) (*model.PropertyField, error)); ok {
+		return rf(ctx, groupID, targetID, objectType, name)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, string) *model.PropertyField); ok {
+		r0 = rf(ctx, groupID, targetID, objectType, name)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.PropertyField)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, string) error); ok {
+		r1 = rf(ctx, groupID, targetID, objectType, name)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetForGroup provides a mock function with given fields: ctx, groupID
 func (_m *PropertyFieldStore) GetForGroup(ctx context.Context, groupID string) ([]*model.PropertyField, error) {
 	ret := _m.Called(ctx, groupID)

--- a/server/channels/store/storetest/property_field_store.go
+++ b/server/channels/store/storetest/property_field_store.go
@@ -503,17 +503,17 @@ func testGetFieldByName(t *testing.T, _ request.CTX, ss store.Store) {
 }
 
 func testGetFieldByNameForObjectType(t *testing.T, _ request.CTX, ss store.Store) {
-	// Two fields share group, target, and name, differing only by ObjectType —
-	// the collision the scoped lookup must disambiguate.
+	// Two system-scoped fields share group and name, differing only by
+	// ObjectType — the collision the scoped lookup must disambiguate.
 	groupID := model.NewId()
-	targetID := model.NewId()
+	targetType := string(model.PropertyFieldTargetLevelSystem)
 
 	userField := &model.PropertyField{
 		GroupID:    groupID,
-		TargetID:   targetID,
 		Name:       "classification",
 		Type:       model.PropertyFieldTypeText,
 		ObjectType: model.PropertyFieldObjectTypeUser,
+		TargetType: targetType,
 	}
 	_, cErr := ss.PropertyField().Create(userField)
 	require.NoError(t, cErr)
@@ -521,29 +521,29 @@ func testGetFieldByNameForObjectType(t *testing.T, _ request.CTX, ss store.Store
 
 	systemField := &model.PropertyField{
 		GroupID:    groupID,
-		TargetID:   targetID,
 		Name:       "classification",
 		Type:       model.PropertyFieldTypeText,
 		ObjectType: model.PropertyFieldObjectTypeSystem,
+		TargetType: targetType,
 	}
 	_, cErr = ss.PropertyField().Create(systemField)
 	require.NoError(t, cErr)
 	require.NotZero(t, systemField.ID)
 
 	t.Run("should resolve to the field matching the requested object type", func(t *testing.T) {
-		field, err := ss.PropertyField().GetFieldByNameForObjectType(context.Background(), groupID, targetID, model.PropertyFieldObjectTypeUser, "classification")
+		field, err := ss.PropertyField().GetFieldByNameForObjectType(context.Background(), groupID, "", model.PropertyFieldObjectTypeUser, "classification")
 		require.NoError(t, err)
 		require.Equal(t, userField.ID, field.ID)
 		require.Equal(t, model.PropertyFieldObjectTypeUser, field.ObjectType)
 
-		field, err = ss.PropertyField().GetFieldByNameForObjectType(context.Background(), groupID, targetID, model.PropertyFieldObjectTypeSystem, "classification")
+		field, err = ss.PropertyField().GetFieldByNameForObjectType(context.Background(), groupID, "", model.PropertyFieldObjectTypeSystem, "classification")
 		require.NoError(t, err)
 		require.Equal(t, systemField.ID, field.ID)
 		require.Equal(t, model.PropertyFieldObjectTypeSystem, field.ObjectType)
 	})
 
 	t.Run("should not match a field of a different object type", func(t *testing.T) {
-		field, err := ss.PropertyField().GetFieldByNameForObjectType(context.Background(), groupID, targetID, model.PropertyFieldObjectTypeChannel, "classification")
+		field, err := ss.PropertyField().GetFieldByNameForObjectType(context.Background(), groupID, "", model.PropertyFieldObjectTypeChannel, "classification")
 		require.Zero(t, field)
 		var enf *store.ErrNotFound
 		require.ErrorAs(t, err, &enf)
@@ -552,7 +552,7 @@ func testGetFieldByNameForObjectType(t *testing.T, _ request.CTX, ss store.Store
 	t.Run("empty object type is matched exactly, not as match-any", func(t *testing.T) {
 		// Neither field has an empty object type, so an empty-object-type lookup
 		// must miss rather than return an arbitrary match.
-		field, err := ss.PropertyField().GetFieldByNameForObjectType(context.Background(), groupID, targetID, "", "classification")
+		field, err := ss.PropertyField().GetFieldByNameForObjectType(context.Background(), groupID, "", "", "classification")
 		require.Zero(t, field)
 		var enf *store.ErrNotFound
 		require.ErrorAs(t, err, &enf)

--- a/server/channels/store/storetest/property_field_store.go
+++ b/server/channels/store/storetest/property_field_store.go
@@ -23,6 +23,7 @@ func TestPropertyFieldStore(t *testing.T, rctx request.CTX, ss store.Store, s Sq
 	t.Run("GetPropertyField", func(t *testing.T) { testGetPropertyField(t, rctx, ss, s) })
 	t.Run("GetManyPropertyFields", func(t *testing.T) { testGetManyPropertyFields(t, rctx, ss) })
 	t.Run("GetFieldByName", func(t *testing.T) { testGetFieldByName(t, rctx, ss) })
+	t.Run("GetFieldByNameForObjectType", func(t *testing.T) { testGetFieldByNameForObjectType(t, rctx, ss) })
 	t.Run("UpdatePropertyField", func(t *testing.T) { testUpdatePropertyField(t, rctx, ss) })
 	t.Run("DeletePropertyField", func(t *testing.T) { testDeletePropertyField(t, rctx, ss) })
 	t.Run("SearchPropertyFields", func(t *testing.T) { testSearchPropertyFields(t, rctx, ss, s) })
@@ -498,6 +499,63 @@ func testGetFieldByName(t *testing.T, _ request.CTX, ss store.Store) {
 		require.Equal(t, replacementField.ID, field.ID)
 		require.Equal(t, model.PropertyFieldTypeText, field.Type)
 		require.Zero(t, field.DeleteAt)
+	})
+}
+
+func testGetFieldByNameForObjectType(t *testing.T, _ request.CTX, ss store.Store) {
+	// Two fields share group, target, and name, differing only by ObjectType —
+	// the collision the scoped lookup must disambiguate.
+	groupID := model.NewId()
+	targetID := model.NewId()
+
+	userField := &model.PropertyField{
+		GroupID:    groupID,
+		TargetID:   targetID,
+		Name:       "classification",
+		Type:       model.PropertyFieldTypeText,
+		ObjectType: model.PropertyFieldObjectTypeUser,
+	}
+	_, cErr := ss.PropertyField().Create(userField)
+	require.NoError(t, cErr)
+	require.NotZero(t, userField.ID)
+
+	systemField := &model.PropertyField{
+		GroupID:    groupID,
+		TargetID:   targetID,
+		Name:       "classification",
+		Type:       model.PropertyFieldTypeText,
+		ObjectType: model.PropertyFieldObjectTypeSystem,
+	}
+	_, cErr = ss.PropertyField().Create(systemField)
+	require.NoError(t, cErr)
+	require.NotZero(t, systemField.ID)
+
+	t.Run("should resolve to the field matching the requested object type", func(t *testing.T) {
+		field, err := ss.PropertyField().GetFieldByNameForObjectType(context.Background(), groupID, targetID, model.PropertyFieldObjectTypeUser, "classification")
+		require.NoError(t, err)
+		require.Equal(t, userField.ID, field.ID)
+		require.Equal(t, model.PropertyFieldObjectTypeUser, field.ObjectType)
+
+		field, err = ss.PropertyField().GetFieldByNameForObjectType(context.Background(), groupID, targetID, model.PropertyFieldObjectTypeSystem, "classification")
+		require.NoError(t, err)
+		require.Equal(t, systemField.ID, field.ID)
+		require.Equal(t, model.PropertyFieldObjectTypeSystem, field.ObjectType)
+	})
+
+	t.Run("should not match a field of a different object type", func(t *testing.T) {
+		field, err := ss.PropertyField().GetFieldByNameForObjectType(context.Background(), groupID, targetID, model.PropertyFieldObjectTypeChannel, "classification")
+		require.Zero(t, field)
+		var enf *store.ErrNotFound
+		require.ErrorAs(t, err, &enf)
+	})
+
+	t.Run("empty object type is matched exactly, not as match-any", func(t *testing.T) {
+		// Neither field has an empty object type, so an empty-object-type lookup
+		// must miss rather than return an arbitrary match.
+		field, err := ss.PropertyField().GetFieldByNameForObjectType(context.Background(), groupID, targetID, "", "classification")
+		require.Zero(t, field)
+		var enf *store.ErrNotFound
+		require.ErrorAs(t, err, &enf)
 	})
 }
 

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -8378,6 +8378,22 @@ func (s *TimerLayerPropertyFieldStore) GetFieldByName(ctx context.Context, group
 	return result, err
 }
 
+func (s *TimerLayerPropertyFieldStore) GetFieldByNameForObjectType(ctx context.Context, groupID string, targetID string, objectType string, name string) (*model.PropertyField, error) {
+	start := time.Now()
+
+	result, err := s.PropertyFieldStore.GetFieldByNameForObjectType(ctx, groupID, targetID, objectType, name)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("PropertyFieldStore.GetFieldByNameForObjectType", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerPropertyFieldStore) GetForGroup(ctx context.Context, groupID string) ([]*model.PropertyField, error) {
 	start := time.Now()
 

--- a/server/channels/testlib/store.go
+++ b/server/channels/testlib/store.go
@@ -199,10 +199,12 @@ func GetMockStoreForSetupFunctions() *mocks.Store {
 
 	managedCategoryField := &model.PropertyField{ID: model.NewId(), GroupID: managedCategoryGroup.ID, Name: model.ManagedCategoryPropertyFieldName}
 	propertyFieldStore.On("GetFieldByName", mock.Anything, managedCategoryGroup.ID, "", model.ManagedCategoryPropertyFieldName).Return(managedCategoryField, nil)
+	propertyFieldStore.On("GetFieldByNameForObjectType", mock.Anything, managedCategoryGroup.ID, "", model.PropertyValueTargetTypeChannel, model.ManagedCategoryPropertyFieldName).Return(managedCategoryField, nil)
 
 	boardField := &model.PropertyField{ID: model.NewId(), GroupID: boardsGroup.ID, Name: model.BoardsPropertyFieldNameBoard}
 	propertyFieldStore.On("GetFieldByName", mock.Anything, boardsGroup.ID, "", model.BoardsPropertyFieldNameBoard).Return(boardField, nil)
 	propertyFieldStore.On("GetFieldByName", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, store.NewErrNotFound("PropertyField", ""))
+	propertyFieldStore.On("GetFieldByNameForObjectType", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, store.NewErrNotFound("PropertyField", ""))
 
 	viewStore := mocks.ViewStore{}
 	mockStore.On("View").Return(&viewStore)


### PR DESCRIPTION
## Overview

In security-conscious deployments it's natural for an admin to create a custom user attribute named "classification". The Classification Markings feature also creates its own internal fields that happen to share that same name, distinguished only by an internal "object type". When a server with a pre-existing user "classification" attribute was upgraded, several places that looked an attribute up by name alone couldn't tell the two apart and would sometimes pick the wrong one.

The most visible effect: an access policy referencing the user's "classification" attribute could end up resolving to the internal field instead, so it evaluated against the wrong set of options. Users' stored values no longer matched what the policy expected, and they lost access to channels they should have kept.

The fix adds a lookup that scopes by both name and object type, so the user's attribute and the internal fields can never be mixed up. All internal callers now use the scoped lookup, and the old name-only lookup is deprecated (it remains only because it's part of the public plugin API).

The companion enterprise change is in mattermost/enterprise#2207.

## Ticket Link

https://mattermost.atlassian.net/browse/MM-69366

## Changes

Adds a name-plus-object-type lookup at the store, service, and app layers, and moves every internal attribute lookup over to it (access policy masking, the invite/members attribute filtering, the boards/content-flagging/managed-category seeders, and the migration retry checks). The previous name-only lookup is marked deprecated and kept solely for the plugin API. Includes a store test covering the name collision. The details of what was changed are in the diff.

## Release Notes

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🔴 High

**Regression Risk:** This change tightens authorization and access-control/masking behavior by switching attribute-field resolution to be object-type scoped across multiple layers (app/service/store, including retry/migration helpers). If any caller still relies on name-only resolution or object-type parameters are incorrect, users could be incorrectly granted or denied access.

**QA Recommendation:** Focus on upgrade/regression validation for deployments with pre-existing custom user attributes named like internal fields (e.g., “classification”), plus targeted checks for access policy evaluation and access-control masking (e.g., source_only/shared_only) and idempotent property/attribute seeding retries (content-flagging, boards, managed categories).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->