### PR TITLE
Add mattermost_system_server_info metric exposing version and build info

### DIFF
--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -196,6 +196,7 @@ type MetricsInterfaceImpl struct {
 	SharedChannelsSyncSendStepHistogram       *prometheus.HistogramVec
 
 	ServerStartTime prometheus.Gauge
+	ServerInfo      prometheus.Gauge
 
 	JobsActive *prometheus.GaugeVec
 
@@ -259,6 +260,19 @@ func init() {
 	platform.RegisterMetricsInterface(func(ps *platform.PlatformService, driver, dataSource string) einterfaces.MetricsInterface {
 		return New(ps, driver, dataSource)
 	})
+}
+
+// mergeLabels returns a new label set combining base with extra. Values in extra
+// take precedence when a key is present in both.
+func mergeLabels(base, extra map[string]string) prometheus.Labels {
+	merged := prometheus.Labels{}
+	for k, v := range base {
+		merged[k] = v
+	}
+	for k, v := range extra {
+		merged[k] = v
+	}
+	return merged
 }
 
 // New creates a new MetricsInterface. The driver and datasource parameters are added during
@@ -1159,6 +1173,21 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 	})
 	m.ServerStartTime.SetToCurrentTime()
 	m.Registry.MustRegister(m.ServerStartTime)
+
+	m.ServerInfo = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Subsystem: MetricsSubsystemSystem,
+		Name:      "server_info",
+		Help:      "The server version and build information. Always 1; read the labels.",
+		ConstLabels: mergeLabels(additionalLabels, map[string]string{
+			"version":               model.CurrentVersion,
+			"build_number":          model.BuildNumber,
+			"build_hash":            model.BuildHash,
+			"build_hash_enterprise": model.BuildHashEnterprise,
+		}),
+	})
+	m.ServerInfo.Set(1)
+	m.Registry.MustRegister(m.ServerInfo)
 
 	m.JobsActive = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -5,6 +5,7 @@ package metrics
 
 import (
 	"database/sql"
+	"maps"
 	"math"
 	"net/url"
 	"os"
@@ -266,12 +267,8 @@ func init() {
 // take precedence when a key is present in both.
 func mergeLabels(base, extra map[string]string) prometheus.Labels {
 	merged := prometheus.Labels{}
-	for k, v := range base {
-		merged[k] = v
-	}
-	for k, v := range extra {
-		merged[k] = v
-	}
+	maps.Copy(merged, base)
+	maps.Copy(merged, extra)
 	return merged
 }
 

--- a/server/enterprise/metrics/metrics_test.go
+++ b/server/enterprise/metrics/metrics_test.go
@@ -350,3 +350,47 @@ func TestObserveClusterReliableFallbackLength(t *testing.T) {
 		require.InDelta(t, float64(length), m.Histogram.GetSampleSum(), 0.001)
 	})
 }
+
+func TestMergeLabels(t *testing.T) {
+	t.Run("combines both maps", func(t *testing.T) {
+		got := mergeLabels(map[string]string{"a": "1"}, map[string]string{"b": "2"})
+		require.Equal(t, prometheus.Labels{"a": "1", "b": "2"}, got)
+	})
+
+	t.Run("extra takes precedence over base", func(t *testing.T) {
+		got := mergeLabels(map[string]string{"a": "1"}, map[string]string{"a": "2"})
+		require.Equal(t, prometheus.Labels{"a": "2"}, got)
+	})
+
+	t.Run("handles nil maps", func(t *testing.T) {
+		require.Equal(t, prometheus.Labels{}, mergeLabels(nil, nil))
+	})
+}
+
+func TestServerInfo(t *testing.T) {
+	th := api4.SetupEnterprise(t, app.StartMetrics)
+
+	configureMetrics(th)
+	mi := th.App.Metrics()
+
+	miImpl, ok := mi.(*MetricsInterfaceImpl)
+	require.True(t, ok, fmt.Sprintf("App.Metrics is not *MetricsInterfaceImpl, but %T", mi))
+
+	m := &prometheusModels.Metric{}
+	require.NoError(t, miImpl.ServerInfo.Write(m))
+
+	t.Run("gauge value is always 1", func(t *testing.T) {
+		require.Equal(t, 1.0, m.Gauge.GetValue())
+	})
+
+	t.Run("carries the build information as labels", func(t *testing.T) {
+		labels := map[string]string{}
+		for _, pair := range m.GetLabel() {
+			labels[pair.GetName()] = pair.GetValue()
+		}
+		require.Equal(t, model.CurrentVersion, labels["version"])
+		require.Equal(t, model.BuildNumber, labels["build_number"])
+		require.Equal(t, model.BuildHash, labels["build_hash"])
+		require.Equal(t, model.BuildHashEnterprise, labels["build_hash_enterprise"])
+	})
+}

--- a/server/enterprise/metrics/metrics_test.go
+++ b/server/enterprise/metrics/metrics_test.go
@@ -388,9 +388,14 @@ func TestServerInfo(t *testing.T) {
 		for _, pair := range m.GetLabel() {
 			labels[pair.GetName()] = pair.GetValue()
 		}
-		require.Equal(t, model.CurrentVersion, labels["version"])
-		require.Equal(t, model.BuildNumber, labels["build_number"])
-		require.Equal(t, model.BuildHash, labels["build_hash"])
-		require.Equal(t, model.BuildHashEnterprise, labels["build_hash_enterprise"])
+		for key, want := range map[string]string{
+			"version":               model.CurrentVersion,
+			"build_number":          model.BuildNumber,
+			"build_hash":            model.BuildHash,
+			"build_hash_enterprise": model.BuildHashEnterprise,
+		} {
+			require.Contains(t, labels, key)
+			require.Equal(t, want, labels[key])
+		}
 	})
 }


### PR DESCRIPTION
#### Summary

Adds a new `mattermost_system_server_info` Prometheus metric that exposes the running server's version and build information as labels on a gauge fixed to `1` (the standard Prometheus "info metric" pattern):

```
mattermost_system_server_info{version="...", build_number="...", build_hash="...", build_hash_enterprise="..."} 1
```

It is registered alongside `ServerStartTime` in the `system` subsystem and set once at startup, so it requires no `einterfaces`/mock changes. The build-info labels are merged with the existing cloud `ConstLabels` (installationId, group, db cluster) via a small `mergeLabels` helper.

This makes it possible to answer "which version/commit is each server actually running?" directly from Prometheus — e.g.:

```
count by (version) (mattermost_system_server_info)
```

which is useful for confirming a deploy or cherry-pick has actually rolled out to a given environment.

#### Release Note

```release-note
Added a new `mattermost_system_server_info` Prometheus metric that exposes the server version and build hash as labels.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: Low 🟢

**Regression Risk:** This is an isolated Prometheus metrics-only addition that registers a new info-style gauge at startup and adds a small label-merge helper used for const labels. The only meaningful risk is metric registration/label correctness, which is covered by new unit tests for both the merge helper and the `ServerInfo` metric/labels.

**QA Recommendation:** Minimal manual QA—verify Prometheus scrape shows `mattermost_system_server_info{version,build_number,build_hash,build_hash_enterprise,...}=1` and that server startup succeeds.
  
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->