### PR TITLE
[MM-69464] Fix data race in pluginapi.ConfigureLogrus

### DIFF
--- a/server/public/pluginapi/logrus.go
+++ b/server/public/pluginapi/logrus.go
@@ -66,7 +66,6 @@ func ConfigureLogrus(logger *logrus.Logger, client *Client) {
 	logger.AddHook(hook)
 	logger.SetOutput(io.Discard)
 
-	// Configure the given logger, not the global standard logger.
 	logger.SetReportCaller(true)
 
 	// By default, log everything to the server, and let it decide what gets through.

--- a/server/public/pluginapi/logrus.go
+++ b/server/public/pluginapi/logrus.go
@@ -60,10 +60,15 @@ func (lh *LogrusHook) Fire(entry *logrus.Entry) error {
 // discarding the default output to avoid duplicating the events across the standard STDOUT proxy.
 func ConfigureLogrus(logger *logrus.Logger, client *Client) {
 	hook := NewLogrusHook(client.Log)
-	logger.Hooks.Add(hook)
+
+	// AddHook (not Hooks.Add) takes the logger mutex, so registering the hook is
+	// safe against goroutines logging through the same logger concurrently.
+	logger.AddHook(hook)
 	logger.SetOutput(io.Discard)
-	logrus.SetReportCaller(true)
+
+	// Configure the given logger, not the global standard logger.
+	logger.SetReportCaller(true)
 
 	// By default, log everything to the server, and let it decide what gets through.
-	logrus.SetLevel(logrus.TraceLevel)
+	logger.SetLevel(logrus.TraceLevel)
 }

--- a/server/public/pluginapi/logrus_test.go
+++ b/server/public/pluginapi/logrus_test.go
@@ -1,6 +1,7 @@
 package pluginapi_test
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
@@ -82,4 +83,40 @@ func TestLogrus(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestConfigureLogrusConcurrentWithLogging guards against a data race between
+// registering the hook and logging through the same logger. Run with -race.
+func TestConfigureLogrusConcurrentWithLogging(t *testing.T) {
+	api := &plugintest.API{}
+	api.On("LogDebug", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Maybe()
+	client := pluginapi.NewClient(api, &plugintest.Driver{})
+
+	logger := logrus.New()
+
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for range 500 {
+				logger.WithField("k", "v").Debug("message")
+			}
+		}()
+	}
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range 50 {
+			pluginapi.ConfigureLogrus(logger, client)
+		}
+	}()
+
+	close(start)
+	wg.Wait()
 }

--- a/server/public/pluginapi/logrus_test.go
+++ b/server/public/pluginapi/logrus_test.go
@@ -98,24 +98,20 @@ func TestConfigureLogrusConcurrentWithLogging(t *testing.T) {
 	start := make(chan struct{})
 
 	for range 4 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			for range 500 {
 				logger.WithField("k", "v").Debug("message")
 			}
-		}()
+		})
 	}
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		<-start
 		for range 50 {
 			pluginapi.ConfigureLogrus(logger, client)
 		}
-	}()
+	})
 
 	close(start)
 	wg.Wait()


### PR DESCRIPTION
#### Summary

`pluginapi.ConfigureLogrus` registered its hook with `logger.Hooks.Add(hook)`, which mutates the hook map **without** holding the logger mutex. logrus copies that map **under** the logger mutex when firing hooks (`Entry.fireHooks`), so calling `ConfigureLogrus` while another goroutine logs through the same logger is a data race, and can panic with `fatal error: concurrent map read and map write`.

This is reachable in production: a plugin that re-runs its activation hook (config/license change, cluster event, upgrade) calls `ConfigureLogrus` again on `logrus.StandardLogger()` while goroutines from the previous activation (schedulers, jobs, request handlers) are still logging through the same global logger. Originally reported as MM-52096 ("Racy test: TestChecklistManagement"); the root cause in the SDK helper was never fixed, so every plugin calling `ConfigureLogrus` still inherits it.

Changes:
- Register the hook with `logger.AddHook(hook)`, which acquires the logger mutex — the same lock `fireHooks` takes.
- Call `SetReportCaller`/`SetLevel` on the passed-in `logger` instead of the package-level `logrus.SetReportCaller`/`logrus.SetLevel`, which previously mutated `logrus.StandardLogger()` regardless of the logger argument.
- Add a `-race` regression test that configures the logger concurrently with logging.

QA: `cd server/public && go test -race -run TestConfigureLogrus ./pluginapi/`. The new test fails with `WARNING: DATA RACE` (`fireHooks` vs `LevelHooks.Add`) when reverted to `logger.Hooks.Add`, and passes with the fix.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-69464

#### Release Note

```release-note
Fixed a data race in pluginapi.ConfigureLogrus that could panic with "concurrent map read and map write" when a plugin configured logrus while logging was in flight. ConfigureLogrus now also applies SetReportCaller/SetLevel to the logger passed in rather than the global standard logger.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change only adjusts hook registration and logger configuration for the provided `*logrus.Logger`, removing a data race. Existing logging behavior should remain the same, except level/caller settings now apply to the passed logger rather than the package-level global.

**QA Recommendation:** Minimal manual QA—run `go test ./...` with `-race`, and spot-check that plugin logs still route correctly when plugins are re-activated concurrently.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->