### PR TITLE
Bumping version of prepackaged boards plugin to 9.3.0

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -166,7 +166,7 @@ PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.10.0
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.2
-PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0-rc2
+PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.6.1
 PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.4.1
@@ -180,7 +180,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.10.0%2B090a26d-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.2%2B1305067-fips
-	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0-rc2%2B5880c13-fips
+	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0%2Bd454327-fips
 endif
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
<!-- What does this PR do? Include QA steps if not covered in the ticket. -->
This PR bumps the version of the prepackaged boards plugin to 9.3.0

#### Ticket Link
<!--
Fixes: https://github.com/mattermost/mattermost/issues/XXX
Fixes: https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!-- Include screenshots or GIFs for UI changes. -->

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note
Prepackage Boards plugin version [v9.3.0](https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.3.0).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** The update is limited to the prepackaged Boards plugin version in the server build configuration, so it does not alter runtime server logic, APIs, or data flows. Risk is mainly limited to packaging/install-time behavior if the new plugin build has compatibility issues.

**QA Recommendation:** Light validation is sufficient: confirm the server package resolves and bundles the expected Boards plugin version and that Boards loads normally in a basic deployment.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->