### PR TITLE
Add "show online only" filter to Channel Members RHS (#33790)

### DIFF
--- a/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.scss
+++ b/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.scss
@@ -4,6 +4,20 @@
         padding: 0 4px 16px;
     }
 
+    &__filter-row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding: 8px 16px 4px;
+    }
+
+    &__filter-label {
+        margin: 0;
+        cursor: pointer;
+        font-size: 13px;
+        color: rgba(var(--center-channel-color-rgb), 0.75);
+    }
+
     &__member-list-separator {
         padding: 0px 12px;
         margin-top: 16px;

--- a/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.tsx
+++ b/webapp/channels/src/components/channel_members_rhs/channel_members_rhs.tsx
@@ -78,7 +78,24 @@ export default function ChannelMembersRHS({
 
     const [page, setPage] = useState(0);
     const [isNextPageLoading, setIsNextPageLoading] = useState(false);
+    // issue #33790: persistent "show online only" toggle so members
+    // can see at a glance who's available in the channel.
+    const [showOnlineOnly, setShowOnlineOnly] = useState(false);
     const {formatMessage} = useIntl();
+
+    // Filter members by online status when the toggle is on. Online + away + dnd
+    // are all considered "available" enough to surface; only "offline" is hidden.
+    const visibleChannelMembers = useMemo(() => {
+        if (!showOnlineOnly) {
+            return channelMembers;
+        }
+        return channelMembers.filter((m) => m.status !== 'offline');
+    }, [channelMembers, showOnlineOnly]);
+
+    const onlineCount = useMemo(
+        () => channelMembers.filter((m) => m.status !== 'offline').length,
+        [channelMembers],
+    );
 
     // Only channels whose policy controls membership surface attribute
     // tags in the RHS — a permission-only policy (e.g. file upload) has
@@ -131,8 +148,8 @@ export default function ChannelMembersRHS({
         const listcp: ListItem[] = [];
         let memberDone = false;
 
-        for (let i = 0; i < channelMembers.length; i++) {
-            const member = channelMembers[i];
+        for (let i = 0; i < visibleChannelMembers.length; i++) {
+            const member = visibleChannelMembers[i];
             if (listcp.length === 0) {
                 let text = null;
                 if (member.membership?.scheme_admin === true) {
@@ -174,7 +191,7 @@ export default function ChannelMembersRHS({
         if (JSON.stringify(list) !== JSON.stringify(listcp)) {
             setList(listcp);
         }
-    }, [channelMembers]);
+    }, [visibleChannelMembers]);
 
     useEffect(() => {
         if (channel.type === Constants.DM_CHANNEL) {
@@ -316,6 +333,25 @@ export default function ChannelMembersRHS({
                     onInput={setSearchTerms}
                 />
             )}
+
+            <div className='channel-members-rhs__filter-row'>
+                <input
+                    id='channelMembersOnlineOnlyToggle'
+                    type='checkbox'
+                    checked={showOnlineOnly}
+                    onChange={(e) => setShowOnlineOnly(e.target.checked)}
+                />
+                <label
+                    htmlFor='channelMembersOnlineOnlyToggle'
+                    className='channel-members-rhs__filter-label'
+                >
+                    <FormattedMessage
+                        id='channel_members_rhs.filter.online_only'
+                        defaultMessage='Show online only ({count})'
+                        values={{count: onlineCount}}
+                    />
+                </label>
+            </div>
 
             <div className='channel-members-rhs__members-container'>
                 {channelMembers.length > 0 && (

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4269,6 +4269,7 @@
   "channel_members_rhs.action_bar.managing_title": "Managing Members",
   "channel_members_rhs.action_bar.members_count_title": "{members_count} members",
   "channel_members_rhs.default_channel_moderation_restrictions": "In this channel, you can only remove guests. Only <link>channel admins</link> can manage other members.",
+  "channel_members_rhs.filter.online_only": "Show online only ({count})",
   "channel_members_rhs.header.title": "Members",
   "channel_members_rhs.list.channel_admin_title": "CHANNEL ADMINS",
   "channel_members_rhs.list.channel_members_title": "MEMBERS",


### PR DESCRIPTION
## Summary

Closes #33790.

Adds a checkbox above the existing Channel Members RHS member list:

- [x] "Show online only (N)" — N is the live count of non-offline members
- [x] Default off; existing behavior is unchanged for users who don't engage with it
- [x] State is local to the RHS panel — no server-side preference, no Redux changes
- [x] Online + away + DND all count as "online enough to surface"; only `offline` is filtered out
- [x] Count and list both update live as users change status (driven by existing status WebSocket events)

## Why this placement

The original issue suggests three possible UI surfaces (sidebar widget, top banner, slash command). I picked the smallest interpretation: the Channel Members RHS is already where Mattermost shows who is in this channel, and each row already shows a status dot — so adding a "filter to just the online ones" toggle there is the minimum-disruption way to satisfy the core request.

Happy to move this to a different surface if maintainers prefer — see the open question below.

## Open question for reviewers

Is the RHS the right home for this, or would you rather see it as a separate channel-header widget / inline banner? I'm flexible — wanted to put up working code so the design discussion has something concrete to react to.

## Test plan

- [ ] Open any channel → click Members icon → confirm "Show online only (N)" appears above the member list
- [ ] Toggle on → list filters to non-offline members; count matches list length
- [ ] Toggle off → full list returns
- [ ] Have a second user change status (online → offline) → count and list update within ~5s without refresh
- [ ] Confirm the toggle is keyboard-accessible (Tab focuses it, Space toggles it)
- [ ] Confirm dark mode / custom theme: label colour uses `--center-channel-color-rgb`, no hardcoded colours
- [ ] Confirm in a DM (panel auto-closes, expected pre-existing behaviour) and a GM (panel shows, toggle works)

## Files changed

- `webapp/channels/src/components/channel_members_rhs/channel_members_rhs.tsx` — state + memos + toggle UI
- `webapp/channels/src/components/channel_members_rhs/channel_members_rhs.scss` — two new BEM rules
- `webapp/channels/src/i18n/en.json` — one new i18n string

### Release Note
Added a "Show online only" filter to the Channel Members panel that hides offline members and shows a live count of those still available.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: Medium 🟠

**Regression Risk:** The change is isolated to the Channel Members RHS, but it modifies how the member list and online count are computed from live presence updates, so regressions are most likely to appear as stale or incorrectly filtered UI when the toggle is enabled. It does not touch auth, persistence, or shared core utilities, and the default state preserves existing behavior.

**QA Recommendation:** Target manual QA in the Channel Members RHS: confirm the checkbox defaults off, verify only `offline` members are hidden when enabled, and ensure the list/count update correctly as presence events (online/away/dnd/offline) arrive.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->