### PR TITLE
Cherry pick of #37122

### DIFF
--- a/server/einterfaces/metrics.go
+++ b/server/einterfaces/metrics.go
@@ -28,6 +28,7 @@ type MetricsInterface interface {
 	IncrementClusterRequest()
 	ObserveClusterRequestDuration(elapsed float64)
 	IncrementClusterEventType(eventType model.ClusterEvent)
+	ObserveClusterReliableFallbackLength(event model.ClusterEvent, length int)
 
 	IncrementLogin()
 	IncrementLoginFail()

--- a/server/einterfaces/mocks/MetricsInterface.go
+++ b/server/einterfaces/mocks/MetricsInterface.go
@@ -413,6 +413,11 @@ func (_m *MetricsInterface) ObserveClientTimeToLastByte(platform string, agent s
 	_m.Called(platform, agent, userID, elapsed)
 }
 
+// ObserveClusterReliableFallbackLength provides a mock function with given fields: event, length
+func (_m *MetricsInterface) ObserveClusterReliableFallbackLength(event model.ClusterEvent, length int) {
+	_m.Called(event, length)
+}
+
 // ObserveClusterRequestDuration provides a mock function with given fields: elapsed
 func (_m *MetricsInterface) ObserveClusterRequestDuration(elapsed float64) {
 	_m.Called(elapsed)

--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -74,8 +74,9 @@ type MetricsInterfaceImpl struct {
 	HTTPErrorsCounter   prometheus.Counter
 	HTTPWebsocketsGauge *prometheus.GaugeVec
 
-	ClusterRequestsDuration prometheus.Histogram
-	ClusterRequestsCounter  prometheus.Counter
+	ClusterRequestsDuration       prometheus.Histogram
+	ClusterRequestsCounter        prometheus.Counter
+	ClusterReliableFallbackLength *prometheus.HistogramVec
 
 	ClusterHealthGauge prometheus.GaugeFunc
 
@@ -546,6 +547,23 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 		m.ClusterEventMap[event] = m.ClusterEventTypeCounters.With(prometheus.Labels{"name": string(event)})
 	}
 	m.ClusterEventMap[model.ClusterEvent("other")] = m.ClusterEventTypeCounters.With(prometheus.Labels{"name": "other"})
+
+	m.ClusterReliableFallbackLength = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Namespace:   MetricsNamespace,
+			Subsystem:   MetricsSubsystemCluster,
+			Name:        "reliable_fallback_tcp",
+			Help:        "The total length in bytes of the SendBestEffort calls (UDP) that had to fallback to SendReliable (TCP) because of the message length.",
+			ConstLabels: additionalLabels,
+			// The data here will start at maxUDPDataLen = (1<<16 - 1) - 8 - 20 - 35 = 65472,
+			// so we start the first bucket at 32KiB, which will always be zero, and add 8
+			// steps exponentially until 4MiB:
+			// 32768, 65536, 131072, 262144, 524288, 1048576, 2097152, 4194304
+			Buckets: prometheus.ExponentialBuckets(32768, 2, 8),
+		},
+		[]string{"event"},
+	)
+	m.Registry.MustRegister(m.ClusterReliableFallbackLength)
 
 	// Login Subsystem
 
@@ -1860,6 +1878,10 @@ func (mi *MetricsInterfaceImpl) IncrementHTTPError() {
 
 func (mi *MetricsInterfaceImpl) IncrementClusterRequest() {
 	mi.ClusterRequestsCounter.Inc()
+}
+
+func (mi *MetricsInterfaceImpl) ObserveClusterReliableFallbackLength(event model.ClusterEvent, length int) {
+	mi.ClusterReliableFallbackLength.With(prometheus.Labels{"event": string(event)}).Observe(float64(length))
 }
 
 func (mi *MetricsInterfaceImpl) ObserveClusterRequestDuration(elapsed float64) {

--- a/server/enterprise/metrics/metrics_test.go
+++ b/server/enterprise/metrics/metrics_test.go
@@ -311,3 +311,42 @@ func TestSearchEngineStatusGauge(t *testing.T) {
 		require.Equal(t, 0.0, readGauge())
 	})
 }
+
+func TestObserveClusterReliableFallbackLength(t *testing.T) {
+	th := api4.SetupEnterprise(t, app.StartMetrics)
+
+	configureMetrics(th)
+	mi := th.App.Metrics()
+
+	miImpl, ok := mi.(*MetricsInterfaceImpl)
+	require.True(t, ok, fmt.Sprintf("App.Metrics is not *MetricsInterfaceImpl, but %T", mi))
+
+	event := model.ClusterEvent("ws_event")
+	length := 42
+	m := &prometheusModels.Metric{}
+
+	t.Run("labels are correct", func(t *testing.T) {
+		_, err := miImpl.ClusterReliableFallbackLength.GetMetricWith(prometheus.Labels{"event": "x"})
+		require.NoError(t, err, "expected 'event' to be a registered label")
+		_, err = miImpl.ClusterReliableFallbackLength.GetMetricWith(prometheus.Labels{"wrong_label": "x"})
+		require.Error(t, err, "expected no label other than 'event' to be registered")
+	})
+
+	t.Run("metric is registered and initialized at 0", func(t *testing.T) {
+		actualMetric, err := miImpl.ClusterReliableFallbackLength.GetMetricWith(prometheus.Labels{"event": string(event)})
+		require.NoError(t, err)
+		require.NoError(t, actualMetric.(prometheus.Histogram).Write(m))
+		require.Equal(t, uint64(0), m.Histogram.GetSampleCount())
+		require.Equal(t, 0.0, m.Histogram.GetSampleSum())
+	})
+
+	t.Run("metric can be observed and the registered value is correct", func(t *testing.T) {
+		mi.ObserveClusterReliableFallbackLength(event, length)
+
+		actualMetric, err := miImpl.ClusterReliableFallbackLength.GetMetricWith(prometheus.Labels{"event": string(event)})
+		require.NoError(t, err)
+		require.NoError(t, actualMetric.(prometheus.Histogram).Write(m))
+		require.Equal(t, uint64(1), m.Histogram.GetSampleCount())
+		require.InDelta(t, float64(length), m.Histogram.GetSampleSum(), 0.001)
+	})
+}


### PR DESCRIPTION
#### Summary
MM-69311: Add a new ClusterReliableFallbackLength metric

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69311

#### Release Note
```release-note
Added a new ClusterReliableFallbackLength metric with the total length in bytes of the SendBestEffort calls (UDP) that had to fallback to TCP because of the message length
```