### PR TITLE
docs: fix spelling of receive in registry.ts

### DIFF
--- a/webapp/channels/src/plugins/registry.ts
+++ b/webapp/channels/src/plugins/registry.ts
@@ -1028,7 +1028,7 @@ export default class PluginRegistry {
      * Note that this is a low-level interface primarily meant for internal use, and is not subject
      * to semver guarantees. It may change in the future.
      * Accepts the following:
-     * - func - A function that recieve the admin console config definitions and return a new
+     * - func - A function that receives the admin console config definitions and returns a new
      *          version of it, which is used for build the admin console.
      * Each plugin can register at most one admin console plugin function, with newer registrations
      * replacing older ones.


### PR DESCRIPTION
Fixes a typo in the documentation comment: 'recieve' -> 'receives' and 'return' -> 'returns'.

<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
<!-- What does this PR do? Include QA steps if not covered in the ticket. -->

#### Ticket Link
<!--
Fixes: https://github.com/mattermost/mattermost/issues/XXX
Fixes: https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!-- Include screenshots or GIFs for UI changes. -->

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is a documentation-only typo correction in a single plugin registry file, so it does not affect runtime behavior, APIs, or shared logic. The blast radius is effectively isolated and there are no high-risk flows involved.

**QA Recommendation:** No manual QA needed beyond a quick documentation review; automated coverage is sufficient for this change.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->