### PR TITLE
[MM-69351] Fix membership store queries for users without AttributeView rows

### DIFF
--- a/server/channels/app/post_metadata.go
+++ b/server/channels/app/post_metadata.go
@@ -445,6 +445,14 @@ func (a *App) sanitizeFileAttachmentsForUser(rctx request.CTX, post *model.Post,
 		return
 	}
 
+	// No requesting user (e.g. a system post created by a background job with no
+	// session, such as the ABAC membership sync's channel-join messages). There
+	// is nobody to sanitize attachments for, so skip. A genuine reader re-runs
+	// this with their own session id when the post is served.
+	if userID == "" {
+		return
+	}
+
 	user, err := a.GetUser(userID)
 	if err != nil {
 		rctx.Logger().Warn("Failed to get user for file attachment sanitization, stripping attachments",

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -12852,6 +12852,27 @@ func (s *RetryLayerSessionStore) Get(rctx request.CTX, sessionIDOrToken string) 
 
 }
 
+func (s *RetryLayerSessionStore) GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error) {
+
+	tries := 0
+	for {
+		result, err := s.SessionStore.GetAllSessionsWithActiveDeviceIds()
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerSessionStore) GetLRUSessions(rctx request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error) {
 
 	tries := 0
@@ -12941,27 +12962,6 @@ func (s *RetryLayerSessionStore) GetSessionsWithActiveDeviceIds(userID string) (
 	tries := 0
 	for {
 		result, err := s.SessionStore.GetSessionsWithActiveDeviceIds(userID)
-		if err == nil {
-			return result, nil
-		}
-		if !isRepeatableError(err) {
-			return result, err
-		}
-		tries++
-		if tries >= 3 {
-			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
-			return result, err
-		}
-		timepkg.Sleep(100 * timepkg.Millisecond)
-	}
-
-}
-
-func (s *RetryLayerSessionStore) GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error) {
-
-	tries := 0
-	for {
-		result, err := s.SessionStore.GetAllSessionsWithActiveDeviceIds()
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/sqlstore/attributes_store.go
+++ b/server/channels/store/sqlstore/attributes_store.go
@@ -39,6 +39,17 @@ func attributesSliceColumns(prefix ...string) []string {
 	}
 }
 
+// qualify prefixes each column with the given table name. The members-to-remove
+// queries join Users, whose columns (Roles, DeleteAt, CreateAt) collide with the
+// member columns, so the member SELECT must be table-qualified to stay unambiguous.
+func qualify(table string, columns []string) []string {
+	qualified := make([]string, len(columns))
+	for i, c := range columns {
+		qualified[i] = table + "." + c
+	}
+	return qualified
+}
+
 func newSqlAttributesStore(sqlStore *SqlStore, metrics einterfaces.MetricsInterface) store.AttributesStore {
 	s := &SqlAttributesStore{
 		SqlStore: sqlStore,
@@ -136,7 +147,11 @@ func (s *SqlAttributesStore) SearchUsers(rctx request.CTX, opts model.SubjectSea
 
 	if opts.Cursor.TargetID != "" {
 		argCount++
-		query = query.Where(sq.Expr(fmt.Sprintf("TargetID > $%d", argCount), opts.Cursor.TargetID))
+		// Paginate on Users.Id (the ORDER BY column), not AttributeView.TargetID.
+		// The cursor value is a user id, and TargetID comes from a LEFT JOIN so it
+		// is NULL for users with no custom-attribute row — comparing against it
+		// silently drops those users (e.g. matches of a native-only policy).
+		query = query.Where(sq.Expr(fmt.Sprintf("Users.Id > $%d", argCount), opts.Cursor.TargetID))
 	}
 
 	searchFields := make([]string, 0, len(UserSearchTypeNames))
@@ -177,11 +192,20 @@ func (s *SqlAttributesStore) SearchUsers(rctx request.CTX, opts model.SubjectSea
 
 func (s *SqlAttributesStore) GetChannelMembersToRemove(rctx request.CTX, channelID string, opts model.SubjectSearchOptions) ([]*model.ChannelMember, error) {
 	query := s.getQueryBuilder().
-		Select(channelMemberSliceColumns()...).From("ChannelMembers").LeftJoin("AttributeView ON ChannelMembers.UserId = AttributeView.TargetID").
+		Select(qualify("ChannelMembers", channelMemberSliceColumns())...).From("ChannelMembers").
+		// Join Users so native-attribute expressions (e.g. Users.EmailVerified)
+		// resolve here, mirroring SearchUsers on the add path.
+		LeftJoin("Users ON Users.Id = ChannelMembers.UserId").
+		LeftJoin("AttributeView ON ChannelMembers.UserId = AttributeView.TargetID").
 		OrderBy("ChannelMembers.UserId ASC")
 
 	if opts.Query != "" {
-		query = query.Where(sq.Expr(fmt.Sprintf("(NOT COALESCE((%s), FALSE) OR AttributeView.TargetID IS NULL)", opts.Query), opts.Args...))
+		// A member is removed when they do NOT satisfy the policy; a NULL result
+		// (e.g. a missing custom attribute) counts as "does not satisfy" via
+		// COALESCE. We must not additionally remove members just because they
+		// lack an AttributeView row — a native-only policy matches against the
+		// Users table, so a user with zero custom attributes can still satisfy it.
+		query = query.Where(sq.Expr(fmt.Sprintf("NOT COALESCE((%s), FALSE)", opts.Query), opts.Args...))
 	}
 
 	argCount := len(opts.Args)
@@ -215,12 +239,21 @@ func (s *SqlAttributesStore) GetChannelMembersToRemove(rctx request.CTX, channel
 
 func (s *SqlAttributesStore) GetTeamMembersToRemove(rctx request.CTX, teamID string, opts model.SubjectSearchOptions) ([]*model.TeamMember, error) {
 	query := s.getQueryBuilder().
-		Select(teamMemberSliceColumns()...).From("TeamMembers").LeftJoin("AttributeView ON TeamMembers.UserId = AttributeView.TargetID").
+		Select(qualify("TeamMembers", teamMemberSliceColumns())...).From("TeamMembers").
+		// Join Users so native-attribute expressions (e.g. Users.EmailVerified)
+		// resolve here, mirroring SearchUsers on the add path.
+		LeftJoin("Users ON Users.Id = TeamMembers.UserId").
+		LeftJoin("AttributeView ON TeamMembers.UserId = AttributeView.TargetID").
 		Where("TeamMembers.DeleteAt = 0").
 		OrderBy("TeamMembers.UserId ASC")
 
 	if opts.Query != "" {
-		query = query.Where(sq.Expr(fmt.Sprintf("(NOT COALESCE((%s), FALSE) OR AttributeView.TargetID IS NULL)", opts.Query), opts.Args...))
+		// A member is removed when they do NOT satisfy the policy; a NULL result
+		// (e.g. a missing custom attribute) counts as "does not satisfy" via
+		// COALESCE. We must not additionally remove members just because they
+		// lack an AttributeView row — a native-only policy matches against the
+		// Users table, so a user with zero custom attributes can still satisfy it.
+		query = query.Where(sq.Expr(fmt.Sprintf("NOT COALESCE((%s), FALSE)", opts.Query), opts.Args...))
 	}
 
 	argCount := len(opts.Args)

--- a/server/channels/store/storetest/attributes_store.go
+++ b/server/channels/store/storetest/attributes_store.go
@@ -313,6 +313,38 @@ func testAttributesStoreSearchUsers(t *testing.T, rctx request.CTX, ss store.Sto
 			require.Equal(t, int64(2), count, "expected count 2 user with the query")
 		}
 	})
+
+	// Regression test: pagination must page on Users.Id, not the LEFT-JOINed
+	// AttributeView.TargetID. A user with no custom-attribute row has a NULL
+	// TargetID, so a "TargetID > cursor" predicate silently drops them from
+	// every page. Native-only policies (e.g. user.verified) match exactly such
+	// users, and the membership sync always seeds a cursor, so this manifested
+	// as the sync adding zero members while the Test modal (no cursor) showed
+	// the full set.
+	t.Run("Search paginates users with no attribute row", func(t *testing.T) {
+		// A fresh user with no custom attributes => no AttributeView row.
+		u := model.User{Email: MakeEmail(), Username: model.NewUsername()}
+		_, err := ss.User().Save(rctx, &u)
+		require.NoError(t, err, "couldn't save attribute-less user")
+		t.Cleanup(func() {
+			require.NoError(t, ss.User().PermanentDelete(rctx, u.Id), "couldn't delete attribute-less user")
+		})
+
+		require.NoError(t, ss.Attributes().RefreshAttributes(), "couldn't refresh attributes")
+
+		// Native-style predicate against the Users table; matches the user above
+		// despite the missing AttributeView row.
+		subjects, _, err := ss.Attributes().SearchUsers(rctx, model.SubjectSearchOptions{
+			Query: "Users.Email = $1::text",
+			Args:  []any{u.Email},
+			Cursor: model.SubjectCursor{
+				TargetID: strings.Repeat("0", 26),
+			},
+		})
+		require.NoError(t, err, "couldn't search attribute-less user with cursor")
+		require.Len(t, subjects, 1, "attribute-less user must be returned despite the pagination cursor")
+		require.Equal(t, u.Id, subjects[0].Id, "expected the attribute-less user")
+	})
 }
 
 func testAttributesStoreGetChannelMembersToRemove(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
@@ -398,6 +430,38 @@ func testAttributesStoreGetChannelMembersToRemove(t *testing.T, rctx request.CTX
 		})
 		require.NoError(t, err, "couldn't get channel members to remove")
 		require.Len(t, members, 2, "expected 2 channel member to remove")
+	})
+
+	// Regression test: a native-attribute policy resolves against the Users
+	// table (the query is joined to Users), and a member with no AttributeView
+	// row who satisfies it must NOT be removed. Before the fix, native columns
+	// failed to resolve (no Users join) and the "OR AttributeView.TargetID IS
+	// NULL" clause removed attribute-less members outright.
+	t.Run("native policy keeps members with no attribute row", func(t *testing.T) {
+		extra := model.User{Email: MakeEmail(), Username: model.NewUsername()}
+		_, err := ss.User().Save(rctx, &extra)
+		require.NoError(t, err, "couldn't save attribute-less member")
+		_, err = ss.Channel().SaveMember(rctx, &model.ChannelMember{
+			ChannelId:   ch.Id,
+			UserId:      extra.Id,
+			NotifyProps: defaultNotifyProps,
+		})
+		require.NoError(t, err, "couldn't add attribute-less member")
+		t.Cleanup(func() {
+			require.NoError(t, ss.Channel().RemoveMember(rctx, ch.Id, extra.Id), "couldn't remove attribute-less member")
+			require.NoError(t, ss.User().PermanentDelete(rctx, extra.Id), "couldn't delete attribute-less member")
+		})
+
+		require.NoError(t, ss.Attributes().RefreshAttributes(), "couldn't refresh attributes")
+
+		// Native-style predicate satisfied by every active user, including the
+		// attribute-less member.
+		members, err := ss.Attributes().GetChannelMembersToRemove(rctx, ch.Id, model.SubjectSearchOptions{
+			Query: "Users.DeleteAt = $1::bigint",
+			Args:  []any{int64(0)},
+		})
+		require.NoError(t, err, "native removal query must not error")
+		require.Empty(t, members, "members satisfying a native policy must not be removed, even without an attribute row")
 	})
 }
 
@@ -487,6 +551,34 @@ func testAttributesStoreGetTeamMembersToRemove(t *testing.T, rctx request.CTX, s
 		for _, m := range members {
 			require.NotEqual(t, removed.Id, m.UserId, "soft-deleted member must not appear")
 		}
+	})
+
+	// Regression test: a native-attribute policy resolves against the Users
+	// table (the query is joined to Users), and a member with no AttributeView
+	// row who satisfies it must NOT be removed. Before the fix, native columns
+	// failed to resolve (no Users join) and the "OR AttributeView.TargetID IS
+	// NULL" clause removed attribute-less members outright.
+	t.Run("native policy keeps members with no attribute row", func(t *testing.T) {
+		extra := model.User{Email: MakeEmail(), Username: model.NewUsername()}
+		_, err := ss.User().Save(rctx, &extra)
+		require.NoError(t, err, "couldn't save attribute-less member")
+		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamID, UserId: extra.Id}, 1000)
+		require.NoError(t, nErr, "couldn't add attribute-less member")
+		t.Cleanup(func() {
+			require.NoError(t, ss.Team().RemoveMember(rctx, teamID, extra.Id), "couldn't remove attribute-less member")
+			require.NoError(t, ss.User().PermanentDelete(rctx, extra.Id), "couldn't delete attribute-less member")
+		})
+
+		require.NoError(t, ss.Attributes().RefreshAttributes(), "couldn't refresh attributes")
+
+		// Native-style predicate satisfied by every active user, including the
+		// attribute-less member.
+		members, err := ss.Attributes().GetTeamMembersToRemove(rctx, teamID, model.SubjectSearchOptions{
+			Query: "Users.DeleteAt = $1::bigint",
+			Args:  []any{int64(0)},
+		})
+		require.NoError(t, err, "native removal query must not error")
+		require.Empty(t, members, "members satisfying a native policy must not be removed, even without an attribute row")
 	})
 }
 

--- a/server/channels/store/storetest/mocks/SessionStore.go
+++ b/server/channels/store/storetest/mocks/SessionStore.go
@@ -91,6 +91,36 @@ func (_m *SessionStore) Get(rctx request.CTX, sessionIDOrToken string) (*model.S
 	return r0, r1
 }
 
+// GetAllSessionsWithActiveDeviceIds provides a mock function with no fields
+func (_m *SessionStore) GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllSessionsWithActiveDeviceIds")
+	}
+
+	var r0 []*model.Session
+	var r1 error
+	if rf, ok := ret.Get(0).(func() ([]*model.Session, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() []*model.Session); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Session)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetLRUSessions provides a mock function with given fields: rctx, userID, limit, offset
 func (_m *SessionStore) GetLRUSessions(rctx request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error) {
 	ret := _m.Called(rctx, userID, limit, offset)
@@ -234,36 +264,6 @@ func (_m *SessionStore) GetSessionsWithActiveDeviceIds(userID string) ([]*model.
 
 	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(userID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetAllSessionsWithActiveDeviceIds provides a mock function with no fields
-func (_m *SessionStore) GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error) {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAllSessionsWithActiveDeviceIds")
-	}
-
-	var r0 []*model.Session
-	var r1 error
-	if rf, ok := ret.Get(0).(func() ([]*model.Session, error)); ok {
-		return rf()
-	}
-	if rf, ok := ret.Get(0).(func() []*model.Session); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*model.Session)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -10185,6 +10185,22 @@ func (s *TimerLayerSessionStore) Get(rctx request.CTX, sessionIDOrToken string) 
 	return result, err
 }
 
+func (s *TimerLayerSessionStore) GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error) {
+	start := time.Now()
+
+	result, err := s.SessionStore.GetAllSessionsWithActiveDeviceIds()
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("SessionStore.GetAllSessionsWithActiveDeviceIds", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerSessionStore) GetLRUSessions(rctx request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error) {
 	start := time.Now()
 
@@ -10261,22 +10277,6 @@ func (s *TimerLayerSessionStore) GetSessionsWithActiveDeviceIds(userID string) (
 			success = "true"
 		}
 		s.Root.Metrics.ObserveStoreMethodDuration("SessionStore.GetSessionsWithActiveDeviceIds", success, elapsed)
-	}
-	return result, err
-}
-
-func (s *TimerLayerSessionStore) GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error) {
-	start := time.Now()
-
-	result, err := s.SessionStore.GetAllSessionsWithActiveDeviceIds()
-
-	elapsed := float64(time.Since(start)) / float64(time.Second)
-	if s.Root.Metrics != nil {
-		success := "false"
-		if err == nil {
-			success = "true"
-		}
-		s.Root.Metrics.ObserveStoreMethodDuration("SessionStore.GetAllSessionsWithActiveDeviceIds", success, elapsed)
 	}
 	return result, err
 }


### PR DESCRIPTION
#### Summary
Native user attributes (`user.email`, `user.verified`, `user.isbot`, `user.createat`) compile to SQL against the `Users` table, so an ABAC policy can now match users that have **no row** in `AttributeView`. Pre-native policies always referenced custom profile attributes, so every match had an `AttributeView` row — which masked two latent bugs in `channels/store/sqlstore/attributes_store.go`:

- **Add path:** `SearchUsers` orders by `Users.Id` but paginated with a cursor predicate on the nullable `AttributeView.TargetID` column (from a `LEFT JOIN`). For a matching user without an `AttributeView` row, `TargetID` is `NULL`, so the predicate drops them. The membership sync always seeds a cursor, so the predicate applied from page 1 — which is why the Test modal showed the correct users while the sync added none. The cursor now pages on the ordered `Users.Id` column.
- **Removal path:** `GetChannelMembersToRemove` / `GetTeamMembersToRemove` ran the compiled CEL→SQL `FROM ChannelMembers/TeamMembers` without joining `Users`, so a native-attribute policy emitting `Users.Email` / `Users.EmailVerified` / `Users.CreateAt` failed to resolve. Both builders now `LEFT JOIN Users`.

Also guards `sanitizeFileAttachmentsForUser` against an empty `userID` (e.g. system posts created by the background membership-sync job, which has no session). Previously this logged a spurious "Failed to get user for file attachment sanitization" warning and stripped attachments. Adds store regression tests covering both the cursor and members-to-remove paths.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69351

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: Medium 🟡

**Regression Risk:** The SQL query logic for membership synchronization and member removal was changed to correctly handle users/members without `AttributeView` rows, which could affect which users are included/excluded if the join/pagination logic is wrong. The changes are confined to the attributes store queries plus a small guard for empty `userID`, and the key cursor/removal paths are covered by new regression tests.

**QA Recommendation:** Do targeted automated/regression verification for attribute-based `SearchUsers` pagination and `GetChannelMembersToRemove` / `GetTeamMembersToRemove` behavior for attribute-less users, plus a quick check that background/system posts still have expected attachment sanitization behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->