### PR TITLE
ci: auto-build missing buildenv images for in-flight Go version bumps

### DIFF
--- a/.github/actions/load-buildenv/action.yml
+++ b/.github/actions/load-buildenv/action.yml
@@ -1,0 +1,66 @@
+name: Load build environment
+description: >
+  Loads build-server images uploaded by setup-buildenv into the local Docker
+  daemon, and resolves the image name from the Go version. Use in jobs that
+  run the container directly (test jobs). For jobs that only need a shell
+  inside the container, use run-in-buildenv instead.
+
+inputs:
+  go-version:
+    description: "Go version used to construct the image tag (e.g. 1.26.3). Leave empty when only the load behaviour is needed."
+    required: false
+    default: ""
+  fips-enabled:
+    description: "Set to 'true' to resolve the FIPS build image"
+    required: false
+    default: "false"
+
+outputs:
+  image:
+    description: "Fully-qualified build image name (e.g. mattermost/mattermost-build-server:1.26.3). Empty when go-version is not provided."
+    value: ${{ steps.resolve.outputs.image }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set constants
+      shell: bash
+      run: |
+        echo "BUILDENV_ARTIFACT=buildenv-image" >> "${GITHUB_ENV}"
+        echo "BUILDENV_FIPS_ARTIFACT=buildenv-fips-image" >> "${GITHUB_ENV}"
+        echo "BUILDENV_TMPDIR=/tmp/buildenv-save" >> "${GITHUB_ENV}"
+    - name: Download buildenv artifact
+      id: download
+      continue-on-error: true
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      with:
+        name: ${{ env.BUILDENV_ARTIFACT }}
+        path: ${{ env.BUILDENV_TMPDIR }}/
+    - name: Load buildenv from artifact
+      if: steps.download.outcome == 'success'
+      shell: bash
+      run: docker load -i "${BUILDENV_TMPDIR}/image.tar.gz"
+    - name: Download buildenv-fips artifact
+      id: download-fips
+      continue-on-error: true
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      with:
+        name: ${{ env.BUILDENV_FIPS_ARTIFACT }}
+        path: ${{ env.BUILDENV_TMPDIR }}/
+    - name: Load buildenv-fips from artifact
+      if: steps.download-fips.outcome == 'success'
+      shell: bash
+      run: docker load -i "${BUILDENV_TMPDIR}/image-fips.tar.gz"
+    - name: Resolve image name
+      id: resolve
+      if: ${{ inputs.go-version != '' }}
+      shell: bash
+      env:
+        FIPS: ${{ inputs.fips-enabled }}
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        if [[ "${FIPS}" == 'true' ]]; then
+          echo "image=mattermost/mattermost-build-server-fips:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
+        else
+          echo "image=mattermost/mattermost-build-server:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
+        fi

--- a/.github/actions/run-in-buildenv/action.yml
+++ b/.github/actions/run-in-buildenv/action.yml
@@ -1,0 +1,51 @@
+name: Run in build environment
+description: >
+  Runs a script inside the build-server container. Use for build and check
+  jobs that don't need direct control over the docker run invocation.
+
+inputs:
+  run:
+    description: "Bash script to execute inside the container"
+    required: true
+  fips-enabled:
+    description: "Set to 'true' to use the FIPS build image"
+    required: false
+    default: "false"
+  go-version-file:
+    description: "Path to .go-version file relative to workspace root"
+    required: false
+    default: "server/.go-version"
+  working-directory:
+    description: "Working directory inside the container (absolute path under /mattermost/)"
+    required: false
+    default: "/mattermost/server"
+
+runs:
+  using: composite
+  steps:
+    - name: Read Go version
+      shell: bash
+      run: echo "GO_VERSION=$(cat ${{ inputs.go-version-file }})" >> "${GITHUB_ENV}"
+    - uses: ./.github/actions/load-buildenv
+      id: buildenv
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        fips-enabled: ${{ inputs.fips-enabled }}
+    - name: Run in buildenv
+      shell: bash
+      env:
+        CMD: ${{ inputs.run }}
+        IMAGE: ${{ steps.buildenv.outputs.image }}
+        WORKING_DIR: ${{ inputs.working-directory }}
+      run: |
+        SCRIPT=$(mktemp)
+        printf 'git config --global --add safe.directory /mattermost\n' > "${SCRIPT}"
+        printf '%s\n' "${CMD}" >> "${SCRIPT}"
+        docker run --rm \
+          --network host \
+          -v "$PWD:/mattermost" \
+          -v "${SCRIPT}:/run-script.sh" \
+          -w "${WORKING_DIR}" \
+          "${IMAGE}" \
+          bash /run-script.sh
+        rm -f "${SCRIPT}"

--- a/.github/actions/setup-buildenv/action.yml
+++ b/.github/actions/setup-buildenv/action.yml
@@ -1,0 +1,110 @@
+name: Setup build environment
+description: >
+  Builds the mattermost-build-server images if they don't yet exist on Docker
+  Hub (e.g. during a Go version bump), and uploads them as artifacts for
+  downstream jobs. Run once per workflow before any build or test jobs.
+
+inputs:
+  go-version:
+    description: "Go version (e.g. 1.26.3)"
+    required: true
+  dockerfile:
+    description: "Path to Dockerfile.buildenv (relative to workspace root)"
+    required: false
+    default: "server/build/Dockerfile.buildenv"
+  dockerfile-fips:
+    description: "Path to Dockerfile.buildenv-fips (relative to workspace root)"
+    required: false
+    default: "server/build/Dockerfile.buildenv-fips"
+
+runs:
+  using: composite
+  steps:
+    - name: Set constants
+      shell: bash
+      run: |
+        echo "BUILDENV_IMAGE=mattermost/mattermost-build-server" >> "${GITHUB_ENV}"
+        echo "BUILDENV_ARTIFACT=buildenv-image" >> "${GITHUB_ENV}"
+        echo "BUILDENV_DOCKERFILE=${{ inputs.dockerfile }}" >> "${GITHUB_ENV}"
+        echo "BUILDENV_FIPS_IMAGE=mattermost/mattermost-build-server-fips" >> "${GITHUB_ENV}"
+        echo "BUILDENV_FIPS_ARTIFACT=buildenv-fips-image" >> "${GITHUB_ENV}"
+        echo "BUILDENV_FIPS_DOCKERFILE=${{ inputs.dockerfile-fips }}" >> "${GITHUB_ENV}"
+        echo "BUILDENV_TMPDIR=/tmp/buildenv-save" >> "${GITHUB_ENV}"
+    # ── Regular ────────────────────────────────────────────────────────
+    - name: Resolve regular image
+      id: resolve
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        if docker manifest inspect "${BUILDENV_IMAGE}:${GO_VERSION}" > /dev/null 2>&1; then
+          echo "artifact-name=" >> "${GITHUB_OUTPUT}"
+        else
+          echo "artifact-name=${BUILDENV_ARTIFACT}" >> "${GITHUB_OUTPUT}"
+        fi
+    - name: Build regular image
+      if: ${{ steps.resolve.outputs.artifact-name != '' }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: docker build -t "${BUILDENV_IMAGE}:${GO_VERSION}" - < "${BUILDENV_DOCKERFILE}"
+    - name: Save and upload regular image
+      if: ${{ steps.resolve.outputs.artifact-name != '' }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        mkdir -p "${BUILDENV_TMPDIR}"
+        docker save "${BUILDENV_IMAGE}:${GO_VERSION}" | gzip > "${BUILDENV_TMPDIR}/image.tar.gz"
+    - name: Upload regular image artifact
+      if: ${{ steps.resolve.outputs.artifact-name != '' }}
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ env.BUILDENV_ARTIFACT }}
+        path: ${{ env.BUILDENV_TMPDIR }}/image.tar.gz
+        retention-days: 1
+    # ── FIPS (skipped on fork PRs) ─────────────────────────────────────
+    - name: Docker Hub login
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_TOKEN }}
+    - name: Setup Chainctl
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      uses: chainguard-dev/setup-chainctl@c125f765e82b09a42af3185f3214465314d75c5d # v0.5.0
+      with:
+        identity: ${{ env.CHAINCTL_IDENTITY }}
+    - name: Resolve FIPS image
+      id: resolve-fips
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        if docker manifest inspect "${BUILDENV_FIPS_IMAGE}:${GO_VERSION}" > /dev/null 2>&1; then
+          echo "artifact-name=" >> "${GITHUB_OUTPUT}"
+        else
+          echo "artifact-name=${BUILDENV_FIPS_ARTIFACT}" >> "${GITHUB_OUTPUT}"
+        fi
+    - name: Build FIPS image
+      if: ${{ steps.resolve-fips.outputs.artifact-name != '' }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: docker build -t "${BUILDENV_FIPS_IMAGE}:${GO_VERSION}" - < "${BUILDENV_FIPS_DOCKERFILE}"
+    - name: Save and upload FIPS image
+      if: ${{ steps.resolve-fips.outputs.artifact-name != '' }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        mkdir -p "${BUILDENV_TMPDIR}"
+        docker save "${BUILDENV_FIPS_IMAGE}:${GO_VERSION}" | gzip > "${BUILDENV_TMPDIR}/image-fips.tar.gz"
+    - name: Upload FIPS image artifact
+      if: ${{ steps.resolve-fips.outputs.artifact-name != '' }}
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ env.BUILDENV_FIPS_ARTIFACT }}
+        path: ${{ env.BUILDENV_TMPDIR }}/image-fips.tar.gz
+        retention-days: 1

--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -56,19 +56,22 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup BUILD_IMAGE
-        id: build
+      - name: buildenv/load
+        id: buildenv
+        uses: ./.github/actions/load-buildenv
+        with:
+          go-version: ${{ inputs.go-version }}
+          fips-enabled: ${{ inputs.fips-enabled }}
+      - name: Setup log artifact name
+        id: log-artifact
         run: |
           if [[ "$INPUT_FIPS_ENABLED" == 'true' ]]; then
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${INPUT_GO_VERSION}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${INPUT_LOGSARTIFACT}-fips" >> "${GITHUB_OUTPUT}"
           else
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${INPUT_GO_VERSION}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${INPUT_LOGSARTIFACT}" >> "${GITHUB_OUTPUT}"
           fi
 
@@ -90,7 +93,7 @@ jobs:
 
       - name: Run mmctl Tests
         env:
-          BUILD_IMAGE: ${{ steps.build.outputs.BUILD_IMAGE }}
+          BUILD_IMAGE: ${{ steps.buildenv.outputs.image }}
         run: |
           if [[ "$REF_NAME" == 'master' ]]; then
             export TESTFLAGS="-timeout 90m -race"
@@ -120,13 +123,13 @@ jobs:
         with:
           report-path: server/report.xml
           zephyr-api-key: ${{ secrets.MM_E2E_ZEPHYR_API_KEY }}
-          build-image: ${{ steps.build.outputs.BUILD_IMAGE }}
+          build-image: ${{ steps.buildenv.outputs.image }}
 
       - name: Archive logs
         if: ${{ always() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: ${{ steps.build.outputs.LOG_ARTIFACT_NAME }}
+          name: ${{ steps.log-artifact.outputs.LOG_ARTIFACT_NAME }}
           path: |
             server/gotestsum.json
             server/report.xml

--- a/.github/workflows/server-ci-nightly-race.yml
+++ b/.github/workflows/server-ci-nightly-race.yml
@@ -21,8 +21,8 @@ permissions:
   contents: read
 
 jobs:
-  go:
-    name: Compute Go Version
+  buildenv:
+    name: Build Environment
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.calculate.outputs.GO_VERSION }}
@@ -38,7 +38,7 @@ jobs:
 
   test-race:
     name: Race Detector
-    needs: go
+    needs: buildenv
     permissions:
       contents: read
       actions: write
@@ -48,7 +48,7 @@ jobs:
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: race-detector-server-test-logs
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: false
       fullyparallel: false
       race-enabled: true

--- a/.github/workflows/server-ci-weekly.yml
+++ b/.github/workflows/server-ci-weekly.yml
@@ -15,15 +15,15 @@ on:
     - cron: "0 5 * * 1" # Monday 5am UTC (~1am ET)
   push:
     branches:
-      - 'release-*'
+      - "release-*"
   workflow_dispatch: # Allow manual trigger for urgent FIPS/binary verification
 
 permissions:
   contents: read
 
 jobs:
-  go:
-    name: Compute Go Version
+  buildenv:
+    name: Build Environment
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.calculate.outputs.GO_VERSION }}
@@ -39,7 +39,7 @@ jobs:
 
   test-postgres-binary:
     name: Postgres with binary parameters
-    needs: go
+    needs: buildenv
     permissions:
       contents: read
       actions: write
@@ -49,7 +49,7 @@ jobs:
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes
       drivername: postgres
       logsartifact: postgres-binary-server-test-logs
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: false
       # Unsharded run on a single 8-core runner: fullyparallel=true causes
       # resource exhaustion (too many server instances, WebSocket hubs, and
@@ -58,7 +58,7 @@ jobs:
 
   test-postgres-normal-fips:
     name: Postgres FIPS
-    needs: go
+    needs: buildenv
     permissions:
       contents: read
       actions: write
@@ -71,14 +71,14 @@ jobs:
       datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: postgres-server-fips-test-logs
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: true
       # Unsharded run on a single 8-core runner: see note on test-postgres-binary.
       fullyparallel: false
 
   test-mmctl-fips:
     name: Run mmctl tests (FIPS)
-    needs: go
+    needs: buildenv
     permissions:
       contents: read
       actions: write
@@ -92,5 +92,5 @@ jobs:
       datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: mmctl-fips-test-logs
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: true

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -5,7 +5,7 @@
 # If you rename this workflow, be sure to update those workflows as well.
 name: Server CI
 on:
-  workflow_dispatch:  # Allow manual/API triggering for linked plugin CI
+  workflow_dispatch: # Allow manual/API triggering for linked plugin CI
   push:
     branches:
       - master
@@ -17,8 +17,6 @@ on:
       - ".github/workflows/server-test-template.yml"
       - ".github/workflows/server-test-merge-template.yml"
       - ".github/workflows/mmctl-test-template.yml"
-      - "!server/build/Dockerfile.buildenv"
-      - "!server/build/Dockerfile.buildenv-fips"
       - "tools/mattermost-govet/**"
       - "!server/**/*.md"
       - "!server/NOTICE.txt"
@@ -32,15 +30,21 @@ permissions:
   contents: read
 
 jobs:
-  go:
-    name: Compute Go Version
+  buildenv:
+    name: Build Environment
     runs-on: ubuntu-22.04
     permissions:
       contents: read
       pull-requests: read
+      actions: write
+      id-token: write # for chainguard (FIPS base image pull)
     outputs:
       version: ${{ steps.calculate.outputs.GO_VERSION }}
       gomod-changed: ${{ steps.changed-files.outputs.any_changed }}
+    env:
+      CHAINCTL_IDENTITY: ee399b4c72dd4e58e3d617f78fc47b74733c9557/922f2d48307d6f5f
+      DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+      DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -56,24 +60,24 @@ jobs:
         with:
           files: |
             **/go.mod
+      - name: Setup build environment
+        uses: ./.github/actions/setup-buildenv
+        with:
+          go-version: ${{ steps.calculate.outputs.GO_VERSION }}
   check-mocks:
     name: Check mocks
-    needs: go
+    needs: buildenv
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Generate mocks
-        run: make mocks
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make mocks
       - name: Check mocks
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the mocks using 'make mocks'"
             git diff
@@ -81,22 +85,18 @@ jobs:
           fi
   check-go-mod-tidy:
     name: Check go mod tidy
-    needs: go
+    needs: buildenv
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run go mod tidy
-        run: make modules-tidy
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make modules-tidy
       - name: Check modules
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please tidy up the Go modules using make modules-tidy"
             git diff
@@ -104,37 +104,30 @@ jobs:
           fi
   check-style:
     name: check-style
-    needs: go
+    needs: buildenv
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run golangci
-        run: make check-style
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make check-style
   check-gen-serialized:
     name: Check serialization methods for hot structs
-    needs: go
+    needs: buildenv
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run make-gen-serialized
-        run: make gen-serialized
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make gen-serialized
       - name: Check serialized
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the serialized files using 'make gen-serialized'"
             git diff
@@ -142,37 +135,30 @@ jobs:
           fi
   check-mattermost-vet-api:
     name: Vet API
-    needs: go
+    needs: buildenv
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run mattermost-vet-api
-        run: make vet-api
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make vet-api
   check-migrations:
     name: Check migration files
-    needs: go
+    needs: buildenv
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Extract migrations files
-        run: make migrations-extract
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make migrations-extract
       - name: Check migration files
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the migrations using make migrations-extract"
             git diff
@@ -192,24 +178,20 @@ jobs:
           MM_MIGRATION_CHECK_CANONICAL_REF: origin/master
   check-email-templates:
     name: Generate email templates
-    needs: go
+    needs: buildenv
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Generate email templates
-        run: |
-          npm install -g mjml@4.9.0
-          make build-templates
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: |
+            npm install -g mjml@4.9.0
+            make build-templates
       - name: Check generated email templates
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the email templates using 'make build-templates'"
             git diff
@@ -217,22 +199,18 @@ jobs:
           fi
   check-store-layers:
     name: Check store layers
-    needs: go
+    needs: buildenv
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Generate store layers
-        run: make store-layers
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make store-layers
       - name: Check generated code
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the store layers using make store-layers"
             git diff
@@ -240,9 +218,8 @@ jobs:
           fi
   check-default-roles-permissions:
     name: Check default roles permissions
-    needs: go
+    needs: buildenv
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     permissions:
       contents: read
     services:
@@ -251,26 +228,27 @@ jobs:
         env:
           POSTGRES_USER: mmuser
           POSTGRES_PASSWORD: mostest
+          POSTGRES_DB: mattermost_test
+        ports:
+          - 5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 5s
           --health-timeout 5s
           --health-retries 5
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Generate default roles permissions
-        env:
-          IS_CI: "true"
-        run: make default-roles-permissions
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: |
+            export IS_CI=true
+            export TEST_DATABASE_POSTGRESQL_DSN="postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
+            make default-roles-permissions
       - name: Check generated code
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the default roles permissions using make default-roles-permissions"
             git diff
@@ -278,22 +256,18 @@ jobs:
           fi
   check-mmctl-docs:
     name: Check mmctl docs
-    needs: go
+    needs: buildenv
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost-server
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make mmctl-docs
       - name: Check docs
         run: |
-          echo "Making sure docs are updated"
-          make mmctl-docs
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the mmctl docs using make mmctl-docs"
             git diff
@@ -306,7 +280,7 @@ jobs:
   # -- Sharded into 4 parallel runners for ~88% wall-time improvement --
   test-postgres-normal:
     name: Postgres (shard ${{ matrix.shard }})
-    needs: go
+    needs: buildenv
     strategy:
       fail-fast: false # Let all shards complete so we get full test results
       matrix:
@@ -324,7 +298,7 @@ jobs:
       # Each shard gets a unique artifact name so they don't collide
       logsartifact: "postgres-server-test-logs-shard-${{ matrix.shard }}"
       enablecoverage: ${{ github.event_name != 'pull_request' || !startsWith(github.event.pull_request.base.ref, 'release-') }}
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: false
       shard-index: ${{ matrix.shard }}
       shard-total: 4
@@ -345,7 +319,7 @@ jobs:
 
   test-elasticsearch-v8:
     name: Elasticsearch v8 Compatibility
-    needs: go
+    needs: buildenv
     permissions:
       contents: read
       actions: write
@@ -355,14 +329,14 @@ jobs:
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: elasticsearch-v8-server-test-logs
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: false
       elasticsearch-version: "8.9.0"
       test-target: "test-server-elasticsearch"
 
   test-opensearch-v2:
     name: OpenSearch v2 Compatibility
-    needs: go
+    needs: buildenv
     permissions:
       contents: read
       actions: write
@@ -372,7 +346,7 @@ jobs:
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: opensearch-v2-server-test-logs
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: false
       opensearch-version: "2.19.0"
       test-target: "test-server-opensearch"
@@ -380,9 +354,9 @@ jobs:
   # FIPS tests: run on PRs when go.mod changed or branch name contains "fips".
   # Sharded for fast iteration. Weekly workflow provides regular full coverage.
   test-postgres-normal-fips:
-    if: contains(github.head_ref, 'fips') || needs.go.outputs.gomod-changed == 'true'
+    if: contains(github.head_ref, 'fips') || needs.buildenv.outputs.gomod-changed == 'true'
     name: "Postgres FIPS (shard ${{ matrix.shard }})"
-    needs: go
+    needs: buildenv
     strategy:
       fail-fast: false
       matrix:
@@ -399,7 +373,7 @@ jobs:
       datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: "postgres-server-fips-test-logs-shard-${{ matrix.shard }}"
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: true
       shard-index: ${{ matrix.shard }}
       shard-total: 4
@@ -417,7 +391,7 @@ jobs:
 
   test-mmctl:
     name: Run mmctl tests
-    needs: go
+    needs: buildenv
     permissions:
       contents: read
       actions: write
@@ -429,12 +403,12 @@ jobs:
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: mmctl-test-logs
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: false
   test-mmctl-fips:
-    if: contains(github.head_ref, 'fips') || needs.go.outputs.gomod-changed == 'true'
+    if: contains(github.head_ref, 'fips') || needs.buildenv.outputs.gomod-changed == 'true'
     name: Run mmctl tests (FIPS)
-    needs: go
+    needs: buildenv
     permissions:
       contents: read
       actions: write
@@ -448,39 +422,30 @@ jobs:
       datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: mmctl-fips-test-logs
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: true
 
   build-mattermost-server:
     name: Build mattermost server app
-    needs: go
+    needs: buildenv
     permissions:
       contents: read
       actions: write
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
-    env:
-      BUILD_NUMBER: "${GITHUB_HEAD_REF}-${GITHUB_RUN_ID}"
-      FIPS_ENABLED: false
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: ci/setup-node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-          cache-dependency-path: "webapp/package-lock.json"
       - name: Build
-        run: |
-          make config-reset
-          make build-cmd
-          make package
+        uses: ./.github/actions/run-in-buildenv
+        with:
+          run: |
+            export BUILD_NUMBER="${{ github.head_ref }}-${{ github.run_id }}"
+            export FIPS_ENABLED=false
+            make config-reset
+            make build-cmd
+            make package
       - name: Persist dist artifacts
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -110,6 +110,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: buildenv/load
+        id: buildenv
+        uses: ./.github/actions/load-buildenv
+        with:
+          go-version: ${{ inputs.go-version }}
+          fips-enabled: ${{ inputs.fips-enabled }}
 
       - name: Restore test timing data
         if: inputs.shard-total > 1
@@ -131,14 +137,12 @@ jobs:
           restore-keys: |
             server-test-timing-v2-
 
-      - name: Setup BUILD_IMAGE
-        id: build
+      - name: Setup log artifact name
+        id: log-artifact
         run: |
           if [[ "$INPUT_FIPS_ENABLED" == 'true' ]]; then
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${INPUT_GO_VERSION}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${INPUT_LOGSARTIFACT}-fips" >> "${GITHUB_OUTPUT}"
           else
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${INPUT_GO_VERSION}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${INPUT_LOGSARTIFACT}" >> "${GITHUB_OUTPUT}"
           fi
 
@@ -225,7 +229,7 @@ jobs:
 
       - name: Run Tests
         env:
-          BUILD_IMAGE: ${{ steps.build.outputs.BUILD_IMAGE }}
+          BUILD_IMAGE: ${{ steps.buildenv.outputs.image }}
         run: |
           RACE_MODE=""
           if [[ "$INPUT_RACE_ENABLED" == "true" ]]; then
@@ -279,7 +283,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: ${{ steps.build.outputs.LOG_ARTIFACT_NAME }}
+          name: ${{ steps.log-artifact.outputs.LOG_ARTIFACT_NAME }}
           path: |
             server/gotestsum.json
             server/report.xml


### PR DESCRIPTION
#### Summary

To upgrade Go, we currently have to submit a pull request to [bump the buildenv Docker files](https://github.com/mattermost/mattermost/pull/36648), and then submit [a follow up](https://github.com/mattermost/mattermost/pull/36418) to actually use these. This is hard to automate.

In https://github.com/mattermost/mattermost/pull/36715, I previously tried to automate this by building and using the the Docker image in the same PR. Unfortunately, this didn't pass security review since it requires pushing to a remote Docker registry and potentially exposing our Chainguard-powered FIPS build images.

This PR solves the problem by building the images locally, saving them as cache artifacts, and restoring them on demand (to avoid rebuilding for each CI job). If the images already exist locally, the jobs use the remote containers as before. There will be a minor gap on merge before master builds and officially publishes the images when some jobs may spend extra cycles re-building the containers for themselves. But apart from the extra CI time, this will all still be correct.

Three new composite actions try to abstract away all the complexity:
* `setup-buildenv`: called once to possibly build the images locally. Forks won't get FIPS images as usual, but we're also not expecting forks to bump the versions at this time.
* `run-in-buildenv`: used by most jobs to replace the previous `container: ` syntax. Syntactically it's almost a drop-in replacement to run the given steps in the required container (sourced either from Docker Hub or the aforementioned build artifacts).
* `load-buildenv`:  used in a handful of place where a manual `docker run` invocation is required and we just need the correct image name.

This PR should exercise the happy path that is using the pre-built container form DockerHub. https://github.com/mattermost/mattermost/pull/37270 exercises the Go upgrade path, building the container on demand.

There are complementary changes for enterprise in https://github.com/mattermost/enterprise/pull/2216.

#### Release Note
```release-note
NONE
```