### PR TITLE
Update Playbooks plugin to v2.9.2 (incl. FIPS)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -161,7 +161,7 @@ PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.4
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.3
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.0
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.9.1
+PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.9.2
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.4
@@ -177,7 +177,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.9.1%2B885dcf9-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.9.2%2Bf7b3499-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.4%2Bf359551-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4%2B5855fe1-fips
 endif


### PR DESCRIPTION
#### Summary
Update Playbooks plugin to v2.9.2 (FIPS and non-FIPS).

The non-FIPS pin is bumped from v2.9.1 to v2.9.2 in the same commit.

The FIPS build is produced from the [`fips.v2.9.2` branch](https://github.com/mattermost/mattermost-plugin-playbooks/pull/2332) of `mattermost-plugin-playbooks`, signed and uploaded via the [`Sign Plugin PR Artifacts` workflow](https://github.com/mattermost/delivery-platform/actions/runs/28185842234).

Source commit on the Playbooks repo: [`f7b3499`](https://github.com/mattermost/mattermost-plugin-playbooks/commit/f7b34995ff8cdf50b5e3ff23457760ab30e7bc78).

The signed FIPS bundle is reachable at [https://plugins.releases.mattermost.com/release/mattermost-plugin-playbooks-v2.9.2%2Bf7b3499-fips-linux-amd64.tar.gz](https://plugins.releases.mattermost.com/release/mattermost-plugin-playbooks-v2.9.2%2Bf7b3499-fips-linux-amd64.tar.gz).

#### Ticket Link
--

#### Screenshots
--

#### Release Note
```release-note
NONE
```
