### PR TITLE
fix: hide calls plugin menu items and icons on unlicensed servers

### DIFF
--- a/webapp/channels/src/plugins/call_button/index.ts
+++ b/webapp/channels/src/plugins/call_button/index.ts
@@ -5,6 +5,8 @@ import {connect} from 'react-redux';
 
 import {getCurrentChannel, getMyCurrentChannelMembership} from 'mattermost-redux/selectors/entities/channels';
 
+import {getCallButtonPluginComponents} from 'selectors/plugins';
+
 import type {GlobalState} from 'types/store/index';
 
 import CallButton from './call_button';
@@ -12,7 +14,7 @@ import CallButton from './call_button';
 function mapStateToProps(state: GlobalState) {
     return {
         currentChannel: getCurrentChannel(state),
-        pluginCallComponents: state.plugins.components.CallButton,
+        pluginCallComponents: getCallButtonPluginComponents(state),
         channelMember: getMyCurrentChannelMembership(state),
         sidebarOpen: state.views.rhs.isSidebarOpen,
     };

--- a/webapp/channels/src/selectors/calls.ts
+++ b/webapp/channels/src/selectors/calls.ts
@@ -4,10 +4,13 @@
 import semver from 'semver';
 
 import type {CallsConfig, UserSessionState} from '@mattermost/calls-common/lib/types';
+import type {Channel} from '@mattermost/types/channels';
+import type {ClientLicense} from '@mattermost/types/config';
 
 import {createSelector} from 'mattermost-redux/selectors/create_selector';
 
-import {suitePluginIds} from 'utils/constants';
+import {Constants, suitePluginIds} from 'utils/constants';
+import {isMinimumEnterpriseLicense} from 'utils/license_utils';
 
 import type {GlobalState} from 'types/store';
 
@@ -60,4 +63,22 @@ export function callsChannelExplicitlyEnabled(state: GlobalState, channelId: str
 export function callsChannelExplicitlyDisabled(state: GlobalState, channelId: string) {
     const enabled = getCallsChannelState(state, channelId).enabled;
     return (typeof enabled !== 'undefined') && !enabled;
+}
+
+export function shouldShowCallsInChannel(license: ClientLicense, channelType?: Channel['type']) {
+    if (channelType === Constants.DM_CHANNEL) {
+        return true;
+    }
+    return isMinimumEnterpriseLicense(license);
+}
+
+export function filterCallsPluginComponents<T extends {pluginId: string}>(
+    components: T[],
+    license: ClientLicense,
+    channelType?: Channel['type'],
+): T[] {
+    if (shouldShowCallsInChannel(license, channelType)) {
+        return components;
+    }
+    return components.filter((component) => component.pluginId !== suitePluginIds.calls);
 }

--- a/webapp/channels/src/selectors/calls.ts
+++ b/webapp/channels/src/selectors/calls.ts
@@ -10,7 +10,7 @@ import type {ClientLicense} from '@mattermost/types/config';
 import {createSelector} from 'mattermost-redux/selectors/create_selector';
 
 import {Constants, suitePluginIds} from 'utils/constants';
-import {isMinimumEnterpriseLicense} from 'utils/license_utils';
+import {isMinimumProfessionalLicense} from 'utils/license_utils';
 
 import type {GlobalState} from 'types/store';
 
@@ -69,7 +69,7 @@ export function shouldShowCallsInChannel(license: ClientLicense, channelType?: C
     if (channelType === Constants.DM_CHANNEL) {
         return true;
     }
-    return isMinimumEnterpriseLicense(license);
+    return isMinimumProfessionalLicense(license);
 }
 
 export function filterCallsPluginComponents<T extends {pluginId: string}>(

--- a/webapp/channels/src/selectors/plugins.test.js
+++ b/webapp/channels/src/selectors/plugins.test.js
@@ -1,8 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {getCallButtonPluginComponents, getChannelHeaderMenuPluginComponents, getChannelMobileHeaderPluginButtons, getPluginUserSettings} from 'selectors/plugins';
-
+import {getCallButtonPluginComponents, getChannelHeaderMenuPluginComponents, getChannelMobileHeaderPluginButtons, getPluginUserSettings, getChannelHeaderPluginComponents, shouldShowCallsInChannel} from 'selectors/plugins';
 import {Constants, LicenseSkus, suitePluginIds} from 'utils/constants';
 
 describe('selectors/plugins', () => {
@@ -389,9 +388,27 @@ describe('selectors/plugins', () => {
             expect(components).toEqual([]);
         });
 
-        test('filters calls button components on unlicensed non-DM channels', () => {
-            const components = getCallButtonPluginComponents(baseState);
-            expect(components).toEqual([]);
+        test('filters calls channel header components on unlicensed non-DM channels', () => {
+            const components = getChannelHeaderPluginComponents(baseState);
+            expect(components.filter(c => c.pluginId === suitePluginIds.calls)).toEqual([]);
+        });
+
+        test('keeps calls UI on professional licensed servers', () => {
+            const proState = {
+                ...baseState,
+                entities: {
+                    ...baseState.entities,
+                    general: {
+                        ...baseState.entities.general,
+                        license: {
+                            IsLicensed: 'true',
+                            SkuShortName: 'professional',
+                        },
+                    },
+                },
+            };
+            expect(getChannelHeaderMenuPluginComponents(proState)).toEqual([callsComponent, otherComponent]);
+            expect(getCallButtonPluginComponents(proState)).toEqual([callsComponent]);
         });
     });
 });

--- a/webapp/channels/src/selectors/plugins.test.js
+++ b/webapp/channels/src/selectors/plugins.test.js
@@ -1,7 +1,8 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {getCallButtonPluginComponents, getChannelHeaderMenuPluginComponents, getChannelMobileHeaderPluginButtons, getPluginUserSettings, getChannelHeaderPluginComponents, shouldShowCallsInChannel} from 'selectors/plugins';
+import {getCallButtonPluginComponents, getChannelHeaderMenuPluginComponents, getChannelMobileHeaderPluginButtons, getPluginUserSettings, getChannelHeaderPluginComponents} from 'selectors/plugins';
+
 import {Constants, LicenseSkus, suitePluginIds} from 'utils/constants';
 
 describe('selectors/plugins', () => {
@@ -390,7 +391,7 @@ describe('selectors/plugins', () => {
 
         test('filters calls channel header components on unlicensed non-DM channels', () => {
             const components = getChannelHeaderPluginComponents(baseState);
-            expect(components.filter(c => c.pluginId === suitePluginIds.calls)).toEqual([]);
+            expect(components.filter((c) => c.pluginId === suitePluginIds.calls)).toEqual([]);
         });
 
         test('keeps calls UI on professional licensed servers', () => {

--- a/webapp/channels/src/selectors/plugins.test.js
+++ b/webapp/channels/src/selectors/plugins.test.js
@@ -1,7 +1,9 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {getChannelHeaderMenuPluginComponents, getPluginUserSettings, getChannelMobileHeaderPluginButtons} from 'selectors/plugins';
+import {getCallButtonPluginComponents, getChannelHeaderMenuPluginComponents, getChannelMobileHeaderPluginButtons, getPluginUserSettings} from 'selectors/plugins';
+
+import {Constants, LicenseSkus, suitePluginIds} from 'utils/constants';
 
 describe('selectors/plugins', () => {
     describe('getPluginUserSettings', () => {
@@ -37,8 +39,13 @@ describe('selectors/plugins', () => {
 
             const state = {
                 entities: {
+                    channels: {
+                        channels: {},
+                        currentChannelId: '',
+                    },
                     general: {
                         config: {},
+                        license: {},
                     },
                     preferences: {
                         myPreferences: {},
@@ -63,8 +70,13 @@ describe('selectors/plugins', () => {
 
             const state = {
                 entities: {
+                    channels: {
+                        channels: {},
+                        currentChannelId: '',
+                    },
                     general: {
                         config: {},
+                        license: {},
                     },
                     preferences: {
                         myPreferences: {},
@@ -90,8 +102,13 @@ describe('selectors/plugins', () => {
 
             const state = {
                 entities: {
+                    channels: {
+                        channels: {},
+                        currentChannelId: '',
+                    },
                     general: {
                         config: {},
+                        license: {},
                     },
                     preferences: {
                         myPreferences: {},
@@ -113,8 +130,13 @@ describe('selectors/plugins', () => {
 
             const state = {
                 entities: {
+                    channels: {
+                        channels: {},
+                        currentChannelId: '',
+                    },
                     general: {
                         config: {},
+                        license: {},
                     },
                     preferences: {
                         myPreferences: {},
@@ -138,8 +160,13 @@ describe('selectors/plugins', () => {
 
             let state = {
                 entities: {
+                    channels: {
+                        channels: {},
+                        currentChannelId: '',
+                    },
                     general: {
                         config: {},
+                        license: {},
                     },
                     preferences: {
                         myPreferences: {},
@@ -211,6 +238,19 @@ describe('selectors/plugins', () => {
     describe('getChannelMobileHeaderPluginButtons', () => {
         it('has no settings', () => {
             const state = {
+                entities: {
+                    channels: {
+                        channels: {},
+                        currentChannelId: '',
+                    },
+                    general: {
+                        config: {},
+                        license: {},
+                    },
+                    preferences: {
+                        myPreferences: {},
+                    },
+                },
                 plugins: {
                     components: {
                         MobileChannelHeaderButton: [],
@@ -227,6 +267,19 @@ describe('selectors/plugins', () => {
                 dropdownText: 'some dropdown text',
             };
             const state = {
+                entities: {
+                    channels: {
+                        channels: {},
+                        currentChannelId: '',
+                    },
+                    general: {
+                        config: {},
+                        license: {},
+                    },
+                    preferences: {
+                        myPreferences: {},
+                    },
+                },
                 plugins: {
                     components: {
                         MobileChannelHeaderButton: [headerButton],
@@ -235,6 +288,110 @@ describe('selectors/plugins', () => {
             };
             const settings = getChannelMobileHeaderPluginButtons(state);
             expect(settings).toEqual([headerButton]);
+        });
+    });
+
+    describe('calls plugin filtering', () => {
+        const callsComponent = {
+            id: 'callsMenuItem',
+            pluginId: suitePluginIds.calls,
+            text: 'Disable calls',
+        };
+
+        const otherComponent = {
+            id: 'otherMenuItem',
+            pluginId: 'other.plugin',
+            text: 'Other action',
+        };
+
+        const baseState = {
+            entities: {
+                channels: {
+                    channels: {
+                        channel1: {
+                            id: 'channel1',
+                            type: Constants.OPEN_CHANNEL,
+                        },
+                        dmChannel: {
+                            id: 'dmChannel',
+                            name: 'user1__user2',
+                            type: Constants.DM_CHANNEL,
+                        },
+                    },
+                    currentChannelId: 'channel1',
+                },
+                general: {
+                    config: {},
+                    license: {
+                        IsLicensed: 'false',
+                    },
+                },
+                preferences: {
+                    myPreferences: {},
+                },
+                users: {
+                    currentUserId: 'user1',
+                    profiles: {},
+                    statuses: {},
+                },
+            },
+            plugins: {
+                components: {
+                    ChannelHeader: [callsComponent, otherComponent],
+                    MobileChannelHeaderButton: [callsComponent],
+                    CallButton: [callsComponent],
+                },
+            },
+        };
+
+        test('filters calls channel header menu items on unlicensed non-DM channels', () => {
+            const components = getChannelHeaderMenuPluginComponents(baseState);
+            expect(components).toEqual([otherComponent]);
+        });
+
+        test('keeps calls channel header menu items in DMs on unlicensed servers', () => {
+            const state = {
+                ...baseState,
+                entities: {
+                    ...baseState.entities,
+                    channels: {
+                        ...baseState.entities.channels,
+                        currentChannelId: 'dmChannel',
+                    },
+                },
+            };
+
+            const components = getChannelHeaderMenuPluginComponents(state);
+            expect(components).toEqual([callsComponent, otherComponent]);
+        });
+
+        test('keeps calls channel header menu items on enterprise licensed channels', () => {
+            const state = {
+                ...baseState,
+                entities: {
+                    ...baseState.entities,
+                    general: {
+                        ...baseState.entities.general,
+                        license: {
+                            IsLicensed: 'true',
+                            SkuShortName: LicenseSkus.Enterprise,
+                        },
+                    },
+                },
+            };
+
+            const components = getChannelHeaderMenuPluginComponents(state);
+            expect(components).toEqual([callsComponent, otherComponent]);
+        });
+
+        test('filters calls mobile header buttons on unlicensed non-DM channels', () => {
+            const components = getChannelMobileHeaderPluginButtons(baseState);
+            expect(components).toEqual([]);
+        });
+
+        test('filters calls button components on unlicensed non-DM channels', () => {
+            const components = getCallButtonPluginComponents(baseState);
+            expect(components).toEqual([]);
         });
     });
 });

--- a/webapp/channels/src/selectors/plugins.ts
+++ b/webapp/channels/src/selectors/plugins.ts
@@ -4,9 +4,12 @@
 import {Preferences} from 'mattermost-redux/constants';
 import {createSelector} from 'mattermost-redux/selectors/create_selector';
 import {appBarEnabled, getAppBarAppBindings} from 'mattermost-redux/selectors/entities/apps';
+import {getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
 import {get} from 'mattermost-redux/selectors/entities/preferences';
 import {createShallowSelector} from 'mattermost-redux/utils/helpers';
+
+import {filterCallsPluginComponents} from 'selectors/calls';
 
 import type {GlobalState} from 'types/store';
 
@@ -39,14 +42,15 @@ export const getChannelHeaderPluginComponents = createSelector(
     (state: GlobalState) => appBarEnabled(state),
     (state: GlobalState) => state.plugins.components.ChannelHeaderButton,
     (state: GlobalState) => state.plugins.components.AppBar,
-    (enabled, channelHeaderComponents = [], appBarComponents = []) => {
-        if (!enabled || !appBarComponents.length) {
-            return channelHeaderComponents;
+    getCurrentChannel,
+    getLicense,
+    (enabled, channelHeaderComponents = [], appBarComponents = [], channel, license) => {
+        let components = channelHeaderComponents;
+        if (enabled && appBarComponents.length) {
+            const appBarPluginIds = appBarComponents.map((appBarComponent) => appBarComponent.pluginId);
+            components = components.filter((channelHeaderComponent) => !appBarPluginIds.includes(channelHeaderComponent.pluginId));
         }
-
-        // Remove channel header icons for plugins that have also registered an app bar component
-        const appBarPluginIds = appBarComponents.map((appBarComponent) => appBarComponent.pluginId);
-        return channelHeaderComponents.filter((channelHeaderComponent) => !appBarPluginIds.includes(channelHeaderComponent.pluginId));
+        return filterCallsPluginComponents(components, license, channel?.type);
     },
 );
 
@@ -69,16 +73,31 @@ export const getChannelHeaderMenuPluginComponents = createShallowSelector(
     'getChannelHeaderMenuPluginComponents',
     getChannelHeaderMenuPluginComponentsShouldRender,
     (state: GlobalState) => state.plugins.components.ChannelHeader,
-    (componentShouldRender = [], channelHeaderMenuComponents = []) => {
-        return channelHeaderMenuComponents.filter((component, idx) => componentShouldRender[idx]);
+    getCurrentChannel,
+    getLicense,
+    (componentShouldRender = [], channelHeaderMenuComponents = [], channel, license) => {
+        const components = channelHeaderMenuComponents.filter((component, idx) => componentShouldRender[idx]);
+        return filterCallsPluginComponents(components, license, channel?.type);
     },
 );
 
 export const getChannelMobileHeaderPluginButtons = createSelector(
     'getChannelMobileHeaderPluginButtons',
     (state: GlobalState) => state.plugins.components.MobileChannelHeaderButton,
-    (components = []) => {
-        return components;
+    getCurrentChannel,
+    getLicense,
+    (components = [], channel, license) => {
+        return filterCallsPluginComponents(components, license, channel?.type);
+    },
+);
+
+export const getCallButtonPluginComponents = createSelector(
+    'getCallButtonPluginComponents',
+    (state: GlobalState) => state.plugins.components.CallButton,
+    getCurrentChannel,
+    getLicense,
+    (components = [], channel, license) => {
+        return filterCallsPluginComponents(components, license, channel?.type);
     },
 );
 


### PR DESCRIPTION
#### Summary
This PR completely hides the Calls-related plugin items, sub-menus, and navbar action buttons in Public channels, Private channels, and Group Messages (GMs) on unlicensed / Team Edition servers, preventing broken menu components and non-functional UI states.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/37318

#### Screenshots
**Fixed Desktop View (Obsolete "Disable calls" item removed from "More actions"):**
<img width="1250" height="896" alt="Screenshot 2026-07-01 134815" src="https://github.com/user-attachments/assets/b241dc2b-5172-4e5b-a6eb-de8f666c15c0" />

**Fixed Mobile View ("Start call" and "Disable calls" menus cleanly hidden, phone icon removed):**
<img width="428" height="812" alt="Screenshot 2026-07-01 134836" src="https://github.com/user-attachments/assets/8cf9064f-a327-4280-aeb0-12a9a573733d" />

#### Release Note
```release-note
Fixed a UI leak where Calls action buttons and sub-menu items were visible on unlicensed servers in non-DM layouts.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Filtering is now centralized in shared channel/header selector logic used by multiple UI surfaces (desktop header menu, mobile header buttons, and the Calls button components). If channel type or license inputs are wrong, Calls UI could be incorrectly shown/hidden on non-DM layouts, but the change is isolated to Calls plugin components and is covered by targeted selector tests.  

**QA Recommendation:** Minimal manual QA: verify on both desktop and mobile for unlicensed servers that Public/Private/Group Messages show no Calls menu entries, sub-menus, or phone icon (and that taps no longer raise the generic error modal), while DMs still show the Calls UI; spot-check Enterprise/Pro still retains Calls in the same layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->