### PR TITLE
[MM-69229] Remove orphaned PermalinkPreviews feature flag

### DIFF
--- a/e2e-tests/playwright/lib/src/server/default_config.ts
+++ b/e2e-tests/playwright/lib/src/server/default_config.ts
@@ -761,7 +761,6 @@ const defaultServerConfig: AdminConfig = {
         EnableSharedChannelsMemberSync: false,
         EnableSyncAllUsersForRemoteCluster: false,
         AppsEnabled: false,
-        PermalinkPreviews: false,
         NormalizeLdapDNs: false,
         WysiwygEditor: false,
         OnboardingTourTips: true,

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -34,8 +34,6 @@ type FeatureFlags struct {
 	// AppsEnabled toggles the Apps framework functionalities both in server and client side
 	AppsEnabled bool
 
-	PermalinkPreviews bool
-
 	NormalizeLdapDNs bool
 
 	// Enable WYSIWYG text editor


### PR DESCRIPTION
#### Summary

Removes the `PermalinkPreviews` feature flag, which had no consumers and no `SetDefaults` entry (it defaulted to zero-value `false`). Permalink preview behavior is controlled by the separate `ServiceSettings.EnablePermalinkPreviews` config setting, which defaults to `true`.

Note too that mobile only references the `EnablePermalinkPreviews` and not this orphaned `PermalinkPreviews` flag.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-69636
Relates-to: https://mattermost.atlassian.net/browse/MM-69229

```release-note
NONE
```



## Change Impact: 🟢 Low

**Regression Risk:** The removed `PermalinkPreviews` field from `FeatureFlags` was explicitly orphaned with zero active consumers in the codebase, as confirmed by comprehensive search showing no references to it. The actual permalink preview functionality is controlled through the separate `ServiceSettings.EnablePermalinkPreviews` setting (which defaults to `true` and remains untouched), ensuring no behavioral changes.

**QA Recommendation:** Manual QA can be safely skipped. The removal is isolated to an unused feature flag field, with the actual permalink preview feature continuing to work through its intended configuration setting. Automated test coverage of the `ServiceSettings.EnablePermalinkPreviews` behavior is sufficient.
