### PR TITLE
update Calls to v1.12.1

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -158,7 +158,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.12.0
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.12.1
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.1
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.1


### PR DESCRIPTION
#### Summary
- Update prepackaged Calls to v1.12.1

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-68811

#### Release Note
```release-note
Mattermost Calls was updated to v1.12.1, fixing a simulcast issue, correcting screen share alert wording, defaulting "Share sound with screen" to on, and restricting the clickable recording badge to the host
```

Calls v1.12.1 https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v1.12.1

This is a patch release intended for v11.9; should be cherry-picked to `release-11.9` after merge.