### PR TITLE
preserve individual plugin configs during patch when absent

### DIFF
--- a/server/channels/api4/config.go
+++ b/server/channels/api4/config.go
@@ -340,9 +340,13 @@ func patchConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.App.HandleMessageExportConfig(cfg, appCfg)
 	}
 
-	// Treating an empty plugins map as nil preserves the existing configs.
-	if len(cfg.PluginSettings.Plugins) == 0 {
-		cfg.PluginSettings.Plugins = nil
+	// Preserve the existing configs for those not present in the patch.
+	if cfg.PluginSettings.Plugins != nil {
+		for id, storedSettings := range appCfg.PluginSettings.Plugins {
+			if _, present := cfg.PluginSettings.Plugins[id]; !present {
+				cfg.PluginSettings.Plugins[id] = storedSettings
+			}
+		}
 	}
 
 	updatedCfg, err := config.Merge(appCfg, cfg, &utils.MergeConfig{

--- a/server/channels/api4/config_local.go
+++ b/server/channels/api4/config_local.go
@@ -116,9 +116,13 @@ func localPatchConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.App.HandleMessageExportConfig(cfg, appCfg)
 	}
 
-	// Treating an empty plugins map as nil preserves the existing configs.
-	if len(cfg.PluginSettings.Plugins) == 0 {
-		cfg.PluginSettings.Plugins = nil
+	// Preserve the existing configs for those not present in the patch.
+	if cfg.PluginSettings.Plugins != nil {
+		for id, storedSettings := range appCfg.PluginSettings.Plugins {
+			if _, present := cfg.PluginSettings.Plugins[id]; !present {
+				cfg.PluginSettings.Plugins[id] = storedSettings
+			}
+		}
 	}
 
 	updatedCfg, mergeErr := config.Merge(appCfg, cfg, &utils.MergeConfig{

--- a/server/channels/api4/config_test.go
+++ b/server/channels/api4/config_test.go
@@ -1029,6 +1029,60 @@ func TestPatchConfig(t *testing.T) {
 		require.Contains(t, storedCfg.PluginSettings.Plugins, "com.example.oauth-plugin")
 		assert.Equal(t, "test-client-id", storedCfg.PluginSettings.Plugins["com.example.oauth-plugin"]["clientid"])
 	})
+
+	t.Run("should preserve plugin configs absent from patch due to partial sync", func(t *testing.T) {
+		// Start with multiple plugins configured.
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.PluginSettings.Enable = new(true)
+			cfg.PluginSettings.Plugins = map[string]map[string]any{
+				"com.example.plugin-a": {"token": "token-a"},
+				"com.example.plugin-b": {"token": "token-b"},
+			}
+		})
+
+		// simulate a client receives a partial sanitized config with only plugin-a, and PATCHes it back. Plugin-b should survive.
+		patch := &model.Config{}
+		patch.PluginSettings.Enable = new(true)
+		patch.PluginSettings.Plugins = map[string]map[string]any{
+			"com.example.plugin-a": {"token": "token-a-updated"},
+		}
+		_, _, err := th.SystemAdminClient.PatchConfig(context.Background(), patch)
+		require.NoError(t, err)
+
+		// All plugin configs must survive; only the synced plugin was in the patch.
+		storedCfg := th.App.Config()
+		require.Contains(t, storedCfg.PluginSettings.Plugins, "com.example.plugin-a")
+		require.Contains(t, storedCfg.PluginSettings.Plugins, "com.example.plugin-b")
+		assert.Equal(t, "token-a-updated", storedCfg.PluginSettings.Plugins["com.example.plugin-a"]["token"])
+		assert.Equal(t, "token-b", storedCfg.PluginSettings.Plugins["com.example.plugin-b"]["token"])
+	})
+
+	t.Run("should preserve plugin configs absent from patch due to partial sync while using local client", func(t *testing.T) {
+		// Start with multiple plugins configured.
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.PluginSettings.Enable = new(true)
+			cfg.PluginSettings.Plugins = map[string]map[string]any{
+				"com.example.plugin-a": {"token": "token-a"},
+				"com.example.plugin-b": {"token": "token-b"},
+			}
+		})
+
+		// Simulate a client receives a partial sanitized config with only plugin-a, and PATCHes it back. Plugin-b should survive.
+		patch := &model.Config{}
+		patch.PluginSettings.Enable = new(true)
+		patch.PluginSettings.Plugins = map[string]map[string]any{
+			"com.example.plugin-a": {"token": "token-a-updated"},
+		}
+		_, _, err := th.LocalClient.PatchConfig(context.Background(), patch)
+		require.NoError(t, err)
+
+		// All plugin configs must survive; only the synced plugin was in the patch.
+		storedCfg := th.App.Config()
+		require.Contains(t, storedCfg.PluginSettings.Plugins, "com.example.plugin-a")
+		require.Contains(t, storedCfg.PluginSettings.Plugins, "com.example.plugin-b")
+		assert.Equal(t, "token-a-updated", storedCfg.PluginSettings.Plugins["com.example.plugin-a"]["token"])
+		assert.Equal(t, "token-b", storedCfg.PluginSettings.Plugins["com.example.plugin-b"]["token"])
+	})
 }
 
 func TestMigrateConfig(t *testing.T) {


### PR DESCRIPTION
#### Summary
During a config PATCH, plugin entries absent from the request are preserved rather than deleted. This fixes config loss when an HA node has incomplete plugin configuration due to issues during sync.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-67629

#### Release Note
```release-note
Fix plugin config loss on HA nodes with incomplete plugin sync.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes modify plugin configuration preservation logic during PATCH operations, which could affect clients relying on the old behavior where empty plugin maps would clear configurations. The change explicitly preserves missing plugin entries by copying them from stored config, affecting both authenticated (`patchConfig`) and local (`localPatchConfig`) endpoints that call `SaveConfig`.

**QA Recommendation:** Manual QA testing is recommended for HA cluster scenarios, specifically: (1) plugin configuration patching and synchronization across HA nodes with partial config visibility, (2) verification that client PATCH requests with incomplete plugin configurations preserve other configured plugins, and (3) cluster-wide config consistency during plugin config updates. Automated test coverage for these scenarios is comprehensive with two new subtests covering both admin and local client flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->