### PR TITLE
Fix broken API documentation links

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,6 @@
 # Mattermost API Documentation
 
-This repository holds the API reference documentation for Mattermost available at [https://developers.mattermost.com/api-reference](https://developers.mattermost.com/api-reference).
+This repository holds the API reference documentation for Mattermost available at [https://developers.mattermost.com/api-documentation](https://developers.mattermost.com/api-documentation).
 
 The Mattermost API reference uses the [OpenAPI standard](https://openapis.org/) and the [ReDoc document generator](https://github.com/Rebilly/ReDoc).
 
@@ -25,4 +25,4 @@ To test locally, run `make build`, `make run` and navigate to `http://127.0.0.1:
 
 ## Deployment
 
-Deployment is handled automatically by our Github Actions. When a pull request is merged, it will automatically be deployed to [https://developers.mattermost.com/api-reference](https://developers.mattermost.com/api-reference).
+Deployment is handled automatically by our Github Actions. When a pull request is merged, it will automatically be deployed to [https://developers.mattermost.com/api-documentation](https://developers.mattermost.com/api-documentation).

--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mattermost-api-reference",
   "version": "1.0.0",
-  "description": "This repository holds the API reference documentation for Mattermost available at https://developers.mattermost.com/api-reference",
+  "description": "This repository holds the API reference documentation for Mattermost available at https://developers.mattermost.com/api-documentation",
   "main": "index.js",
   "dependencies": {
     "@redocly/cli": "^1.13.0",


### PR DESCRIPTION
## Summary

Updates outdated API documentation links from `/api-reference` to `/api-documentation`.

This fixes broken links in:

- `api/README.md`
- `api/package.json`

The previous URL returns 404, while the updated URL points to the current Mattermost API documentation page.

## Testing

Verified that https://developers.mattermost.com/api-documentation/ is accessible.

## Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** The update is limited to documentation metadata and link targets in two files, with no impact on runtime behavior, shared modules, or public APIs. Regression risk is minimal and unlikely to affect unrelated systems.

**QA Recommendation:** No manual QA is required beyond a quick link verification, since the change is isolated and non-functional.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->