### PR TITLE
Add PluginRPCTeardownGuard to fix plugin RPC teardown race

### DIFF
--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -208,7 +208,7 @@ func (ch *Channels) initPlugins(rctx request.CTX, pluginDir, webappPluginDir str
 		pluginDir,
 		webappPluginDir,
 		ch.srv.Log(),
-		ch.srv.GetMetrics(),
+		plugin.WithMetrics(ch.srv.GetMetrics()),
 	)
 	if err != nil {
 		ch.srv.Log().Error("Failed to start up plugins", mlog.Err(err))

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -209,6 +209,7 @@ func (ch *Channels) initPlugins(rctx request.CTX, pluginDir, webappPluginDir str
 		webappPluginDir,
 		ch.srv.Log(),
 		plugin.WithMetrics(ch.srv.GetMetrics()),
+		plugin.WithTeardownGuardEnabled(ch.cfgSvc.Config().FeatureFlags.PluginRPCTeardownGuard),
 	)
 	if err != nil {
 		ch.srv.Log().Error("Failed to start up plugins", mlog.Err(err))

--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -93,7 +93,7 @@ func setupMultiPluginAPITest(t *testing.T, pluginCodes []string, pluginManifests
 		return app.NewPluginAPI(rctx, manifest)
 	}
 
-	env, err := plugin.NewEnvironment(newPluginAPI, NewDriverImpl(app.Srv()), pluginDir, webappPluginDir, app.Log(), nil)
+	env, err := plugin.NewEnvironment(newPluginAPI, NewDriverImpl(app.Srv()), pluginDir, webappPluginDir, app.Log())
 	require.NoError(t, err)
 
 	require.Equal(t, len(pluginCodes), len(pluginIDs))
@@ -1126,7 +1126,7 @@ func TestPluginAPIGetPlugins(t *testing.T) {
 	defer os.RemoveAll(pluginDir)
 	defer os.RemoveAll(webappPluginDir)
 
-	env, err := plugin.NewEnvironment(th.NewPluginAPI, NewDriverImpl(th.Server), pluginDir, webappPluginDir, th.App.Log(), nil)
+	env, err := plugin.NewEnvironment(th.NewPluginAPI, NewDriverImpl(th.Server), pluginDir, webappPluginDir, th.App.Log())
 	require.NoError(t, err)
 
 	pluginIDs := []string{"pluginid1", "pluginid2", "pluginid3"}
@@ -1216,7 +1216,7 @@ func TestInstallPlugin(t *testing.T) {
 			return app.NewPluginAPI(rctx, manifest)
 		}
 
-		env, err := plugin.NewEnvironment(newPluginAPI, NewDriverImpl(app.Srv()), pluginDir, webappPluginDir, app.Log(), nil)
+		env, err := plugin.NewEnvironment(newPluginAPI, NewDriverImpl(app.Srv()), pluginDir, webappPluginDir, app.Log())
 		require.NoError(t, err)
 
 		app.ch.SetPluginsEnvironment(env)
@@ -2321,7 +2321,7 @@ func TestAPIMetrics(t *testing.T) {
 		defer os.RemoveAll(pluginDir)
 		defer os.RemoveAll(webappPluginDir)
 
-		env, err := plugin.NewEnvironment(th.NewPluginAPI, NewDriverImpl(th.Server), pluginDir, webappPluginDir, th.App.Log(), metricsMock)
+		env, err := plugin.NewEnvironment(th.NewPluginAPI, NewDriverImpl(th.Server), pluginDir, webappPluginDir, th.App.Log(), plugin.WithMetrics(metricsMock))
 		require.NoError(t, err)
 
 		th.App.ch.SetPluginsEnvironment(env)
@@ -2888,7 +2888,7 @@ func TestPluginUploadsAPI(t *testing.T) {
 	newPluginAPI := func(manifest *model.Manifest) plugin.API {
 		return th.App.NewPluginAPI(th.Context, manifest)
 	}
-	env, err := plugin.NewEnvironment(newPluginAPI, NewDriverImpl(th.App.Srv()), pluginDir, webappPluginDir, th.App.Log(), nil)
+	env, err := plugin.NewEnvironment(newPluginAPI, NewDriverImpl(th.App.Srv()), pluginDir, webappPluginDir, th.App.Log())
 	require.NoError(t, err)
 
 	th.App.ch.SetPluginsEnvironment(env)
@@ -2928,7 +2928,7 @@ func TestConfigurationWillBeSavedHook(t *testing.T) {
 		newPluginAPI := func(manifest *model.Manifest) plugin.API {
 			return th.App.NewPluginAPI(th.Context, manifest)
 		}
-		env, err := plugin.NewEnvironment(newPluginAPI, NewDriverImpl(th.App.Srv()), pluginDir, webappPluginDir, th.App.Log(), nil)
+		env, err := plugin.NewEnvironment(newPluginAPI, NewDriverImpl(th.App.Srv()), pluginDir, webappPluginDir, th.App.Log())
 		require.NoError(t, err)
 
 		th.App.ch.SetPluginsEnvironment(env)

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -49,7 +49,7 @@ func setAppEnvironmentWithPlugins(t *testing.T, pluginCode []string, app *App, a
 	webappPluginDir, err := os.MkdirTemp("", "")
 	require.NoError(t, err)
 
-	env, err := plugin.NewEnvironment(apiFunc, NewDriverImpl(app.Srv()), pluginDir, webappPluginDir, app.Log(), nil)
+	env, err := plugin.NewEnvironment(apiFunc, NewDriverImpl(app.Srv()), pluginDir, webappPluginDir, app.Log())
 	require.NoError(t, err)
 
 	app.ch.SetPluginsEnvironment(env)
@@ -1203,7 +1203,7 @@ func TestHookMetrics(t *testing.T) {
 		defer os.RemoveAll(pluginDir)
 		defer os.RemoveAll(webappPluginDir)
 
-		env, err := plugin.NewEnvironment(th.NewPluginAPI, NewDriverImpl(th.Server), pluginDir, webappPluginDir, th.App.Log(), metricsMock)
+		env, err := plugin.NewEnvironment(th.NewPluginAPI, NewDriverImpl(th.Server), pluginDir, webappPluginDir, th.App.Log(), plugin.WithMetrics(metricsMock))
 		require.NoError(t, err)
 
 		th.App.ch.SetPluginsEnvironment(env)

--- a/server/channels/app/shared_channel_test.go
+++ b/server/channels/app/shared_channel_test.go
@@ -1865,7 +1865,7 @@ func activatePluginFromTemplate(t *testing.T, th *TestHelper, pluginID, template
 	newPluginAPI := func(manifest *model.Manifest) plugin.API {
 		return th.App.NewPluginAPI(th.Context, manifest)
 	}
-	env, err := plugin.NewEnvironment(newPluginAPI, NewDriverImpl(th.App.Srv()), pluginDir, webappPluginDir, th.App.Log(), nil)
+	env, err := plugin.NewEnvironment(newPluginAPI, NewDriverImpl(th.App.Srv()), pluginDir, webappPluginDir, th.App.Log())
 	require.NoError(t, err)
 
 	th.App.ch.SetPluginsEnvironment(env)

--- a/server/channels/web/web_test.go
+++ b/server/channels/web/web_test.go
@@ -281,7 +281,7 @@ func TestPublicFilesRequest(t *testing.T) {
 	defer os.RemoveAll(pluginDir)
 	defer os.RemoveAll(webappPluginDir)
 
-	env, err := plugin.NewEnvironment(th.NewPluginAPI, app.NewDriverImpl(th.Server), pluginDir, webappPluginDir, th.App.Log(), nil)
+	env, err := plugin.NewEnvironment(th.NewPluginAPI, app.NewDriverImpl(th.Server), pluginDir, webappPluginDir, th.App.Log())
 	require.NoError(t, err)
 
 	pluginID := "com.mattermost.sample"

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -143,6 +143,10 @@ type FeatureFlags struct {
 
 	// Enable the new mm_blocks Interactive Messages framework
 	MmBlocksEnabled bool
+
+	// Guard plugin RPC hook dispatch against a concurrently deactivating plugin, avoiding
+	// "connection is shut down" errors during plugin/pod restarts.
+	PluginRPCTeardownGuard bool
 }
 
 func (f *FeatureFlags) SetDefaults() {
@@ -203,6 +207,8 @@ func (f *FeatureFlags) SetDefaults() {
 	f.PropertyFieldRank = true
 
 	f.MmBlocksEnabled = true
+
+	f.PluginRPCTeardownGuard = true
 }
 
 // IsChannelPermissionPoliciesEnabled reports whether channel-scope

--- a/server/public/plugin/environment.go
+++ b/server/public/plugin/environment.go
@@ -63,22 +63,41 @@ type Environment struct {
 	prepackagedPluginsLock           sync.RWMutex
 }
 
+// EnvironmentOption configures optional Environment behavior at construction time. See
+// WithMetrics.
+type EnvironmentOption func(*Environment) error
+
+// WithMetrics records plugin hook and lifecycle metrics via the given implementation.
+func WithMetrics(metrics metricsInterface) EnvironmentOption {
+	return func(env *Environment) error {
+		env.metrics = metrics
+		return nil
+	}
+}
+
 func NewEnvironment(
 	newAPIImpl apiImplCreatorFunc,
 	dbDriver AppDriver,
 	pluginDir string,
 	webappPluginDir string,
 	logger *mlog.Logger,
-	metrics metricsInterface,
+	opts ...EnvironmentOption,
 ) (*Environment, error) {
-	return &Environment{
+	env := &Environment{
 		logger:          logger,
-		metrics:         metrics,
 		newAPIImpl:      newAPIImpl,
 		dbDriver:        dbDriver,
 		pluginDir:       pluginDir,
 		webappPluginDir: webappPluginDir,
-	}, nil
+	}
+
+	for _, opt := range opts {
+		if err := opt(env); err != nil {
+			return nil, errors.Wrap(err, "failed to apply environment option")
+		}
+	}
+
+	return env, nil
 }
 
 // Performs a full scan of the given path.

--- a/server/public/plugin/environment.go
+++ b/server/public/plugin/environment.go
@@ -74,8 +74,7 @@ type Environment struct {
 	teardownGuardEnabled bool
 }
 
-// EnvironmentOption configures optional Environment behavior at construction time. See
-// WithMetrics and WithTeardownGuardEnabled.
+// EnvironmentOption configures optional Environment behavior at construction time.
 type EnvironmentOption func(*Environment) error
 
 // WithMetrics records plugin hook and lifecycle metrics via the given implementation.
@@ -105,13 +104,11 @@ func NewEnvironment(
 	opts ...EnvironmentOption,
 ) (*Environment, error) {
 	env := &Environment{
-		logger:          logger,
-		newAPIImpl:      newAPIImpl,
-		dbDriver:        dbDriver,
-		pluginDir:       pluginDir,
-		webappPluginDir: webappPluginDir,
-		// Defaults to enabled so callers (tests included) get the race guard for free; pass
-		// WithTeardownGuardEnabled(false) to opt out, e.g. to mirror a disabled feature flag.
+		logger:               logger,
+		newAPIImpl:           newAPIImpl,
+		dbDriver:             dbDriver,
+		pluginDir:            pluginDir,
+		webappPluginDir:      webappPluginDir,
 		teardownGuardEnabled: true,
 	}
 

--- a/server/public/plugin/environment.go
+++ b/server/public/plugin/environment.go
@@ -37,9 +37,9 @@ type registeredPlugin struct {
 	supervisor *supervisor
 
 	// mu guards RPC hook dispatch against concurrent teardown. Writers (Deactivate/Shutdown)
-	// hold it for the duration of OnDeactivate+Shutdown so that once teardown begins, readers
-	// (RunMultiPluginHook*) fail fast via TryRLock instead of queuing behind the closing
-	// connection.
+	// hold it only for the supervisor Shutdown call, after OnDeactivate has already run with
+	// the connection live, so that once teardown begins, readers (RunMultiPluginHook*) fail
+	// fast via TryRLock instead of queuing behind the closing connection.
 	mu *sync.RWMutex
 }
 

--- a/server/public/plugin/environment.go
+++ b/server/public/plugin/environment.go
@@ -116,6 +116,9 @@ func NewEnvironment(
 	}
 
 	for _, opt := range opts {
+		if opt == nil {
+			continue
+		}
 		if err := opt(env); err != nil {
 			return nil, errors.Wrap(err, "failed to apply environment option")
 		}

--- a/server/public/plugin/environment.go
+++ b/server/public/plugin/environment.go
@@ -35,6 +35,12 @@ type registeredPlugin struct {
 	Error      string
 
 	supervisor *supervisor
+
+	// mu guards RPC hook dispatch against concurrent teardown. Writers (Deactivate/Shutdown)
+	// hold it for the duration of OnDeactivate+Shutdown so that once teardown begins, readers
+	// (RunMultiPluginHook*) fail fast via TryRLock instead of queuing behind the closing
+	// connection.
+	mu *sync.RWMutex
 }
 
 // PrepackagedPlugin is a plugin prepackaged with the server and found on startup.
@@ -61,16 +67,31 @@ type Environment struct {
 	prepackagedPlugins               []*PrepackagedPlugin
 	transitionallyPrepackagedPlugins []*PrepackagedPlugin
 	prepackagedPluginsLock           sync.RWMutex
+
+	// teardownGuardEnabled gates the per-plugin RPC dispatch/teardown race guard, backed by the
+	// PluginRPCTeardownGuard feature flag. Fixed for the lifetime of the Environment; set via
+	// WithTeardownGuardEnabled, defaulting to enabled.
+	teardownGuardEnabled bool
 }
 
 // EnvironmentOption configures optional Environment behavior at construction time. See
-// WithMetrics.
+// WithMetrics and WithTeardownGuardEnabled.
 type EnvironmentOption func(*Environment) error
 
 // WithMetrics records plugin hook and lifecycle metrics via the given implementation.
 func WithMetrics(metrics metricsInterface) EnvironmentOption {
 	return func(env *Environment) error {
 		env.metrics = metrics
+		return nil
+	}
+}
+
+// WithTeardownGuardEnabled toggles the RPC dispatch/teardown race guard used by
+// RunMultiPluginHook*, Deactivate, and Shutdown. Backed by the PluginRPCTeardownGuard feature
+// flag; enabled by default if this option is not supplied.
+func WithTeardownGuardEnabled(enabled bool) EnvironmentOption {
+	return func(env *Environment) error {
+		env.teardownGuardEnabled = enabled
 		return nil
 	}
 }
@@ -89,6 +110,9 @@ func NewEnvironment(
 		dbDriver:        dbDriver,
 		pluginDir:       pluginDir,
 		webappPluginDir: webappPluginDir,
+		// Defaults to enabled so callers (tests included) get the race guard for free; pass
+		// WithTeardownGuardEnabled(false) to opt out, e.g. to mirror a disabled feature flag.
+		teardownGuardEnabled: true,
 	}
 
 	for _, opt := range opts {
@@ -471,6 +495,7 @@ func (env *Environment) Deactivate(id string) bool {
 	if !ok {
 		return false
 	}
+	rp := p.(registeredPlugin)
 
 	isActive := env.IsActive(id)
 
@@ -480,10 +505,20 @@ func (env *Environment) Deactivate(id string) bool {
 		return false
 	}
 
-	rp := p.(registeredPlugin)
 	if rp.supervisor != nil {
+		// OnDeactivate runs with the connection still fully live, so a plugin is free to call
+		// back into the API (e.g. CreatePost), which may dispatch further hooks to itself;
+		// don't hold the lock across it.
 		if err := rp.supervisor.Hooks().OnDeactivate(); err != nil {
 			env.logger.Error("Plugin OnDeactivate() error", mlog.String("plugin_id", rp.BundleInfo.Manifest.Id), mlog.Err(err))
+		}
+
+		if env.teardownGuardEnabled {
+			// Blocks until any in-flight RunMultiPluginHook* dispatches release their RLock,
+			// and causes new dispatches to fail fast via TryRLock rather than racing the RPC
+			// connection close below.
+			rp.mu.Lock()
+			defer rp.mu.Unlock()
 		}
 		rp.supervisor.Shutdown()
 	}
@@ -515,6 +550,9 @@ func (env *Environment) Shutdown() {
 		done := make(chan bool)
 		go func() {
 			defer close(done)
+			// OnDeactivate runs with the connection still fully live, so a plugin is free to
+			// call back into the API, which may dispatch further hooks to itself; don't hold
+			// the lock across it.
 			if err := rp.supervisor.Hooks().OnDeactivate(); err != nil {
 				env.logger.Error("Plugin OnDeactivate() error", mlog.String("plugin_id", rp.BundleInfo.Manifest.Id), mlog.Err(err))
 			}
@@ -529,6 +567,13 @@ func (env *Environment) Shutdown() {
 			case <-done:
 			}
 
+			if env.teardownGuardEnabled {
+				// Blocks until any in-flight RunMultiPluginHook* dispatches release their
+				// RLock, and causes new dispatches to fail fast via TryRLock rather than
+				// racing the RPC connection close below.
+				rp.mu.Lock()
+				defer rp.mu.Unlock()
+			}
 			rp.supervisor.Shutdown()
 		}()
 
@@ -658,6 +703,15 @@ func (env *Environment) RunMultiPluginHook(hookRunnerFunc func(hooks Hooks, mani
 			return true
 		}
 
+		if env.teardownGuardEnabled {
+			// TryRLock fails fast instead of queuing if the plugin is concurrently tearing
+			// down, avoiding a call into an RPC connection that's mid-close.
+			if !rp.mu.TryRLock() {
+				return true
+			}
+			defer rp.mu.RUnlock()
+		}
+
 		hookStartTime := time.Now()
 		result := hookRunnerFunc(rp.supervisor.Hooks(), rp.BundleInfo.Manifest)
 
@@ -696,6 +750,13 @@ func (env *Environment) RunMultiPluginHookExcluding(
 			return true
 		}
 
+		if env.teardownGuardEnabled {
+			if !rp.mu.TryRLock() {
+				return true
+			}
+			defer rp.mu.RUnlock()
+		}
+
 		hookStartTime := time.Now()
 		cont := hookRunnerFunc(rp.supervisor.Hooks(), rp.BundleInfo.Manifest)
 
@@ -725,6 +786,13 @@ func (env *Environment) RunMultiPluginHookWithRPCErr(hookRunnerFunc func(hooks H
 
 		if rp.supervisor == nil || !rp.supervisor.Implements(hookId) || !env.IsActive(rp.BundleInfo.Manifest.Id) {
 			return true
+		}
+
+		if env.teardownGuardEnabled {
+			if !rp.mu.TryRLock() {
+				return true
+			}
+			defer rp.mu.RUnlock()
 		}
 
 		hookStartTime := time.Now()
@@ -774,7 +842,7 @@ func (env *Environment) SetPrepackagedPlugins(plugins, transitionalPlugins []*Pr
 
 func newRegisteredPlugin(bundle *model.BundleInfo) registeredPlugin {
 	state := model.PluginStateNotRunning
-	return registeredPlugin{State: state, BundleInfo: bundle}
+	return registeredPlugin{State: state, BundleInfo: bundle, mu: &sync.RWMutex{}}
 }
 
 // TogglePluginHealthCheckJob starts a new job if one is not running and is set to enabled, or kills an existing one if set to disabled.

--- a/server/public/plugin/environment_teardown_guard_test.go
+++ b/server/public/plugin/environment_teardown_guard_test.go
@@ -86,7 +86,7 @@ func TestNewEnvironmentOptionError(t *testing.T) {
 	logger := mlog.CreateConsoleTestLogger(t)
 	apiImpl := func(*model.Manifest) API { return nil }
 	sentinel := errors.New("boom")
-	failingOption := EnvironmentOption(func(*Environment) error { return sentinel })
+	failingOption := func(*Environment) error { return sentinel }
 
 	env, err := NewEnvironment(apiImpl, nil, t.TempDir(), t.TempDir(), logger, failingOption)
 	require.Nil(t, env)
@@ -145,11 +145,9 @@ func TestDeactivateBlocksConcurrentHookDispatch(t *testing.T) {
 
 	var wg sync.WaitGroup
 	stop := make(chan struct{})
-	var errCount int32
+	var errCount atomic.Int32
 
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case <-stop:
@@ -160,10 +158,10 @@ func TestDeactivateBlocksConcurrentHookDispatch(t *testing.T) {
 				return true, hooks.MessageHasBeenPostedWithRPCErr(&Context{}, &model.Post{})
 			}, MessageHasBeenPostedID)
 			if runErr != nil {
-				atomic.AddInt32(&errCount, 1)
+				errCount.Add(1)
 			}
 		}
-	}()
+	})
 
 	// Give the hammering goroutine a head start before tearing down.
 	time.Sleep(10 * time.Millisecond)
@@ -172,5 +170,5 @@ func TestDeactivateBlocksConcurrentHookDispatch(t *testing.T) {
 	close(stop)
 	wg.Wait()
 
-	require.Zero(t, atomic.LoadInt32(&errCount), "no hook dispatch should race the closing RPC connection")
+	require.Zero(t, errCount.Load(), "no hook dispatch should race the closing RPC connection")
 }

--- a/server/public/plugin/environment_teardown_guard_test.go
+++ b/server/public/plugin/environment_teardown_guard_test.go
@@ -1,0 +1,176 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package plugin
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin/utils"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+)
+
+// activateTeardownGuardTestPlugin compiles and activates a minimal plugin implementing
+// MessageHasBeenPosted, returning the environment and the plugin's id.
+func activateTeardownGuardTestPlugin(t *testing.T, opts ...EnvironmentOption) (*Environment, string) {
+	t.Helper()
+
+	pluginDir, err := os.MkdirTemp("", "mm-teardown-guard-plugin")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(pluginDir) })
+	webappPluginDir, err := os.MkdirTemp("", "mm-teardown-guard-webapp")
+	require.NoError(t, err)
+	t.Cleanup(func() { os.RemoveAll(webappPluginDir) })
+
+	pluginID := "test-teardown-guard-plugin"
+	require.NoError(t, os.MkdirAll(filepath.Join(pluginDir, pluginID), 0700))
+	backend := filepath.Join(pluginDir, pluginID, "backend.exe")
+
+	utils.CompileGo(t, `
+		package main
+
+		import (
+			"github.com/mattermost/mattermost/server/public/model"
+			"github.com/mattermost/mattermost/server/public/plugin"
+		)
+
+		type MyPlugin struct {
+			plugin.MattermostPlugin
+		}
+
+		func (p *MyPlugin) MessageHasBeenPosted(c *plugin.Context, post *model.Post) {}
+
+		func main() {
+			plugin.ClientMain(&MyPlugin{})
+		}
+	`, backend)
+
+	require.NoError(t, os.WriteFile(
+		filepath.Join(pluginDir, pluginID, "plugin.json"),
+		[]byte(`{"id":"`+pluginID+`","server":{"executable":"backend.exe"}}`),
+		0600,
+	))
+
+	logger := mlog.CreateConsoleTestLogger(t)
+	apiImpl := func(*model.Manifest) API { return nil }
+	env, err := NewEnvironment(apiImpl, nil, pluginDir, webappPluginDir, logger, opts...)
+	require.NoError(t, err)
+	t.Cleanup(env.Shutdown)
+
+	_, _, err = env.Activate(pluginID)
+	require.NoError(t, err)
+	require.True(t, env.IsActive(pluginID))
+
+	return env, pluginID
+}
+
+func TestNewEnvironmentSkipsNilOptions(t *testing.T) {
+	logger := mlog.CreateConsoleTestLogger(t)
+	apiImpl := func(*model.Manifest) API { return nil }
+
+	env, err := NewEnvironment(apiImpl, nil, t.TempDir(), t.TempDir(), logger, nil, WithTeardownGuardEnabled(false), nil)
+	require.NoError(t, err)
+	require.False(t, env.teardownGuardEnabled)
+}
+
+func TestNewEnvironmentOptionError(t *testing.T) {
+	logger := mlog.CreateConsoleTestLogger(t)
+	apiImpl := func(*model.Manifest) API { return nil }
+	sentinel := errors.New("boom")
+	failingOption := EnvironmentOption(func(*Environment) error { return sentinel })
+
+	env, err := NewEnvironment(apiImpl, nil, t.TempDir(), t.TempDir(), logger, failingOption)
+	require.Nil(t, env)
+	require.ErrorIs(t, err, sentinel)
+}
+
+func TestRunMultiPluginHookSkipsWhileWriteLockHeld(t *testing.T) {
+	env, pluginID := activateTeardownGuardTestPlugin(t)
+
+	p, ok := env.registeredPlugins.Load(pluginID)
+	require.True(t, ok)
+	rp := p.(registeredPlugin)
+
+	rp.mu.Lock()
+	var calls int
+	env.RunMultiPluginHook(func(_ Hooks, _ *model.Manifest) bool {
+		calls++
+		return true
+	}, MessageHasBeenPostedID)
+	rp.mu.Unlock()
+	require.Equal(t, 0, calls, "hook should be skipped while the write lock is held")
+
+	calls = 0
+	env.RunMultiPluginHook(func(_ Hooks, _ *model.Manifest) bool {
+		calls++
+		return true
+	}, MessageHasBeenPostedID)
+	require.Equal(t, 1, calls, "hook should run once the write lock is released")
+}
+
+func TestRunMultiPluginHookIgnoresLockWhenGuardDisabled(t *testing.T) {
+	env, pluginID := activateTeardownGuardTestPlugin(t, WithTeardownGuardEnabled(false))
+
+	p, ok := env.registeredPlugins.Load(pluginID)
+	require.True(t, ok)
+	rp := p.(registeredPlugin)
+
+	rp.mu.Lock()
+	defer rp.mu.Unlock()
+
+	var calls int
+	env.RunMultiPluginHook(func(_ Hooks, _ *model.Manifest) bool {
+		calls++
+		return true
+	}, MessageHasBeenPostedID)
+	require.Equal(t, 1, calls, "hook should still run when the teardown guard is disabled")
+}
+
+// TestDeactivateBlocksConcurrentHookDispatch hammers RunMultiPluginHookWithRPCErr concurrently with
+// Deactivate and asserts the guard prevents any dispatch into the plugin's closing RPC connection:
+// every observed call either completes cleanly (before teardown starts) or is skipped entirely (once
+// teardown begins), but none surfaces a transport error. Run with -race to also confirm the guard
+// itself is race-free.
+func TestDeactivateBlocksConcurrentHookDispatch(t *testing.T) {
+	env, pluginID := activateTeardownGuardTestPlugin(t)
+
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	var errCount int32
+
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			runErr := env.RunMultiPluginHookWithRPCErr(func(hooks HooksWithRPCErr, _ *model.Manifest) (bool, error) {
+				return true, hooks.MessageHasBeenPostedWithRPCErr(&Context{}, &model.Post{})
+			}, MessageHasBeenPostedID)
+			if runErr != nil {
+				atomic.AddInt32(&errCount, 1)
+			}
+		}
+	}()
+
+	// Give the hammering goroutine a head start before tearing down.
+	time.Sleep(10 * time.Millisecond)
+	require.True(t, env.Deactivate(pluginID))
+
+	close(stop)
+	wg.Wait()
+
+	require.Zero(t, atomic.LoadInt32(&errCount), "no hook dispatch should race the closing RPC connection")
+}

--- a/server/public/plugin/environment_test.go
+++ b/server/public/plugin/environment_test.go
@@ -116,7 +116,7 @@ func TestHasPluginImplementing(t *testing.T) {
 
 	logger := mlog.CreateConsoleTestLogger(t)
 	apiImpl := func(*model.Manifest) API { return nil }
-	env, err := NewEnvironment(apiImpl, nil, pluginDir, webappPluginDir, logger, nil)
+	env, err := NewEnvironment(apiImpl, nil, pluginDir, webappPluginDir, logger)
 	require.NoError(t, err)
 	t.Cleanup(env.Shutdown)
 

--- a/server/public/plugin/environment_with_rpcerr_test.go
+++ b/server/public/plugin/environment_with_rpcerr_test.go
@@ -66,7 +66,7 @@ func TestRunMultiPluginHookWithRPCErr(t *testing.T) {
 
 	logger := mlog.CreateConsoleTestLogger(t)
 	apiImpl := func(*model.Manifest) API { return nil }
-	env, err := NewEnvironment(apiImpl, nil, pluginDir, webappPluginDir, logger, nil)
+	env, err := NewEnvironment(apiImpl, nil, pluginDir, webappPluginDir, logger)
 	require.NoError(t, err)
 	t.Cleanup(env.Shutdown)
 


### PR DESCRIPTION
#### Summary
When Hub restarts or a plugin is upgraded, the logs are filled with errors like these (for various plugins, not just Calls):
```
RPC call WebSocketMessageHasBeenPosted to plugin failed plugin_id=com.mattermost.calls error=connection is shut down
```

But these are spurious: the plugin isn't supposed to be handling requests at this point! Guard against this by trying a per-plugin `RWMutex` when calling hooks. On shutdown, we acquire the write lock, blocking all new hook calls and (automatically) waiting for the queue of active hook invocations that hold the read lock. Gated by the new `PluginRPCTeardownGuard` feature flag, defaulted to `true`.

Broken into two commits to refactor `plugin.NewEnvironment` to use the functional option pattern for optional parameters.

#### Release Note
```release-note
Added the PluginRPCTeardownGuard feature flag (enabled by default) to prevent spurious "connection is shut down" errors when a plugin hook is invoked while the plugin is concurrently being deactivated or the server is shutting down.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: Medium 🟡

**Regression Risk:** This alters plugin hook dispatch vs teardown concurrency and changes `plugin.NewEnvironment` construction semantics (options/feature-flag plumbing), which could affect plugin startup/shutdown behavior and hook execution timing. Although feature-flagged and covered by new concurrency-focused tests, the flag defaults to enabled, increasing exposure to real deployments if any edge-case timing differs.

**QA Recommendation:** Light manual QA targeting plugin restart/upgrade and shutdown/restart overlap (default flag on), verifying hooks still fire correctly and no spurious RPC shutdown errors occur.
  
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->