### PR TITLE
Bump prepackaged Playbooks plugin to v2.10.0

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -162,7 +162,7 @@ PLUGIN_PACKAGES += mattermost-plugin-calls-v1.12.0
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.1
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.0
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.10.0-rc2
+PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.10.0
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.0
@@ -178,7 +178,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.10.0-rc2%2B30c1de8-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.10.0%2B090a26d-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.0%2B82431f9-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0-rc2%2B5880c13-fips
 endif


### PR DESCRIPTION
#### Summary
Bumps the prepackaged Playbooks plugin (and its FIPS variant) from `v2.10.0-rc2` to the `v2.10.0` GA release, for v11.9.

- Non-FIPS: `mattermost-plugin-playbooks-v2.10.0`
- FIPS: `mattermost-plugin-playbooks-v2.10.0%2B090a26d-fips` (`090a26d` is the tagged release commit)

Both bundles and their signatures are published on `plugins.releases.mattermost.com` (verified HTTP 200).

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68810

#### Release Note
```release-note
Updated the prepackaged Playbooks plugin to v2.10.0.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to Makefile configuration—a straightforward plugin version bump from RC to GA with no code logic modifications. The PR author has verified both plugin bundles and signatures are published and accessible, eliminating deployment risks.

**QA Recommendation:** Manual QA can be skipped if automated tests confirm successful plugin bundle resolution and packaging. Standard smoke testing of the Playbooks plugin functionality in the built artifact is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->