### PR TITLE
[release-11.9] [MM-69528] Enable feature flags for ranked attributes, permission policies and masking by default

### DIFF
--- a/server/channels/api4/access_control_test.go
+++ b/server/channels/api4/access_control_test.go
@@ -16,8 +16,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// maskingOffTestConfig disables attribute-value masking for policy-endpoint
+// tests that do not cover masking. ABAC and other ABAC sub-flags default on.
+func maskingOffTestConfig(cfg *model.Config) {
+	cfg.FeatureFlags.AttributeValueMasking = false
+}
+
+func allowTestFeatureFlagUpdates(t *testing.T, th *TestHelper) {
+	t.Helper()
+	th.ConfigStore.SetReadOnlyFF(false)
+}
+
+func updateTestFeatureFlags(t *testing.T, th *TestHelper, fn func(cfg *model.Config)) {
+	t.Helper()
+	allowTestFeatureFlagUpdates(t, th)
+	th.App.UpdateConfig(fn)
+}
+
+func restoreABACFeatureFlagDefaults(cfg *model.Config) {
+	cfg.FeatureFlags.PermissionPolicies = true
+	cfg.FeatureFlags.ChannelPermissionPolicies = true
+	cfg.FeatureFlags.PolicySimulation = true
+	cfg.AccessControlSettings.EnableAttributeBasedAccessControl = model.NewPointer(true)
+}
+
 func TestCreateAccessControlPolicy(t *testing.T) {
-	th := SetupConfig(t, func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true }).InitBasic(t)
+	th := SetupConfig(t, maskingOffTestConfig).InitBasic(t)
 
 	samplePolicy := &model.AccessControlPolicy{
 		ID:       th.BasicChannel.Id,
@@ -273,7 +297,7 @@ func TestCreateAccessControlPolicy(t *testing.T) {
 		ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		require.True(t, ok, "SetLicense should return true")
 
-		th.App.UpdateConfig(func(cfg *model.Config) {
+		updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 			cfg.FeatureFlags.PermissionPolicies = false
 			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
 		})
@@ -319,7 +343,7 @@ func TestCreateAccessControlPolicy(t *testing.T) {
 		th.App.Srv().Channels().AccessControl = mockAccessControlService
 		mockAccessControlService.On("SavePolicy", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("*model.AccessControlPolicy")).Return(permissionPolicy, nil).Times(1)
 
-		th.App.UpdateConfig(func(cfg *model.Config) {
+		updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 			cfg.FeatureFlags.PermissionPolicies = true
 			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
 		})
@@ -341,14 +365,12 @@ func TestCreateAccessControlPolicy(t *testing.T) {
 		ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		require.True(t, ok, "SetLicense should return true")
 
-		th.App.UpdateConfig(func(cfg *model.Config) {
+		updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 			cfg.FeatureFlags.PermissionPolicies = true
 			cfg.FeatureFlags.ChannelPermissionPolicies = false
 			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
 		})
-		defer th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.FeatureFlags.PermissionPolicies = false
-		})
+		defer updateTestFeatureFlags(t, th, restoreABACFeatureFlagDefaults)
 
 		channelPolicy := &model.AccessControlPolicy{
 			ID:       model.NewId(),
@@ -381,14 +403,12 @@ func TestCreateAccessControlPolicy(t *testing.T) {
 		ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		require.True(t, ok, "SetLicense should return true")
 
-		th.App.UpdateConfig(func(cfg *model.Config) {
+		updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 			cfg.FeatureFlags.PermissionPolicies = false
 			cfg.FeatureFlags.ChannelPermissionPolicies = true
 			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
 		})
-		defer th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.FeatureFlags.ChannelPermissionPolicies = false
-		})
+		defer updateTestFeatureFlags(t, th, restoreABACFeatureFlagDefaults)
 
 		channelPolicy := &model.AccessControlPolicy{
 			ID:       model.NewId(),
@@ -443,15 +463,12 @@ func TestCreateAccessControlPolicy(t *testing.T) {
 		// other tests, so the mock returns success straight away.
 		mockAccessControlService.On("SavePolicy", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("*model.AccessControlPolicy")).Return(channelPolicy, nil).Times(1)
 
-		th.App.UpdateConfig(func(cfg *model.Config) {
+		updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 			cfg.FeatureFlags.PermissionPolicies = true
 			cfg.FeatureFlags.ChannelPermissionPolicies = true
 			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
 		})
-		defer th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.FeatureFlags.PermissionPolicies = false
-			cfg.FeatureFlags.ChannelPermissionPolicies = false
-		})
+		defer updateTestFeatureFlags(t, th, restoreABACFeatureFlagDefaults)
 
 		_, resp, err := th.SystemAdminClient.CreateAccessControlPolicy(context.Background(), channelPolicy)
 		require.NoError(t, err)
@@ -498,7 +515,7 @@ func TestCreateAccessControlPolicy(t *testing.T) {
 }
 
 func TestGetAccessControlPolicy(t *testing.T) {
-	th := SetupConfig(t, func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true }).InitBasic(t)
+	th := SetupConfig(t, maskingOffTestConfig).InitBasic(t)
 
 	samplePolicy := &model.AccessControlPolicy{
 		ID:       model.NewId(),
@@ -626,7 +643,7 @@ func TestGetAccessControlPolicy(t *testing.T) {
 }
 
 func TestDeleteAccessControlPolicy(t *testing.T) {
-	th := SetupConfig(t, func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true }).InitBasic(t)
+	th := SetupConfig(t, maskingOffTestConfig).InitBasic(t)
 
 	samplePolicyID := model.NewId()
 
@@ -702,7 +719,7 @@ func TestDeleteAccessControlPolicy(t *testing.T) {
 }
 
 func TestCheckExpression(t *testing.T) {
-	th := SetupConfig(t, func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true }).InitBasic(t)
+	th := SetupConfig(t, maskingOffTestConfig).InitBasic(t)
 
 	t.Run("CheckExpression without license", func(t *testing.T) {
 		_, resp, err := th.SystemAdminClient.CheckExpression(context.Background(), "true")
@@ -837,7 +854,7 @@ func TestCheckExpression(t *testing.T) {
 }
 
 func TestTestExpression(t *testing.T) {
-	th := SetupConfig(t, func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true }).InitBasic(t)
+	th := SetupConfig(t, maskingOffTestConfig).InitBasic(t)
 
 	t.Run("TestExpression without license", func(t *testing.T) {
 		_, resp, err := th.SystemAdminClient.TestExpression(context.Background(), model.QueryExpressionParams{})
@@ -884,7 +901,7 @@ func TestTestExpression(t *testing.T) {
 }
 
 func TestSearchAccessControlPolicies(t *testing.T) {
-	th := SetupConfig(t, func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true }).InitBasic(t)
+	th := SetupConfig(t, maskingOffTestConfig).InitBasic(t)
 
 	t.Run("SearchAccessControlPolicies without license", func(t *testing.T) {
 		_, resp, err := th.SystemAdminClient.SearchAccessControlPolicies(context.Background(), model.AccessControlPolicySearch{})
@@ -935,7 +952,7 @@ func TestSearchAccessControlPolicies(t *testing.T) {
 		ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		require.True(t, ok, "SetLicense should return true")
 
-		th.App.UpdateConfig(func(cfg *model.Config) {
+		updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 			cfg.FeatureFlags.PermissionPolicies = false
 			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
 		})
@@ -959,7 +976,7 @@ func TestSearchAccessControlPolicies(t *testing.T) {
 			Type: model.AccessControlPolicyTypePermission,
 		}).Return([]*model.AccessControlPolicy{}, int64(0), nil).Times(1)
 
-		th.App.UpdateConfig(func(cfg *model.Config) {
+		updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 			cfg.FeatureFlags.PermissionPolicies = true
 			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
 		})
@@ -1058,7 +1075,7 @@ func TestSearchTeamAccessControlPolicies(t *testing.T) {
 }
 
 func TestAssignAccessPolicy(t *testing.T) {
-	th := SetupConfig(t, func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true }).InitBasic(t)
+	th := SetupConfig(t, maskingOffTestConfig).InitBasic(t)
 
 	samplePolicy := &model.AccessControlPolicy{
 		ID:       model.NewId(),
@@ -1135,7 +1152,7 @@ func TestAssignAccessPolicy(t *testing.T) {
 }
 
 func TestUnassignAccessPolicy(t *testing.T) {
-	th := SetupConfig(t, func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true }).InitBasic(t)
+	th := SetupConfig(t, maskingOffTestConfig).InitBasic(t)
 
 	samplePolicy := &model.AccessControlPolicy{
 		ID:       model.NewId(),
@@ -1208,7 +1225,7 @@ func TestUnassignAccessPolicy(t *testing.T) {
 }
 
 func TestGetChannelsForAccessControlPolicy(t *testing.T) {
-	th := SetupConfig(t, func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true }).InitBasic(t)
+	th := SetupConfig(t, maskingOffTestConfig).InitBasic(t)
 
 	samplePolicy := &model.AccessControlPolicy{
 		ID:       model.NewId(),
@@ -1266,7 +1283,7 @@ func TestGetChannelsForAccessControlPolicy(t *testing.T) {
 }
 
 func TestSearchChannelsForAccessControlPolicy(t *testing.T) {
-	th := SetupConfig(t, func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true }).InitBasic(t)
+	th := SetupConfig(t, maskingOffTestConfig).InitBasic(t)
 
 	newSamplePolicy := func() *model.AccessControlPolicy {
 		return &model.AccessControlPolicy{
@@ -1480,7 +1497,7 @@ func TestSearchChannelsForAccessControlPolicy(t *testing.T) {
 }
 
 func TestSetActiveStatus(t *testing.T) {
-	th := Setup(t).InitBasic(t)
+	th := SetupConfig(t, maskingOffTestConfig).InitBasic(t)
 
 	samplePolicy := &model.AccessControlPolicy{
 		ID:       th.BasicChannel.Id,
@@ -1669,8 +1686,9 @@ func setupTeamAdminABAC(t *testing.T, th *TestHelper) *mocks.AccessControlServic
 	mockACS := &mocks.AccessControlServiceInterface{}
 	th.App.Srv().Channels().AccessControl = mockACS
 
-	th.App.UpdateConfig(func(cfg *model.Config) {
+	updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 		cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
+		cfg.FeatureFlags.AttributeValueMasking = false
 	})
 
 	th.AddPermissionToRole(t, model.PermissionManageTeamAccessRules.Id, model.TeamAdminRoleId)
@@ -1713,12 +1731,7 @@ func newParentPolicy(teamID string) *model.AccessControlPolicy {
 // fail-closed branch (unknown property field) so the masking always produces the
 // "--------" sentinel without requiring a real CPA setup.
 func TestResponseMaskingOnPolicyEndpoints(t *testing.T) {
-	// SetupConfig sets FFs before route init via SetReadOnlyFF(false). Avoids
-	// os.Setenv which isn't parallel-safe.
-	th := SetupConfig(t, func(cfg *model.Config) {
-		cfg.FeatureFlags.AttributeBasedAccessControl = true
-		cfg.FeatureFlags.AttributeValueMasking = true
-	}).InitBasic(t)
+	th := Setup(t).InitBasic(t)
 
 	ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 	require.True(t, ok, "SetLicense should return true")
@@ -2652,7 +2665,7 @@ func TestScopeReconciliationCrossTeam(t *testing.T) {
 // proxies to the access-control service which we mock here so the test
 // stays focused on the API surface (auth + payload validation).
 func TestSimulatePolicyForUsers(t *testing.T) {
-	th := SetupConfig(t, func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true }).InitBasic(t)
+	th := SetupConfig(t, maskingOffTestConfig).InitBasic(t)
 
 	t.Run("returns 501 when umbrella PermissionPolicies flag is disabled", func(t *testing.T) {
 		// Set the Enterprise Advanced license up-front so any future
@@ -2667,7 +2680,7 @@ func TestSimulatePolicyForUsers(t *testing.T) {
 		ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		require.True(t, ok)
 
-		th.App.UpdateConfig(func(cfg *model.Config) {
+		updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 			cfg.FeatureFlags.PermissionPolicies = false
 			cfg.FeatureFlags.PolicySimulation = true // sub-flag alone must not be enough
 		})
@@ -2695,13 +2708,11 @@ func TestSimulatePolicyForUsers(t *testing.T) {
 		ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		require.True(t, ok)
 
-		th.App.UpdateConfig(func(cfg *model.Config) {
+		updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 			cfg.FeatureFlags.PermissionPolicies = true
 			cfg.FeatureFlags.PolicySimulation = false
 		})
-		defer th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.FeatureFlags.PermissionPolicies = false
-		})
+		defer updateTestFeatureFlags(t, th, restoreABACFeatureFlagDefaults)
 
 		body := mustMarshal(t, model.PolicySimulationByUsersParams{
 			Policy: &model.AccessControlPolicy{ID: model.NewId(), Type: model.AccessControlPolicyTypeChannel},
@@ -2723,14 +2734,11 @@ func TestSimulatePolicyForUsers(t *testing.T) {
 		require.True(t, ok)
 		defer th.App.Srv().SetLicense(nil)
 
-		th.App.UpdateConfig(func(cfg *model.Config) {
+		updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 			cfg.FeatureFlags.PermissionPolicies = true
 			cfg.FeatureFlags.PolicySimulation = true
 		})
-		defer th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.FeatureFlags.PermissionPolicies = false
-			cfg.FeatureFlags.PolicySimulation = false
-		})
+		defer updateTestFeatureFlags(t, th, restoreABACFeatureFlagDefaults)
 
 		body := mustMarshal(t, model.PolicySimulationByUsersParams{
 			Policy:  &model.AccessControlPolicy{ID: model.NewId(), Type: model.AccessControlPolicyTypeChannel},
@@ -2747,15 +2755,12 @@ func TestSimulatePolicyForUsers(t *testing.T) {
 		ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		require.True(t, ok)
 
-		th.App.UpdateConfig(func(cfg *model.Config) {
+		updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 			cfg.FeatureFlags.PermissionPolicies = true
 			cfg.FeatureFlags.PolicySimulation = true
 			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = model.NewPointer(true)
 		})
-		defer th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.FeatureFlags.PermissionPolicies = false
-			cfg.FeatureFlags.PolicySimulation = false
-		})
+		defer updateTestFeatureFlags(t, th, restoreABACFeatureFlagDefaults)
 
 		mockACS := &mocks.AccessControlServiceInterface{}
 		th.App.Srv().Channels().AccessControl = mockACS
@@ -2774,15 +2779,12 @@ func TestSimulatePolicyForUsers(t *testing.T) {
 		ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		require.True(t, ok)
 
-		th.App.UpdateConfig(func(cfg *model.Config) {
+		updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 			cfg.FeatureFlags.PermissionPolicies = true
 			cfg.FeatureFlags.PolicySimulation = true
 			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = model.NewPointer(true)
 		})
-		defer th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.FeatureFlags.PermissionPolicies = false
-			cfg.FeatureFlags.PolicySimulation = false
-		})
+		defer updateTestFeatureFlags(t, th, restoreABACFeatureFlagDefaults)
 
 		mockACS := &mocks.AccessControlServiceInterface{}
 		mockACS.On("SimulatePolicyForUsers", mock.Anything, mock.Anything).Return(
@@ -2807,15 +2809,12 @@ func TestSimulatePolicyForUsers(t *testing.T) {
 		ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
 		require.True(t, ok)
 
-		th.App.UpdateConfig(func(cfg *model.Config) {
+		updateTestFeatureFlags(t, th, func(cfg *model.Config) {
 			cfg.FeatureFlags.PermissionPolicies = true
 			cfg.FeatureFlags.PolicySimulation = true
 			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = model.NewPointer(true)
 		})
-		defer th.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.FeatureFlags.PermissionPolicies = false
-			cfg.FeatureFlags.PolicySimulation = false
-		})
+		defer updateTestFeatureFlags(t, th, restoreABACFeatureFlagDefaults)
 
 		mockACS := &mocks.AccessControlServiceInterface{}
 		th.App.Srv().Channels().AccessControl = mockACS

--- a/server/channels/app/access_control_test.go
+++ b/server/channels/app/access_control_test.go
@@ -25,8 +25,19 @@ func celSafeName() string {
 	return "f_" + model.NewId()
 }
 
+func storeMockWithMaskingOff(tb testing.TB) *TestHelper {
+	tb.Helper()
+	th := SetupWithStoreMock(tb)
+	// Mutate in place — UpdateConfig persists config and triggers
+	// listeners that call Store.Post(), which the mock store lacks.
+	th.App.Config().FeatureFlags.AttributeValueMasking = false
+	return th
+}
+
 func TestCreateOrUpdateAccessControlPolicy(t *testing.T) {
-	th := Setup(t).InitBasic(t)
+	th := SetupConfig(t, func(cfg *model.Config) {
+		cfg.FeatureFlags.AttributeValueMasking = false
+	}).InitBasic(t)
 
 	t.Run("Feature not enabled", func(t *testing.T) {
 		th.App.Srv().ch.AccessControl = nil
@@ -115,7 +126,7 @@ func TestCreateOrUpdateAccessControlPolicy(t *testing.T) {
 	})
 
 	t.Run("Channel-type policy broadcasts policy enforced update", func(t *testing.T) {
-		thMock := SetupWithStoreMock(t)
+		thMock := storeMockWithMaskingOff(t)
 
 		channelID := model.NewId()
 		channelPolicy := &model.AccessControlPolicy{
@@ -157,7 +168,7 @@ func TestCreateOrUpdateAccessControlPolicy(t *testing.T) {
 	})
 
 	t.Run("Parent-type policy does not broadcast channel-only update", func(t *testing.T) {
-		thMock := SetupWithStoreMock(t)
+		thMock := storeMockWithMaskingOff(t)
 
 		parentID := model.NewId()
 		parentPolicy := &model.AccessControlPolicy{
@@ -341,10 +352,7 @@ func TestDeleteAccessControlPolicy(t *testing.T) {
 		// could not audit. The canonical walker's HasMaskedValuesForCaller is mocked
 		// to return true, simulating a hidden-value field without requiring a full
 		// CPA setup for the test.
-		th := SetupConfig(t, func(cfg *model.Config) {
-			cfg.FeatureFlags.AttributeBasedAccessControl = true
-			cfg.FeatureFlags.AttributeValueMasking = true
-		}).InitBasic(t)
+		th := Setup(t).InitBasic(t)
 
 		callerID := model.NewId()
 		th.Context = th.Context.WithSession(&model.Session{UserId: callerID, Id: model.NewId()}).(*request.Context)
@@ -378,9 +386,7 @@ func TestDeleteAccessControlPolicy(t *testing.T) {
 		// Belt-and-braces: with AttributeValueMasking off, the masking guard must not
 		// fire — the policy deletes normally even if the caller wouldn't have seen all
 		// values. Guards against accidentally inverting the flag condition.
-		thMock := SetupWithStoreMock(t)
-		// Note: SetupWithStoreMock doesn't take a config callback. Feature flags
-		// default to false, which is exactly the state this test wants.
+		thMock := storeMockWithMaskingOff(t)
 
 		thMock.Context = thMock.Context.WithSession(&model.Session{UserId: model.NewId(), Id: model.NewId()}).(*request.Context)
 
@@ -2129,6 +2135,7 @@ func TestHasPermissionToFileAction(t *testing.T) {
 		mockAccessControl := &mocks.AccessControlServiceInterface{}
 		th.App.Srv().ch.AccessControl = mockAccessControl
 
+		th.ConfigStore.SetReadOnlyFF(false)
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(false)
 			cfg.FeatureFlags.PermissionPolicies = true
@@ -2142,6 +2149,7 @@ func TestHasPermissionToFileAction(t *testing.T) {
 		mockAccessControl := &mocks.AccessControlServiceInterface{}
 		th.App.Srv().ch.AccessControl = mockAccessControl
 
+		th.ConfigStore.SetReadOnlyFF(false)
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
 			cfg.FeatureFlags.PermissionPolicies = false
@@ -4475,7 +4483,7 @@ func TestPublishChannelPolicyEnforcedUpdateHydratesBroadcastPayload(t *testing.T
 	// broadcast payload so connected clients can react to action-set
 	// changes without a follow-up REST round-trip. The hydration happens
 	// after GetChannel reloads the (now-policy-enforced) channel post-save.
-	thMock := SetupWithStoreMock(t)
+	thMock := storeMockWithMaskingOff(t)
 
 	channelID := model.NewId()
 	channelPolicy := &model.AccessControlPolicy{
@@ -4920,10 +4928,7 @@ func TestUpdateAccessControlPoliciesActive_MaskingGuard(t *testing.T) {
 	t.Run("deactivation blocked when caller has masked values", func(t *testing.T) {
 		// policyHasMaskedValuesForCaller resolves the property group from the store,
 		// so this subtest uses SetupConfig + InitBasic rather than a mock store.
-		th := SetupConfig(t, func(cfg *model.Config) {
-			cfg.FeatureFlags.AttributeBasedAccessControl = true
-			cfg.FeatureFlags.AttributeValueMasking = true
-		}).InitBasic(t)
+		th := Setup(t).InitBasic(t)
 
 		callerID := model.NewId()
 		th.Context = th.Context.WithSession(&model.Session{UserId: callerID, Id: model.NewId()}).(*request.Context)
@@ -4956,10 +4961,6 @@ func TestUpdateAccessControlPoliciesActive_MaskingGuard(t *testing.T) {
 	t.Run("activation always allowed even when caller has masked values", func(t *testing.T) {
 		// The guard skips Active=true updates, so no property store access is needed.
 		thMock := SetupWithStoreMock(t)
-		thMock.App.UpdateConfig(func(cfg *model.Config) {
-			cfg.FeatureFlags.AttributeBasedAccessControl = true
-			cfg.FeatureFlags.AttributeValueMasking = true
-		})
 
 		callerID := model.NewId()
 		thMock.Context = thMock.Context.WithSession(&model.Session{UserId: callerID, Id: model.NewId()}).(*request.Context)
@@ -4997,7 +4998,7 @@ func TestUpdateAccessControlPoliciesActive_MaskingGuard(t *testing.T) {
 	})
 
 	t.Run("deactivation allowed when masking flag is off", func(t *testing.T) {
-		thMock := SetupWithStoreMock(t)
+		thMock := storeMockWithMaskingOff(t)
 		thMock.Context = thMock.Context.WithSession(&model.Session{UserId: model.NewId(), Id: model.NewId()}).(*request.Context)
 
 		channelID := model.NewId()
@@ -5130,10 +5131,7 @@ func TestMaskPolicyExpressions_FailClosedUsesDenyAllSentinel(t *testing.T) {
 	callerID := model.NewId()
 
 	t.Run("MaskExpressionForCaller failure masks rule to deny-all sentinel", func(t *testing.T) {
-		th2 := SetupConfig(t, func(cfg *model.Config) {
-			cfg.FeatureFlags.AttributeBasedAccessControl = true
-			cfg.FeatureFlags.AttributeValueMasking = true
-		}).InitBasic(t)
+		th2 := Setup(t).InitBasic(t)
 
 		policy := &model.AccessControlPolicy{
 			Rules: []model.AccessControlPolicyRule{

--- a/server/channels/app/authentication_test.go
+++ b/server/channels/app/authentication_test.go
@@ -616,12 +616,6 @@ func TestCheckLdapUserPasswordConcurrency(t *testing.T) {
 				// Capture all concurrent errors
 				appErrs := make([]*model.AppError, concurrentAttempts)
 
-				if tc.doLoginExpectedErrID == "ent.ldap.do_login.invalid_password.app_error" {
-					mockLdap.Mock.On("DoLogin", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil, &model.AppError{Id: tc.doLoginExpectedErrID}).Times(concurrentAttempts)
-				} else {
-					mockLdap.Mock.On("DoLogin", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("string"), tc.password).Return(user, nil).Times(concurrentAttempts)
-				}
-
 				// Wait to complete the test
 				var completeWG sync.WaitGroup
 				completeWG.Add(concurrentAttempts)
@@ -629,6 +623,12 @@ func TestCheckLdapUserPasswordConcurrency(t *testing.T) {
 				for i := range concurrentAttempts {
 					go func(i int) {
 						defer completeWG.Done()
+
+						if tc.doLoginExpectedErrID == "ent.ldap.do_login.invalid_password.app_error" {
+							mockLdap.Mock.On("DoLogin", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil, &model.AppError{Id: tc.doLoginExpectedErrID})
+						} else {
+							mockLdap.Mock.On("DoLogin", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("string"), tc.password).Return(user, nil)
+						}
 						_, appErrs[i] = th.App.checkLdapUserPasswordAndAllCriteria(th.Context, user, tc.password, tc.mfaToken)
 					}(i)
 				}

--- a/server/channels/app/authentication_test.go
+++ b/server/channels/app/authentication_test.go
@@ -616,6 +616,12 @@ func TestCheckLdapUserPasswordConcurrency(t *testing.T) {
 				// Capture all concurrent errors
 				appErrs := make([]*model.AppError, concurrentAttempts)
 
+				if tc.doLoginExpectedErrID == "ent.ldap.do_login.invalid_password.app_error" {
+					mockLdap.Mock.On("DoLogin", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil, &model.AppError{Id: tc.doLoginExpectedErrID}).Times(concurrentAttempts)
+				} else {
+					mockLdap.Mock.On("DoLogin", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("string"), tc.password).Return(user, nil).Times(concurrentAttempts)
+				}
+
 				// Wait to complete the test
 				var completeWG sync.WaitGroup
 				completeWG.Add(concurrentAttempts)
@@ -623,12 +629,6 @@ func TestCheckLdapUserPasswordConcurrency(t *testing.T) {
 				for i := range concurrentAttempts {
 					go func(i int) {
 						defer completeWG.Done()
-
-						if tc.doLoginExpectedErrID == "ent.ldap.do_login.invalid_password.app_error" {
-							mockLdap.Mock.On("DoLogin", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("string"), mock.AnythingOfType("string")).Return(nil, &model.AppError{Id: tc.doLoginExpectedErrID})
-						} else {
-							mockLdap.Mock.On("DoLogin", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("string"), tc.password).Return(user, nil)
-						}
 						_, appErrs[i] = th.App.checkLdapUserPasswordAndAllCriteria(th.Context, user, tc.password, tc.mfaToken)
 					}(i)
 				}

--- a/server/channels/app/property_field.go
+++ b/server/channels/app/property_field.go
@@ -76,7 +76,7 @@ func (a *App) publishPropertyFieldEvent(rctx request.CTX, eventType model.Websoc
 // (template/system/channel in the access_control group) legitimately use the
 // rank type and ship behind the separate, GA-by-default ClassificationMarkings
 // flag. Gating those here would break the classification admin panel (create
-// and edit alike) whenever PropertyFieldRank is off, which is the default.
+// and edit alike) whenever PropertyFieldRank is off.
 func (a *App) rankPropertyFieldGate(where string, field *model.PropertyField) *model.AppError {
 	if field == nil || field.Type != model.PropertyFieldTypeRank {
 		return nil

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -187,11 +187,11 @@ func (f *FeatureFlags) SetDefaults() {
 	f.ExperimentalAuditSettingsSystemConsoleUI = true
 	f.CustomProfileAttributes = true
 	f.AttributeBasedAccessControl = true
-	f.AttributeValueMasking = false
-	f.PermissionPolicies = false
+	f.AttributeValueMasking = true
+	f.PermissionPolicies = true
 	f.TeamMembershipAccessControl = false
-	f.ChannelPermissionPolicies = false
-	f.PolicySimulation = false
+	f.ChannelPermissionPolicies = true
+	f.PolicySimulation = true
 	f.ContentFlagging = true
 	f.EnableMattermostEntry = true
 
@@ -224,7 +224,7 @@ func (f *FeatureFlags) SetDefaults() {
 
 	f.MobileEphemeralMode = false
 
-	f.PropertyFieldRank = false
+	f.PropertyFieldRank = true
 }
 
 // IsChannelPermissionPoliciesEnabled reports whether channel-scope

--- a/server/public/model/feature_flags_test.go
+++ b/server/public/model/feature_flags_test.go
@@ -55,8 +55,16 @@ func TestFeatureFlagsSetDefaults_AttributeValueMasking(t *testing.T) {
 	var flags FeatureFlags
 	flags.SetDefaults()
 
-	require.False(t, flags.AttributeValueMasking, "AttributeValueMasking should default to false")
-	require.Equal(t, "false", flags.ToMap()["AttributeValueMasking"])
+	require.True(t, flags.AttributeValueMasking, "AttributeValueMasking should default to true")
+	require.Equal(t, "true", flags.ToMap()["AttributeValueMasking"])
+}
+
+func TestFeatureFlagsSetDefaults_PropertyFieldRank(t *testing.T) {
+	var flags FeatureFlags
+	flags.SetDefaults()
+
+	require.True(t, flags.PropertyFieldRank, "PropertyFieldRank should default to true")
+	require.Equal(t, "true", flags.ToMap()["PropertyFieldRank"])
 }
 
 // TestFeatureFlagsPermissionPoliciesDependencies pins down the
@@ -66,12 +74,12 @@ func TestFeatureFlagsSetDefaults_AttributeValueMasking(t *testing.T) {
 // dependency (additional gates, new sub-flags) only have to update
 // one place and existing call sites stay correct.
 func TestFeatureFlagsPermissionPoliciesDependencies(t *testing.T) {
-	t.Run("both helpers are off when defaults are applied", func(t *testing.T) {
+	t.Run("both helpers are on when defaults are applied", func(t *testing.T) {
 		var f FeatureFlags
 		f.SetDefaults()
 
-		require.False(t, f.IsChannelPermissionPoliciesEnabled())
-		require.False(t, f.IsPolicySimulationEnabled())
+		require.True(t, f.IsChannelPermissionPoliciesEnabled())
+		require.True(t, f.IsPolicySimulationEnabled())
 	})
 
 	t.Run("sub-flag alone is not enough — the umbrella must be on too", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
Cherry pick of #37265 on release-11.9.

/cc @app/cursor

#### Conflict Resolution
- `server/public/model/feature_flags.go`: set `PropertyFieldRank = true` per cherry-pick; omitted `f.MmBlocksEnabled = true` from upstream because release-11.9 has no `MmBlocksEnabled` flag (ABAC defaults auto-merged).

#### Release Note
```release-note
NONE
```