### PR TITLE
Automated cherry pick of #37172

### DIFF
--- a/server/channels/app/access_control_test.go
+++ b/server/channels/app/access_control_test.go
@@ -4188,6 +4188,220 @@ func TestGetChannelHydratesPolicyActions(t *testing.T) {
 	})
 }
 
+func TestGetChannelsForTeamForUserHydratesPolicyActions(t *testing.T) {
+	// App.GetChannelsForTeamForUser feeds the webapp's team channel list
+	// (GET /users/me/teams/{team_id}/channels), which is the source for the
+	// guest-invite channel picker. The picker reads policy_actions.membership
+	// and falls back to the bare policy_enforced flag when policy_actions is
+	// absent, so this seam must hydrate the action map — otherwise a
+	// permission-only channel is wrongly hidden from the picker.
+	t.Run("Permission-only channel is hydrated so it is not mistaken for membership-gated", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+
+		teamID := model.NewId()
+		userID := model.NewId()
+		permChannelID := model.NewId()
+		plainChannelID := model.NewId()
+
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore)
+		mockChannelStore.On("GetChannels", teamID, userID, mock.AnythingOfType("*model.ChannelSearchOpts")).
+			Return(model.ChannelList{
+				{Id: permChannelID, TeamId: teamID, PolicyEnforced: true},
+				{Id: plainChannelID, TeamId: teamID, PolicyEnforced: false},
+			}, nil).Once()
+
+		mockACPStore := storemocks.AccessControlPolicyStore{}
+		mockStore.On("AccessControlPolicy").Return(&mockACPStore)
+		mockACPStore.On("GetActionsForPolicies", thMock.Context, []string{permChannelID}).
+			Return(map[string]map[string]bool{
+				permChannelID: {model.AccessControlPolicyActionUploadFileAttachment: true},
+			}, nil).Once()
+
+		channels, appErr := thMock.App.GetChannelsForTeamForUser(thMock.Context, teamID, userID, &model.ChannelSearchOpts{})
+		require.Nil(t, appErr)
+		require.Len(t, channels, 2)
+
+		var permChannel, plainChannel *model.Channel
+		for _, ch := range channels {
+			switch ch.Id {
+			case permChannelID:
+				permChannel = ch
+			case plainChannelID:
+				plainChannel = ch
+			}
+		}
+		require.NotNil(t, permChannel)
+		require.NotNil(t, plainChannel)
+
+		require.Equal(t, map[string]bool{model.AccessControlPolicyActionUploadFileAttachment: true}, permChannel.PolicyActions,
+			"permission-only channel must carry its hydrated action map so the guest picker does not fall back to policy_enforced")
+		require.False(t, permChannel.HasMembershipPolicyAction(),
+			"permission-only channel must NOT report membership — this is the guest-picker bug fix invariant")
+		require.Nil(t, plainChannel.PolicyActions, "channels without a policy must not be touched")
+		mockACPStore.AssertExpectations(t)
+	})
+
+	t.Run("Membership-gated channel keeps reporting membership after hydration", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+
+		teamID := model.NewId()
+		userID := model.NewId()
+		channelID := model.NewId()
+
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore)
+		mockChannelStore.On("GetChannels", teamID, userID, mock.AnythingOfType("*model.ChannelSearchOpts")).
+			Return(model.ChannelList{{Id: channelID, TeamId: teamID, PolicyEnforced: true}}, nil).Once()
+
+		mockACPStore := storemocks.AccessControlPolicyStore{}
+		mockStore.On("AccessControlPolicy").Return(&mockACPStore)
+		mockACPStore.On("GetActionsForPolicies", thMock.Context, []string{channelID}).
+			Return(map[string]map[string]bool{
+				channelID: {model.AccessControlPolicyActionMembership: true},
+			}, nil).Once()
+
+		channels, appErr := thMock.App.GetChannelsForTeamForUser(thMock.Context, teamID, userID, &model.ChannelSearchOpts{})
+		require.Nil(t, appErr)
+		require.Len(t, channels, 1)
+		require.True(t, channels[0].HasMembershipPolicyAction(),
+			"membership-gated channels must still resolve as membership-controlled")
+		mockACPStore.AssertExpectations(t)
+	})
+
+	t.Run("Hydration failure degrades to the channel list without failing the request", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+
+		teamID := model.NewId()
+		userID := model.NewId()
+		channelID := model.NewId()
+
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore)
+		mockChannelStore.On("GetChannels", teamID, userID, mock.AnythingOfType("*model.ChannelSearchOpts")).
+			Return(model.ChannelList{{Id: channelID, TeamId: teamID, PolicyEnforced: true}}, nil).Once()
+
+		mockACPStore := storemocks.AccessControlPolicyStore{}
+		mockStore.On("AccessControlPolicy").Return(&mockACPStore)
+		mockACPStore.On("GetActionsForPolicies", thMock.Context, []string{channelID}).
+			Return(nil, errors.New("boom")).Once()
+
+		channels, appErr := thMock.App.GetChannelsForTeamForUser(thMock.Context, teamID, userID, &model.ChannelSearchOpts{})
+		require.Nil(t, appErr, "a hydration error must not fail the channel list; the seam degrades to legacy behavior")
+		require.Len(t, channels, 1)
+		require.Nil(t, channels[0].PolicyActions, "on hydration failure the channel is returned unhydrated, not partially populated")
+		mockACPStore.AssertExpectations(t)
+	})
+}
+
+func TestSearchChannelsHydratePolicyActions(t *testing.T) {
+	// The guest-invite picker searches channels via SearchChannels /
+	// SearchChannelsForUser. Search results merge into the webapp channel
+	// store, so they must carry the same hydrated action map as the bootstrap
+	// list; otherwise a search would overwrite a hydrated channel with an
+	// unhydrated copy and re-hide a permission-only channel.
+	t.Run("SearchChannels hydrates permission-only results", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+
+		teamID := model.NewId()
+		channelID := model.NewId()
+		plainChannelID := model.NewId()
+
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore)
+		mockChannelStore.On("SearchInTeam", teamID, "perm", true).
+			Return(model.ChannelList{
+				{Id: channelID, TeamId: teamID, PolicyEnforced: true},
+				{Id: plainChannelID, TeamId: teamID, PolicyEnforced: false},
+			}, nil).Once()
+
+		mockACPStore := storemocks.AccessControlPolicyStore{}
+		mockStore.On("AccessControlPolicy").Return(&mockACPStore)
+		mockACPStore.On("GetActionsForPolicies", thMock.Context, []string{channelID}).
+			Return(map[string]map[string]bool{
+				channelID: {model.AccessControlPolicyActionUploadFileAttachment: true},
+			}, nil).Once()
+
+		channels, appErr := thMock.App.SearchChannels(thMock.Context, teamID, "perm")
+		require.Nil(t, appErr)
+		require.Len(t, channels, 2)
+
+		var permChannel, plainChannel *model.Channel
+		for _, ch := range channels {
+			switch ch.Id {
+			case channelID:
+				permChannel = ch
+			case plainChannelID:
+				plainChannel = ch
+			}
+		}
+		require.NotNil(t, permChannel)
+		require.NotNil(t, plainChannel)
+		require.False(t, permChannel.HasMembershipPolicyAction(),
+			"permission-only search result must not report membership")
+		require.True(t, permChannel.HasPolicyAction(model.AccessControlPolicyActionUploadFileAttachment))
+		require.Nil(t, plainChannel.PolicyActions, "channels without a policy must not be touched")
+		mockACPStore.AssertExpectations(t)
+	})
+
+	t.Run("SearchChannelsForUser hydrates permission-only results", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+
+		teamID := model.NewId()
+		userID := model.NewId()
+		channelID := model.NewId()
+
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore)
+		mockChannelStore.On("SearchForUserInTeam", userID, teamID, "perm", true).
+			Return(model.ChannelList{{Id: channelID, TeamId: teamID, PolicyEnforced: true}}, nil).Once()
+
+		mockACPStore := storemocks.AccessControlPolicyStore{}
+		mockStore.On("AccessControlPolicy").Return(&mockACPStore)
+		mockACPStore.On("GetActionsForPolicies", thMock.Context, []string{channelID}).
+			Return(map[string]map[string]bool{
+				channelID: {model.AccessControlPolicyActionUploadFileAttachment: true},
+			}, nil).Once()
+
+		channels, appErr := thMock.App.SearchChannelsForUser(thMock.Context, userID, teamID, "perm")
+		require.Nil(t, appErr)
+		require.Len(t, channels, 1)
+		require.False(t, channels[0].HasMembershipPolicyAction(),
+			"permission-only search result must not report membership")
+		require.True(t, channels[0].HasPolicyAction(model.AccessControlPolicyActionUploadFileAttachment))
+		mockACPStore.AssertExpectations(t)
+	})
+
+	t.Run("Hydration failure degrades to the search results without failing the request", func(t *testing.T) {
+		thMock := SetupWithStoreMock(t)
+		mockStore := thMock.App.Srv().Store().(*storemocks.Store)
+
+		teamID := model.NewId()
+		channelID := model.NewId()
+
+		mockChannelStore := storemocks.ChannelStore{}
+		mockStore.On("Channel").Return(&mockChannelStore)
+		mockChannelStore.On("SearchInTeam", teamID, "perm", true).
+			Return(model.ChannelList{{Id: channelID, TeamId: teamID, PolicyEnforced: true}}, nil).Once()
+
+		mockACPStore := storemocks.AccessControlPolicyStore{}
+		mockStore.On("AccessControlPolicy").Return(&mockACPStore)
+		mockACPStore.On("GetActionsForPolicies", thMock.Context, []string{channelID}).
+			Return(nil, errors.New("boom")).Once()
+
+		channels, appErr := thMock.App.SearchChannels(thMock.Context, teamID, "perm")
+		require.Nil(t, appErr, "a hydration error must not fail the search; the seam degrades to legacy behavior")
+		require.Len(t, channels, 1)
+		require.Nil(t, channels[0].PolicyActions, "on hydration failure the channel is returned unhydrated, not partially populated")
+		mockACPStore.AssertExpectations(t)
+	})
+}
+
 func TestChannelAccessControlled(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 	th.App.UpdateConfig(func(cfg *model.Config) {

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -2320,7 +2320,23 @@ func (s *Server) getChannelsForTeamForUser(rctx request.CTX, teamID string, user
 }
 
 func (a *App) GetChannelsForTeamForUser(rctx request.CTX, teamID string, userID string, opts *model.ChannelSearchOpts) (model.ChannelList, *model.AppError) {
-	return a.Srv().getChannelsForTeamForUser(rctx, teamID, userID, opts)
+	channels, appErr := a.Srv().getChannelsForTeamForUser(rctx, teamID, userID, opts)
+	if appErr != nil {
+		return nil, appErr
+	}
+	// Hydrate the policy action set so the frontend can distinguish a
+	// membership policy from a permission-only one (e.g. file upload) without
+	// a second round-trip. Without this the guest-invite picker reads the bare
+	// PolicyEnforced flag and wrongly hides permission-only channels. No-op for
+	// channels without an attached policy, keeping the no-policy path free.
+	if appErr := a.HydrateChannelsPolicyActions(rctx, channels); appErr != nil {
+		rctx.Logger().Warn("Failed to hydrate channel policy actions for team channels; returning channels without action map",
+			mlog.String("team_id", teamID),
+			mlog.String("user_id", userID),
+			mlog.Err(appErr),
+		)
+	}
+	return channels, nil
 }
 
 func (a *App) GetChannelsForUser(rctx request.CTX, userID string, includeDeleted bool, lastDeleteAt, pageSize int, fromChannelID string) (model.ChannelList, *model.AppError) {
@@ -3371,6 +3387,17 @@ func (a *App) SearchChannels(rctx request.CTX, teamID string, term string) (mode
 		return nil, model.NewAppError("SearchChannels", "app.channel.search.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
+	// Hydrate policy actions so search results carry the same action map as the
+	// bootstrap channel list; otherwise a search would overwrite a hydrated
+	// channel in the frontend store with an unhydrated copy. No-op without a
+	// policy attached.
+	if appErr := a.HydrateChannelsPolicyActions(rctx, channelList); appErr != nil {
+		rctx.Logger().Warn("Failed to hydrate channel policy actions for search results; returning channels without action map",
+			mlog.String("team_id", teamID),
+			mlog.Err(appErr),
+		)
+	}
+
 	return channelList, nil
 }
 
@@ -3382,6 +3409,18 @@ func (a *App) SearchChannelsForUser(rctx request.CTX, userID, teamID, term strin
 	channelList, err := a.Srv().Store().Channel().SearchForUserInTeam(userID, teamID, term, includeDeleted)
 	if err != nil {
 		return nil, model.NewAppError("SearchChannelsForUser", "app.channel.search.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+
+	// Hydrate policy actions so search results carry the same action map as the
+	// bootstrap channel list; otherwise a search would overwrite a hydrated
+	// channel in the frontend store with an unhydrated copy. No-op without a
+	// policy attached.
+	if appErr := a.HydrateChannelsPolicyActions(rctx, channelList); appErr != nil {
+		rctx.Logger().Warn("Failed to hydrate channel policy actions for user search results; returning channels without action map",
+			mlog.String("team_id", teamID),
+			mlog.String("user_id", userID),
+			mlog.Err(appErr),
+		)
 	}
 
 	return channelList, nil


### PR DESCRIPTION
Cherry pick of #37172 on release-11.9.

/cc  @cursor[bot]

```release-note
NONE
```