### PR TITLE
Fix flaky TestUserHasJoinedChannel

### DIFF
--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -2855,7 +2855,8 @@ func assertHookPostExists(t *testing.T, th *TestHelper, channelID, expectedMessa
 	t.Helper()
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		posts, appErr := th.App.GetPosts(th.Context, channelID, 0, 30)
+		// Page size 31 bypasses postLastPostsCache (only 30/60 are cached).
+		posts, appErr := th.App.GetPosts(th.Context, channelID, 0, 31)
 		if !assert.Nil(c, appErr) {
 			return
 		}


### PR DESCRIPTION
#### Summary
Fix flake in `TestUserHasJoinedChannel` (`github.com/mattermost/mattermost/server/v8/channels/app`). Tests-only change — no production behavior changes.

**Root cause:** `assertHookPostExists` polls `GetPosts` with a page size of 30, which is served from `postLastPostsCache`. The `UserHasJoinedChannel` hook runs asynchronously and creates its verification post via plugin RPC. Under `ENABLE_FULLY_PARALLEL_TESTS`, a poll can miss the hook post on a cache miss, then cache the incomplete page after `InvalidateLastPostTimeCache` runs but before the hook post is visible — subsequent polls keep reading the stale cached page until the 30s `Eventually` window expires.

**Fix:** Use page size 31 in `assertHookPostExists` so `GetPosts` bypasses `postLastPostsCache` (only limits 30 and 60 are cached). Hook message assertions are unchanged.

**Verification:**
- `ENABLE_FULLY_PARALLEL_TESTS=true go test -parallel 8 -run '^TestUserHasJoinedChannel$' -race -count=100 -timeout=30m ./channels/app` — 100/100 green locally.
- Reproduced the original failure on master before applying the fix (3/100 with the same flags: `expected hook post ... not found` after ~33s).

**Originally introduced in:** 03f2eaaa0b by cpoile ([MM-68400] Four plugin hooks and ChannelGuard enforcement (#36152)).

previous fix: https://github.com/mattermost/mattermost/pull/37273 (insufficient — flake still reproduces under fully parallel CI)

cc @marianunez

#### Ticket Link
Flaky test reported here: https://github.com/mattermost/mattermost/pull/37285

#### Screenshots
N/A — tests-only change.

```release-note
NONE
```

[MM-68400]: https://mattermost.atlassian.net/browse/MM-68400?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** This is a narrowly scoped test-only adjustment in a single helper, with no production logic, APIs, persistence, or auth flows affected. The blast radius is limited to flaky test execution behavior, and the rollback path is straightforward.

**QA Recommendation:** Minimal manual QA is needed; rely on the existing automated test coverage and targeted repeated test runs if additional confidence is desired.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->