### PR TITLE
Fix alphabetical ordering of GetAllSessionsWithActiveDeviceIds in generated store layers

### DIFF
--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -12852,6 +12852,27 @@ func (s *RetryLayerSessionStore) Get(rctx request.CTX, sessionIDOrToken string) 
 
 }
 
+func (s *RetryLayerSessionStore) GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error) {
+
+	tries := 0
+	for {
+		result, err := s.SessionStore.GetAllSessionsWithActiveDeviceIds()
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerSessionStore) GetLRUSessions(rctx request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error) {
 
 	tries := 0
@@ -12941,27 +12962,6 @@ func (s *RetryLayerSessionStore) GetSessionsWithActiveDeviceIds(userID string) (
 	tries := 0
 	for {
 		result, err := s.SessionStore.GetSessionsWithActiveDeviceIds(userID)
-		if err == nil {
-			return result, nil
-		}
-		if !isRepeatableError(err) {
-			return result, err
-		}
-		tries++
-		if tries >= 3 {
-			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
-			return result, err
-		}
-		timepkg.Sleep(100 * timepkg.Millisecond)
-	}
-
-}
-
-func (s *RetryLayerSessionStore) GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error) {
-
-	tries := 0
-	for {
-		result, err := s.SessionStore.GetAllSessionsWithActiveDeviceIds()
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/storetest/mocks/SessionStore.go
+++ b/server/channels/store/storetest/mocks/SessionStore.go
@@ -91,6 +91,36 @@ func (_m *SessionStore) Get(rctx request.CTX, sessionIDOrToken string) (*model.S
 	return r0, r1
 }
 
+// GetAllSessionsWithActiveDeviceIds provides a mock function with no fields
+func (_m *SessionStore) GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAllSessionsWithActiveDeviceIds")
+	}
+
+	var r0 []*model.Session
+	var r1 error
+	if rf, ok := ret.Get(0).(func() ([]*model.Session, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() []*model.Session); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Session)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetLRUSessions provides a mock function with given fields: rctx, userID, limit, offset
 func (_m *SessionStore) GetLRUSessions(rctx request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error) {
 	ret := _m.Called(rctx, userID, limit, offset)
@@ -234,36 +264,6 @@ func (_m *SessionStore) GetSessionsWithActiveDeviceIds(userID string) ([]*model.
 
 	if rf, ok := ret.Get(1).(func(string) error); ok {
 		r1 = rf(userID)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetAllSessionsWithActiveDeviceIds provides a mock function with no fields
-func (_m *SessionStore) GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error) {
-	ret := _m.Called()
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetAllSessionsWithActiveDeviceIds")
-	}
-
-	var r0 []*model.Session
-	var r1 error
-	if rf, ok := ret.Get(0).(func() ([]*model.Session, error)); ok {
-		return rf()
-	}
-	if rf, ok := ret.Get(0).(func() []*model.Session); ok {
-		r0 = rf()
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*model.Session)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -10185,6 +10185,22 @@ func (s *TimerLayerSessionStore) Get(rctx request.CTX, sessionIDOrToken string) 
 	return result, err
 }
 
+func (s *TimerLayerSessionStore) GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error) {
+	start := time.Now()
+
+	result, err := s.SessionStore.GetAllSessionsWithActiveDeviceIds()
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("SessionStore.GetAllSessionsWithActiveDeviceIds", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerSessionStore) GetLRUSessions(rctx request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error) {
 	start := time.Now()
 
@@ -10261,22 +10277,6 @@ func (s *TimerLayerSessionStore) GetSessionsWithActiveDeviceIds(userID string) (
 			success = "true"
 		}
 		s.Root.Metrics.ObserveStoreMethodDuration("SessionStore.GetSessionsWithActiveDeviceIds", success, elapsed)
-	}
-	return result, err
-}
-
-func (s *TimerLayerSessionStore) GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error) {
-	start := time.Now()
-
-	result, err := s.SessionStore.GetAllSessionsWithActiveDeviceIds()
-
-	elapsed := float64(time.Since(start)) / float64(time.Second)
-	if s.Root.Metrics != nil {
-		success := "false"
-		if err == nil {
-			success = "true"
-		}
-		s.Root.Metrics.ObserveStoreMethodDuration("SessionStore.GetAllSessionsWithActiveDeviceIds", success, elapsed)
 	}
 	return result, err
 }


### PR DESCRIPTION
#### Summary

`GetAllSessionsWithActiveDeviceIds` was added to the `SessionStore` interface by PR #36945 but was placed out of alphabetical order in the three auto-generated store layer files. The code generator sorts methods lexicographically, so `GetAll...` (A) must appear before `GetLRU...` (L) and `GetSessions...` (S). This was causing the `check-store-layers` and `check-mocks` steps to fail in Server CI on master.

Moves `GetAllSessionsWithActiveDeviceIds` to its correct position (before `GetLRUSessions`) in:
- `server/channels/store/retrylayer/retrylayer.go`
- `server/channels/store/timerlayer/timerlayer.go`
- `server/channels/store/storetest/mocks/SessionStore.go`

Verified locally with `make store-mocks store-layers` — no diff after regeneration.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/actions/runs/28226609436

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** Low risk because this is an ordering-only update in generated store-layer and mock files, with no behavior, signatures, or data flow changes. The affected code is session-store related, but the change is limited to method placement and should not alter runtime logic.

**QA Recommendation:** Minimal manual QA needed; rely on the existing generator checks/regeneration validation to confirm the file ordering stays consistent.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->