### PR TITLE
[MM-69229] Remove orphaned DeprecateCloudFree feature flag

### DIFF
--- a/e2e-tests/playwright/lib/src/server/default_config.ts
+++ b/e2e-tests/playwright/lib/src/server/default_config.ts
@@ -765,7 +765,6 @@ const defaultServerConfig: AdminConfig = {
         NormalizeLdapDNs: false,
         WysiwygEditor: false,
         OnboardingTourTips: true,
-        DeprecateCloudFree: false,
         EnableExportDirectDownload: false,
         MoveThreadsEnabled: false,
         StreamlinedMarketplace: true,

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -43,8 +43,6 @@ type FeatureFlags struct {
 
 	OnboardingTourTips bool
 
-	DeprecateCloudFree bool
-
 	EnableExportDirectDownload bool
 
 	MoveThreadsEnabled bool
@@ -171,7 +169,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.EnableSharedChannelsPlugins = true
 	f.AppsEnabled = false
 	f.NormalizeLdapDNs = false
-	f.DeprecateCloudFree = false
 	f.WysiwygEditor = false
 	f.OnboardingTourTips = true
 	f.EnableExportDirectDownload = false


### PR DESCRIPTION
#### Summary

Removes the orphaned `DeprecateCloudFree` feature flag. This flag shipped in v8.0.0 and had no remaining consumers — the Cloud Free deprecation-banner code that once read it is long gone. Only the struct field, its `SetDefaults` entry, and the e2e `default_config` mirror remained. Removing it changes no behavior.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-69635
Relates-to: https://mattermost.atlassian.net/browse/MM-69229

```release-note
NONE
```



## Change Impact: 🟢 Low

**Regression Risk:** Virtually no risk. The flag has zero remaining consumers in the codebase (verified by comprehensive search), making this a safe removal of unused declarations. The changes are purely structural—removing a struct field definition and its test configuration entry—with no business logic or behavioral impact.

**QA Recommendation:** Manual QA can be skipped. This is a straightforward cleanup of orphaned code with no functional consequences. Standard automated testing of feature flag initialization and e2e test configuration should provide adequate coverage.
