### PR TITLE
Fix typo in support packet FileStore error field YAML tag

### DIFF
--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -88,7 +88,7 @@ type SupportPacketDiagnostics struct {
 
 	FileStore struct {
 		Status         string `yaml:"file_status"`
-		Error          string `yaml:"erorr,omitempty"`
+		Error          string `yaml:"error,omitempty"`
 		Driver         string `yaml:"file_driver"`
 		FilesystemType string `yaml:"filesystem_type,omitempty"`
 		TotalMB        uint64 `yaml:"total_mb,omitempty"`


### PR DESCRIPTION
#### Summary
Fixed a typo in the YAML tag for the `FileStore.Error` field in the support packet diagnostics struct. The tag was incorrectly spelled as `erorr` instead of `error`, which would cause the error field to be serialized with the wrong key name in YAML output.

#### Ticket Link
<!-- Add ticket link if available -->

#### Release Note
```release-note
NONE
```

https://claude.ai/code/session_01USpaSnNREid74Sw3TS3R7W

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is an isolated typo fix in a YAML struct tag affecting only the `FileStore.Error` field serialization. The change is confined to a single line in a diagnostic model struct and has no cascading effects on other modules. The support packet diagnostics feature is not part of core business logic or critical user-facing paths, minimizing regression risk.

**QA Recommendation:** Minimal manual QA required. Verify that the generated diagnostics YAML output contains the correct "error" key (instead of the misspelled "erorr") within the file_store section. Existing test coverage for support packet generation provides adequate automated validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->