### PR TITLE
Add missing aria-label to App Bar plugin icons

### DIFF
--- a/webapp/channels/src/components/app_bar/__snapshots__/app_bar.test.tsx.snap
+++ b/webapp/channels/src/components/app_bar/__snapshots__/app_bar.test.tsx.snap
@@ -13,6 +13,7 @@ exports[`components/app_bar/app_bar should match snapshot on mount 1`] = `
         id="app-bar-icon-playbooks"
       >
         <div
+          aria-label="Playbooks Tooltip"
           class="app-bar__old-icon app-bar__icon-inner app-bar__icon-inner--centered"
           role="button"
           tabindex="0"
@@ -52,6 +53,7 @@ exports[`components/app_bar/app_bar should match snapshot on mount when App Bar 
         id="app-bar-icon-playbooks"
       >
         <div
+          aria-label="Playbooks Tooltip"
           class="app-bar__old-icon app-bar__icon-inner app-bar__icon-inner--centered"
           role="button"
           tabindex="0"

--- a/webapp/channels/src/components/app_bar/app_bar.test.tsx
+++ b/webapp/channels/src/components/app_bar/app_bar.test.tsx
@@ -114,6 +114,14 @@ describe('components/app_bar/app_bar', () => {
         expect(asFragment()).toMatchSnapshot();
     });
 
+    test('plugin App Bar icon button should expose its tooltip as an accessible name', () => {
+        renderWithContext(
+            <AppBar/>,
+            initialState,
+        );
+        expect(screen.getByRole('button', {name: 'Playbooks Tooltip'})).toBeInTheDocument();
+    });
+
     test('should match snapshot on mount when App Bar is disabled', () => {
         const testState = mergeObjects(initialState, {
             entities: {

--- a/webapp/channels/src/components/app_bar/app_bar_plugin_component.tsx
+++ b/webapp/channels/src/components/app_bar/app_bar_plugin_component.tsx
@@ -61,6 +61,7 @@ const AppBarPluginComponent = (props: PluginComponentProps) => {
         <div
             role='button'
             tabIndex={0}
+            aria-label={tooltipText}
             className='app-bar__icon-inner'
         >
             <img
@@ -79,6 +80,7 @@ const AppBarPluginComponent = (props: PluginComponentProps) => {
             <div
                 role='button'
                 tabIndex={0}
+                aria-label={tooltipText}
                 className={classNames('app-bar__old-icon app-bar__icon-inner app-bar__icon-inner--centered', {'app-bar__old-icon--active': isButtonActive})}
             >
                 {component.icon}

--- a/webapp/channels/src/components/app_bar/app_bar_plugin_component.tsx
+++ b/webapp/channels/src/components/app_bar/app_bar_plugin_component.tsx
@@ -90,7 +90,14 @@ const AppBarPluginComponent = (props: PluginComponentProps) => {
 
     if (imageLoadState === ImageLoadState.ERROR) {
         content = (
-            <PluginIcon className='icon__plugin'/>
+            <div
+                role='button'
+                tabIndex={0}
+                aria-label={tooltipText}
+                className='app-bar__old-icon app-bar__icon-inner app-bar__icon-inner--centered'
+            >
+                <PluginIcon className='icon__plugin'/>
+            </div>
         );
     }
 


### PR DESCRIPTION
#### Summary

Plugin icons in the App Bar are rendered as `<div role="button" tabIndex={0}>` in `webapp/channels/src/components/app_bar/app_bar_plugin_component.tsx`, but the interactive element has no accessible name. When a keyboard or screen reader user tabs to an App Bar plugin icon, assistive technology announces only a generic "button" with no indication of which plugin it belongs to. An automated accessibility audit (axe) flags this under the `aria-command-name` / `button-name` rules, failing WCAG 2.1 SC 4.1.2 (Name, Role, Value).

The component already computes `tooltipText` (`component.tooltipText || component.dropdownText || component.pluginId`) for the visual tooltip shown on hover, so an appropriate accessible name is already available — it just was not exposed to the accessibility tree. This change adds `aria-label={tooltipText}` to both interactive `role="button"` elements (the `iconUrl` image branch and the `.app-bar__old-icon` fallback branch), so screen readers announce the same label sighted users see on hover. The sibling `app_bar_binding.tsx`, which renders App Bar icons for Apps framework bindings, already sets `aria-label` this way, so this brings plugin icons in line with the existing pattern.

A regression test is added asserting the App Bar plugin button is reachable by its accessible name, and the existing snapshots are updated to include the new attribute.

QA steps:
1. Install or enable any plugin that registers an App Bar icon (for example Playbooks, or any plugin that calls `registerAppBarComponent`).
2. Open a channel and locate the plugin's icon in the App Bar on the right edge.
3. Inspect the icon's interactive element and confirm it now has an `aria-label` matching the icon's tooltip text.
4. With a screen reader running, tab to the icon and confirm it announces the tooltip text instead of an unlabeled "button".

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/36604

#### Screenshots

After the change, the App Bar plugin icon exposes an accessible name matching its tooltip:

<img width="1189" height="916" alt="App Bar plugin icon aria-label in DevTools" src="https://github.com/user-attachments/assets/c1a27c10-a663-4476-9bc4-cece74743d6e" />

#### Release Note
```release-note
Fixed App Bar plugin icons missing an accessible name, so screen readers now announce the plugin's tooltip instead of an unlabeled button.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to the App Bar plugin icon component and its associated test coverage, with no impact to auth, data, or shared core logic. The only behavior change is adding an accessible name to existing interactive icon buttons, so regression risk is limited.

**QA Recommendation:** Light manual QA is sufficient: verify the App Bar plugin icon is still clickable/focusable and that screen readers expose the expected label.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->