### PR TITLE
Bump prepackaged Agents plugin to v2.4.2

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -165,7 +165,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.1
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.10.0
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.1
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.2
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0-rc2
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.6.1
@@ -179,7 +179,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.10.0%2B090a26d-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.1%2Bad98a52-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.2%2B1305067-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0-rc2%2B5880c13-fips
 endif
 


### PR DESCRIPTION
Bumps `mattermost-plugin-agents` from v2.4.1 to v2.4.2 (standard and FIPS) in `server/Makefile`.

Release: https://github.com/mattermost/mattermost-plugin-agents/releases/tag/v2.4.2

Intended to be cherry-picked to release-11.9.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** This is an isolated package-version bump in `server/Makefile` with no changes to runtime logic, shared utilities, or user-facing behavior. The main risk is limited to plugin packaging/artifact resolution during builds.

**QA Recommendation:** Minimal manual QA is needed; verify the standard and FIPS build/package steps resolve the updated plugin artifacts successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->