### PR TITLE
feat: add recovery mechanism for removed devices in push notifications

### DIFF
--- a/server/channels/app/expirynotify.go
+++ b/server/channels/app/expirynotify.go
@@ -56,7 +56,7 @@ func (a *App) NotifySessionsExpired() error {
 			mlog.String("post_id", msg.PostId),
 		))
 
-		errPush := a.sendToPushProxy(rctx, tmpMessage, session)
+		errPush := a.sendToPushProxy(rctx, tmpMessage, session, false)
 		if errPush != nil {
 			reason := model.NotificationReasonPushProxySendError
 			if errPush.Error() == notificationErrorRemoveDevice {

--- a/server/channels/app/notification_push.go
+++ b/server/channels/app/notification_push.go
@@ -52,23 +52,24 @@ type PushNotificationsHub struct {
 }
 
 type PushNotification struct {
-	notificationType   notificationType
-	currentSessionId   string
-	userID             string
-	channelID          string
-	rootID             string
-	post               *model.Post
-	user               *model.User
-	channel            *model.Channel
-	senderName         string
-	channelName        string
-	explicitMention    bool
-	channelWideMention bool
-	replyToThreadType  string
+	notificationType     notificationType
+	forTestNotification  bool
+	currentSessionId     string
+	userID               string
+	channelID            string
+	rootID               string
+	post                 *model.Post
+	user                 *model.User
+	channel              *model.Channel
+	senderName           string
+	channelName          string
+	explicitMention      bool
+	channelWideMention   bool
+	replyToThreadType    string
 }
 
 func (a *App) sendPushNotificationSync(rctx request.CTX, post *model.Post, user *model.User, channel *model.Channel, channelName string, senderName string,
-	explicitMention bool, channelWideMention bool, replyToThreadType string,
+	explicitMention bool, channelWideMention bool, replyToThreadType string, forTestNotification bool,
 ) *model.AppError {
 	cfg := a.Config()
 	msg, appErr := a.BuildPushNotificationMessage(
@@ -87,10 +88,10 @@ func (a *App) sendPushNotificationSync(rctx request.CTX, post *model.Post, user 
 		return appErr
 	}
 
-	return a.sendPushNotificationToAllSessions(rctx, msg, user.Id, "")
+	return a.sendPushNotificationToAllSessions(rctx, msg, user.Id, "", forTestNotification)
 }
 
-func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.PushNotification, userID string, skipSessionId string) *model.AppError {
+func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.PushNotification, userID string, skipSessionId string, forTestNotification bool) *model.AppError {
 	rejectionReason := ""
 
 	if msg == nil {
@@ -146,7 +147,7 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 		return nil
 	}
 
-	sessions, appErr := a.getMobileAppSessions(userID)
+	sessions, appErr := a.getMobileAppSessions(userID, forTestNotification)
 	if appErr != nil {
 		a.CountNotificationReason(model.NotificationStatusError, model.NotificationTypePush, model.NotificationReasonFetchError, model.NotificationNoPlatform)
 		rctx.Logger().LogM(mlog.MlvlNotificationError, "Failed to send mobile app sessions",
@@ -177,8 +178,12 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 		// We made a copy to avoid decoding and parsing all the time
 		tmpMessage := msg.DeepCopy()
 
-		standardUsable := session.DeviceId != "" && session.Props[model.SessionPropLastRemovedDeviceId] != session.DeviceId
-		voIPUsable := session.VoIPDeviceId != "" && session.Props[model.SessionPropLastRemovedVoIPDeviceId] != session.VoIPDeviceId
+		standardUsable := session.DeviceId != ""
+		voIPUsable := session.VoIPDeviceId != ""
+		if !forTestNotification {
+			standardUsable = standardUsable && session.Props[model.SessionPropLastRemovedDeviceId] != session.DeviceId
+			voIPUsable = voIPUsable && session.Props[model.SessionPropLastRemovedVoIPDeviceId] != session.VoIPDeviceId
+		}
 
 		var deviceId string
 		if tmpMessage.Transport == model.PushTransportVoIP {
@@ -225,7 +230,7 @@ func (a *App) sendPushNotificationToAllSessions(rctx request.CTX, msg *model.Pus
 		}
 		tmpMessage.Signature = signature
 
-		err = a.sendToPushProxy(rctx, tmpMessage, session)
+		err = a.sendToPushProxy(rctx, tmpMessage, session, forTestNotification)
 		if err != nil {
 			reason := model.NotificationReasonPushProxySendError
 			if err.Error() == notificationErrorRemoveDevice {
@@ -285,9 +290,12 @@ func (a *App) sendPushNotification(notification *PostNotification, user *model.U
 	channelName := notification.GetChannelName(nameFormat, user.Id)
 	senderName := notification.GetSenderName(nameFormat, *cfg.ServiceSettings.EnablePostUsernameOverride)
 
+	forTestNotification := post.GetProp(model.PostPropsTestNotification) != nil && post.GetProp(model.PostPropsTestNotification) != ""
+
 	select {
 	case a.Srv().PushNotificationsHub.notificationsChan <- PushNotification{
-		notificationType:   notificationTypeMessage,
+		notificationType:    notificationTypeMessage,
+		forTestNotification: forTestNotification,
 		post:               post,
 		user:               user,
 		channel:            channel,
@@ -393,7 +401,7 @@ func (a *App) clearPushNotificationSync(rctx request.CTX, currentSessionId, user
 		IsCRTEnabled:     isCRTEnabled,
 	}
 
-	return a.sendPushNotificationToAllSessions(rctx, msg, userID, currentSessionId)
+	return a.sendPushNotificationToAllSessions(rctx, msg, userID, currentSessionId, false)
 }
 
 func (a *App) clearPushNotification(currentSessionId, userID, channelID, rootID string) {
@@ -423,7 +431,7 @@ func (a *App) updateMobileAppBadgeSync(rctx request.CTX, userID string) *model.A
 		ContentAvailable: 1,
 		Badge:            badgeCount,
 	}
-	return a.sendPushNotificationToAllSessions(rctx, msg, userID, "")
+	return a.sendPushNotificationToAllSessions(rctx, msg, userID, "", false)
 }
 
 func (a *App) UpdateMobileAppBadge(userID string) {
@@ -491,6 +499,7 @@ func (hub *PushNotificationsHub) start(rctx request.CTX) {
 						notification.explicitMention,
 						notification.channelWideMention,
 						notification.replyToThreadType,
+						notification.forTestNotification,
 					)
 				case notificationTypeUpdateBadge:
 					err = hub.app.updateMobileAppBadgeSync(rctx, notification.userID)
@@ -567,7 +576,7 @@ func (a *App) rawSendToPushProxy(msg *model.PushNotification) (model.PushRespons
 	return pushResponse, nil
 }
 
-func (a *App) sendToPushProxy(rctx request.CTX, msg *model.PushNotification, session *model.Session) error {
+func (a *App) sendToPushProxy(rctx request.CTX, msg *model.PushNotification, session *model.Session, recoverRemovedDeviceOnSuccess bool) error {
 	msg.ServerId = a.ServerId()
 
 	rctx.Logger().LogM(mlog.MlvlNotificationTrace, "Notification will be sent",
@@ -601,7 +610,75 @@ func (a *App) sendToPushProxy(rctx request.CTX, msg *model.PushNotification, ses
 	case model.PushStatusFail:
 		return errors.New(pushResponse[model.PushStatusErrorMsg])
 	}
+
+	if recoverRemovedDeviceOnSuccess {
+		a.recoverRemovedDeviceFromSession(rctx, session, msg)
+	}
 	return nil
+}
+
+func (a *App) recoverRemovedDeviceFromSession(rctx request.CTX, session *model.Session, msg *model.PushNotification) {
+	removedProp := model.SessionPropLastRemovedDeviceId
+	deviceID := session.DeviceId
+	if msg.Transport == model.PushTransportVoIP {
+		removedProp = model.SessionPropLastRemovedVoIPDeviceId
+		deviceID = session.VoIPDeviceId
+	}
+
+	if deviceID == "" || session.Props[removedProp] != deviceID {
+		return
+	}
+
+	appErr := a.SetExtraSessionProps(session, map[string]string{
+		removedProp: "",
+	})
+	if appErr != nil {
+		rctx.Logger().Error("Failed to recover session device after successful test notification",
+			mlog.String("user_id", session.UserId),
+			mlog.String("session_id", session.Id),
+			mlog.String("deviceId", model.RedactDeviceId(deviceID)),
+			mlog.Err(appErr),
+		)
+		return
+	}
+
+	a.ClearSessionCacheForUser(session.UserId)
+	rctx.Logger().Info("Recovered session device from last_removed state after successful test notification",
+		mlog.String("user_id", session.UserId),
+		mlog.String("session_id", session.Id),
+		mlog.String("deviceId", model.RedactDeviceId(deviceID)),
+		mlog.String("transport", string(msg.Transport)),
+	)
+}
+
+func (a *App) recoverRemovedDeviceForTestPush(rctx request.CTX, userID, deviceID string) {
+	sessions, appErr := a.getMobileAppSessions(userID, true)
+	if appErr != nil {
+		rctx.Logger().Error("Failed to get mobile app sessions while recovering device from test push",
+			mlog.String("user_id", userID),
+			mlog.String("deviceId", model.RedactDeviceId(deviceID)),
+			mlog.Err(appErr),
+		)
+		return
+	}
+
+	msg := &model.PushNotification{
+		Transport: model.PushTransportStandard,
+	}
+	msg.SetDeviceIdAndPlatform(deviceID)
+
+	for _, session := range sessions {
+		if session.DeviceId == deviceID {
+			a.recoverRemovedDeviceFromSession(rctx, session, msg)
+		}
+		if session.VoIPDeviceId == deviceID {
+			voIPMsg := &model.PushNotification{
+				Transport: model.PushTransportVoIP,
+			}
+			voIPMsg.SetDeviceIdAndPlatform(deviceID)
+			a.recoverRemovedDeviceFromSession(rctx, session, voIPMsg)
+		}
+	}
 }
 
 func (a *App) SendAckToPushProxy(rctx request.CTX, ack *model.PushNotificationAck) error {
@@ -650,8 +727,14 @@ func (a *App) SendAckToPushProxy(rctx request.CTX, ack *model.PushNotificationAc
 	return err
 }
 
-func (a *App) getMobileAppSessions(userID string) ([]*model.Session, *model.AppError) {
-	sessions, err := a.Srv().Store().Session().GetSessionsWithActiveDeviceIds(userID)
+func (a *App) getMobileAppSessions(userID string, forTestNotification bool) ([]*model.Session, *model.AppError) {
+	var sessions []*model.Session
+	var err error
+	if forTestNotification {
+		sessions, err = a.Srv().Store().Session().GetSessionsWithActiveDeviceIdsForTestNotifications(userID)
+	} else {
+		sessions, err = a.Srv().Store().Session().GetSessionsWithActiveDeviceIds(userID)
+	}
 	if err != nil {
 		return nil, model.NewAppError("getMobileAppSessions", "app.session.get_sessions.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -845,6 +928,10 @@ func (a *App) SendTestPushNotification(rctx request.CTX, deviceId string) string
 			mlog.Err(errors.New(pushResponse[model.PushStatusErrorMsg])),
 		)
 		return "unknown"
+	}
+
+	if session := rctx.Session(); session != nil {
+		a.recoverRemovedDeviceForTestPush(rctx, session.UserId, deviceId)
 	}
 
 	return "true"

--- a/server/channels/app/notification_push_test.go
+++ b/server/channels/app/notification_push_test.go
@@ -1095,11 +1095,11 @@ func TestSendPushNotifications(t *testing.T) {
 	require.Nil(t, err)
 
 	t.Run("should return error if data is not valid or nil", func(t *testing.T) {
-		err := th.App.sendPushNotificationToAllSessions(th.Context, nil, th.BasicUser.Id, "")
+		err := th.App.sendPushNotificationToAllSessions(th.Context, nil, th.BasicUser.Id, "", false)
 		require.NotNil(t, err)
 		assert.Equal(t, "api.push_notifications.message.parse.app_error", err.Id)
 		// Errors derived of using an empty object are handled internally through the notifications log
-		err = th.App.sendPushNotificationToAllSessions(th.Context, &model.PushNotification{}, th.BasicUser.Id, "")
+		err = th.App.sendPushNotificationToAllSessions(th.Context, &model.PushNotification{}, th.BasicUser.Id, "", false)
 		require.Nil(t, err)
 	})
 }
@@ -1211,7 +1211,7 @@ func TestSendPushNotificationsTransportRouting(t *testing.T) {
 				SubType:   model.PushSubTypeCalls,
 				Transport: tc.transport,
 			}
-			appErr := th.App.sendPushNotificationToAllSessions(th.Context, msg, th.BasicUser.Id, "")
+			appErr := th.App.sendPushNotificationToAllSessions(th.Context, msg, th.BasicUser.Id, "", false)
 			require.Nil(t, appErr)
 
 			if !tc.expectSent {
@@ -1258,7 +1258,7 @@ func TestSendPushNotificationsVoIPRemoveTracking(t *testing.T) {
 		SubType:   model.PushSubTypeCalls,
 		Transport: model.PushTransportVoIP,
 	}
-	appErr := th.App.sendPushNotificationToAllSessions(th.Context, msg, th.BasicUser.Id, "")
+	appErr := th.App.sendPushNotificationToAllSessions(th.Context, msg, th.BasicUser.Id, "", false)
 	require.Nil(t, appErr)
 
 	require.Eventually(t, func() bool {
@@ -1278,7 +1278,7 @@ func TestSendPushNotificationsVoIPRemoveTracking(t *testing.T) {
 		SubType:   model.PushSubTypeCalls,
 		Transport: model.PushTransportVoIP,
 	}
-	appErr = th.App.sendPushNotificationToAllSessions(th.Context, msg2, th.BasicUser.Id, "")
+	appErr = th.App.sendPushNotificationToAllSessions(th.Context, msg2, th.BasicUser.Id, "", false)
 	require.Nil(t, appErr)
 
 	require.Eventually(t, func() bool {
@@ -1642,6 +1642,109 @@ func TestSendTestPushNotification(t *testing.T) {
 	require.Equal(t, 2, handler.numReqs())
 	assert.Equal(t, model.PushTypeTest, handler.notifications()[0].Type)
 	assert.Equal(t, model.PushTypeTest, handler.notifications()[1].Type)
+}
+
+func TestSendPushNotificationToAllSessionsRecoversRemovedDeviceOnTestNotification(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	const deviceToken = model.PushNotifyAppleReactNative + ":removedtoken"
+
+	handler := &testPushNotificationHandler{t: t, behavior: "simple"}
+	pushServer := httptest.NewServer(http.HandlerFunc(handler.handleReq))
+	defer pushServer.Close()
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.EmailSettings.PushNotificationServer = pushServer.URL
+	})
+
+	session, appErr := th.App.CreateSession(th.Context, &model.Session{
+		UserId:    th.BasicUser.Id,
+		DeviceId:  deviceToken,
+		ExpiresAt: model.GetMillis() + 100000,
+		Props: map[string]string{
+			model.SessionPropLastRemovedDeviceId: deviceToken,
+		},
+	})
+	require.Nil(t, appErr)
+
+	msg := &model.PushNotification{
+		Type: model.PushTypeMessage,
+	}
+	appErr = th.App.sendPushNotificationToAllSessions(th.Context, msg, th.BasicUser.Id, "", true)
+	require.Nil(t, appErr)
+
+	updatedSession, err := th.App.Srv().Store().Session().Get(th.Context, session.Id)
+	require.NoError(t, err)
+	require.Empty(t, updatedSession.Props[model.SessionPropLastRemovedDeviceId])
+}
+
+func TestSendPushNotificationToAllSessionsDoesNotRecoverRemovedDeviceForRegularNotifications(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	const deviceToken = model.PushNotifyAppleReactNative + ":removedtoken"
+
+	handler := &testPushNotificationHandler{t: t, behavior: "simple"}
+	pushServer := httptest.NewServer(http.HandlerFunc(handler.handleReq))
+	defer pushServer.Close()
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.EmailSettings.PushNotificationServer = pushServer.URL
+	})
+
+	session, appErr := th.App.CreateSession(th.Context, &model.Session{
+		UserId:    th.BasicUser.Id,
+		DeviceId:  deviceToken,
+		ExpiresAt: model.GetMillis() + 100000,
+		Props: map[string]string{
+			model.SessionPropLastRemovedDeviceId: deviceToken,
+		},
+	})
+	require.Nil(t, appErr)
+
+	msg := &model.PushNotification{
+		Type: model.PushTypeMessage,
+	}
+	appErr = th.App.sendPushNotificationToAllSessions(th.Context, msg, th.BasicUser.Id, "", false)
+	require.Nil(t, appErr)
+
+	updatedSession, err := th.App.Srv().Store().Session().Get(th.Context, session.Id)
+	require.NoError(t, err)
+	require.Equal(t, deviceToken, updatedSession.Props[model.SessionPropLastRemovedDeviceId])
+	assert.Empty(t, handler.notifications())
+}
+
+func TestSendTestPushNotificationRecoversRemovedDevice(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	const deviceToken = model.PushNotifyAppleReactNative + ":testtoken"
+
+	handler := &testPushNotificationHandler{t: t, behavior: "simple"}
+	pushServer := httptest.NewServer(http.HandlerFunc(handler.handleReq))
+	defer pushServer.Close()
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.EmailSettings.PushNotificationServer = pushServer.URL
+	})
+
+	session, appErr := th.App.CreateSession(th.Context, &model.Session{
+		UserId:    th.BasicUser.Id,
+		DeviceId:  deviceToken,
+		ExpiresAt: model.GetMillis() + 100000,
+		Props: map[string]string{
+			model.SessionPropLastRemovedDeviceId: deviceToken,
+		},
+	})
+	require.Nil(t, appErr)
+
+	result := th.App.SendTestPushNotification(th.Context.WithSession(session), deviceToken)
+	assert.Equal(t, "true", result)
+
+	updatedSession, err := th.App.Srv().Store().Session().Get(th.Context, session.Id)
+	require.NoError(t, err)
+	require.Empty(t, updatedSession.Props[model.SessionPropLastRemovedDeviceId])
 }
 
 func TestSendAckToPushProxy(t *testing.T) {

--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -1490,7 +1490,7 @@ func (api *PluginAPI) GetUploadSession(uploadID string) (*model.UploadSession, e
 
 func (api *PluginAPI) SendPushNotification(notification *model.PushNotification, userID string) *model.AppError {
 	// Ignoring skipSessionId because it's only used internally to clear push notifications
-	return api.app.sendPushNotificationToAllSessions(api.ctx, notification, userID, "")
+	return api.app.sendPushNotificationToAllSessions(api.ctx, notification, userID, "", false)
 }
 
 func (api *PluginAPI) RegisterPluginForSharedChannels(opts model.RegisterPluginOpts) (remoteID string, err error) {

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -1711,7 +1711,7 @@ func TestHookNotificationWillBePushedTransportPreserved(t *testing.T) {
 				SubType:   model.PushSubTypeCalls,
 				Transport: model.PushTransportVoIP,
 			}
-			appErr := th.App.sendPushNotificationToAllSessions(th.Context, msg, th.BasicUser.Id, "")
+			appErr := th.App.sendPushNotificationToAllSessions(th.Context, msg, th.BasicUser.Id, "", false)
 			require.Nil(t, appErr)
 
 			require.Eventually(t, func() bool {

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -3315,6 +3315,7 @@ func (a *App) SendTestMessage(rctx request.CTX, userID string) (*model.Post, *mo
 		Type:      model.PostTypeDefault,
 		UserId:    bot.UserId,
 	}
+	post.AddProp(model.PostPropsTestNotification, model.NewId())
 
 	// We don't check the preview membership because the test message does not send a link to a different post.
 	post, _, err = a.CreatePost(rctx, post, channel, model.CreatePostFlags{ForceNotification: true})

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -12978,6 +12978,27 @@ func (s *RetryLayerSessionStore) GetSessionsWithActiveDeviceIds(userID string) (
 
 }
 
+func (s *RetryLayerSessionStore) GetSessionsWithActiveDeviceIdsForTestNotifications(userID string) ([]*model.Session, error) {
+
+	tries := 0
+	for {
+		result, err := s.SessionStore.GetSessionsWithActiveDeviceIdsForTestNotifications(userID)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerSessionStore) PermanentDeleteSessionsByUser(teamID string) error {
 
 	tries := 0

--- a/server/channels/store/sqlstore/session_store.go
+++ b/server/channels/store/sqlstore/session_store.go
@@ -204,6 +204,28 @@ func (me SqlSessionStore) GetSessionsWithActiveDeviceIds(userId string) ([]*mode
 	return sessions, nil
 }
 
+func (me SqlSessionStore) GetSessionsWithActiveDeviceIdsForTestNotifications(userId string) ([]*model.Session, error) {
+	now := model.GetMillis()
+
+	// Same as GetSessionsWithActiveDeviceIds but includes sessions whose device
+	// tokens were previously marked removed so test notifications can attempt recovery.
+	builder := me.sessionSelectQuery.
+		Where(sq.Eq{"UserId": userId}).
+		Where(sq.NotEq{"ExpiresAt": 0}).
+		Where(sq.GtOrEq{"ExpiresAt": now}).
+		Where(sq.Or{
+			sq.NotEq{"DeviceId": ""},
+			sq.NotEq{"VoIPDeviceId": ""},
+		})
+
+	sessions := []*model.Session{}
+
+	if err := me.GetReplica().SelectBuilder(&sessions, builder); err != nil {
+		return nil, errors.Wrapf(err, "failed to find Sessions with userId=%s for test notifications", userId)
+	}
+	return sessions, nil
+}
+
 func (me SqlSessionStore) GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error) {
 	builder := me.sessionSelectQuery.
 		Where(sq.NotEq{"DeviceId": ""}).

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -550,6 +550,7 @@ type SessionStore interface {
 	GetLRUSessions(rctx request.CTX, userID string, limit uint64, offset uint64) ([]*model.Session, error)
 	GetMobileSessionMetadata() ([]*model.MobileSessionMetadata, error)
 	GetSessionsWithActiveDeviceIds(userID string) ([]*model.Session, error)
+	GetSessionsWithActiveDeviceIdsForTestNotifications(userID string) ([]*model.Session, error)
 	GetAllSessionsWithActiveDeviceIds() ([]*model.Session, error)
 	GetSessionsExpired(thresholdMillis int64, mobileOnly bool, unnotifiedOnly bool) ([]*model.Session, error)
 	UpdateExpiredNotify(sessionid string, notified bool) error

--- a/server/channels/store/storetest/mocks/SessionStore.go
+++ b/server/channels/store/storetest/mocks/SessionStore.go
@@ -271,6 +271,36 @@ func (_m *SessionStore) GetSessionsWithActiveDeviceIds(userID string) ([]*model.
 	return r0, r1
 }
 
+// GetSessionsWithActiveDeviceIdsForTestNotifications provides a mock function with given fields: userID
+func (_m *SessionStore) GetSessionsWithActiveDeviceIdsForTestNotifications(userID string) ([]*model.Session, error) {
+	ret := _m.Called(userID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSessionsWithActiveDeviceIdsForTestNotifications")
+	}
+
+	var r0 []*model.Session
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) ([]*model.Session, error)); ok {
+		return rf(userID)
+	}
+	if rf, ok := ret.Get(0).(func(string) []*model.Session); ok {
+		r0 = rf(userID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Session)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(userID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // PermanentDeleteSessionsByUser provides a mock function with given fields: teamID
 func (_m *SessionStore) PermanentDeleteSessionsByUser(teamID string) error {
 	ret := _m.Called(teamID)

--- a/server/channels/store/storetest/session_store.go
+++ b/server/channels/store/storetest/session_store.go
@@ -40,6 +40,7 @@ func TestSessionStore(t *testing.T, rctx request.CTX, ss store.Store) {
 	t.Run("UpdateExpiredNotify", func(t *testing.T) { testUpdateExpiredNotify(t, rctx, ss) })
 	t.Run("GetLRUSessions", func(t *testing.T) { testGetLRUSessions(t, rctx, ss) })
 	t.Run("GetSessionsWithActiveDeviceIds", func(t *testing.T) { testGetSessionsWithActiveDeviceIds(t, rctx, ss) })
+	t.Run("GetSessionsWithActiveDeviceIdsForTestNotifications", func(t *testing.T) { testGetSessionsWithActiveDeviceIdsForTestNotifications(t, rctx, ss) })
 	t.Run("GetAllSessionsWithActiveDeviceIds", func(t *testing.T) { testGetAllSessionsWithActiveDeviceIds(t, rctx, ss) })
 	t.Run("GetMobileSessionMetadata", func(t *testing.T) { testGetMobileSessionMetadata(t, rctx, ss) })
 }
@@ -532,6 +533,44 @@ func testGetSessionsWithActiveDeviceIds(t *testing.T, rctx request.CTX, ss store
 	require.False(t, sessionIds[s4.Id])
 	require.False(t, sessionIds[s5.Id])
 	require.False(t, sessionIds[s8.Id])
+}
+
+func testGetSessionsWithActiveDeviceIdsForTestNotifications(t *testing.T, rctx request.CTX, ss store.Store) {
+	userId := model.NewId()
+
+	s1 := &model.Session{}
+	s1.UserId = userId
+	s1.ExpiresAt = model.GetMillis() + 100000
+	s1.DeviceId = model.NewId()
+	s1, err := ss.Session().Save(rctx, s1)
+	require.NoError(t, err)
+
+	s3 := &model.Session{}
+	s3.UserId = userId
+	s3.ExpiresAt = model.GetMillis() + 100000
+	s3.DeviceId = model.NewId()
+	s3.AddProp(model.SessionPropLastRemovedDeviceId, s3.DeviceId)
+	s3, err = ss.Session().Save(rctx, s3)
+	require.NoError(t, err)
+
+	s5 := &model.Session{}
+	s5.UserId = userId
+	s5.ExpiresAt = model.GetMillis() - 100000
+	s5.DeviceId = model.NewId()
+	s5, err = ss.Session().Save(rctx, s5)
+	require.NoError(t, err)
+
+	sessions, err := ss.Session().GetSessionsWithActiveDeviceIdsForTestNotifications(userId)
+	require.NoError(t, err)
+	require.Len(t, sessions, 2)
+
+	sessionIds := make(map[string]bool)
+	for _, session := range sessions {
+		sessionIds[session.Id] = true
+	}
+	require.True(t, sessionIds[s1.Id])
+	require.True(t, sessionIds[s3.Id], "sessions marked as removed should be included for test notifications")
+	require.False(t, sessionIds[s5.Id])
 }
 
 func testUpdateExpiredNotify(t *testing.T, rctx request.CTX, ss store.Store) {

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -10281,6 +10281,22 @@ func (s *TimerLayerSessionStore) GetSessionsWithActiveDeviceIds(userID string) (
 	return result, err
 }
 
+func (s *TimerLayerSessionStore) GetSessionsWithActiveDeviceIdsForTestNotifications(userID string) ([]*model.Session, error) {
+	start := time.Now()
+
+	result, err := s.SessionStore.GetSessionsWithActiveDeviceIdsForTestNotifications(userID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("SessionStore.GetSessionsWithActiveDeviceIdsForTestNotifications", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerSessionStore) PermanentDeleteSessionsByUser(teamID string) error {
 	start := time.Now()
 

--- a/server/public/model/post.go
+++ b/server/public/model/post.go
@@ -97,6 +97,7 @@ const (
 	PostPropsGroupHighlightDisabled   = "disable_group_highlight"
 	PostPropsPreviewedPost            = "previewed_post"
 	PostPropsForceNotification        = "force_notification"
+	PostPropsTestNotification         = "test_notification"
 	PostPropsChannelMentions          = "channel_mentions"
 	PostPropsCurrentTeamId            = "current_team_id"
 	PostPropsUnsafeLinks              = "unsafe_links"
@@ -585,6 +586,7 @@ func (o *Post) SanitizeProps() {
 	membersToSanitize := []string{
 		PropsAddChannelMember,
 		PostPropsForceNotification,
+		PostPropsTestNotification,
 	}
 
 	for _, member := range membersToSanitize {


### PR DESCRIPTION
#### Summary

Fixes push notification recovery for mobile sessions that were incorrectly marked as removed.

When the push proxy returns `REMOVE`, the device token is stored in the session's `last_removed_device_id` (or `last_removed_voip_device_id`) property, and that session is excluded from future push notifications until the user logs in again. Temporary push proxy or network failures could incorrectly mark valid devices as removed.

This change adds a **test-notification-only** recovery path:

* `POST /api/v4/notifications/test` (Admin test notification) now includes sessions with `last_removed_device_id` set as push targets.
* `GET /api/v4/system/ping?device_id=<device_id>` clears the matching `last_removed_device_id` or `last_removed_voip_device_id` for the user's session after a successful test push.
* Successful test pushes remove the corresponding `last_removed_*` property and log the recovery.
* Regular push notifications remain unchanged and continue to exclude sessions marked with removed device IDs.

**QA Steps**

1. Mark a mobile session as removed (for example, simulate a push proxy `REMOVE` response).
2. Verify that regular push notifications are not sent to that session.
3. Send a test notification from **System Console → Environment → Push Notification Server → Send Test Notification**, or call `POST /api/v4/notifications/test`.
4. Verify that the test push is delivered to the previously excluded session.
5. Verify that `last_removed_device_id` is cleared after the successful test push.
6. Verify that regular push notifications work again without requiring the user to log in again.
7. Optionally, call `GET /api/v4/system/ping?device_id=<device_id>` and verify `CanReceiveNotifications: true` and that the session is recovered.

#### Ticket Link
https://github.com/mattermost/mattermost/issues/33657
#### Release Note

```release-note
Test push notifications now attempted delivery to sessions previously marked with last_removed_device_id and restored those sessions after a successful test push, allowing recovery from temporary push proxy failures without requiring users to log in again.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟠 Medium

**Regression Risk:** This touches shared push-notification/session-store paths across app, store, and model layers, including test-push recovery logic and session filtering. The behavior change is adjacent to a high-risk flow (mobile push delivery/session state), but it is scoped and appears covered by targeted tests.

**QA Recommendation:** Perform focused manual QA on the test-notification recovery path and confirm regular push delivery still excludes/reincludes sessions as expected after recovery.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->