### PR TITLE
Mirror postgres images for versions 15, 16, and 17

### DIFF
--- a/server/scripts/mirror-docker-images.json
+++ b/server/scripts/mirror-docker-images.json
@@ -3,7 +3,10 @@
     "10": "postgres:10@sha256:7a484b11fcabd39596b1bf08780cdb61fa9b0d8bfad0844dbdce3a6922df95d1",
     "12": "postgres:12@sha256:cc7a021d9aff3aa02788d35c27a5cc32d4790ad92d72232a6be75b76ab7d79db",
     "13": "postgres:13@sha256:1b154a7bbf474aa1a2e67dc7c976835645fe6c3425320e7ad3f5a926d509e8fc",
-    "14": "postgres:14@sha256:1c418702ab77adc7e84c7e726c2ab4f9cb63b8f997341ffcfab56629bab1429d"
+    "14": "postgres:14@sha256:1c418702ab77adc7e84c7e726c2ab4f9cb63b8f997341ffcfab56629bab1429d",
+    "15": "postgres:15@sha256:6ab12ad4395ee49ab49fe19530f7e183c5a9c97fc47cf687b3e281bec5f91ee4",
+    "16": "postgres:16@sha256:9c1534cbf839ec70409508a874f4c02bf4739de2f32f77efe080eef1cfd34bf4",
+    "17": "postgres:17@sha256:4f6c1ec9743885ba6438a91f7c08c4ef4d645a41eae31fc8521c2d831c622107"
   },
   "minio": {
     "RELEASE.2019-10-11T00-38-09Z-1": "minio/minio:RELEASE.2019-10-11T00-38-09Z@sha256:0d02f16a1662653f9b961211b21ed7de04bf04492f44c2b7594bacbfcc519eb5",


### PR DESCRIPTION
#### Summary

Adds mirrored Docker image entries for PostgreSQL 15, 16, and 17 to `mirror-docker-images.json`. Once this lands on master, the `docker-push-mirrored.yml` workflow will publish these images to `mattermostdevelopment/mirrored-postgres` on Docker Hub.

This is a prerequisite for bumping the minimum supported Postgres version in E2E tests (MM-65990), which references `mattermostdevelopment/mirrored-postgres:15`.

#### Ticket Link

Relates-to: https://mattermost.atlassian.net/browse/MM-65990

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** This change is isolated to mirrored Docker image configuration and does not affect runtime logic, APIs, persistence, or auth flows. The main risk is limited to image publishing/availability for the added Postgres tags.

**QA Recommendation:** Minimal manual QA is needed; verify the mirror publish workflow includes the new Postgres versions and that the expected Docker tags are available after the pipeline runs.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->