### PR TITLE
ci: replace volatile e2e-platform-pkgs cache with shared webapp-setup

### DIFF
--- a/.github/actions/webapp-setup/action.yml
+++ b/.github/actions/webapp-setup/action.yml
@@ -1,6 +1,12 @@
 name: "Web app setup"
 description: "Set up NPM and dependencies"
 
+inputs:
+  read-only:
+    description: "Restore from cache without saving"
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -9,8 +15,9 @@ runs:
       with:
         node-version-file: ".nvmrc"
     - name: ci/cache-node-modules
+      if: inputs.read-only != 'true'
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-      id: cache-node-modules
+      id: cache-node-modules-rw
       with:
         path: |
           webapp/node_modules
@@ -20,8 +27,26 @@ runs:
           webapp/platform/shared/node_modules
           webapp/platform/types/node_modules
         key: node-modules-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json') }}
+    - name: ci/restore-node-modules
+      if: inputs.read-only == 'true'
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      id: cache-node-modules-ro
+      with:
+        path: |
+          webapp/node_modules
+          webapp/channels/node_modules
+          webapp/platform/client/node_modules
+          webapp/platform/components/node_modules
+          webapp/platform/shared/node_modules
+          webapp/platform/types/node_modules
+        key: node-modules-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json') }}
+    - name: ci/resolve-cache-hit
+      id: cache-hit
+      shell: bash
+      run: |
+        echo "cache-hit=${{ steps.cache-node-modules-rw.outputs.cache-hit || steps.cache-node-modules-ro.outputs.cache-hit }}" >> $GITHUB_OUTPUT
     - name: ci/get-node-modules
-      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      if: steps.cache-hit.outputs.cache-hit != 'true'
       shell: bash
       working-directory: webapp
       run: |
@@ -29,7 +54,7 @@ runs:
     - name: ci/build-platform-packages
       # These are built automatically when depenedencies are installed, but they aren't cached properly, so we need to
       # manually build them when the cache is hit. They aren't worth caching because they have too many dependencies.
-      if: steps.cache-node-modules.outputs.cache-hit == 'true'
+      if: steps.cache-hit.outputs.cache-hit == 'true'
       shell: bash
       working-directory: webapp
       run: |

--- a/.github/actions/webapp-setup/action.yml
+++ b/.github/actions/webapp-setup/action.yml
@@ -52,7 +52,7 @@ runs:
       run: |
         make node_modules
     - name: ci/build-platform-packages
-      # These are built automatically when depenedencies are installed, but they aren't cached properly, so we need to
+      # These are built automatically when dependencies are installed, but they aren't cached properly, so we need to
       # manually build them when the cache is hit. They aren't worth caching because they have too many dependencies.
       if: steps.cache-hit.outputs.cache-hit == 'true'
       shell: bash

--- a/.github/workflows/e2e-tests-cypress-template-v2.yml
+++ b/.github/workflows/e2e-tests-cypress-template-v2.yml
@@ -198,7 +198,9 @@ jobs:
           echo "workers=$(jq -nc --argjson n "${INPUT_WORKERS}" '[range(1; $n+1)]')" >> $GITHUB_OUTPUT
           echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
 
-  # Install cypress node_modules once, then workers restore from cache.
+  # Install webapp node_modules once via the shared webapp-setup action, then
+  # workers restore the same stable cache. See e2e-tests-playwright-template-v2.yml
+  # for a full explanation of why the volatile e2e-platform-pkgs cache was dropped.
   prep-deps:
     name: prep-deps
     runs-on: ubuntu-24.04
@@ -212,29 +214,8 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 1
-      - name: ci/setup-node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: ".nvmrc"
-      - name: ci/cache-platform-pkgs
-        # `webapp/node_modules/@mattermost/{client,types}` are the workspace
-        # symlinks Node walks up to find when platform/client requires
-        # @mattermost/types. Without them, module resolution fails inside
-        # the slim slice.
-        id: cache-platform-pkgs
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: |
-            webapp/**/node_modules
-            webapp/platform/client/lib
-            webapp/platform/types/lib
-          key: e2e-platform-pkgs-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json', 'webapp/platform/client/src/**', 'webapp/platform/client/tsconfig*.json', 'webapp/platform/types/src/**', 'webapp/platform/types/tsconfig*.json') }}
-      - name: ci/build-platform-pkgs
-        # Full webapp install is needed for tsc + workspace linking; the
-        # postinstall builds platform/{client,types}/lib. We only cache those.
-        if: steps.cache-platform-pkgs.outputs.cache-hit != 'true'
-        working-directory: webapp
-        run: make node_modules
+      - name: ci/setup-webapp-node-modules
+        uses: ./.github/actions/webapp-setup
       - name: ci/cache-cypress-deps
         # node_modules + the cypress binary (downloaded to ~/.cache/Cypress by
         # cypress's postinstall, not into node_modules). Both must be cached;
@@ -332,21 +313,10 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
-      - name: ci/setup-node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - name: ci/setup-webapp-node-modules
+        uses: ./.github/actions/webapp-setup
         with:
-          node-version-file: ".nvmrc"
-      - name: ci/restore-platform-pkgs
-        # Built lib/ for @mattermost/client and @mattermost/types, plus the
-        # webapp workspace symlinks under webapp/node_modules/@mattermost/.
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: |
-            webapp/**/node_modules
-            webapp/platform/client/lib
-            webapp/platform/types/lib
-          key: e2e-platform-pkgs-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json', 'webapp/platform/client/src/**', 'webapp/platform/client/tsconfig*.json', 'webapp/platform/types/src/**', 'webapp/platform/types/tsconfig*.json') }}
-          fail-on-cache-miss: true
+          read-only: "true"
       - name: ci/restore-cypress-deps
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:

--- a/.github/workflows/e2e-tests-cypress-template-v2.yml
+++ b/.github/workflows/e2e-tests-cypress-template-v2.yml
@@ -199,8 +199,8 @@ jobs:
           echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
 
   # Install webapp node_modules once via the shared webapp-setup action, then
-  # workers restore the same stable cache. See e2e-tests-playwright-template-v2.yml
-  # for a full explanation of why the volatile e2e-platform-pkgs cache was dropped.
+  # workers restore the same stable cache. The node_modules cache is keyed only
+  # on webapp/package-lock.json and is shared with webapp-ci.yml jobs.
   prep-deps:
     name: prep-deps
     runs-on: ubuntu-24.04

--- a/.github/workflows/e2e-tests-playwright-template-v2.yml
+++ b/.github/workflows/e2e-tests-playwright-template-v2.yml
@@ -163,9 +163,13 @@ jobs:
           echo "workers=$(jq -nc --argjson n "${INPUT_WORKERS}" '[range(1; $n+1)]')" >> $GITHUB_OUTPUT
           echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
 
-  # Build @mattermost/client + @mattermost/types and install playwright deps once,
-  # then workers restore from cache. Playwright only consumes those two packages
-  # from webapp, so we cache just their built lib/ instead of all of webapp/node_modules.
+  # Install webapp node_modules once via the shared webapp-setup action, then
+  # workers restore the same stable cache. The platform/{client,types}/lib outputs
+  # are rebuilt by npm run postinstall on every cache hit rather than cached
+  # separately — their source changes every commit, so caching them generates a
+  # new ~370 MB entry per commit. The node_modules cache is keyed only on
+  # webapp/package-lock.json, which is stable across source changes, so it is
+  # shared with webapp-ci.yml jobs and rarely needs a cold build.
   prep-deps:
     name: prep-deps
     runs-on: ubuntu-24.04
@@ -179,29 +183,8 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 1
-      - name: ci/setup-node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: ".nvmrc"
-      - name: ci/cache-platform-pkgs
-        # `webapp/node_modules/@mattermost/{client,types}` are the workspace
-        # symlinks Node walks up to find when platform/client requires
-        # @mattermost/types. Without them, module resolution fails inside
-        # the slim slice.
-        id: cache-platform-pkgs
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: |
-            webapp/**/node_modules
-            webapp/platform/client/lib
-            webapp/platform/types/lib
-          key: e2e-platform-pkgs-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json', 'webapp/platform/client/src/**', 'webapp/platform/client/tsconfig*.json', 'webapp/platform/types/src/**', 'webapp/platform/types/tsconfig*.json') }}
-      - name: ci/build-platform-pkgs
-        # Full webapp install is needed for tsc + workspace linking; the
-        # postinstall builds platform/{client,types}/lib. We only cache those.
-        if: steps.cache-platform-pkgs.outputs.cache-hit != 'true'
-        working-directory: webapp
-        run: make node_modules
+      - name: ci/setup-webapp-node-modules
+        uses: ./.github/actions/webapp-setup
       - name: ci/cache-playwright-deps
         # Caches node_modules + the rolled-up @mattermost/playwright-lib dist
         # so workers don't re-run rollup on every job.
@@ -306,21 +289,10 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
-      - name: ci/setup-node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+      - name: ci/setup-webapp-node-modules
+        uses: ./.github/actions/webapp-setup
         with:
-          node-version-file: ".nvmrc"
-      - name: ci/restore-platform-pkgs
-        # Built lib/ for @mattermost/client and @mattermost/types, plus the
-        # webapp workspace symlinks under webapp/node_modules/@mattermost/.
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: |
-            webapp/**/node_modules
-            webapp/platform/client/lib
-            webapp/platform/types/lib
-          key: e2e-platform-pkgs-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json', 'webapp/platform/client/src/**', 'webapp/platform/client/tsconfig*.json', 'webapp/platform/types/src/**', 'webapp/platform/types/tsconfig*.json') }}
-          fail-on-cache-miss: true
+          read-only: "true"
       - name: ci/restore-playwright-deps
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:

--- a/.github/workflows/e2e-tests-playwright-template-v2.yml
+++ b/.github/workflows/e2e-tests-playwright-template-v2.yml
@@ -164,12 +164,8 @@ jobs:
           echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
 
   # Install webapp node_modules once via the shared webapp-setup action, then
-  # workers restore the same stable cache. The platform/{client,types}/lib outputs
-  # are rebuilt by npm run postinstall on every cache hit rather than cached
-  # separately — their source changes every commit, so caching them generates a
-  # new ~370 MB entry per commit. The node_modules cache is keyed only on
-  # webapp/package-lock.json, which is stable across source changes, so it is
-  # shared with webapp-ci.yml jobs and rarely needs a cold build.
+  # workers restore the same stable cache. The node_modules cache is keyed only
+  # on webapp/package-lock.json and is shared with webapp-ci.yml jobs.
   prep-deps:
     name: prep-deps
     runs-on: ubuntu-24.04


### PR DESCRIPTION
#### Summary
Our [cache usage](https://github.com/mattermost/mattermost/actions/caches) is regularly warning about `Approaching total cache storage limit (10.54 GB of 10 GB Used)`. This actively prevents us from [exploring new caching ideas](https://github.com/mattermost/mattermost/pull/36711) for fear of adding to the overall problem.

In a bid to reduce cache usage, I'm proposing that we ditch the `e2e-platform-pkgs-*` cache in favour of reusing the one already managed by the `webapp-setup` action. One big problem with `e2e-platform-pkgs-*` is that it keys off `webapp/platform/client/src/**` and `webapp/platform/types/src/**`, resulting it more cache churn than might otherwise be needed. The `webapp-setup` action, by contrast, keys off just `package-lock.json`, and thus changes relatively infrequently.

The tradeoff is the need to `npm run postinstall` after restoring the (slightly different) cache, but this cost seems negligible if we can save on cache thrashing overall.

**Expected cache impact:** ~2.85 GB of `e2e-platform-pkgs-Linux-*` entries eliminated; the `node-modules-Linux-*` entry they're replaced by is already present in most cases.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The shared `webapp-setup` composite action now branches between cache save vs restore-only (`read-only`) and relies on unified cache-hit detection; if the resolved cache-hit signal is incorrect, workers may skip `npm run postinstall` on a restored cache and end up with an inconsistent `webapp` dependency state. The change is CI-only but affects multiple E2E workflow templates that reuse the same composite action.

**QA Recommendation:** Validate by running a few CI executions covering both Cypress and Playwright (including worker jobs that use `read-only: "true"`) and confirm the workflows complete successfully and dependency setup remains consistent; no additional manual QA is expected beyond watching the CI results.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->