### PR TITLE
MM-69408 - Fix quadratic markdown autolink trimming

### DIFF
--- a/server/public/shared/markdown/autolink.go
+++ b/server/public/shared/markdown/autolink.go
@@ -182,12 +182,33 @@ func trimTrailingCharactersFromLink(markdown string, start int, end int) int {
 		}
 	}
 
+	numClosing := 0
+	numOpening := 0
+	for i := 0; i < linkEnd; i++ {
+		if runes[i] == '(' {
+			numOpening += 1
+		} else if runes[i] == ')' {
+			numClosing += 1
+		}
+	}
+
+	trimLinkEnd := func(newEnd int) {
+		for i := newEnd; i < linkEnd; i++ {
+			if runes[i] == '(' {
+				numOpening -= 1
+			} else if runes[i] == ')' {
+				numClosing -= 1
+			}
+		}
+		linkEnd = newEnd
+	}
+
 	for linkEnd > 0 {
 		c := runes[linkEnd-1]
 
 		if !canEndAutolink(c) {
 			// Trim trailing quotes, periods, etc
-			linkEnd = linkEnd - 1
+			trimLinkEnd(linkEnd - 1)
 		} else if c == ';' {
 			// Trim a trailing HTML entity
 			newEnd := linkEnd - 2
@@ -197,17 +218,14 @@ func trimTrailingCharactersFromLink(markdown string, start int, end int) int {
 			}
 
 			if newEnd < linkEnd-2 && runes[newEnd] == '&' {
-				linkEnd = newEnd
+				trimLinkEnd(newEnd)
 			} else {
 				// This isn't actually an HTML entity, so just trim the semicolon
-				linkEnd = linkEnd - 1
+				trimLinkEnd(linkEnd - 1)
 			}
 		} else if c == ')' {
 			// Only allow an autolink ending with a bracket if that bracket is part of a matching pair of brackets.
 			// If there are more closing brackets than opening ones, remove the extra bracket
-
-			numClosing := 0
-			numOpening := 0
 
 			// Examples (input text => output linked portion):
 			//
@@ -223,20 +241,12 @@ func trimTrailingCharactersFromLink(markdown string, start int, end int) int {
 			//  http://www.pokemon.com/Pikachu_((Electric))
 			//    => http://www.pokemon.com/Pikachu_((Electric))
 
-			for i := 0; i < linkEnd; i++ {
-				if runes[i] == '(' {
-					numOpening += 1
-				} else if runes[i] == ')' {
-					numClosing += 1
-				}
-			}
-
 			if numClosing <= numOpening {
 				// There's fewer or equal closing brackets, so we've found the end of the link
 				break
 			}
 
-			linkEnd -= 1
+			trimLinkEnd(linkEnd - 1)
 		} else {
 			// There's no special characters at the end of the link, so we're at the end
 			break

--- a/server/public/shared/markdown/autolink_test.go
+++ b/server/public/shared/markdown/autolink_test.go
@@ -4,6 +4,8 @@
 package markdown
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -703,6 +705,18 @@ func TestTrimTrailingCharactersFromLink(t *testing.T) {
 			ExpectedEnd: 54,
 		},
 		{
+			Input:       "https://example.com/" + strings.Repeat(")", 4096),
+			ExpectedEnd: len("https://example.com/"),
+		},
+		{
+			Input:       "https://example.com/path_(with_" + strings.Repeat("nested_", 10) + "parens)",
+			ExpectedEnd: len("https://example.com/path_(with_" + strings.Repeat("nested_", 10) + "parens)"),
+		},
+		{
+			Input:       "https://example.com/path_((opening-heavy)",
+			ExpectedEnd: len("https://example.com/path_((opening-heavy)"),
+		},
+		{
 			Input:       "https://en.wikipedia.org/wiki/Dolphin_(disambiguation)_(disambiguation)",
 			ExpectedEnd: 71,
 		},
@@ -795,6 +809,22 @@ func TestTrimTrailingCharactersFromLink(t *testing.T) {
 			}
 
 			assert.Equal(t, testCase.ExpectedEnd, trimTrailingCharactersFromLink(testCase.Input, testCase.Start, testCase.End))
+		})
+	}
+}
+
+func BenchmarkTrimTrailingCharactersFromLink_UnmatchedClosingParens(b *testing.B) {
+	for _, size := range []int{128, 1024, 8192, 65536} {
+		b.Run(fmt.Sprintf("closing-%d", size), func(b *testing.B) {
+			input := "https://example.com/" + strings.Repeat(")", size)
+			expectedEnd := len("https://example.com/")
+
+			b.ReportAllocs()
+			for i := 0; i < b.N; i++ {
+				if end := trimTrailingCharactersFromLink(input, 0, len(input)); end != expectedEnd {
+					b.Fatalf("expected end %d, got %d", expectedEnd, end)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
#### Summary
Improve Markdown autolink parsing performance for links with complex trailing punctuation.

Technical description: The autolink trimming routine now tracks delimiter balance incrementally while preserving existing link boundary behavior. Added focused coverage and a benchmark for long trailing punctuation cases.

Before vs After — trimTrailingCharactersFromLink on https://example.com/ + N×) (**used the same unit benchmarking unit test against master vs the branch with the changes**)


Benchmark: `BenchmarkTrimTrailingCharactersFromLink_UnmatchedClosingParens`
Input: `https://example.com/` followed by N unmatched trailing `)` characters.
Machine: Apple M4 Max (`darwin/arm64`), Go `go test -benchmem`.

## Before vs After

| N (trailing `)`) | BEFORE (pre-fix) | AFTER (fix) | Speedup |
|---|---|---|---|
| 128   | 5,925 ns          | 736 ns     | ~8×     |
| 1,024 | 273,859 ns        | 4,398 ns   | ~62×    |
| 8,192 | 15,487,647 ns (15.5 ms) | 34,635 ns | ~447×   |
| 65,536 | 1,053,746,208 ns (1.05 s) | 275,121 ns | ~3,830× |

## Scaling (each step = 8× input)

**BEFORE — quadratic, O(N²):**

- 128 → 1,024: 46× slower
- 1,024 → 8,192: 57× slower
- 8,192 → 65,536: 68× slower

Time grows ~64× per 8× input → O(N²).

**AFTER — linear, O(N):**

- 128 → 1,024: 6× slower
- 1,024 → 8,192: 7.9× slower
- 8,192 → 65,536: 7.9× slower

Time grows ~8× per 8× input → O(N).

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69408

#### Screenshots
n/a


#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** This changes shared Markdown autolink trimming logic used in link parsing, so regressions could affect how trailing punctuation and unmatched parentheses are handled across user content. The added targeted tests and benchmark reduce risk, but edge-case parsing behavior is still sensitive to subtle off-by-one or boundary changes.

**QA Recommendation:** Light manual QA is recommended for Markdown links with complex trailing punctuation and nested/unbalanced parentheses, in addition to relying on automated coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->