### PR TITLE
Skip flaky TestKeepFlaggedPost (MM-69511)

### DIFF
--- a/server/channels/api4/content_flagging_test.go
+++ b/server/channels/api4/content_flagging_test.go
@@ -1187,6 +1187,8 @@ func TestKeepFlaggedPost(t *testing.T) {
 	})
 
 	t.Run("Should preserve file attachments and edit history when keeping flagged post", func(t *testing.T) {
+		t.Skip("Skipped due to flakiness — tracked in https://mattermost.atlassian.net/browse/MM-69511")
+
 		th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		defer th.RemoveLicense(t)
 


### PR DESCRIPTION
#### Summary
Skip flaky subtest `TestKeepFlaggedPost/Should_preserve_file_attachments_and_edit_history_when_keeping_flagged_post` (`github.com/mattermost/mattermost/server/v8/channels/api4`) while the root cause is investigated under [MM-69511](https://mattermost.atlassian.net/browse/MM-69511).
Tests-only change — no production behavior changes.

**Why skip:** Could not reproduce the flake locally after the full ladder in §4 (~300+ runs across `-count=50/100`, `-race`, `-shuffle=on`, and `ENABLE_FULLY_PARALLEL_TESTS=true`). A tests-only fix would be a guess. Skipping unblocks CI while the Jira ticket tracks investigation.

**Originally introduced in:** b96f7c1a8d by harshilsharma63 (Content flagging actions implementation tests #35035).

cc @marianunez

#### Ticket Link
- Jira: https://mattermost.atlassian.net/browse/MM-69511
- Source flake report: https://github.com/mattermost/mattermost/pull/35495

#### Release Note
```release-note
NONE
```

[MM-69511]: https://mattermost.atlassian.net/browse/MM-69511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** Low. This is a tests-only change that skips one flaky subtest in a single test file, so it does not alter production code, APIs, or shared logic. The main risk is reduced coverage for that specific verification path until the underlying flake is resolved.

**QA Recommendation:** Minimal manual QA needed; rely on CI and existing automated coverage, with follow-up validation once the flaky test is fixed.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->