### PR TITLE
Automated cherry pick of #37209

### DIFF
--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -5,6 +5,7 @@ package metrics
 
 import (
 	"database/sql"
+	"maps"
 	"math"
 	"net/url"
 	"os"
@@ -196,6 +197,7 @@ type MetricsInterfaceImpl struct {
 	SharedChannelsSyncSendStepHistogram       *prometheus.HistogramVec
 
 	ServerStartTime prometheus.Gauge
+	ServerInfo      prometheus.Gauge
 
 	JobsActive *prometheus.GaugeVec
 
@@ -259,6 +261,15 @@ func init() {
 	platform.RegisterMetricsInterface(func(ps *platform.PlatformService, driver, dataSource string) einterfaces.MetricsInterface {
 		return New(ps, driver, dataSource)
 	})
+}
+
+// mergeLabels returns a new label set combining base with extra. Values in extra
+// take precedence when a key is present in both.
+func mergeLabels(base, extra map[string]string) prometheus.Labels {
+	merged := prometheus.Labels{}
+	maps.Copy(merged, base)
+	maps.Copy(merged, extra)
+	return merged
 }
 
 // New creates a new MetricsInterface. The driver and datasource parameters are added during
@@ -1159,6 +1170,21 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 	})
 	m.ServerStartTime.SetToCurrentTime()
 	m.Registry.MustRegister(m.ServerStartTime)
+
+	m.ServerInfo = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace: MetricsNamespace,
+		Subsystem: MetricsSubsystemSystem,
+		Name:      "server_info",
+		Help:      "The server version and build information. Always 1; read the labels.",
+		ConstLabels: mergeLabels(additionalLabels, map[string]string{
+			"version":               model.CurrentVersion,
+			"build_number":          model.BuildNumber,
+			"build_hash":            model.BuildHash,
+			"build_hash_enterprise": model.BuildHashEnterprise,
+		}),
+	})
+	m.ServerInfo.Set(1)
+	m.Registry.MustRegister(m.ServerInfo)
 
 	m.JobsActive = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{

--- a/server/enterprise/metrics/metrics_test.go
+++ b/server/enterprise/metrics/metrics_test.go
@@ -350,3 +350,52 @@ func TestObserveClusterReliableFallbackLength(t *testing.T) {
 		require.InDelta(t, float64(length), m.Histogram.GetSampleSum(), 0.001)
 	})
 }
+
+func TestMergeLabels(t *testing.T) {
+	t.Run("combines both maps", func(t *testing.T) {
+		got := mergeLabels(map[string]string{"a": "1"}, map[string]string{"b": "2"})
+		require.Equal(t, prometheus.Labels{"a": "1", "b": "2"}, got)
+	})
+
+	t.Run("extra takes precedence over base", func(t *testing.T) {
+		got := mergeLabels(map[string]string{"a": "1"}, map[string]string{"a": "2"})
+		require.Equal(t, prometheus.Labels{"a": "2"}, got)
+	})
+
+	t.Run("handles nil maps", func(t *testing.T) {
+		require.Equal(t, prometheus.Labels{}, mergeLabels(nil, nil))
+	})
+}
+
+func TestServerInfo(t *testing.T) {
+	th := api4.SetupEnterprise(t, app.StartMetrics)
+
+	configureMetrics(th)
+	mi := th.App.Metrics()
+
+	miImpl, ok := mi.(*MetricsInterfaceImpl)
+	require.True(t, ok, fmt.Sprintf("App.Metrics is not *MetricsInterfaceImpl, but %T", mi))
+
+	m := &prometheusModels.Metric{}
+	require.NoError(t, miImpl.ServerInfo.Write(m))
+
+	t.Run("gauge value is always 1", func(t *testing.T) {
+		require.Equal(t, 1.0, m.Gauge.GetValue())
+	})
+
+	t.Run("carries the build information as labels", func(t *testing.T) {
+		labels := map[string]string{}
+		for _, pair := range m.GetLabel() {
+			labels[pair.GetName()] = pair.GetValue()
+		}
+		for key, want := range map[string]string{
+			"version":               model.CurrentVersion,
+			"build_number":          model.BuildNumber,
+			"build_hash":            model.BuildHash,
+			"build_hash_enterprise": model.BuildHashEnterprise,
+		} {
+			require.Contains(t, labels, key)
+			require.Equal(t, want, labels[key])
+		}
+	})
+}


### PR DESCRIPTION
Cherry pick of #37209 on release-11.9.

/cc  @lieut-data

```release-note
NONE
```