### PR TITLE
[MM-69704] Add job create, show, and cancel commands to mmctl

### DIFF
--- a/server/cmd/mmctl/commands/job.go
+++ b/server/cmd/mmctl/commands/job.go
@@ -32,6 +32,36 @@ var listJobsCmd = &cobra.Command{
 	RunE: withClient(listJobsCmdF),
 }
 
+var createJobCmd = &cobra.Command{
+	Use:   "create [type]",
+	Short: "Create a new job",
+	Long:  "Create a new job of the given type. Use --data to pass type-specific options as key=value pairs.",
+	Example: `  job create ldap_sync
+	job create data_retention
+	job create message_export --data batch_size=1000`,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: jobTypeCompletionF,
+	RunE:              withClient(createJobCmdF),
+}
+
+var showJobCmd = &cobra.Command{
+	Use:               "show [job]",
+	Short:             "Show a job",
+	Example:           "  job show jobID",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: validateArgsWithClient(jobCompletionF),
+	RunE:              withClient(showJobCmdF),
+}
+
+var cancelJobCmd = &cobra.Command{
+	Use:               "cancel [job]",
+	Short:             "Cancel a job",
+	Example:           "  job cancel jobID",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: validateArgsWithClient(jobCompletionF),
+	RunE:              withClient(cancelJobCmdF),
+}
+
 var updateJobCmd = &cobra.Command{
 	Use:   "update [job] [status]",
 	Short: "Update the status of a job",
@@ -49,17 +79,22 @@ var updateJobCmd = &cobra.Command{
 }
 
 func init() {
-	listJobsCmd.Flags().Int("page", 0, "Page number to fetch for the list of import jobs")
-	listJobsCmd.Flags().Int("per-page", 5, "Number of import jobs to be fetched")
-	listJobsCmd.Flags().Bool("all", false, "Fetch all import jobs. --page flag will be ignored if provided")
+	listJobsCmd.Flags().Int("page", 0, "Page number to fetch for the list of jobs")
+	listJobsCmd.Flags().Int("per-page", 5, "Number of jobs to be fetched")
+	listJobsCmd.Flags().Bool("all", false, "Fetch all jobs. --page flag will be ignored if provided")
 	listJobsCmd.Flags().StringSlice("ids", nil, "Comma-separated list of job IDs to which the operation will be applied. All other flags are ignored")
 	listJobsCmd.Flags().String("status", "", "Filter by job status")
 	listJobsCmd.Flags().String("type", "", "Filter by job type")
+
+	createJobCmd.Flags().StringToString("data", nil, "Comma-separated list of key=value pairs passed to the job as type-specific options")
 
 	updateJobCmd.Flags().Bool("force", false, "Setting a job status is restricted to certain statuses. You can overwrite these restrictions by using --force. This might cause unexpected behaviour on your Mattermost Server. Use this option with caution.")
 
 	JobCmd.AddCommand(
 		listJobsCmd,
+		createJobCmd,
+		showJobCmd,
+		cancelJobCmd,
 		updateJobCmd,
 	)
 
@@ -127,6 +162,75 @@ func updateJobCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func createJobCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	jobType := args[0]
+	if !model.IsValidJobType(jobType) {
+		return fmt.Errorf("invalid job type: %s", jobType)
+	}
+
+	data, err := cmd.Flags().GetStringToString("data")
+	if err != nil {
+		return err
+	}
+
+	job, _, err := c.CreateJob(context.TODO(), &model.Job{
+		Type: jobType,
+		Data: data,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create job: %w", err)
+	}
+
+	printer.PrintT("Job successfully created, ID: {{.Id}}", job)
+
+	return nil
+}
+
+func showJobCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	jobId := args[0]
+	if !model.IsValidId(jobId) {
+		return fmt.Errorf("invalid job ID: %s", jobId)
+	}
+
+	job, _, err := c.GetJob(context.TODO(), jobId)
+	if err != nil {
+		return fmt.Errorf("failed to get job: %w", err)
+	}
+
+	printJob(job)
+
+	return nil
+}
+
+func cancelJobCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	jobId := args[0]
+	if !model.IsValidId(jobId) {
+		return fmt.Errorf("invalid job ID: %s", jobId)
+	}
+
+	if _, err := c.CancelJob(context.TODO(), jobId); err != nil {
+		return fmt.Errorf("failed to cancel job: %w", err)
+	}
+
+	return nil
+}
+
+func jobTypeCompletionF(_ *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+	if len(args) > 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return model.AllJobTypes[:], cobra.ShellCompDirectiveNoFileComp
+}
+
+func jobCompletionF(ctx context.Context, c client.Client, cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return fetchAndComplete(
+		func(ctx context.Context, c client.Client, page, perPage int) ([]*model.Job, *model.Response, error) {
+			return c.GetJobs(ctx, "", "", page, perPage)
+		},
+		func(j *model.Job) []string { return []string{j.Id} },
+	)(ctx, c, cmd, args, toComplete)
 }
 
 func jobListCmdF(c client.Client, command *cobra.Command, jobType string, status string) error {

--- a/server/cmd/mmctl/commands/job.go
+++ b/server/cmd/mmctl/commands/job.go
@@ -165,10 +165,6 @@ func updateJobCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 }
 
 func createJobCmdF(c client.Client, cmd *cobra.Command, args []string) error {
-	// The type is intentionally not validated against model.AllJobTypes: that
-	// list is a curated subset and omits creatable types (e.g. access_control_sync).
-	// The server validates the type per its create-job permissions and returns a
-	// clear error for anything it can't schedule.
 	jobType := args[0]
 
 	data, err := cmd.Flags().GetStringToString("data")

--- a/server/cmd/mmctl/commands/job.go
+++ b/server/cmd/mmctl/commands/job.go
@@ -165,10 +165,11 @@ func updateJobCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 }
 
 func createJobCmdF(c client.Client, cmd *cobra.Command, args []string) error {
+	// The type is intentionally not validated against model.AllJobTypes: that
+	// list is a curated subset and omits creatable types (e.g. access_control_sync).
+	// The server validates the type per its create-job permissions and returns a
+	// clear error for anything it can't schedule.
 	jobType := args[0]
-	if !model.IsValidJobType(jobType) {
-		return fmt.Errorf("invalid job type: %s", jobType)
-	}
 
 	data, err := cmd.Flags().GetStringToString("data")
 	if err != nil {

--- a/server/cmd/mmctl/commands/job_e2e_test.go
+++ b/server/cmd/mmctl/commands/job_e2e_test.go
@@ -1,0 +1,142 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"time"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/client"
+	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/printer"
+
+	"github.com/spf13/cobra"
+)
+
+func (s *MmctlE2ETestSuite) TestCreateJobCmdF() {
+	s.SetupTestHelper().InitBasic(s.T())
+
+	newCmd := func() *cobra.Command {
+		cmd := &cobra.Command{}
+		cmd.Flags().StringToString("data", nil, "")
+		return cmd
+	}
+
+	s.Run("create a job without permissions", func() {
+		printer.Clean()
+
+		err := createJobCmdF(s.th.Client, newCmd(), []string{model.JobTypeExportProcess})
+		s.Require().EqualError(err, "failed to create job: You do not have the appropriate permissions.")
+		s.Require().Empty(printer.GetLines())
+		s.Require().Empty(printer.GetErrorLines())
+	})
+
+	s.RunForSystemAdminAndLocal("create a job", func(c client.Client) {
+		printer.Clean()
+
+		err := createJobCmdF(c, newCmd(), []string{model.JobTypeExportProcess})
+		s.Require().Nil(err)
+		s.Require().Empty(printer.GetErrorLines())
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(model.JobTypeExportProcess, printer.GetLines()[0].(*model.Job).Type)
+	})
+
+	s.RunForSystemAdminAndLocal("create a job with data", func(c client.Client) {
+		printer.Clean()
+
+		cmd := newCmd()
+		err := cmd.Flags().Set("data", "include_attachments=true")
+		s.Require().NoError(err)
+
+		err = createJobCmdF(c, cmd, []string{model.JobTypeExportProcess})
+		s.Require().Nil(err)
+		s.Require().Empty(printer.GetErrorLines())
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal("true", printer.GetLines()[0].(*model.Job).Data["include_attachments"])
+	})
+}
+
+func (s *MmctlE2ETestSuite) TestShowJobCmdF() {
+	s.SetupTestHelper().InitBasic(s.T())
+
+	job, appErr := s.th.App.CreateJob(s.th.Context, &model.Job{
+		Type: model.JobTypeExportProcess,
+	})
+	s.Require().Nil(appErr)
+
+	s.Run("show a job without permissions", func() {
+		printer.Clean()
+
+		err := showJobCmdF(s.th.Client, &cobra.Command{}, []string{job.Id})
+		s.Require().EqualError(err, "failed to get job: You do not have the appropriate permissions.")
+		s.Require().Empty(printer.GetLines())
+		s.Require().Empty(printer.GetErrorLines())
+	})
+
+	s.RunForSystemAdminAndLocal("show a job that does not exist", func(c client.Client) {
+		printer.Clean()
+
+		err := showJobCmdF(c, &cobra.Command{}, []string{model.NewId()})
+		s.Require().ErrorContains(err, "failed to get job: Unable to get the job.")
+		s.Require().Empty(printer.GetLines())
+		s.Require().Empty(printer.GetErrorLines())
+	})
+
+	s.RunForSystemAdminAndLocal("show a job", func(c client.Client) {
+		printer.Clean()
+
+		err := showJobCmdF(c, &cobra.Command{}, []string{job.Id})
+		s.Require().Nil(err)
+		s.Require().Empty(printer.GetErrorLines())
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(job, printer.GetLines()[0].(*model.Job))
+	})
+}
+
+func (s *MmctlE2ETestSuite) TestCancelJobCmdF() {
+	s.SetupTestHelper().InitBasic(s.T())
+
+	s.Run("cancel a job without permissions", func() {
+		printer.Clean()
+
+		job, appErr := s.th.App.CreateJob(s.th.Context, &model.Job{
+			Type: model.JobTypeExportProcess,
+		})
+		s.Require().Nil(appErr)
+
+		err := cancelJobCmdF(s.th.Client, &cobra.Command{}, []string{job.Id})
+		s.Require().EqualError(err, "failed to cancel job: You do not have the appropriate permissions.")
+		s.Require().Empty(printer.GetLines())
+		s.Require().Empty(printer.GetErrorLines())
+	})
+
+	s.RunForSystemAdminAndLocal("cancel a job that does not exist", func(c client.Client) {
+		printer.Clean()
+
+		err := cancelJobCmdF(c, &cobra.Command{}, []string{model.NewId()})
+		s.Require().ErrorContains(err, "failed to cancel job: Unable to get the job.")
+		s.Require().Empty(printer.GetLines())
+		s.Require().Empty(printer.GetErrorLines())
+	})
+
+	s.RunForSystemAdminAndLocal("cancel a job", func(c client.Client) {
+		printer.Clean()
+
+		job, appErr := s.th.App.CreateJob(s.th.Context, &model.Job{
+			Type: model.JobTypeExportProcess,
+		})
+		s.Require().Nil(appErr)
+
+		time.Sleep(time.Millisecond)
+
+		err := cancelJobCmdF(c, &cobra.Command{}, []string{job.Id})
+		s.Require().Nil(err)
+		s.Require().Empty(printer.GetLines())
+		s.Require().Empty(printer.GetErrorLines())
+
+		// Refresh the job to confirm it was canceled.
+		job, appErr = s.th.App.GetJob(s.th.Context, job.Id)
+		s.Require().Nil(appErr)
+		s.Require().Equal(model.JobStatusCanceled, job.Status)
+	})
+}

--- a/server/cmd/mmctl/commands/job_test.go
+++ b/server/cmd/mmctl/commands/job_test.go
@@ -232,15 +232,26 @@ func (s *MmctlUnitTestSuite) TestCreateJobCmdF() {
 		s.Equal(mockJob, printer.GetLines()[0].(*model.Job))
 	})
 
-	s.Run("create job with invalid type", func() {
+	s.Run("forwards type not in AllJobTypes to the server", func() {
+		// access_control_sync is creatable but absent from model.AllJobTypes,
+		// so the command must not validate against that list and instead let
+		// the server decide.
 		printer.Clean()
+		mockJob := &model.Job{Id: model.NewId(), Type: model.JobTypeAccessControlSync}
 
 		cmd := &cobra.Command{}
 		cmd.Flags().StringToString("data", nil, "")
 
-		err := createJobCmdF(s.client, cmd, []string{"not_a_real_job_type"})
-		s.Require().NotNil(err)
-		s.Empty(printer.GetLines())
+		s.client.
+			EXPECT().
+			CreateJob(context.TODO(), &model.Job{Type: model.JobTypeAccessControlSync, Data: map[string]string{}}).
+			Return(mockJob, &model.Response{}, nil).
+			Times(1)
+
+		err := createJobCmdF(s.client, cmd, []string{model.JobTypeAccessControlSync})
+		s.Require().Nil(err)
+		s.Len(printer.GetLines(), 1)
+		s.Empty(printer.GetErrorLines())
 	})
 
 	s.Run("create job returns server error", func() {

--- a/server/cmd/mmctl/commands/job_test.go
+++ b/server/cmd/mmctl/commands/job_test.go
@@ -5,6 +5,7 @@ package commands
 
 import (
 	"context"
+	"errors"
 
 	"github.com/mattermost/mattermost/server/public/model"
 
@@ -200,5 +201,140 @@ func (s *MmctlUnitTestSuite) TestUpdateJobCmdF() {
 
 		err := updateJobCmdF(s.client, cmd, []string{id, model.JobStatusPending})
 		s.Require().Nil(err)
+	})
+}
+
+func (s *MmctlUnitTestSuite) TestCreateJobCmdF() {
+	s.Run("create job with data", func() {
+		printer.Clean()
+		data := map[string]string{"batch_size": "1000"}
+		mockJob := &model.Job{
+			Id:   model.NewId(),
+			Type: model.JobTypeMessageExport,
+			Data: data,
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().StringToString("data", data, "")
+
+		s.client.
+			EXPECT().
+			CreateJob(context.TODO(), &model.Job{Type: model.JobTypeMessageExport, Data: data}).
+			Return(mockJob, &model.Response{}, nil).
+			Times(1)
+
+		err := createJobCmdF(s.client, cmd, []string{model.JobTypeMessageExport})
+		s.Require().Nil(err)
+		s.Len(printer.GetLines(), 1)
+		s.Empty(printer.GetErrorLines())
+		s.Equal(mockJob, printer.GetLines()[0].(*model.Job))
+	})
+
+	s.Run("create job with invalid type", func() {
+		printer.Clean()
+
+		cmd := &cobra.Command{}
+		cmd.Flags().StringToString("data", nil, "")
+
+		err := createJobCmdF(s.client, cmd, []string{"not_a_real_job_type"})
+		s.Require().NotNil(err)
+		s.Empty(printer.GetLines())
+	})
+
+	s.Run("create job returns server error", func() {
+		printer.Clean()
+
+		cmd := &cobra.Command{}
+		cmd.Flags().StringToString("data", nil, "")
+
+		s.client.
+			EXPECT().
+			CreateJob(context.TODO(), &model.Job{Type: model.JobTypeLdapSync, Data: map[string]string{}}).
+			Return(nil, &model.Response{}, errors.New("some-error")).
+			Times(1)
+
+		err := createJobCmdF(s.client, cmd, []string{model.JobTypeLdapSync})
+		s.Require().NotNil(err)
+		s.Empty(printer.GetLines())
+	})
+}
+
+func (s *MmctlUnitTestSuite) TestJobTypeCompletionF() {
+	s.Run("suggests all job types for the first argument", func() {
+		suggestions, directive := jobTypeCompletionF(&cobra.Command{}, []string{}, "")
+		s.Equal(cobra.ShellCompDirectiveNoFileComp, directive)
+		s.ElementsMatch(model.AllJobTypes[:], suggestions)
+	})
+
+	s.Run("suggests nothing once the type is provided", func() {
+		suggestions, directive := jobTypeCompletionF(&cobra.Command{}, []string{model.JobTypeLdapSync}, "")
+		s.Equal(cobra.ShellCompDirectiveNoFileComp, directive)
+		s.Empty(suggestions)
+	})
+}
+
+func (s *MmctlUnitTestSuite) TestShowJobCmdF() {
+	s.Run("show job", func() {
+		printer.Clean()
+		id := model.NewId()
+		mockJob := &model.Job{Id: id}
+
+		s.client.
+			EXPECT().
+			GetJob(context.TODO(), id).
+			Return(mockJob, &model.Response{}, nil).
+			Times(1)
+
+		err := showJobCmdF(s.client, &cobra.Command{}, []string{id})
+		s.Require().Nil(err)
+		s.Len(printer.GetLines(), 1)
+		s.Empty(printer.GetErrorLines())
+		s.Equal(mockJob, printer.GetLines()[0].(*model.Job))
+	})
+
+	s.Run("show job with invalid ID", func() {
+		printer.Clean()
+
+		err := showJobCmdF(s.client, &cobra.Command{}, []string{"invalid-id"})
+		s.Require().NotNil(err)
+		s.Empty(printer.GetLines())
+	})
+}
+
+func (s *MmctlUnitTestSuite) TestCancelJobCmdF() {
+	s.Run("cancel job", func() {
+		printer.Clean()
+		id := model.NewId()
+
+		s.client.
+			EXPECT().
+			CancelJob(context.TODO(), id).
+			Return(&model.Response{}, nil).
+			Times(1)
+
+		err := cancelJobCmdF(s.client, &cobra.Command{}, []string{id})
+		s.Require().Nil(err)
+		s.Empty(printer.GetErrorLines())
+	})
+
+	s.Run("cancel job with invalid ID", func() {
+		printer.Clean()
+
+		err := cancelJobCmdF(s.client, &cobra.Command{}, []string{"invalid-id"})
+		s.Require().NotNil(err)
+	})
+
+	s.Run("cancel job returns server error", func() {
+		printer.Clean()
+		id := model.NewId()
+
+		s.client.
+			EXPECT().
+			CancelJob(context.TODO(), id).
+			Return(&model.Response{}, errors.New("some-error")).
+			Times(1)
+
+		err := cancelJobCmdF(s.client, &cobra.Command{}, []string{id})
+		s.Require().NotNil(err)
 	})
 }

--- a/server/cmd/mmctl/commands/job_test.go
+++ b/server/cmd/mmctl/commands/job_test.go
@@ -233,9 +233,6 @@ func (s *MmctlUnitTestSuite) TestCreateJobCmdF() {
 	})
 
 	s.Run("forwards type not in AllJobTypes to the server", func() {
-		// access_control_sync is creatable but absent from model.AllJobTypes,
-		// so the command must not validate against that list and instead let
-		// the server decide.
 		printer.Clean()
 		mockJob := &model.Job{Id: model.NewId(), Type: model.JobTypeAccessControlSync}
 

--- a/server/cmd/mmctl/commands/job_test.go
+++ b/server/cmd/mmctl/commands/job_test.go
@@ -215,7 +215,9 @@ func (s *MmctlUnitTestSuite) TestCreateJobCmdF() {
 		}
 
 		cmd := &cobra.Command{}
-		cmd.Flags().StringToString("data", data, "")
+		cmd.Flags().StringToString("data", nil, "")
+		err := cmd.Flags().Set("data", "batch_size=1000")
+		s.Require().NoError(err)
 
 		s.client.
 			EXPECT().
@@ -223,7 +225,7 @@ func (s *MmctlUnitTestSuite) TestCreateJobCmdF() {
 			Return(mockJob, &model.Response{}, nil).
 			Times(1)
 
-		err := createJobCmdF(s.client, cmd, []string{model.JobTypeMessageExport})
+		err = createJobCmdF(s.client, cmd, []string{model.JobTypeMessageExport})
 		s.Require().Nil(err)
 		s.Len(printer.GetLines(), 1)
 		s.Empty(printer.GetErrorLines())

--- a/server/cmd/mmctl/docs/mmctl_job.rst
+++ b/server/cmd/mmctl/docs/mmctl_job.rst
@@ -37,6 +37,9 @@ SEE ALSO
 ~~~~~~~~
 
 * `mmctl <mmctl.rst>`_ 	 - Remote client for the Open Source, self-hosted Slack-alternative
+* `mmctl job cancel <mmctl_job_cancel.rst>`_ 	 - Cancel a job
+* `mmctl job create <mmctl_job_create.rst>`_ 	 - Create a new job
 * `mmctl job list <mmctl_job_list.rst>`_ 	 - List the latest jobs
+* `mmctl job show <mmctl_job_show.rst>`_ 	 - Show a job
 * `mmctl job update <mmctl_job_update.rst>`_ 	 - Update the status of a job
 

--- a/server/cmd/mmctl/docs/mmctl_job_cancel.rst
+++ b/server/cmd/mmctl/docs/mmctl_job_cancel.rst
@@ -1,42 +1,33 @@
-.. _mmctl_job_list:
+.. _mmctl_job_cancel:
 
-mmctl job list
---------------
+mmctl job cancel
+----------------
 
-List the latest jobs
+Cancel a job
 
 Synopsis
 ~~~~~~~~
 
 
-List the latest jobs
+Cancel a job
 
 ::
 
-  mmctl job list [flags]
+  mmctl job cancel [job] [flags]
 
 Examples
 ~~~~~~~~
 
 ::
 
-    job list
-  	job list --ids jobID1,jobID2
-  	job list --type ldap_sync --status success
-  	job list --type ldap_sync --status success --page 0 --per-page 10
+    job cancel jobID
 
 Options
 ~~~~~~~
 
 ::
 
-      --all             Fetch all jobs. --page flag will be ignored if provided
-  -h, --help            help for list
-      --ids strings     Comma-separated list of job IDs to which the operation will be applied. All other flags are ignored
-      --page int        Page number to fetch for the list of jobs
-      --per-page int    Number of jobs to be fetched (default 5)
-      --status string   Filter by job status
-      --type string     Filter by job type
+  -h, --help   help for cancel
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/server/cmd/mmctl/docs/mmctl_job_create.rst
+++ b/server/cmd/mmctl/docs/mmctl_job_create.rst
@@ -1,42 +1,36 @@
-.. _mmctl_job_list:
+.. _mmctl_job_create:
 
-mmctl job list
---------------
+mmctl job create
+----------------
 
-List the latest jobs
+Create a new job
 
 Synopsis
 ~~~~~~~~
 
 
-List the latest jobs
+Create a new job of the given type. Use --data to pass type-specific options as key=value pairs.
 
 ::
 
-  mmctl job list [flags]
+  mmctl job create [type] [flags]
 
 Examples
 ~~~~~~~~
 
 ::
 
-    job list
-  	job list --ids jobID1,jobID2
-  	job list --type ldap_sync --status success
-  	job list --type ldap_sync --status success --page 0 --per-page 10
+    job create ldap_sync
+  	job create data_retention
+  	job create message_export --data batch_size=1000
 
 Options
 ~~~~~~~
 
 ::
 
-      --all             Fetch all jobs. --page flag will be ignored if provided
-  -h, --help            help for list
-      --ids strings     Comma-separated list of job IDs to which the operation will be applied. All other flags are ignored
-      --page int        Page number to fetch for the list of jobs
-      --per-page int    Number of jobs to be fetched (default 5)
-      --status string   Filter by job status
-      --type string     Filter by job type
+      --data stringToString   Comma-separated list of key=value pairs passed to the job as type-specific options (default [])
+  -h, --help                  help for create
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/server/cmd/mmctl/docs/mmctl_job_show.rst
+++ b/server/cmd/mmctl/docs/mmctl_job_show.rst
@@ -1,42 +1,33 @@
-.. _mmctl_job_list:
+.. _mmctl_job_show:
 
-mmctl job list
+mmctl job show
 --------------
 
-List the latest jobs
+Show a job
 
 Synopsis
 ~~~~~~~~
 
 
-List the latest jobs
+Show a job
 
 ::
 
-  mmctl job list [flags]
+  mmctl job show [job] [flags]
 
 Examples
 ~~~~~~~~
 
 ::
 
-    job list
-  	job list --ids jobID1,jobID2
-  	job list --type ldap_sync --status success
-  	job list --type ldap_sync --status success --page 0 --per-page 10
+    job show jobID
 
 Options
 ~~~~~~~
 
 ::
 
-      --all             Fetch all jobs. --page flag will be ignored if provided
-  -h, --help            help for list
-      --ids strings     Comma-separated list of job IDs to which the operation will be applied. All other flags are ignored
-      --page int        Page number to fetch for the list of jobs
-      --per-page int    Number of jobs to be fetched (default 5)
-      --status string   Filter by job status
-      --type string     Filter by job type
+  -h, --help   help for show
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
#### Summary
This PR adds three new job management commands to mmctl:
- `mmctl job create [type]` - Create a new job of a specified type with optional type-specific data parameters
- `mmctl job show [job]` - Display details of a specific job
- `mmctl job cancel [job]` - Cancel a running job

The implementation includes:
- Command definitions with proper argument validation and shell completion support (including job-type completion for `create`)
- Command handler functions with error handling and validation
- Comprehensive unit tests covering success and error scenarios
- Documentation files for the new commands
- Minor documentation updates to existing job list command (changed "import jobs" to "jobs")

This PR is intentionally scoped to the **mmctl client** only.

`job create` no longer validates the job type against `model.AllJobTypes` client-side: that list is a curated subset and omits creatable types (e.g. `access_control_sync`), so validation is left to the server, which returns a clear error for anything it can't schedule.

#### Follow-up
While testing `mmctl job show` we found that several internal job types can't be read or managed through the jobs API at all (even for system admins / over the local socket), because their types aren't mapped in the server-side permission checks — and that `model.AllJobTypes` is a stale, dual-purpose list. Those are pre-existing server-side issues and are tracked separately in **MM-69559**; they are deliberately not addressed here.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-69704

#### Release Note
```release-note
Added new mmctl commands: `job create` to create jobs with type-specific options, `job show` to display job details, and `job cancel` to cancel running jobs.
```

https://claude.ai/code/session_016PPSJWjdwv5Eearabtt2UQ


## Change Impact: Medium 🟡

**Regression Risk:** The change is primarily limited to the `mmctl job` CLI by adding new `create/show/cancel` subcommands and updating completion/help text, but it also alters client-side behavior by removing local job-type validation in favor of server-side validation. New code paths (argument parsing, `--data` handling, and completion fetching) could introduce regressions if edge-case inputs or API/format assumptions differ from expectations.  

**QA Recommendation:** Light manual QA is recommended to validate end-to-end command wiring for create/show/cancel (including `--data` parsing) and shell completion behavior; automated unit tests already cover core success/error paths.
  
*Generated by CodeRabbitAI*
