### PR TITLE
Fix flaky TestSendInviteEmails

### DIFF
--- a/server/channels/app/email/email_test.go
+++ b/server/channels/app/email/email_test.go
@@ -4,6 +4,7 @@
 package email
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -114,7 +115,9 @@ func TestSendInviteEmails(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 	th.ConfigureInbucketMail(t)
 
-	emailTo := "test@example.com"
+	emailTo := strings.ToLower(model.NewId()) + "@example.com"
+	err := mail.DeleteMailBox(emailTo)
+	require.NoError(t, err, "Failed to delete mailbox")
 
 	retrieveEmail := func(t *testing.T) mail.JSONMessageInbucket {
 		t.Helper()


### PR DESCRIPTION
#### Summary
Fix flake in `TestSendInviteEmails` (`channels/app/email`). Tests-only change — no production behavior changes.

**Root cause:** The test delivered all invite emails to the shared Inbucket mailbox for `test@example.com`. Inbucket keys mailboxes by the local part of the address (`test`), so parallel tests in `platform/shared/mail` and other CI shards writing to the same address can leave multiple messages in the mailbox. `retrieveEmail` then fails `require.Len(t, resultsMailbox, 1)` when more than one message is present.

**Fix:** Generate a unique recipient address per `TestSendInviteEmails` run with `strings.ToLower(model.NewId()) + "@example.com"` and delete that mailbox at setup. Each test instance now has an isolated Inbucket mailbox while still exercising the same send/verify paths.

**Verification:**
- `go test -race -count=5 -timeout=20m ./channels/app/email/... ./platform/shared/mail/...` — green locally (this combination reproduced the flake before the fix).
- Reverted the fix and re-ran the same cross-package race loop; observed `should have 1 item(s), but has 2` failures on the shared `test@example.com` mailbox.

**Originally introduced in:** 0bd19e682c by streamer45 (Sanitize message in email template).

cc @marianunez

#### Ticket Link
Flaky test reported here: https://github.com/mattermost/mattermost/pull/37133

#### Screenshots
N/A — tests-only change.

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** This is a tests-only update isolated to `channels/app/email` and only changes the recipient mailbox used by `TestSendInviteEmails` to avoid shared Inbucket collisions. It does not affect production code, shared utilities, or critical runtime paths, so regression risk is low.

**QA Recommendation:** Automated test coverage is sufficient; no additional manual QA is necessary beyond verifying the targeted test suite passes reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->