### PR TITLE
[MM-69351] Fix membership store queries for users without AttributeView rows

### DIFF
--- a/server/channels/app/post_metadata.go
+++ b/server/channels/app/post_metadata.go
@@ -445,6 +445,14 @@ func (a *App) sanitizeFileAttachmentsForUser(rctx request.CTX, post *model.Post,
 		return
 	}
 
+	// No requesting user (e.g. a system post created by a background job with no
+	// session, such as the ABAC membership sync's channel-join messages). There
+	// is nobody to sanitize attachments for, so skip. A genuine reader re-runs
+	// this with their own session id when the post is served.
+	if userID == "" {
+		return
+	}
+
 	user, err := a.GetUser(userID)
 	if err != nil {
 		rctx.Logger().Warn("Failed to get user for file attachment sanitization, stripping attachments",

--- a/server/channels/store/sqlstore/attributes_store.go
+++ b/server/channels/store/sqlstore/attributes_store.go
@@ -39,6 +39,17 @@ func attributesSliceColumns(prefix ...string) []string {
 	}
 }
 
+// qualify prefixes each column with the given table name. The members-to-remove
+// queries join Users, whose columns (Roles, DeleteAt, CreateAt) collide with the
+// member columns, so the member SELECT must be table-qualified to stay unambiguous.
+func qualify(table string, columns []string) []string {
+	qualified := make([]string, len(columns))
+	for i, c := range columns {
+		qualified[i] = table + "." + c
+	}
+	return qualified
+}
+
 func newSqlAttributesStore(sqlStore *SqlStore, metrics einterfaces.MetricsInterface) store.AttributesStore {
 	s := &SqlAttributesStore{
 		SqlStore: sqlStore,
@@ -136,7 +147,11 @@ func (s *SqlAttributesStore) SearchUsers(rctx request.CTX, opts model.SubjectSea
 
 	if opts.Cursor.TargetID != "" {
 		argCount++
-		query = query.Where(sq.Expr(fmt.Sprintf("TargetID > $%d", argCount), opts.Cursor.TargetID))
+		// Paginate on Users.Id (the ORDER BY column), not AttributeView.TargetID.
+		// The cursor value is a user id, and TargetID comes from a LEFT JOIN so it
+		// is NULL for users with no custom-attribute row — comparing against it
+		// silently drops those users (e.g. matches of a native-only policy).
+		query = query.Where(sq.Expr(fmt.Sprintf("Users.Id > $%d", argCount), opts.Cursor.TargetID))
 	}
 
 	searchFields := make([]string, 0, len(UserSearchTypeNames))
@@ -177,11 +192,20 @@ func (s *SqlAttributesStore) SearchUsers(rctx request.CTX, opts model.SubjectSea
 
 func (s *SqlAttributesStore) GetChannelMembersToRemove(rctx request.CTX, channelID string, opts model.SubjectSearchOptions) ([]*model.ChannelMember, error) {
 	query := s.getQueryBuilder().
-		Select(channelMemberSliceColumns()...).From("ChannelMembers").LeftJoin("AttributeView ON ChannelMembers.UserId = AttributeView.TargetID").
+		Select(qualify("ChannelMembers", channelMemberSliceColumns())...).From("ChannelMembers").
+		// Join Users so native-attribute expressions (e.g. Users.EmailVerified)
+		// resolve here, mirroring SearchUsers on the add path.
+		LeftJoin("Users ON Users.Id = ChannelMembers.UserId").
+		LeftJoin("AttributeView ON ChannelMembers.UserId = AttributeView.TargetID").
 		OrderBy("ChannelMembers.UserId ASC")
 
 	if opts.Query != "" {
-		query = query.Where(sq.Expr(fmt.Sprintf("(NOT COALESCE((%s), FALSE) OR AttributeView.TargetID IS NULL)", opts.Query), opts.Args...))
+		// A member is removed when they do NOT satisfy the policy; a NULL result
+		// (e.g. a missing custom attribute) counts as "does not satisfy" via
+		// COALESCE. We must not additionally remove members just because they
+		// lack an AttributeView row — a native-only policy matches against the
+		// Users table, so a user with zero custom attributes can still satisfy it.
+		query = query.Where(sq.Expr(fmt.Sprintf("NOT COALESCE((%s), FALSE)", opts.Query), opts.Args...))
 	}
 
 	argCount := len(opts.Args)
@@ -215,12 +239,21 @@ func (s *SqlAttributesStore) GetChannelMembersToRemove(rctx request.CTX, channel
 
 func (s *SqlAttributesStore) GetTeamMembersToRemove(rctx request.CTX, teamID string, opts model.SubjectSearchOptions) ([]*model.TeamMember, error) {
 	query := s.getQueryBuilder().
-		Select(teamMemberSliceColumns()...).From("TeamMembers").LeftJoin("AttributeView ON TeamMembers.UserId = AttributeView.TargetID").
+		Select(qualify("TeamMembers", teamMemberSliceColumns())...).From("TeamMembers").
+		// Join Users so native-attribute expressions (e.g. Users.EmailVerified)
+		// resolve here, mirroring SearchUsers on the add path.
+		LeftJoin("Users ON Users.Id = TeamMembers.UserId").
+		LeftJoin("AttributeView ON TeamMembers.UserId = AttributeView.TargetID").
 		Where("TeamMembers.DeleteAt = 0").
 		OrderBy("TeamMembers.UserId ASC")
 
 	if opts.Query != "" {
-		query = query.Where(sq.Expr(fmt.Sprintf("(NOT COALESCE((%s), FALSE) OR AttributeView.TargetID IS NULL)", opts.Query), opts.Args...))
+		// A member is removed when they do NOT satisfy the policy; a NULL result
+		// (e.g. a missing custom attribute) counts as "does not satisfy" via
+		// COALESCE. We must not additionally remove members just because they
+		// lack an AttributeView row — a native-only policy matches against the
+		// Users table, so a user with zero custom attributes can still satisfy it.
+		query = query.Where(sq.Expr(fmt.Sprintf("NOT COALESCE((%s), FALSE)", opts.Query), opts.Args...))
 	}
 
 	argCount := len(opts.Args)

--- a/server/channels/store/storetest/attributes_store.go
+++ b/server/channels/store/storetest/attributes_store.go
@@ -313,6 +313,38 @@ func testAttributesStoreSearchUsers(t *testing.T, rctx request.CTX, ss store.Sto
 			require.Equal(t, int64(2), count, "expected count 2 user with the query")
 		}
 	})
+
+	// Regression test: pagination must page on Users.Id, not the LEFT-JOINed
+	// AttributeView.TargetID. A user with no custom-attribute row has a NULL
+	// TargetID, so a "TargetID > cursor" predicate silently drops them from
+	// every page. Native-only policies (e.g. user.verified) match exactly such
+	// users, and the membership sync always seeds a cursor, so this manifested
+	// as the sync adding zero members while the Test modal (no cursor) showed
+	// the full set.
+	t.Run("Search paginates users with no attribute row", func(t *testing.T) {
+		// A fresh user with no custom attributes => no AttributeView row.
+		u := model.User{Email: MakeEmail(), Username: model.NewUsername()}
+		_, err := ss.User().Save(rctx, &u)
+		require.NoError(t, err, "couldn't save attribute-less user")
+		t.Cleanup(func() {
+			require.NoError(t, ss.User().PermanentDelete(rctx, u.Id), "couldn't delete attribute-less user")
+		})
+
+		require.NoError(t, ss.Attributes().RefreshAttributes(), "couldn't refresh attributes")
+
+		// Native-style predicate against the Users table; matches the user above
+		// despite the missing AttributeView row.
+		subjects, _, err := ss.Attributes().SearchUsers(rctx, model.SubjectSearchOptions{
+			Query: "Users.Email = $1::text",
+			Args:  []any{u.Email},
+			Cursor: model.SubjectCursor{
+				TargetID: strings.Repeat("0", 26),
+			},
+		})
+		require.NoError(t, err, "couldn't search attribute-less user with cursor")
+		require.Len(t, subjects, 1, "attribute-less user must be returned despite the pagination cursor")
+		require.Equal(t, u.Id, subjects[0].Id, "expected the attribute-less user")
+	})
 }
 
 func testAttributesStoreGetChannelMembersToRemove(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
@@ -398,6 +430,38 @@ func testAttributesStoreGetChannelMembersToRemove(t *testing.T, rctx request.CTX
 		})
 		require.NoError(t, err, "couldn't get channel members to remove")
 		require.Len(t, members, 2, "expected 2 channel member to remove")
+	})
+
+	// Regression test: a native-attribute policy resolves against the Users
+	// table (the query is joined to Users), and a member with no AttributeView
+	// row who satisfies it must NOT be removed. Before the fix, native columns
+	// failed to resolve (no Users join) and the "OR AttributeView.TargetID IS
+	// NULL" clause removed attribute-less members outright.
+	t.Run("native policy keeps members with no attribute row", func(t *testing.T) {
+		extra := model.User{Email: MakeEmail(), Username: model.NewUsername()}
+		_, err := ss.User().Save(rctx, &extra)
+		require.NoError(t, err, "couldn't save attribute-less member")
+		_, err = ss.Channel().SaveMember(rctx, &model.ChannelMember{
+			ChannelId:   ch.Id,
+			UserId:      extra.Id,
+			NotifyProps: defaultNotifyProps,
+		})
+		require.NoError(t, err, "couldn't add attribute-less member")
+		t.Cleanup(func() {
+			require.NoError(t, ss.Channel().RemoveMember(rctx, ch.Id, extra.Id), "couldn't remove attribute-less member")
+			require.NoError(t, ss.User().PermanentDelete(rctx, extra.Id), "couldn't delete attribute-less member")
+		})
+
+		require.NoError(t, ss.Attributes().RefreshAttributes(), "couldn't refresh attributes")
+
+		// Native-style predicate satisfied by every active user, including the
+		// attribute-less member.
+		members, err := ss.Attributes().GetChannelMembersToRemove(rctx, ch.Id, model.SubjectSearchOptions{
+			Query: "Users.DeleteAt = $1::bigint",
+			Args:  []any{int64(0)},
+		})
+		require.NoError(t, err, "native removal query must not error")
+		require.Empty(t, members, "members satisfying a native policy must not be removed, even without an attribute row")
 	})
 }
 
@@ -487,6 +551,34 @@ func testAttributesStoreGetTeamMembersToRemove(t *testing.T, rctx request.CTX, s
 		for _, m := range members {
 			require.NotEqual(t, removed.Id, m.UserId, "soft-deleted member must not appear")
 		}
+	})
+
+	// Regression test: a native-attribute policy resolves against the Users
+	// table (the query is joined to Users), and a member with no AttributeView
+	// row who satisfies it must NOT be removed. Before the fix, native columns
+	// failed to resolve (no Users join) and the "OR AttributeView.TargetID IS
+	// NULL" clause removed attribute-less members outright.
+	t.Run("native policy keeps members with no attribute row", func(t *testing.T) {
+		extra := model.User{Email: MakeEmail(), Username: model.NewUsername()}
+		_, err := ss.User().Save(rctx, &extra)
+		require.NoError(t, err, "couldn't save attribute-less member")
+		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamID, UserId: extra.Id}, 1000)
+		require.NoError(t, nErr, "couldn't add attribute-less member")
+		t.Cleanup(func() {
+			require.NoError(t, ss.Team().RemoveMember(rctx, teamID, extra.Id), "couldn't remove attribute-less member")
+			require.NoError(t, ss.User().PermanentDelete(rctx, extra.Id), "couldn't delete attribute-less member")
+		})
+
+		require.NoError(t, ss.Attributes().RefreshAttributes(), "couldn't refresh attributes")
+
+		// Native-style predicate satisfied by every active user, including the
+		// attribute-less member.
+		members, err := ss.Attributes().GetTeamMembersToRemove(rctx, teamID, model.SubjectSearchOptions{
+			Query: "Users.DeleteAt = $1::bigint",
+			Args:  []any{int64(0)},
+		})
+		require.NoError(t, err, "native removal query must not error")
+		require.Empty(t, members, "members satisfying a native policy must not be removed, even without an attribute row")
 	})
 }
 


### PR DESCRIPTION
#### Summary
Follow-up bug fixes for native ABAC user attributes. Native attributes resolve against the `Users` table, so a membership policy can now match users who have **no row in the `AttributeView`** materialized view. Two latent assumptions in `channels/store/sqlstore/attributes_store.go` broke for such users:

- **`SearchUsers` pagination (add path).** The query orders by `Users.Id` but paginated with a cursor predicate on the LEFT-joined `AttributeView.TargetID`, which is `NULL` for users with no custom attributes (so `TargetID > cursor` is `NULL`/false and they are dropped). The membership sync always seeds a cursor, so it silently added **zero** members while the Test modal (no cursor) showed the full match set. Now pages on `Users.Id` (the `ORDER BY` column).
- **`GetChannelMembersToRemove` / `GetTeamMembersToRemove` (removal path).** These didn't join `Users` (so native expressions like `Users.EmailVerified` failed to resolve) and removed any member lacking an `AttributeView` row via `OR AttributeView.TargetID IS NULL`. They now `LEFT JOIN Users` and drop that clause — `NOT COALESCE(expr, FALSE)` already removes non-matching members, while letting attribute-less users who satisfy a native policy stay. Member `SELECT` columns are table-qualified to avoid ambiguity with the joined `Users` columns.

CPA-only behavior is unchanged (a null-`Properties` row already yields `NOT COALESCE(expr, FALSE) = TRUE`); the difference only surfaces for native-only / sparse-CPA policies.

Once the sync actually adds members, it creates channel-join system posts in a background job with no session. Those flow through `CreatePost` -> `SanitizePostMetadataForUser(rctx, post, rctx.Session().UserId)` with an empty user id, so `sanitizeFileAttachmentsForUser` called `GetUser("")` and logged `Failed to get user for file attachment sanitization` once per added member. This PR also skips that sanitization when there is no requesting user — a genuine reader re-runs it with their own session id when the post is served, so download enforcement is unaffected.

Verified against local dev: a native-only channel policy (`user.verified == true && user.createat.youngerThanDays(45)`) matched 59 eligible users but synced 0 before the fix; the generated query returns 59 once paging on `Users.Id`.

QA steps:
- Create a membership policy using only native attributes (e.g. `user.verified == true`) on a channel, assign it as auto-add, run the sync, and confirm matching users with no custom attributes are added (and that no "Failed to get user for file attachment sanitization" warnings are logged).
- Confirm a private-channel native policy correctly removes only non-matching members and keeps attribute-less matchers.
- Confirm existing CPA-only add/remove policies behave as before.

Adds store regression tests covering an attribute-less user paged by `SearchUsers` and kept by both members-to-remove paths.

Stacked on #37133 (Phase 5); base `MM-69336`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69351

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)