### PR TITLE
Add plugin metadata panel to management and settings pages

### DIFF
--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
@@ -85,7 +85,7 @@ describe('custom plugin sections and settings', () => {
     const expectPluginPageTitle = (pluginName: string, pluginId: string) => {
         const panel = screen.getByTestId('plugin-metadata-panel');
         expect(panel).toHaveTextContent(`${pluginName} (${pluginId}`);
-        expect(document.querySelector('.admin-console__header')).toContainElement(panel);
+        expect(document.querySelector('.PluginMetadataPanel__settingsWrapper')).toContainElement(panel);
     };
 
     it('empty sections and settings', () => {

--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
@@ -86,6 +86,7 @@ describe('custom plugin sections and settings', () => {
         const panel = screen.getByTestId('plugin-metadata-panel');
         expect(panel).toHaveTextContent(`${pluginName} (${pluginId}`);
         expect(document.querySelector('.PluginMetadataPanel__settingsWrapper')).toContainElement(panel);
+        expect(screen.getByRole('heading', {level: 1, hidden: true})).toHaveTextContent(pluginName);
     };
 
     it('empty sections and settings', () => {

--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
@@ -82,9 +82,10 @@ describe('custom plugin sections and settings', () => {
         },
     };
 
-    const expectPluginPageTitle = (pluginName: string) => {
-        expect(screen.getByTestId('plugin-metadata-panel')).toBeInTheDocument();
-        expect(document.querySelector('.admin-console__header')).toHaveTextContent(pluginName);
+    const expectPluginPageTitle = (pluginName: string, pluginId: string) => {
+        const panel = screen.getByTestId('plugin-metadata-panel');
+        expect(panel).toHaveTextContent(`${pluginName} (${pluginId}`);
+        expect(document.querySelector('.admin-console__header')).toContainElement(panel);
     };
 
     it('empty sections and settings', () => {
@@ -95,7 +96,7 @@ describe('custom plugin sections and settings', () => {
             />,
             {...baseState});
 
-        expectPluginPageTitle('testplugin');
+        expectPluginPageTitle('testplugin', 'testplugin');
         expect(screen.getByTestId('PluginSettings.PluginStates.testplugin.Enable')).toBeInTheDocument();
         expect(screen.getByText('This is the header')).toBeInTheDocument();
         expect(screen.getByText('This is the footer')).toBeInTheDocument();
@@ -165,7 +166,7 @@ describe('custom plugin sections and settings', () => {
             />,
             {...state});
 
-        expectPluginPageTitle('testplugin');
+        expectPluginPageTitle('testplugin', 'testplugin');
         expect(screen.getByTestId('PluginSettings.PluginStates.testplugin.Enable')).toBeInTheDocument();
         expect(screen.getByText('In order to view and configure plugin settings, enable the plugin and click Save.')).toBeInTheDocument();
         expect(screen.queryByText('Custom Section 1')).not.toBeInTheDocument();
@@ -244,7 +245,7 @@ describe('custom plugin sections and settings', () => {
             />,
             {...state});
 
-        expectPluginPageTitle('testplugin');
+        expectPluginPageTitle('testplugin', 'testplugin');
         expect(screen.getByTestId('PluginSettings.PluginStates.testplugin.Enable')).toBeInTheDocument();
         expect(screen.queryByText('In order to view and configure plugin settings, enable the plugin and click Save.')).not.toBeInTheDocument();
         expect(screen.queryByText('Custom Section 1')).toBeInTheDocument();
@@ -347,7 +348,7 @@ describe('custom plugin sections and settings', () => {
             />,
             {...state});
 
-        expectPluginPageTitle('testplugin');
+        expectPluginPageTitle('testplugin', 'testplugin');
         expect(screen.getByTestId('PluginSettings.PluginStates.testplugin.Enable')).toBeInTheDocument();
         expect(screen.queryByText('In order to view and configure plugin settings, enable the plugin and click Save.')).not.toBeInTheDocument();
         expect(screen.getByText('Custom Component Section 1')).toBeInTheDocument();

--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
@@ -82,6 +82,11 @@ describe('custom plugin sections and settings', () => {
         },
     };
 
+    const expectPluginPageTitle = (pluginName: string) => {
+        expect(screen.getByTestId('plugin-metadata-panel')).toBeInTheDocument();
+        expect(document.querySelector('.admin-console__header')).toHaveTextContent(pluginName);
+    };
+
     it('empty sections and settings', () => {
         renderWithContext(
             <CustomPluginSettings
@@ -90,7 +95,7 @@ describe('custom plugin sections and settings', () => {
             />,
             {...baseState});
 
-        expect(screen.getByText('testplugin')).toBeInTheDocument();
+        expectPluginPageTitle('testplugin');
         expect(screen.getByTestId('PluginSettings.PluginStates.testplugin.Enable')).toBeInTheDocument();
         expect(screen.getByText('This is the header')).toBeInTheDocument();
         expect(screen.getByText('This is the footer')).toBeInTheDocument();
@@ -160,7 +165,7 @@ describe('custom plugin sections and settings', () => {
             />,
             {...state});
 
-        expect(screen.getByText('testplugin')).toBeInTheDocument();
+        expectPluginPageTitle('testplugin');
         expect(screen.getByTestId('PluginSettings.PluginStates.testplugin.Enable')).toBeInTheDocument();
         expect(screen.getByText('In order to view and configure plugin settings, enable the plugin and click Save.')).toBeInTheDocument();
         expect(screen.queryByText('Custom Section 1')).not.toBeInTheDocument();
@@ -239,7 +244,7 @@ describe('custom plugin sections and settings', () => {
             />,
             {...state});
 
-        expect(screen.getByText('testplugin')).toBeInTheDocument();
+        expectPluginPageTitle('testplugin');
         expect(screen.getByTestId('PluginSettings.PluginStates.testplugin.Enable')).toBeInTheDocument();
         expect(screen.queryByText('In order to view and configure plugin settings, enable the plugin and click Save.')).not.toBeInTheDocument();
         expect(screen.queryByText('Custom Section 1')).toBeInTheDocument();
@@ -342,7 +347,7 @@ describe('custom plugin sections and settings', () => {
             />,
             {...state});
 
-        expect(screen.getByText('testplugin')).toBeInTheDocument();
+        expectPluginPageTitle('testplugin');
         expect(screen.getByTestId('PluginSettings.PluginStates.testplugin.Enable')).toBeInTheDocument();
         expect(screen.queryByText('In order to view and configure plugin settings, enable the plugin and click Save.')).not.toBeInTheDocument();
         expect(screen.getByText('Custom Component Section 1')).toBeInTheDocument();

--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
@@ -103,6 +103,42 @@ describe('custom plugin sections and settings', () => {
         expect(screen.getByText('This is the footer')).toBeInTheDocument();
     });
 
+    it('renders plugin metadata with distinct display name and id', () => {
+        const pluginId = 'com.mattermost.fl3xx';
+        const pluginName = 'FL3XX';
+        const namedPlugin = {
+            ...plugin,
+            id: pluginId,
+            name: pluginName,
+        };
+
+        renderWithContext(
+            <CustomPluginSettings
+                {...baseProps}
+                match={{params: {plugin_id: pluginId}} as match<{plugin_id: string}>}
+                config={{
+                    PluginSettings: {
+                        Plugins: {
+                            [pluginId]: {},
+                        },
+                    } as unknown as PluginSettings,
+                }}
+                patchConfig={jest.fn()}
+            />,
+            {
+                entities: {
+                    admin: {
+                        plugins: {
+                            [pluginId]: namedPlugin,
+                        },
+                    },
+                },
+            },
+        );
+
+        expectPluginPageTitle(pluginName, pluginId);
+    });
+
     it('all custom sections with plugin disabled should show single warning', () => {
         const state = {
             ...baseState,

--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.ts
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.ts
@@ -204,6 +204,7 @@ function makeMapStateToProps() {
             schema: getPluginSchema(state, pluginId),
             roles: getRoles(state),
             plugin: state.entities.admin.plugins?.[pluginId],
+            pluginVersion: state.entities.admin.pluginStatuses?.[pluginId]?.version,
         };
     };
 }

--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.ts
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.ts
@@ -203,6 +203,7 @@ function makeMapStateToProps() {
         return {
             schema: getPluginSchema(state, pluginId),
             roles: getRoles(state),
+            plugin: state.entities.admin.plugins?.[pluginId],
         };
     };
 }

--- a/webapp/channels/src/components/admin_console/plugin_management/__snapshots__/plugin_management.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/plugin_management/__snapshots__/plugin_management.test.tsx.snap
@@ -4205,15 +4205,29 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         </strong>
                          (
                         <span
-                          data-testid="plugin-metadata-id"
+                          class="PluginMetadataPanel__idWrapper"
                         >
-                          plugin_0
+                          <code
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                          >
+                            plugin_0
+                          </code>
+                          <span
+                            aria-label="Copy text"
+                            class="post-code__clipboard PluginMetadataPanel__copy"
+                            role="button"
+                          >
+                            <i
+                              class="icon icon-content-copy"
+                            />
+                          </span>
                         </span>
                          - 
                         <span
                           data-testid="plugin-metadata-version"
                         >
-                          0.1.0
+                          v0.1.0
                         </span>
                         )
                       </span>
@@ -4323,15 +4337,29 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         </strong>
                          (
                         <span
-                          data-testid="plugin-metadata-id"
+                          class="PluginMetadataPanel__idWrapper"
                         >
-                          plugin_1
+                          <code
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                          >
+                            plugin_1
+                          </code>
+                          <span
+                            aria-label="Copy text"
+                            class="post-code__clipboard PluginMetadataPanel__copy"
+                            role="button"
+                          >
+                            <i
+                              class="icon icon-content-copy"
+                            />
+                          </span>
                         </span>
                          - 
                         <span
                           data-testid="plugin-metadata-version"
                         >
-                          0.0.1
+                          v0.0.1
                         </span>
                         )
                       </span>
@@ -4885,15 +4913,29 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         </strong>
                          (
                         <span
-                          data-testid="plugin-metadata-id"
+                          class="PluginMetadataPanel__idWrapper"
                         >
-                          plugin_0
+                          <code
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                          >
+                            plugin_0
+                          </code>
+                          <span
+                            aria-label="Copy text"
+                            class="post-code__clipboard PluginMetadataPanel__copy"
+                            role="button"
+                          >
+                            <i
+                              class="icon icon-content-copy"
+                            />
+                          </span>
                         </span>
                          - 
                         <span
                           data-testid="plugin-metadata-version"
                         >
-                          0.1.0
+                          v0.1.0
                         </span>
                         )
                       </span>
@@ -5371,15 +5413,29 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         </strong>
                          (
                         <span
-                          data-testid="plugin-metadata-id"
+                          class="PluginMetadataPanel__idWrapper"
                         >
-                          plugin_0
+                          <code
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                          >
+                            plugin_0
+                          </code>
+                          <span
+                            aria-label="Copy text"
+                            class="post-code__clipboard PluginMetadataPanel__copy"
+                            role="button"
+                          >
+                            <i
+                              class="icon icon-content-copy"
+                            />
+                          </span>
                         </span>
                          - 
                         <span
                           data-testid="plugin-metadata-version"
                         >
-                          0.1.0
+                          v0.1.0
                         </span>
                         )
                       </span>
@@ -5857,15 +5913,29 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         </strong>
                          (
                         <span
-                          data-testid="plugin-metadata-id"
+                          class="PluginMetadataPanel__idWrapper"
                         >
-                          plugin_0
+                          <code
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                          >
+                            plugin_0
+                          </code>
+                          <span
+                            aria-label="Copy text"
+                            class="post-code__clipboard PluginMetadataPanel__copy"
+                            role="button"
+                          >
+                            <i
+                              class="icon icon-content-copy"
+                            />
+                          </span>
                         </span>
                          - 
                         <span
                           data-testid="plugin-metadata-version"
                         >
-                          0.1.0
+                          v0.1.0
                         </span>
                         )
                       </span>
@@ -6343,15 +6413,29 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         </strong>
                          (
                         <span
-                          data-testid="plugin-metadata-id"
+                          class="PluginMetadataPanel__idWrapper"
                         >
-                          plugin_0
+                          <code
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                          >
+                            plugin_0
+                          </code>
+                          <span
+                            aria-label="Copy text"
+                            class="post-code__clipboard PluginMetadataPanel__copy"
+                            role="button"
+                          >
+                            <i
+                              class="icon icon-content-copy"
+                            />
+                          </span>
                         </span>
                          - 
                         <span
                           data-testid="plugin-metadata-version"
                         >
-                          0.1.0
+                          v0.1.0
                         </span>
                         )
                       </span>
@@ -6453,15 +6537,29 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         </strong>
                          (
                         <span
-                          data-testid="plugin-metadata-id"
+                          class="PluginMetadataPanel__idWrapper"
                         >
-                          plugin_1
+                          <code
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                          >
+                            plugin_1
+                          </code>
+                          <span
+                            aria-label="Copy text"
+                            class="post-code__clipboard PluginMetadataPanel__copy"
+                            role="button"
+                          >
+                            <i
+                              class="icon icon-content-copy"
+                            />
+                          </span>
                         </span>
                          - 
                         <span
                           data-testid="plugin-metadata-version"
                         >
-                          0.0.1
+                          v0.0.1
                         </span>
                         )
                       </span>

--- a/webapp/channels/src/components/admin_console/plugin_management/__snapshots__/plugin_management.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/plugin_management/__snapshots__/plugin_management.test.tsx.snap
@@ -4208,23 +4208,13 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            class="PluginMetadataPanel__idWrapper"
+                            aria-label="Copy text"
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                            role="button"
+                            tabindex="0"
                           >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_0
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard PluginMetadataPanel__copy"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
+                            plugin_0
                           </span>
                            - 
                           <span
@@ -4344,23 +4334,13 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            class="PluginMetadataPanel__idWrapper"
+                            aria-label="Copy text"
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                            role="button"
+                            tabindex="0"
                           >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_1
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard PluginMetadataPanel__copy"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
+                            plugin_1
                           </span>
                            - 
                           <span
@@ -4924,23 +4904,13 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            class="PluginMetadataPanel__idWrapper"
+                            aria-label="Copy text"
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                            role="button"
+                            tabindex="0"
                           >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_0
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard PluginMetadataPanel__copy"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
+                            plugin_0
                           </span>
                            - 
                           <span
@@ -5428,23 +5398,13 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            class="PluginMetadataPanel__idWrapper"
+                            aria-label="Copy text"
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                            role="button"
+                            tabindex="0"
                           >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_0
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard PluginMetadataPanel__copy"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
+                            plugin_0
                           </span>
                            - 
                           <span
@@ -5932,23 +5892,13 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            class="PluginMetadataPanel__idWrapper"
+                            aria-label="Copy text"
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                            role="button"
+                            tabindex="0"
                           >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_0
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard PluginMetadataPanel__copy"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
+                            plugin_0
                           </span>
                            - 
                           <span
@@ -6436,23 +6386,13 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            class="PluginMetadataPanel__idWrapper"
+                            aria-label="Copy text"
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                            role="button"
+                            tabindex="0"
                           >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_0
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard PluginMetadataPanel__copy"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
+                            plugin_0
                           </span>
                            - 
                           <span
@@ -6564,23 +6504,13 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            class="PluginMetadataPanel__idWrapper"
+                            aria-label="Copy text"
+                            class="PluginMetadataPanel__id"
+                            data-testid="plugin-metadata-id"
+                            role="button"
+                            tabindex="0"
                           >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_1
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard PluginMetadataPanel__copy"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
+                            plugin_1
                           </span>
                            - 
                           <span

--- a/webapp/channels/src/components/admin_console/plugin_management/__snapshots__/plugin_management.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/plugin_management/__snapshots__/plugin_management.test.tsx.snap
@@ -4203,33 +4203,37 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 0
                         </strong>
-                         (
                         <span
-                          class="PluginMetadataPanel__idWrapper"
+                          class="PluginMetadataPanel__metadata"
                         >
-                          <code
-                            class="PluginMetadataPanel__id"
-                            data-testid="plugin-metadata-id"
-                          >
-                            plugin_0
-                          </code>
+                           (
                           <span
-                            aria-label="Copy text"
-                            class="post-code__clipboard PluginMetadataPanel__copy"
-                            role="button"
+                            class="PluginMetadataPanel__idWrapper"
                           >
-                            <i
-                              class="icon icon-content-copy"
-                            />
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_0
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard PluginMetadataPanel__copy"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
                           </span>
+                           - 
+                          <span
+                            data-testid="plugin-metadata-version"
+                          >
+                            v0.1.0
+                          </span>
+                          )
                         </span>
-                         - 
-                        <span
-                          data-testid="plugin-metadata-version"
-                        >
-                          v0.1.0
-                        </span>
-                        )
                       </span>
                       <div
                         class="pt-2"
@@ -4335,33 +4339,37 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 1
                         </strong>
-                         (
                         <span
-                          class="PluginMetadataPanel__idWrapper"
+                          class="PluginMetadataPanel__metadata"
                         >
-                          <code
-                            class="PluginMetadataPanel__id"
-                            data-testid="plugin-metadata-id"
-                          >
-                            plugin_1
-                          </code>
+                           (
                           <span
-                            aria-label="Copy text"
-                            class="post-code__clipboard PluginMetadataPanel__copy"
-                            role="button"
+                            class="PluginMetadataPanel__idWrapper"
                           >
-                            <i
-                              class="icon icon-content-copy"
-                            />
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_1
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard PluginMetadataPanel__copy"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
                           </span>
+                           - 
+                          <span
+                            data-testid="plugin-metadata-version"
+                          >
+                            v0.0.1
+                          </span>
+                          )
                         </span>
-                         - 
-                        <span
-                          data-testid="plugin-metadata-version"
-                        >
-                          v0.0.1
-                        </span>
-                        )
                       </span>
                       <div
                         class="pt-2"
@@ -4911,33 +4919,37 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 0
                         </strong>
-                         (
                         <span
-                          class="PluginMetadataPanel__idWrapper"
+                          class="PluginMetadataPanel__metadata"
                         >
-                          <code
-                            class="PluginMetadataPanel__id"
-                            data-testid="plugin-metadata-id"
-                          >
-                            plugin_0
-                          </code>
+                           (
                           <span
-                            aria-label="Copy text"
-                            class="post-code__clipboard PluginMetadataPanel__copy"
-                            role="button"
+                            class="PluginMetadataPanel__idWrapper"
                           >
-                            <i
-                              class="icon icon-content-copy"
-                            />
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_0
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard PluginMetadataPanel__copy"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
                           </span>
+                           - 
+                          <span
+                            data-testid="plugin-metadata-version"
+                          >
+                            v0.1.0
+                          </span>
+                          )
                         </span>
-                         - 
-                        <span
-                          data-testid="plugin-metadata-version"
-                        >
-                          v0.1.0
-                        </span>
-                        )
                       </span>
                       <div
                         class="pt-2"
@@ -5411,33 +5423,37 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 0
                         </strong>
-                         (
                         <span
-                          class="PluginMetadataPanel__idWrapper"
+                          class="PluginMetadataPanel__metadata"
                         >
-                          <code
-                            class="PluginMetadataPanel__id"
-                            data-testid="plugin-metadata-id"
-                          >
-                            plugin_0
-                          </code>
+                           (
                           <span
-                            aria-label="Copy text"
-                            class="post-code__clipboard PluginMetadataPanel__copy"
-                            role="button"
+                            class="PluginMetadataPanel__idWrapper"
                           >
-                            <i
-                              class="icon icon-content-copy"
-                            />
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_0
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard PluginMetadataPanel__copy"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
                           </span>
+                           - 
+                          <span
+                            data-testid="plugin-metadata-version"
+                          >
+                            v0.1.0
+                          </span>
+                          )
                         </span>
-                         - 
-                        <span
-                          data-testid="plugin-metadata-version"
-                        >
-                          v0.1.0
-                        </span>
-                        )
                       </span>
                       <div
                         class="pt-2"
@@ -5911,33 +5927,37 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 0
                         </strong>
-                         (
                         <span
-                          class="PluginMetadataPanel__idWrapper"
+                          class="PluginMetadataPanel__metadata"
                         >
-                          <code
-                            class="PluginMetadataPanel__id"
-                            data-testid="plugin-metadata-id"
-                          >
-                            plugin_0
-                          </code>
+                           (
                           <span
-                            aria-label="Copy text"
-                            class="post-code__clipboard PluginMetadataPanel__copy"
-                            role="button"
+                            class="PluginMetadataPanel__idWrapper"
                           >
-                            <i
-                              class="icon icon-content-copy"
-                            />
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_0
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard PluginMetadataPanel__copy"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
                           </span>
+                           - 
+                          <span
+                            data-testid="plugin-metadata-version"
+                          >
+                            v0.1.0
+                          </span>
+                          )
                         </span>
-                         - 
-                        <span
-                          data-testid="plugin-metadata-version"
-                        >
-                          v0.1.0
-                        </span>
-                        )
                       </span>
                       <div
                         class="pt-2"
@@ -6411,33 +6431,37 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 0
                         </strong>
-                         (
                         <span
-                          class="PluginMetadataPanel__idWrapper"
+                          class="PluginMetadataPanel__metadata"
                         >
-                          <code
-                            class="PluginMetadataPanel__id"
-                            data-testid="plugin-metadata-id"
-                          >
-                            plugin_0
-                          </code>
+                           (
                           <span
-                            aria-label="Copy text"
-                            class="post-code__clipboard PluginMetadataPanel__copy"
-                            role="button"
+                            class="PluginMetadataPanel__idWrapper"
                           >
-                            <i
-                              class="icon icon-content-copy"
-                            />
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_0
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard PluginMetadataPanel__copy"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
                           </span>
+                           - 
+                          <span
+                            data-testid="plugin-metadata-version"
+                          >
+                            v0.1.0
+                          </span>
+                          )
                         </span>
-                         - 
-                        <span
-                          data-testid="plugin-metadata-version"
-                        >
-                          v0.1.0
-                        </span>
-                        )
                       </span>
                       <div
                         class="pt-2"
@@ -6535,33 +6559,37 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 1
                         </strong>
-                         (
                         <span
-                          class="PluginMetadataPanel__idWrapper"
+                          class="PluginMetadataPanel__metadata"
                         >
-                          <code
-                            class="PluginMetadataPanel__id"
-                            data-testid="plugin-metadata-id"
-                          >
-                            plugin_1
-                          </code>
+                           (
                           <span
-                            aria-label="Copy text"
-                            class="post-code__clipboard PluginMetadataPanel__copy"
-                            role="button"
+                            class="PluginMetadataPanel__idWrapper"
                           >
-                            <i
-                              class="icon icon-content-copy"
-                            />
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_1
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard PluginMetadataPanel__copy"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
                           </span>
+                           - 
+                          <span
+                            data-testid="plugin-metadata-version"
+                          >
+                            v0.0.1
+                          </span>
+                          )
                         </span>
-                         - 
-                        <span
-                          data-testid="plugin-metadata-version"
-                        >
-                          v0.0.1
-                        </span>
-                        )
                       </span>
                       <div
                         class="pt-2"

--- a/webapp/channels/src/components/admin_console/plugin_management/__snapshots__/plugin_management.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/plugin_management/__snapshots__/plugin_management.test.tsx.snap
@@ -4200,11 +4200,54 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 0
                         </strong>
-                         (
-                        plugin_0
-                         - 
-                        0.1.0
-                        )
+                      </div>
+                      <div
+                        class="PluginMetadataPanel PluginMetadataPanel--management"
+                        data-testid="plugin-metadata-panel"
+                      >
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Plugin ID:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                          >
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_0
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Version:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                            data-testid="plugin-metadata-version"
+                          >
+                            0.1.0
+                          </span>
+                        </div>
                       </div>
                       <div
                         class="pt-2"
@@ -4307,11 +4350,54 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 1
                         </strong>
-                         (
-                        plugin_1
-                         - 
-                        0.0.1
-                        )
+                      </div>
+                      <div
+                        class="PluginMetadataPanel PluginMetadataPanel--management"
+                        data-testid="plugin-metadata-panel"
+                      >
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Plugin ID:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                          >
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_1
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Version:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                            data-testid="plugin-metadata-version"
+                          >
+                            0.0.1
+                          </span>
+                        </div>
                       </div>
                       <div
                         class="pt-2"
@@ -4858,11 +4944,54 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 0
                         </strong>
-                         (
-                        plugin_0
-                         - 
-                        0.1.0
-                        )
+                      </div>
+                      <div
+                        class="PluginMetadataPanel PluginMetadataPanel--management"
+                        data-testid="plugin-metadata-panel"
+                      >
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Plugin ID:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                          >
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_0
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Version:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                            data-testid="plugin-metadata-version"
+                          >
+                            0.1.0
+                          </span>
+                        </div>
                       </div>
                       <div
                         class="pt-2"
@@ -5333,11 +5462,54 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 0
                         </strong>
-                         (
-                        plugin_0
-                         - 
-                        0.1.0
-                        )
+                      </div>
+                      <div
+                        class="PluginMetadataPanel PluginMetadataPanel--management"
+                        data-testid="plugin-metadata-panel"
+                      >
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Plugin ID:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                          >
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_0
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Version:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                            data-testid="plugin-metadata-version"
+                          >
+                            0.1.0
+                          </span>
+                        </div>
                       </div>
                       <div
                         class="pt-2"
@@ -5808,11 +5980,54 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 0
                         </strong>
-                         (
-                        plugin_0
-                         - 
-                        0.1.0
-                        )
+                      </div>
+                      <div
+                        class="PluginMetadataPanel PluginMetadataPanel--management"
+                        data-testid="plugin-metadata-panel"
+                      >
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Plugin ID:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                          >
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_0
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Version:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                            data-testid="plugin-metadata-version"
+                          >
+                            0.1.0
+                          </span>
+                        </div>
                       </div>
                       <div
                         class="pt-2"
@@ -6283,11 +6498,54 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 0
                         </strong>
-                         (
-                        plugin_0
-                         - 
-                        0.1.0
-                        )
+                      </div>
+                      <div
+                        class="PluginMetadataPanel PluginMetadataPanel--management"
+                        data-testid="plugin-metadata-panel"
+                      >
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Plugin ID:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                          >
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_0
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Version:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                            data-testid="plugin-metadata-version"
+                          >
+                            0.1.0
+                          </span>
+                        </div>
                       </div>
                       <div
                         class="pt-2"
@@ -6382,11 +6640,54 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         <strong>
                           Plugin 1
                         </strong>
-                         (
-                        plugin_1
-                         - 
-                        0.0.1
-                        )
+                      </div>
+                      <div
+                        class="PluginMetadataPanel PluginMetadataPanel--management"
+                        data-testid="plugin-metadata-panel"
+                      >
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Plugin ID:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                          >
+                            <span
+                              class="PluginMetadataPanel__id"
+                              data-testid="plugin-metadata-id"
+                            >
+                              plugin_1
+                            </span>
+                            <span
+                              aria-label="Copy text"
+                              class="post-code__clipboard"
+                              role="button"
+                            >
+                              <i
+                                class="icon icon-content-copy"
+                              />
+                            </span>
+                          </span>
+                        </div>
+                        <div
+                          class="PluginMetadataPanel__row"
+                        >
+                          <span
+                            class="PluginMetadataPanel__label"
+                          >
+                            Version:
+                          </span>
+                          <span
+                            class="PluginMetadataPanel__value"
+                            data-testid="plugin-metadata-version"
+                          >
+                            0.0.1
+                          </span>
+                        </div>
                       </div>
                       <div
                         class="pt-2"

--- a/webapp/channels/src/components/admin_console/plugin_management/__snapshots__/plugin_management.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/plugin_management/__snapshots__/plugin_management.test.tsx.snap
@@ -4208,7 +4208,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            aria-label="Copy text"
+                            aria-label="Copy"
                             class="PluginMetadataPanel__id"
                             data-testid="plugin-metadata-id"
                             role="button"
@@ -4334,7 +4334,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            aria-label="Copy text"
+                            aria-label="Copy"
                             class="PluginMetadataPanel__id"
                             data-testid="plugin-metadata-id"
                             role="button"
@@ -4904,7 +4904,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            aria-label="Copy text"
+                            aria-label="Copy"
                             class="PluginMetadataPanel__id"
                             data-testid="plugin-metadata-id"
                             role="button"
@@ -5398,7 +5398,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            aria-label="Copy text"
+                            aria-label="Copy"
                             class="PluginMetadataPanel__id"
                             data-testid="plugin-metadata-id"
                             role="button"
@@ -5892,7 +5892,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            aria-label="Copy text"
+                            aria-label="Copy"
                             class="PluginMetadataPanel__id"
                             data-testid="plugin-metadata-id"
                             role="button"
@@ -6386,7 +6386,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            aria-label="Copy text"
+                            aria-label="Copy"
                             class="PluginMetadataPanel__id"
                             data-testid="plugin-metadata-id"
                             role="button"
@@ -6504,7 +6504,7 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                         >
                            (
                           <span
-                            aria-label="Copy text"
+                            aria-label="Copy"
                             class="PluginMetadataPanel__id"
                             data-testid="plugin-metadata-id"
                             role="button"

--- a/webapp/channels/src/components/admin_console/plugin_management/__snapshots__/plugin_management.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/plugin_management/__snapshots__/plugin_management.test.tsx.snap
@@ -4196,59 +4196,27 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                     <div
                       data-testid="plugin_0"
                     >
-                      <div>
+                      <span
+                        class="PluginMetadataPanel"
+                        data-testid="plugin-metadata-panel"
+                      >
                         <strong>
                           Plugin 0
                         </strong>
-                      </div>
-                      <div
-                        class="PluginMetadataPanel PluginMetadataPanel--management"
-                        data-testid="plugin-metadata-panel"
-                      >
-                        <div
-                          class="PluginMetadataPanel__row"
+                         (
+                        <span
+                          data-testid="plugin-metadata-id"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Plugin ID:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                          >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_0
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
-                          </span>
-                        </div>
-                        <div
-                          class="PluginMetadataPanel__row"
+                          plugin_0
+                        </span>
+                         - 
+                        <span
+                          data-testid="plugin-metadata-version"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Version:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                            data-testid="plugin-metadata-version"
-                          >
-                            0.1.0
-                          </span>
-                        </div>
-                      </div>
+                          0.1.0
+                        </span>
+                        )
+                      </span>
                       <div
                         class="pt-2"
                       >
@@ -4346,59 +4314,27 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                     <div
                       data-testid="plugin_1"
                     >
-                      <div>
+                      <span
+                        class="PluginMetadataPanel"
+                        data-testid="plugin-metadata-panel"
+                      >
                         <strong>
                           Plugin 1
                         </strong>
-                      </div>
-                      <div
-                        class="PluginMetadataPanel PluginMetadataPanel--management"
-                        data-testid="plugin-metadata-panel"
-                      >
-                        <div
-                          class="PluginMetadataPanel__row"
+                         (
+                        <span
+                          data-testid="plugin-metadata-id"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Plugin ID:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                          >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_1
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
-                          </span>
-                        </div>
-                        <div
-                          class="PluginMetadataPanel__row"
+                          plugin_1
+                        </span>
+                         - 
+                        <span
+                          data-testid="plugin-metadata-version"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Version:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                            data-testid="plugin-metadata-version"
-                          >
-                            0.0.1
-                          </span>
-                        </div>
-                      </div>
+                          0.0.1
+                        </span>
+                        )
+                      </span>
                       <div
                         class="pt-2"
                       >
@@ -4940,59 +4876,27 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                     <div
                       data-testid="plugin_0"
                     >
-                      <div>
+                      <span
+                        class="PluginMetadataPanel"
+                        data-testid="plugin-metadata-panel"
+                      >
                         <strong>
                           Plugin 0
                         </strong>
-                      </div>
-                      <div
-                        class="PluginMetadataPanel PluginMetadataPanel--management"
-                        data-testid="plugin-metadata-panel"
-                      >
-                        <div
-                          class="PluginMetadataPanel__row"
+                         (
+                        <span
+                          data-testid="plugin-metadata-id"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Plugin ID:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                          >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_0
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
-                          </span>
-                        </div>
-                        <div
-                          class="PluginMetadataPanel__row"
+                          plugin_0
+                        </span>
+                         - 
+                        <span
+                          data-testid="plugin-metadata-version"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Version:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                            data-testid="plugin-metadata-version"
-                          >
-                            0.1.0
-                          </span>
-                        </div>
-                      </div>
+                          0.1.0
+                        </span>
+                        )
+                      </span>
                       <div
                         class="pt-2"
                       >
@@ -5458,59 +5362,27 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                     <div
                       data-testid="plugin_0"
                     >
-                      <div>
+                      <span
+                        class="PluginMetadataPanel"
+                        data-testid="plugin-metadata-panel"
+                      >
                         <strong>
                           Plugin 0
                         </strong>
-                      </div>
-                      <div
-                        class="PluginMetadataPanel PluginMetadataPanel--management"
-                        data-testid="plugin-metadata-panel"
-                      >
-                        <div
-                          class="PluginMetadataPanel__row"
+                         (
+                        <span
+                          data-testid="plugin-metadata-id"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Plugin ID:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                          >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_0
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
-                          </span>
-                        </div>
-                        <div
-                          class="PluginMetadataPanel__row"
+                          plugin_0
+                        </span>
+                         - 
+                        <span
+                          data-testid="plugin-metadata-version"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Version:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                            data-testid="plugin-metadata-version"
-                          >
-                            0.1.0
-                          </span>
-                        </div>
-                      </div>
+                          0.1.0
+                        </span>
+                        )
+                      </span>
                       <div
                         class="pt-2"
                       >
@@ -5976,59 +5848,27 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                     <div
                       data-testid="plugin_0"
                     >
-                      <div>
+                      <span
+                        class="PluginMetadataPanel"
+                        data-testid="plugin-metadata-panel"
+                      >
                         <strong>
                           Plugin 0
                         </strong>
-                      </div>
-                      <div
-                        class="PluginMetadataPanel PluginMetadataPanel--management"
-                        data-testid="plugin-metadata-panel"
-                      >
-                        <div
-                          class="PluginMetadataPanel__row"
+                         (
+                        <span
+                          data-testid="plugin-metadata-id"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Plugin ID:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                          >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_0
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
-                          </span>
-                        </div>
-                        <div
-                          class="PluginMetadataPanel__row"
+                          plugin_0
+                        </span>
+                         - 
+                        <span
+                          data-testid="plugin-metadata-version"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Version:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                            data-testid="plugin-metadata-version"
-                          >
-                            0.1.0
-                          </span>
-                        </div>
-                      </div>
+                          0.1.0
+                        </span>
+                        )
+                      </span>
                       <div
                         class="pt-2"
                       >
@@ -6494,59 +6334,27 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                     <div
                       data-testid="plugin_0"
                     >
-                      <div>
+                      <span
+                        class="PluginMetadataPanel"
+                        data-testid="plugin-metadata-panel"
+                      >
                         <strong>
                           Plugin 0
                         </strong>
-                      </div>
-                      <div
-                        class="PluginMetadataPanel PluginMetadataPanel--management"
-                        data-testid="plugin-metadata-panel"
-                      >
-                        <div
-                          class="PluginMetadataPanel__row"
+                         (
+                        <span
+                          data-testid="plugin-metadata-id"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Plugin ID:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                          >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_0
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
-                          </span>
-                        </div>
-                        <div
-                          class="PluginMetadataPanel__row"
+                          plugin_0
+                        </span>
+                         - 
+                        <span
+                          data-testid="plugin-metadata-version"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Version:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                            data-testid="plugin-metadata-version"
-                          >
-                            0.1.0
-                          </span>
-                        </div>
-                      </div>
+                          0.1.0
+                        </span>
+                        )
+                      </span>
                       <div
                         class="pt-2"
                       >
@@ -6636,59 +6444,27 @@ exports[`components/PluginManagement should match snapshot, with installed plugi
                     <div
                       data-testid="plugin_1"
                     >
-                      <div>
+                      <span
+                        class="PluginMetadataPanel"
+                        data-testid="plugin-metadata-panel"
+                      >
                         <strong>
                           Plugin 1
                         </strong>
-                      </div>
-                      <div
-                        class="PluginMetadataPanel PluginMetadataPanel--management"
-                        data-testid="plugin-metadata-panel"
-                      >
-                        <div
-                          class="PluginMetadataPanel__row"
+                         (
+                        <span
+                          data-testid="plugin-metadata-id"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Plugin ID:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                          >
-                            <span
-                              class="PluginMetadataPanel__id"
-                              data-testid="plugin-metadata-id"
-                            >
-                              plugin_1
-                            </span>
-                            <span
-                              aria-label="Copy text"
-                              class="post-code__clipboard"
-                              role="button"
-                            >
-                              <i
-                                class="icon icon-content-copy"
-                              />
-                            </span>
-                          </span>
-                        </div>
-                        <div
-                          class="PluginMetadataPanel__row"
+                          plugin_1
+                        </span>
+                         - 
+                        <span
+                          data-testid="plugin-metadata-version"
                         >
-                          <span
-                            class="PluginMetadataPanel__label"
-                          >
-                            Version:
-                          </span>
-                          <span
-                            class="PluginMetadataPanel__value"
-                            data-testid="plugin-metadata-version"
-                          >
-                            0.0.1
-                          </span>
-                        </div>
-                      </div>
+                          0.0.1
+                        </span>
+                        )
+                      </span>
                       <div
                         class="pt-2"
                       >

--- a/webapp/channels/src/components/admin_console/plugin_management/plugin_management.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_management/plugin_management.tsx
@@ -22,9 +22,9 @@ import {DeveloperLinks} from 'utils/constants';
 import * as Utils from 'utils/utils';
 
 import BooleanSetting from '../boolean_setting';
-import PluginMetadataPanel from '../plugin_metadata_panel/plugin_metadata_panel';
 import OLDAdminSettings from '../old_admin_settings';
 import type {BaseProps, BaseState} from '../old_admin_settings';
+import PluginMetadataPanel from '../plugin_metadata_panel/plugin_metadata_panel';
 import SettingSet from '../setting_set';
 import SettingsGroup from '../settings_group';
 import TextSetting from '../text_setting';

--- a/webapp/channels/src/components/admin_console/plugin_management/plugin_management.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_management/plugin_management.tsx
@@ -436,15 +436,12 @@ const PluginItem = ({
 
     return (
         <div data-testid={pluginStatus.id}>
-            <div>
-                <strong>{pluginStatus.name}</strong>
-            </div>
             <PluginMetadataPanel
+                name={pluginStatus.name}
                 id={pluginStatus.id}
                 version={pluginStatus.version}
                 homepageUrl={plugin?.homepage_url}
                 releaseNotesUrl={plugin?.release_notes_url}
-                variant='management'
             />
             {description}
             <div className='pt-2'>

--- a/webapp/channels/src/components/admin_console/plugin_management/plugin_management.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_management/plugin_management.tsx
@@ -22,6 +22,7 @@ import {DeveloperLinks} from 'utils/constants';
 import * as Utils from 'utils/utils';
 
 import BooleanSetting from '../boolean_setting';
+import PluginMetadataPanel from '../plugin_metadata_panel/plugin_metadata_panel';
 import OLDAdminSettings from '../old_admin_settings';
 import type {BaseProps, BaseState} from '../old_admin_settings';
 import SettingSet from '../setting_set';
@@ -178,6 +179,10 @@ type PluginStatus = {
 
 type PluginItemProps = {
     pluginStatus: PluginStatus;
+    plugin?: {
+        homepage_url?: string;
+        release_notes_url?: string;
+    };
     removing: boolean;
     handleEnable: (e: any) => any;
     handleDisable: (e: any) => any;
@@ -228,6 +233,7 @@ export const searchableStrings = [
 
 const PluginItem = ({
     pluginStatus,
+    plugin,
     removing,
     handleEnable,
     handleDisable,
@@ -432,12 +438,14 @@ const PluginItem = ({
         <div data-testid={pluginStatus.id}>
             <div>
                 <strong>{pluginStatus.name}</strong>
-                {' ('}
-                {pluginStatus.id}
-                {' - '}
-                {pluginStatus.version}
-                {')'}
             </div>
+            <PluginMetadataPanel
+                id={pluginStatus.id}
+                version={pluginStatus.version}
+                homepageUrl={plugin?.homepage_url}
+                releaseNotesUrl={plugin?.release_notes_url}
+                variant='management'
+            />
             {description}
             <div className='pt-2'>
                 {activateButton}
@@ -997,6 +1005,7 @@ export class PluginManagement extends OLDAdminSettings<Props, State> {
                     <PluginItem
                         key={pluginStatus.id}
                         pluginStatus={pluginStatus}
+                        plugin={p}
                         removing={this.state.removing === pluginStatus.id}
                         handleEnable={this.handleEnable}
                         handleDisable={this.handleDisable}

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
@@ -1,4 +1,23 @@
 .PluginMetadataPanel {
     font-size: inherit;
     line-height: inherit;
+
+    &__idWrapper {
+        display: inline-flex;
+        align-items: center;
+        gap: 2px;
+        vertical-align: baseline;
+    }
+
+    &__id {
+        font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
+        font-size: 0.9em;
+        padding: 1px 4px;
+        border-radius: 3px;
+    }
+
+    &__copy {
+        position: relative;
+        top: 1px;
+    }
 }

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
@@ -2,6 +2,10 @@
     font-size: inherit;
     line-height: inherit;
 
+    &__settingsWrapper {
+        margin-bottom: 16px;
+    }
+
     &__idWrapper {
         display: inline-flex;
         align-items: center;

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
@@ -6,11 +6,24 @@
         margin-bottom: 16px;
     }
 
+    &__metadata {
+        color: rgba(var(--center-channel-color-rgb), 0.64);
+        font-size: 0.9em;
+
+        a {
+            color: var(--link-color);
+        }
+    }
+
     &__idWrapper {
         display: inline-flex;
         align-items: center;
         gap: 2px;
         vertical-align: baseline;
+    }
+
+    &__id {
+        font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
     }
 
     &__copy.post-code__clipboard {

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
@@ -16,8 +16,8 @@
     }
 
     &__id {
-        font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
         cursor: pointer;
+        font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
 
         &:hover {
             color: var(--link-color);

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
@@ -15,27 +15,12 @@
         }
     }
 
-    &__idWrapper {
-        display: inline-flex;
-        align-items: center;
-        gap: 2px;
-        vertical-align: baseline;
-    }
-
     &__id {
         font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
-    }
+        cursor: pointer;
 
-    &__copy.post-code__clipboard {
-        position: relative;
-        top: 1px;
-        width: 18px;
-        height: 18px;
-
-        > i {
-            margin-top: 0;
-            margin-left: 0;
-            font-size: 14px;
+        &:hover {
+            color: var(--link-color);
         }
     }
 }

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
@@ -13,15 +13,16 @@
         vertical-align: baseline;
     }
 
-    &__id {
-        padding: 1px 4px;
-        border-radius: 3px;
-        font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
-        font-size: 0.9em;
-    }
-
-    &__copy {
+    &__copy.post-code__clipboard {
         position: relative;
         top: 1px;
+        width: 18px;
+        height: 18px;
+
+        > i {
+            margin-top: 0;
+            margin-left: 0;
+            font-size: 14px;
+        }
     }
 }

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
@@ -1,0 +1,42 @@
+.PluginMetadataPanel {
+    font-size: 13px;
+    line-height: 20px;
+
+    &__row {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        margin-top: 4px;
+    }
+
+    &__label {
+        flex-shrink: 0;
+        min-width: 80px;
+        color: rgba(var(--center-channel-color-rgb), 0.64);
+    }
+
+    &__value {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        min-width: 0;
+    }
+
+    &__id {
+        font-family: 'Open Sans', sans-serif;
+        word-break: break-all;
+    }
+
+    &__links {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 12px;
+        margin-top: 8px;
+    }
+
+    &--settings {
+        margin-bottom: 20px;
+        padding-bottom: 16px;
+        border-bottom: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
+    }
+}

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
@@ -1,42 +1,4 @@
 .PluginMetadataPanel {
-    font-size: 13px;
-    line-height: 20px;
-
-    &__row {
-        display: flex;
-        align-items: center;
-        gap: 8px;
-        margin-top: 4px;
-    }
-
-    &__label {
-        flex-shrink: 0;
-        min-width: 80px;
-        color: rgba(var(--center-channel-color-rgb), 0.64);
-    }
-
-    &__value {
-        display: flex;
-        align-items: center;
-        gap: 4px;
-        min-width: 0;
-    }
-
-    &__id {
-        font-family: 'Open Sans', sans-serif;
-        word-break: break-all;
-    }
-
-    &__links {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 12px;
-        margin-top: 8px;
-    }
-
-    &--settings {
-        margin-bottom: 20px;
-        padding-bottom: 16px;
-        border-bottom: 1px solid rgba(var(--center-channel-color-rgb), 0.08);
-    }
+    font-size: inherit;
+    line-height: inherit;
 }

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.scss
@@ -14,10 +14,10 @@
     }
 
     &__id {
-        font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
-        font-size: 0.9em;
         padding: 1px 4px;
         border-radius: 3px;
+        font-family: Menlo, Monaco, Consolas, 'Courier New', monospace;
+        font-size: 0.9em;
     }
 
     &__copy {

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
@@ -20,7 +20,7 @@ describe('formatPluginVersion', () => {
 });
 
 describe('PluginMetadataPanel', () => {
-    test('should render plugin name, code-styled id, and version on one line', () => {
+    test('should render plugin name, id, and version on one line', () => {
         renderWithContext(
             <PluginMetadataPanel
                 name='FL3XX'
@@ -30,7 +30,6 @@ describe('PluginMetadataPanel', () => {
         );
 
         expect(screen.getByTestId('plugin-metadata-panel')).toHaveTextContent('FL3XX (com.mattermost.fl3xx - v0.7.4)');
-        expect(screen.getByTestId('plugin-metadata-id').tagName).toBe('CODE');
         expect(screen.getByTestId('plugin-metadata-id')).toHaveTextContent('com.mattermost.fl3xx');
         expect(screen.getByTestId('plugin-metadata-version')).toHaveTextContent('v0.7.4');
         expect(screen.getByRole('button', {name: 'Copy text'})).toBeInTheDocument();

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
@@ -32,7 +32,7 @@ describe('PluginMetadataPanel', () => {
         expect(screen.getByTestId('plugin-metadata-panel')).toHaveTextContent('FL3XX (com.mattermost.fl3xx - v0.7.4)');
         expect(screen.getByTestId('plugin-metadata-id')).toHaveTextContent('com.mattermost.fl3xx');
         expect(screen.getByTestId('plugin-metadata-version')).toHaveTextContent('v0.7.4');
-        expect(screen.getByRole('button', {name: 'Copy text'})).toBeInTheDocument();
+        expect(screen.getByRole('button', {name: 'Copy text'})).toHaveTextContent('com.mattermost.fl3xx');
     });
 
     test('should fall back to plugin id when display name is missing', () => {

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
@@ -36,7 +36,33 @@ describe('PluginMetadataPanel', () => {
         expect(screen.getByRole('button', {name: 'Copy text'})).toBeInTheDocument();
     });
 
-    test('should link display name to website and release notes when provided', () => {
+    test('should fall back to plugin id when display name is missing', () => {
+        renderWithContext(
+            <PluginMetadataPanel
+                name='   '
+                id='com.mattermost.fl3xx'
+                version='0.7.4'
+            />,
+        );
+
+        expect(screen.getByTestId('plugin-metadata-panel')).toHaveTextContent('com.mattermost.fl3xx (com.mattermost.fl3xx - v0.7.4)');
+        expect(screen.getByText('com.mattermost.fl3xx', {selector: 'strong'})).toBeInTheDocument();
+    });
+
+    test('should omit version segment when version is missing', () => {
+        renderWithContext(
+            <PluginMetadataPanel
+                name='FL3XX'
+                id='com.mattermost.fl3xx'
+                version=''
+            />,
+        );
+
+        expect(screen.getByTestId('plugin-metadata-panel')).toHaveTextContent('FL3XX (com.mattermost.fl3xx)');
+        expect(screen.queryByTestId('plugin-metadata-version')).not.toBeInTheDocument();
+    });
+
+    test('should link display name to website and version to release notes when provided', () => {
         renderWithContext(
             <PluginMetadataPanel
                 name='Agents Plugin'
@@ -48,8 +74,8 @@ describe('PluginMetadataPanel', () => {
         );
 
         expect(screen.getByRole('link', {name: 'Agents Plugin'})).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-plugin-ai');
-        expect(screen.getByText('release notes')).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-plugin-ai/releases/tag/v1.2.3');
-        expect(screen.queryByText('website')).not.toBeInTheDocument();
+        expect(screen.getByRole('link', {name: 'v1.2.3'})).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-plugin-ai/releases/tag/v1.2.3');
+        expect(screen.queryByText('release notes')).not.toBeInTheDocument();
     });
 
     test('should not render links when urls are not provided', () => {

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
@@ -3,12 +3,24 @@
 
 import React from 'react';
 
-import PluginMetadataPanel from 'components/admin_console/plugin_metadata_panel/plugin_metadata_panel';
+import PluginMetadataPanel, {formatPluginVersion} from 'components/admin_console/plugin_metadata_panel/plugin_metadata_panel';
 
 import {screen, renderWithContext} from 'tests/react_testing_utils';
 
+describe('formatPluginVersion', () => {
+    test('should prefix version with v when missing', () => {
+        expect(formatPluginVersion('0.7.4')).toBe('v0.7.4');
+        expect(formatPluginVersion('1.2.3')).toBe('v1.2.3');
+    });
+
+    test('should not duplicate v prefix', () => {
+        expect(formatPluginVersion('v0.7.4')).toBe('v0.7.4');
+        expect(formatPluginVersion('V1.0.0')).toBe('V1.0.0');
+    });
+});
+
 describe('PluginMetadataPanel', () => {
-    test('should render plugin name, id, and version on one line', () => {
+    test('should render plugin name, code-styled id, and version on one line', () => {
         renderWithContext(
             <PluginMetadataPanel
                 name='FL3XX'
@@ -17,12 +29,14 @@ describe('PluginMetadataPanel', () => {
             />,
         );
 
-        expect(screen.getByTestId('plugin-metadata-panel')).toHaveTextContent('FL3XX (com.mattermost.fl3xx - 0.7.4)');
+        expect(screen.getByTestId('plugin-metadata-panel')).toHaveTextContent('FL3XX (com.mattermost.fl3xx - v0.7.4)');
+        expect(screen.getByTestId('plugin-metadata-id').tagName).toBe('CODE');
         expect(screen.getByTestId('plugin-metadata-id')).toHaveTextContent('com.mattermost.fl3xx');
-        expect(screen.getByTestId('plugin-metadata-version')).toHaveTextContent('0.7.4');
+        expect(screen.getByTestId('plugin-metadata-version')).toHaveTextContent('v0.7.4');
+        expect(screen.getByRole('button', {name: 'Copy text'})).toBeInTheDocument();
     });
 
-    test('should render website and release notes links when provided', () => {
+    test('should link display name to website and release notes when provided', () => {
         renderWithContext(
             <PluginMetadataPanel
                 name='Agents Plugin'
@@ -33,8 +47,9 @@ describe('PluginMetadataPanel', () => {
             />,
         );
 
-        expect(screen.getByText('website')).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-plugin-ai');
+        expect(screen.getByRole('link', {name: 'Agents Plugin'})).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-plugin-ai');
         expect(screen.getByText('release notes')).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-plugin-ai/releases/tag/v1.2.3');
+        expect(screen.queryByText('website')).not.toBeInTheDocument();
     });
 
     test('should not render links when urls are not provided', () => {
@@ -46,7 +61,6 @@ describe('PluginMetadataPanel', () => {
             />,
         );
 
-        expect(screen.queryByText('website')).not.toBeInTheDocument();
-        expect(screen.queryByText('release notes')).not.toBeInTheDocument();
+        expect(screen.queryByRole('link')).not.toBeInTheDocument();
     });
 });

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
@@ -8,21 +8,24 @@ import PluginMetadataPanel from 'components/admin_console/plugin_metadata_panel/
 import {screen, renderWithContext} from 'tests/react_testing_utils';
 
 describe('PluginMetadataPanel', () => {
-    test('should render plugin id and version', () => {
+    test('should render plugin name, id, and version on one line', () => {
         renderWithContext(
             <PluginMetadataPanel
-                id='com.mattermost.ai'
-                version='1.2.3'
+                name='FL3XX'
+                id='com.mattermost.fl3xx'
+                version='0.7.4'
             />,
         );
 
-        expect(screen.getByTestId('plugin-metadata-id')).toHaveTextContent('com.mattermost.ai');
-        expect(screen.getByTestId('plugin-metadata-version')).toHaveTextContent('1.2.3');
+        expect(screen.getByTestId('plugin-metadata-panel')).toHaveTextContent('FL3XX (com.mattermost.fl3xx - 0.7.4)');
+        expect(screen.getByTestId('plugin-metadata-id')).toHaveTextContent('com.mattermost.fl3xx');
+        expect(screen.getByTestId('plugin-metadata-version')).toHaveTextContent('0.7.4');
     });
 
     test('should render website and release notes links when provided', () => {
         renderWithContext(
             <PluginMetadataPanel
+                name='Agents Plugin'
                 id='com.mattermost.ai'
                 version='1.2.3'
                 homepageUrl='https://github.com/mattermost/mattermost-plugin-ai'
@@ -30,19 +33,20 @@ describe('PluginMetadataPanel', () => {
             />,
         );
 
-        expect(screen.getByText('Website')).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-plugin-ai');
-        expect(screen.getByText('Release notes')).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-plugin-ai/releases/tag/v1.2.3');
+        expect(screen.getByText('website')).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-plugin-ai');
+        expect(screen.getByText('release notes')).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-plugin-ai/releases/tag/v1.2.3');
     });
 
     test('should not render links when urls are not provided', () => {
         renderWithContext(
             <PluginMetadataPanel
+                name='Agents Plugin'
                 id='com.mattermost.ai'
                 version='1.2.3'
             />,
         );
 
-        expect(screen.queryByText('Website')).not.toBeInTheDocument();
-        expect(screen.queryByText('Release notes')).not.toBeInTheDocument();
+        expect(screen.queryByText('website')).not.toBeInTheDocument();
+        expect(screen.queryByText('release notes')).not.toBeInTheDocument();
     });
 });

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
@@ -32,7 +32,7 @@ describe('PluginMetadataPanel', () => {
         expect(screen.getByTestId('plugin-metadata-panel')).toHaveTextContent('FL3XX (com.mattermost.fl3xx - v0.7.4)');
         expect(screen.getByTestId('plugin-metadata-id')).toHaveTextContent('com.mattermost.fl3xx');
         expect(screen.getByTestId('plugin-metadata-version')).toHaveTextContent('v0.7.4');
-        expect(screen.getByRole('button', {name: 'Copy text'})).toHaveTextContent('com.mattermost.fl3xx');
+        expect(screen.getByRole('button', {name: 'Copy'})).toHaveTextContent('com.mattermost.fl3xx');
     });
 
     test('should fall back to plugin id when display name is missing', () => {

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.test.tsx
@@ -1,0 +1,48 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import PluginMetadataPanel from 'components/admin_console/plugin_metadata_panel/plugin_metadata_panel';
+
+import {screen, renderWithContext} from 'tests/react_testing_utils';
+
+describe('PluginMetadataPanel', () => {
+    test('should render plugin id and version', () => {
+        renderWithContext(
+            <PluginMetadataPanel
+                id='com.mattermost.ai'
+                version='1.2.3'
+            />,
+        );
+
+        expect(screen.getByTestId('plugin-metadata-id')).toHaveTextContent('com.mattermost.ai');
+        expect(screen.getByTestId('plugin-metadata-version')).toHaveTextContent('1.2.3');
+    });
+
+    test('should render website and release notes links when provided', () => {
+        renderWithContext(
+            <PluginMetadataPanel
+                id='com.mattermost.ai'
+                version='1.2.3'
+                homepageUrl='https://github.com/mattermost/mattermost-plugin-ai'
+                releaseNotesUrl='https://github.com/mattermost/mattermost-plugin-ai/releases/tag/v1.2.3'
+            />,
+        );
+
+        expect(screen.getByText('Website')).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-plugin-ai');
+        expect(screen.getByText('Release notes')).toHaveAttribute('href', 'https://github.com/mattermost/mattermost-plugin-ai/releases/tag/v1.2.3');
+    });
+
+    test('should not render links when urls are not provided', () => {
+        renderWithContext(
+            <PluginMetadataPanel
+                id='com.mattermost.ai'
+                version='1.2.3'
+            />,
+        );
+
+        expect(screen.queryByText('Website')).not.toBeInTheDocument();
+        expect(screen.queryByText('Release notes')).not.toBeInTheDocument();
+    });
+});

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
@@ -5,20 +5,25 @@ import classNames from 'classnames';
 import React from 'react';
 import {defineMessages, FormattedMessage} from 'react-intl';
 
+import CopyButton from 'components/copy_button';
 import ExternalLink from 'components/external_link';
 
 import './plugin_metadata_panel.scss';
 
 const messages = defineMessages({
-    website: {
-        id: 'admin.plugin.metadata.website',
-        defaultMessage: 'website',
-    },
     releaseNotes: {
         id: 'admin.plugin.metadata.releaseNotes',
         defaultMessage: 'release notes',
     },
 });
+
+export function formatPluginVersion(version: string): string {
+    if (!version) {
+        return version;
+    }
+
+    return /^v/i.test(version) ? version : `v${version}`;
+}
 
 export type PluginMetadataPanelProps = {
     name: string;
@@ -37,27 +42,42 @@ const PluginMetadataPanel = ({
     releaseNotesUrl,
     className,
 }: PluginMetadataPanelProps) => {
+    const formattedVersion = formatPluginVersion(version);
+
+    let nameElement: React.ReactNode = <strong>{name}</strong>;
+    if (homepageUrl) {
+        nameElement = (
+            <ExternalLink
+                href={homepageUrl}
+                location='plugin_metadata_panel'
+            >
+                <strong>{name}</strong>
+            </ExternalLink>
+        );
+    }
+
     return (
         <span
             className={classNames('PluginMetadataPanel', className)}
             data-testid='plugin-metadata-panel'
         >
-            <strong>{name}</strong>
+            {nameElement}
             {' ('}
-            <span data-testid='plugin-metadata-id'>{id}</span>
+            <span className='PluginMetadataPanel__idWrapper'>
+                <code
+                    className='PluginMetadataPanel__id'
+                    data-testid='plugin-metadata-id'
+                >
+                    {id}
+                </code>
+                <CopyButton
+                    content={id}
+                    isForText={true}
+                    className='PluginMetadataPanel__copy'
+                />
+            </span>
             {' - '}
-            <span data-testid='plugin-metadata-version'>{version}</span>
-            {homepageUrl && (
-                <>
-                    {' - '}
-                    <ExternalLink
-                        href={homepageUrl}
-                        location='plugin_metadata_panel'
-                    >
-                        <FormattedMessage {...messages.website}/>
-                    </ExternalLink>
-                </>
-            )}
+            <span data-testid='plugin-metadata-version'>{formattedVersion}</span>
             {releaseNotesUrl && (
                 <>
                     {' - '}

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
@@ -3,19 +3,11 @@
 
 import classNames from 'classnames';
 import React from 'react';
-import {defineMessages, FormattedMessage} from 'react-intl';
 
 import CopyButton from 'components/copy_button';
 import ExternalLink from 'components/external_link';
 
 import './plugin_metadata_panel.scss';
-
-const messages = defineMessages({
-    releaseNotes: {
-        id: 'admin.plugin.metadata.releaseNotes',
-        defaultMessage: 'release notes',
-    },
-});
 
 export function formatPluginVersion(version: string): string {
     if (!version) {
@@ -42,17 +34,40 @@ const PluginMetadataPanel = ({
     releaseNotesUrl,
     className,
 }: PluginMetadataPanelProps) => {
+    const displayName = name.trim() || id;
     const formattedVersion = formatPluginVersion(version);
 
-    let nameElement: React.ReactNode = <strong>{name}</strong>;
+    let nameElement: React.ReactNode = <strong>{displayName}</strong>;
     if (homepageUrl) {
         nameElement = (
             <ExternalLink
                 href={homepageUrl}
                 location='plugin_metadata_panel'
             >
-                <strong>{name}</strong>
+                <strong>{displayName}</strong>
             </ExternalLink>
+        );
+    }
+
+    let versionElement: React.ReactNode = null;
+    if (formattedVersion) {
+        versionElement = (
+            <>
+                {' - '}
+                {releaseNotesUrl ? (
+                    <ExternalLink
+                        href={releaseNotesUrl}
+                        location='plugin_metadata_panel'
+                        data-testid='plugin-metadata-version'
+                    >
+                        {formattedVersion}
+                    </ExternalLink>
+                ) : (
+                    <span data-testid='plugin-metadata-version'>
+                        {formattedVersion}
+                    </span>
+                )}
+            </>
         );
     }
 
@@ -76,19 +91,7 @@ const PluginMetadataPanel = ({
                     className='PluginMetadataPanel__copy'
                 />
             </span>
-            {' - '}
-            <span data-testid='plugin-metadata-version'>{formattedVersion}</span>
-            {releaseNotesUrl && (
-                <>
-                    {' - '}
-                    <ExternalLink
-                        href={releaseNotesUrl}
-                        location='plugin_metadata_panel'
-                    >
-                        <FormattedMessage {...messages.releaseNotes}/>
-                    </ExternalLink>
-                </>
-            )}
+            {versionElement}
             {')'}
         </span>
     );

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
@@ -22,7 +22,7 @@ export function formatPluginVersion(version: string): string {
         return version;
     }
 
-    return /^v/i.test(version) ? version : `v${version}`;
+    return (/^v/i).test(version) ? version : `v${version}`;
 }
 
 export type PluginMetadataPanelProps = {

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
@@ -77,22 +77,24 @@ const PluginMetadataPanel = ({
             data-testid='plugin-metadata-panel'
         >
             {nameElement}
-            {' ('}
-            <span className='PluginMetadataPanel__idWrapper'>
-                <span
-                    className='PluginMetadataPanel__id'
-                    data-testid='plugin-metadata-id'
-                >
-                    {id}
+            <span className='PluginMetadataPanel__metadata'>
+                {' ('}
+                <span className='PluginMetadataPanel__idWrapper'>
+                    <span
+                        className='PluginMetadataPanel__id'
+                        data-testid='plugin-metadata-id'
+                    >
+                        {id}
+                    </span>
+                    <CopyButton
+                        content={id}
+                        isForText={true}
+                        className='PluginMetadataPanel__copy'
+                    />
                 </span>
-                <CopyButton
-                    content={id}
-                    isForText={true}
-                    className='PluginMetadataPanel__copy'
-                />
+                {versionElement}
+                {')'}
             </span>
-            {versionElement}
-            {')'}
         </span>
     );
 };

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
@@ -2,10 +2,14 @@
 // See LICENSE.txt for license information.
 
 import classNames from 'classnames';
-import React from 'react';
+import React, {useRef, useState} from 'react';
+import {FormattedMessage, defineMessages, useIntl} from 'react-intl';
 
-import CopyButton from 'components/copy_button';
+import {WithTooltip} from '@mattermost/shared/components/tooltip';
+
 import ExternalLink from 'components/external_link';
+
+import {copyToClipboard} from 'utils/utils';
 
 import './plugin_metadata_panel.scss';
 
@@ -24,6 +28,62 @@ export type PluginMetadataPanelProps = {
     homepageUrl?: string;
     releaseNotesUrl?: string;
     className?: string;
+};
+
+const copyMessages = defineMessages({
+    copied: {
+        id: 'copied.message',
+        defaultMessage: 'Copied',
+    },
+    copyText: {
+        id: 'copy.text.message',
+        defaultMessage: 'Copy text',
+    },
+});
+
+const PluginMetadataId = ({id}: {id: string}) => {
+    const intl = useIntl();
+    const [isCopied, setIsCopied] = useState(false);
+    const timerRef = useRef<NodeJS.Timeout | null>(null);
+
+    const copyId = (e: React.MouseEvent | React.KeyboardEvent) => {
+        e.preventDefault();
+        setIsCopied(true);
+
+        if (timerRef.current) {
+            clearTimeout(timerRef.current);
+        }
+
+        timerRef.current = setTimeout(() => {
+            setIsCopied(false);
+        }, 2000);
+
+        copyToClipboard(id);
+    };
+
+    const tooltipMessage = isCopied ? copyMessages.copied : copyMessages.copyText;
+
+    return (
+        <WithTooltip
+            title={<FormattedMessage {...tooltipMessage}/>}
+        >
+            <span
+                className='PluginMetadataPanel__id'
+                data-testid='plugin-metadata-id'
+                onClick={copyId}
+                onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                        copyId(e);
+                    }
+                }}
+                role='button'
+                tabIndex={0}
+                aria-label={intl.formatMessage(tooltipMessage)}
+            >
+                {id}
+            </span>
+        </WithTooltip>
+    );
 };
 
 const PluginMetadataPanel = ({
@@ -79,19 +139,7 @@ const PluginMetadataPanel = ({
             {nameElement}
             <span className='PluginMetadataPanel__metadata'>
                 {' ('}
-                <span className='PluginMetadataPanel__idWrapper'>
-                    <span
-                        className='PluginMetadataPanel__id'
-                        data-testid='plugin-metadata-id'
-                    >
-                        {id}
-                    </span>
-                    <CopyButton
-                        content={id}
-                        isForText={true}
-                        className='PluginMetadataPanel__copy'
-                    />
-                </span>
+                <PluginMetadataId id={id}/>
                 {versionElement}
                 {')'}
             </span>

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
@@ -79,12 +79,12 @@ const PluginMetadataPanel = ({
             {nameElement}
             {' ('}
             <span className='PluginMetadataPanel__idWrapper'>
-                <code
+                <span
                     className='PluginMetadataPanel__id'
                     data-testid='plugin-metadata-id'
                 >
                     {id}
-                </code>
+                </span>
                 <CopyButton
                     content={id}
                     isForText={true}

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
@@ -5,107 +5,72 @@ import classNames from 'classnames';
 import React from 'react';
 import {defineMessages, FormattedMessage} from 'react-intl';
 
-import CopyButton from 'components/copy_button';
 import ExternalLink from 'components/external_link';
 
 import './plugin_metadata_panel.scss';
 
 const messages = defineMessages({
-    pluginId: {
-        id: 'admin.plugin.metadata.pluginId',
-        defaultMessage: 'Plugin ID:',
-    },
-    version: {
-        id: 'admin.plugin.metadata.version',
-        defaultMessage: 'Version:',
-    },
     website: {
         id: 'admin.plugin.metadata.website',
-        defaultMessage: 'Website',
+        defaultMessage: 'website',
     },
     releaseNotes: {
         id: 'admin.plugin.metadata.releaseNotes',
-        defaultMessage: 'Release notes',
+        defaultMessage: 'release notes',
     },
 });
 
 export type PluginMetadataPanelProps = {
+    name: string;
     id: string;
     version: string;
     homepageUrl?: string;
     releaseNotesUrl?: string;
-    variant?: 'management' | 'settings';
     className?: string;
 };
 
 const PluginMetadataPanel = ({
+    name,
     id,
     version,
     homepageUrl,
     releaseNotesUrl,
-    variant = 'management',
     className,
 }: PluginMetadataPanelProps) => {
-    const hasLinks = Boolean(homepageUrl || releaseNotesUrl);
-
     return (
-        <div
-            className={classNames(
-                'PluginMetadataPanel',
-                `PluginMetadataPanel--${variant}`,
-                className,
-            )}
+        <span
+            className={classNames('PluginMetadataPanel', className)}
             data-testid='plugin-metadata-panel'
         >
-            <div className='PluginMetadataPanel__row'>
-                <span className='PluginMetadataPanel__label'>
-                    <FormattedMessage {...messages.pluginId}/>
-                </span>
-                <span className='PluginMetadataPanel__value'>
-                    <span
-                        className='PluginMetadataPanel__id'
-                        data-testid='plugin-metadata-id'
+            <strong>{name}</strong>
+            {' ('}
+            <span data-testid='plugin-metadata-id'>{id}</span>
+            {' - '}
+            <span data-testid='plugin-metadata-version'>{version}</span>
+            {homepageUrl && (
+                <>
+                    {' - '}
+                    <ExternalLink
+                        href={homepageUrl}
+                        location='plugin_metadata_panel'
                     >
-                        {id}
-                    </span>
-                    <CopyButton
-                        content={id}
-                        isForText={true}
-                    />
-                </span>
-            </div>
-            <div className='PluginMetadataPanel__row'>
-                <span className='PluginMetadataPanel__label'>
-                    <FormattedMessage {...messages.version}/>
-                </span>
-                <span
-                    className='PluginMetadataPanel__value'
-                    data-testid='plugin-metadata-version'
-                >
-                    {version}
-                </span>
-            </div>
-            {hasLinks && (
-                <div className='PluginMetadataPanel__links'>
-                    {homepageUrl && (
-                        <ExternalLink
-                            href={homepageUrl}
-                            location='plugin_metadata_panel'
-                        >
-                            <FormattedMessage {...messages.website}/>
-                        </ExternalLink>
-                    )}
-                    {releaseNotesUrl && (
-                        <ExternalLink
-                            href={releaseNotesUrl}
-                            location='plugin_metadata_panel'
-                        >
-                            <FormattedMessage {...messages.releaseNotes}/>
-                        </ExternalLink>
-                    )}
-                </div>
+                        <FormattedMessage {...messages.website}/>
+                    </ExternalLink>
+                </>
             )}
-        </div>
+            {releaseNotesUrl && (
+                <>
+                    {' - '}
+                    <ExternalLink
+                        href={releaseNotesUrl}
+                        location='plugin_metadata_panel'
+                    >
+                        <FormattedMessage {...messages.releaseNotes}/>
+                    </ExternalLink>
+                </>
+            )}
+            {')'}
+        </span>
     );
 };
 

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
@@ -1,0 +1,112 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import classNames from 'classnames';
+import React from 'react';
+import {defineMessages, FormattedMessage} from 'react-intl';
+
+import CopyButton from 'components/copy_button';
+import ExternalLink from 'components/external_link';
+
+import './plugin_metadata_panel.scss';
+
+const messages = defineMessages({
+    pluginId: {
+        id: 'admin.plugin.metadata.pluginId',
+        defaultMessage: 'Plugin ID:',
+    },
+    version: {
+        id: 'admin.plugin.metadata.version',
+        defaultMessage: 'Version:',
+    },
+    website: {
+        id: 'admin.plugin.metadata.website',
+        defaultMessage: 'Website',
+    },
+    releaseNotes: {
+        id: 'admin.plugin.metadata.releaseNotes',
+        defaultMessage: 'Release notes',
+    },
+});
+
+export type PluginMetadataPanelProps = {
+    id: string;
+    version: string;
+    homepageUrl?: string;
+    releaseNotesUrl?: string;
+    variant?: 'management' | 'settings';
+    className?: string;
+};
+
+const PluginMetadataPanel = ({
+    id,
+    version,
+    homepageUrl,
+    releaseNotesUrl,
+    variant = 'management',
+    className,
+}: PluginMetadataPanelProps) => {
+    const hasLinks = Boolean(homepageUrl || releaseNotesUrl);
+
+    return (
+        <div
+            className={classNames(
+                'PluginMetadataPanel',
+                `PluginMetadataPanel--${variant}`,
+                className,
+            )}
+            data-testid='plugin-metadata-panel'
+        >
+            <div className='PluginMetadataPanel__row'>
+                <span className='PluginMetadataPanel__label'>
+                    <FormattedMessage {...messages.pluginId}/>
+                </span>
+                <span className='PluginMetadataPanel__value'>
+                    <span
+                        className='PluginMetadataPanel__id'
+                        data-testid='plugin-metadata-id'
+                    >
+                        {id}
+                    </span>
+                    <CopyButton
+                        content={id}
+                        isForText={true}
+                    />
+                </span>
+            </div>
+            <div className='PluginMetadataPanel__row'>
+                <span className='PluginMetadataPanel__label'>
+                    <FormattedMessage {...messages.version}/>
+                </span>
+                <span
+                    className='PluginMetadataPanel__value'
+                    data-testid='plugin-metadata-version'
+                >
+                    {version}
+                </span>
+            </div>
+            {hasLinks && (
+                <div className='PluginMetadataPanel__links'>
+                    {homepageUrl && (
+                        <ExternalLink
+                            href={homepageUrl}
+                            location='plugin_metadata_panel'
+                        >
+                            <FormattedMessage {...messages.website}/>
+                        </ExternalLink>
+                    )}
+                    {releaseNotesUrl && (
+                        <ExternalLink
+                            href={releaseNotesUrl}
+                            location='plugin_metadata_panel'
+                        >
+                            <FormattedMessage {...messages.releaseNotes}/>
+                        </ExternalLink>
+                    )}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default PluginMetadataPanel;

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
@@ -2,14 +2,13 @@
 // See LICENSE.txt for license information.
 
 import classNames from 'classnames';
-import React, {useRef, useState} from 'react';
-import {FormattedMessage, defineMessages, useIntl} from 'react-intl';
+import React from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
 
 import {WithTooltip} from '@mattermost/shared/components/tooltip';
 
+import useCopyText, {messages as copyMessages} from 'components/common/hooks/useCopyText';
 import ExternalLink from 'components/external_link';
-
-import {copyToClipboard} from 'utils/utils';
 
 import './plugin_metadata_panel.scss';
 
@@ -30,38 +29,19 @@ export type PluginMetadataPanelProps = {
     className?: string;
 };
 
-const copyMessages = defineMessages({
-    copied: {
-        id: 'copied.message',
-        defaultMessage: 'Copied',
-    },
-    copyText: {
-        id: 'copy.text.message',
-        defaultMessage: 'Copy text',
-    },
-});
-
 const PluginMetadataId = ({id}: {id: string}) => {
     const intl = useIntl();
-    const [isCopied, setIsCopied] = useState(false);
-    const timerRef = useRef<NodeJS.Timeout | null>(null);
+    const {copiedRecently, onClick: copyId} = useCopyText({
+        text: id,
+        successCopyTimeout: 2000,
+    });
 
-    const copyId = (e: React.MouseEvent | React.KeyboardEvent) => {
+    const tooltipMessage = copiedRecently ? copyMessages.copied : copyMessages.copy;
+
+    const handleCopy = (e: React.MouseEvent | React.KeyboardEvent) => {
         e.preventDefault();
-        setIsCopied(true);
-
-        if (timerRef.current) {
-            clearTimeout(timerRef.current);
-        }
-
-        timerRef.current = setTimeout(() => {
-            setIsCopied(false);
-        }, 2000);
-
-        copyToClipboard(id);
+        copyId();
     };
-
-    const tooltipMessage = isCopied ? copyMessages.copied : copyMessages.copyText;
 
     return (
         <WithTooltip
@@ -70,10 +50,10 @@ const PluginMetadataId = ({id}: {id: string}) => {
             <span
                 className='PluginMetadataPanel__id'
                 data-testid='plugin-metadata-id'
-                onClick={copyId}
+                onClick={handleCopy}
                 onKeyDown={(e) => {
                     if (e.key === 'Enter' || e.key === ' ') {
-                        copyId(e);
+                        handleCopy(e);
                     }
                 }}
                 role='button'

--- a/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_metadata_panel/plugin_metadata_panel.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import classNames from 'classnames';
-import React from 'react';
+import React, {useCallback, useMemo} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 
 import {WithTooltip} from '@mattermost/shared/components/tooltip';
@@ -38,24 +38,30 @@ const PluginMetadataId = ({id}: {id: string}) => {
 
     const tooltipMessage = copiedRecently ? copyMessages.copied : copyMessages.copy;
 
-    const handleCopy = (e: React.MouseEvent | React.KeyboardEvent) => {
+    const handleCopy = useCallback((e: React.MouseEvent | React.KeyboardEvent) => {
         e.preventDefault();
         copyId();
-    };
+    }, [copyId]);
+
+    const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+            handleCopy(e);
+        }
+    }, [handleCopy]);
+
+    const tooltipTitle = useMemo(() => (
+        <FormattedMessage {...tooltipMessage}/>
+    ), [tooltipMessage]);
 
     return (
         <WithTooltip
-            title={<FormattedMessage {...tooltipMessage}/>}
+            title={tooltipTitle}
         >
             <span
                 className='PluginMetadataPanel__id'
                 data-testid='plugin-metadata-id'
                 onClick={handleCopy}
-                onKeyDown={(e) => {
-                    if (e.key === 'Enter' || e.key === ' ') {
-                        handleCopy(e);
-                    }
-                }}
+                onKeyDown={handleKeyDown}
                 role='button'
                 tabIndex={0}
                 aria-label={intl.formatMessage(tooltipMessage)}

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -83,6 +83,7 @@ export type SchemaAdminSettingsProps = {
     isCurrentUserSystemAdmin: boolean;
     enterpriseReady: boolean;
     plugin?: PluginRedux;
+    pluginVersion?: string;
 } & WrappedComponentProps;
 
 type State = {
@@ -305,6 +306,10 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
             return '';
         }
 
+        if (this.props.plugin) {
+            return null;
+        }
+
         const betaBadge = this.props.schema.isBeta && (
             <BetaTag
                 variant='default'
@@ -312,21 +317,6 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
                 className='admin-header-beta-badge'
             />
         );
-
-        if (this.props.plugin) {
-            return (
-                <AdminHeader>
-                    <PluginMetadataPanel
-                        name={this.props.plugin.name}
-                        id={this.props.plugin.id}
-                        version={this.props.plugin.version}
-                        homepageUrl={this.props.plugin.homepage_url}
-                        releaseNotesUrl={this.props.plugin.release_notes_url}
-                    />
-                    {betaBadge}
-                </AdminHeader>
-            );
-        }
 
         let name: string | MessageDescriptor = this.props.schema.id;
         if (('name' in this.props.schema)) {
@@ -349,6 +339,24 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
                 />
                 {betaBadge}
             </AdminHeader>
+        );
+    };
+
+    renderPluginMetadata = () => {
+        if (!this.props.plugin) {
+            return null;
+        }
+
+        return (
+            <div className='PluginMetadataPanel__settingsWrapper'>
+                <PluginMetadataPanel
+                    name={this.props.plugin.name}
+                    id={this.props.plugin.id}
+                    version={this.props.pluginVersion || this.props.plugin.version}
+                    homepageUrl={this.props.plugin.homepage_url}
+                    releaseNotesUrl={this.props.plugin.release_notes_url}
+                />
+            </div>
         );
     };
 
@@ -1366,6 +1374,7 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
                 {this.renderTitle()}
                 <div className='admin-console__wrapper'>
                     <div className='admin-console__content'>
+                        {this.renderPluginMetadata()}
                         <form
                             className='form-horizontal'
                             role='form'

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -306,8 +306,25 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
             return '';
         }
 
+        let name: string | MessageDescriptor = this.props.schema.id;
+        if (('name' in this.props.schema)) {
+            name = this.props.schema.name;
+        }
+
         if (this.props.plugin) {
-            return null;
+            const title = typeof name === 'string' ? (
+                name
+            ) : (
+                <FormattedMessage
+                    {...name}
+                />
+            );
+
+            return (
+                <h1 className='sr-only'>
+                    {title}
+                </h1>
+            );
         }
 
         const betaBadge = this.props.schema.isBeta && (
@@ -317,11 +334,6 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
                 className='admin-header-beta-badge'
             />
         );
-
-        let name: string | MessageDescriptor = this.props.schema.id;
-        if (('name' in this.props.schema)) {
-            name = this.props.schema.name;
-        }
 
         if (typeof name === 'string') {
             return (

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -9,6 +9,7 @@ import {Link} from 'react-router-dom';
 import {WithTooltip} from '@mattermost/shared/components/tooltip';
 import type {CloudState} from '@mattermost/types/cloud';
 import type {AdminConfig, ClientLicense, EnvironmentConfig} from '@mattermost/types/config';
+import type {PluginRedux} from '@mattermost/types/plugins';
 import type {Role} from '@mattermost/types/roles';
 import type {DeepPartial} from '@mattermost/types/utilities';
 
@@ -40,6 +41,7 @@ import * as I18n from 'i18n/i18n';
 import Constants from 'utils/constants';
 import {mappingValueFromRoles, rolesFromMapping} from 'utils/policy_roles_adapter';
 
+import PluginMetadataPanel from './plugin_metadata_panel/plugin_metadata_panel';
 import Setting from './setting';
 import type {AdminDefinitionConfigSchemaSection, AdminDefinitionSetting, AdminDefinitionSettingBanner, AdminDefinitionSettingDropdownOption, AdminDefinitionSubSectionSchema, ConsoleAccess} from './types';
 
@@ -80,6 +82,7 @@ export type SchemaAdminSettingsProps = {
     cloud: CloudState;
     isCurrentUserSystemAdmin: boolean;
     enterpriseReady: boolean;
+    plugin?: PluginRedux;
 } & WrappedComponentProps;
 
 type State = {
@@ -1348,6 +1351,15 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
                 {this.renderTitle()}
                 <div className='admin-console__wrapper'>
                     <div className='admin-console__content'>
+                        {this.props.plugin && (
+                            <PluginMetadataPanel
+                                id={this.props.plugin.id}
+                                version={this.props.plugin.version}
+                                homepageUrl={this.props.plugin.homepage_url}
+                                releaseNotesUrl={this.props.plugin.release_notes_url}
+                                variant='settings'
+                            />
+                        )}
                         <form
                             className='form-horizontal'
                             role='form'

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -305,11 +305,6 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
             return '';
         }
 
-        let name: string | MessageDescriptor = this.props.schema.id;
-        if (('name' in this.props.schema)) {
-            name = this.props.schema.name;
-        }
-
         const betaBadge = this.props.schema.isBeta && (
             <BetaTag
                 variant='default'
@@ -317,6 +312,26 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
                 className='admin-header-beta-badge'
             />
         );
+
+        if (this.props.plugin) {
+            return (
+                <AdminHeader>
+                    <PluginMetadataPanel
+                        name={this.props.plugin.name}
+                        id={this.props.plugin.id}
+                        version={this.props.plugin.version}
+                        homepageUrl={this.props.plugin.homepage_url}
+                        releaseNotesUrl={this.props.plugin.release_notes_url}
+                    />
+                    {betaBadge}
+                </AdminHeader>
+            );
+        }
+
+        let name: string | MessageDescriptor = this.props.schema.id;
+        if (('name' in this.props.schema)) {
+            name = this.props.schema.name;
+        }
 
         if (typeof name === 'string') {
             return (
@@ -1351,15 +1366,6 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
                 {this.renderTitle()}
                 <div className='admin-console__wrapper'>
                     <div className='admin-console__content'>
-                        {this.props.plugin && (
-                            <PluginMetadataPanel
-                                id={this.props.plugin.id}
-                                version={this.props.plugin.version}
-                                homepageUrl={this.props.plugin.homepage_url}
-                                releaseNotesUrl={this.props.plugin.release_notes_url}
-                                variant='settings'
-                            />
-                        )}
                         <form
                             className='form-horizontal'
                             role='form'

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -2628,7 +2628,6 @@
   "admin.plugin.installedDesc": "Installed plugins on your Mattermost server.",
   "admin.plugin.installedTitle": "Installed Plugins: ",
   "admin.plugin.management.title": "Plugin Management",
-  "admin.plugin.metadata.releaseNotes": "release notes",
   "admin.plugin.multiple_versions_warning": "There are multiple versions of this plugin installed across your cluster. Re-install this plugin to ensure it works consistently.",
   "admin.plugin.no_plugins": "No installed plugins.",
   "admin.plugin.remove": "Remove",

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -2628,6 +2628,7 @@
   "admin.plugin.installedDesc": "Installed plugins on your Mattermost server.",
   "admin.plugin.installedTitle": "Installed Plugins: ",
   "admin.plugin.management.title": "Plugin Management",
+  "admin.plugin.metadata.releaseNotes": "release notes",
   "admin.plugin.multiple_versions_warning": "There are multiple versions of this plugin installed across your cluster. Re-install this plugin to ensure it works consistently.",
   "admin.plugin.no_plugins": "No installed plugins.",
   "admin.plugin.remove": "Remove",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -326,6 +326,7 @@
       "version": "26.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -533,6 +534,7 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2242,6 +2244,7 @@
       "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.29.0",
         "@babel/helper-compilation-targets": "^7.28.6",
@@ -2595,6 +2598,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2618,6 +2622,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2810,6 +2815,7 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -3073,6 +3079,7 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -5137,6 +5144,7 @@
       "integrity": "sha512-LTATglVUPGkPf15zX1wTMlZ0+AU7cGEGF6ekVF1crA8eHUWsGjrYTB+Ht4E3HTrCok8weQG+K01rJndCp/l4XA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/core": "^0.16.13"
@@ -5179,6 +5187,7 @@
       "integrity": "sha512-8Z1k96ZFxlhK2bgrY1JNWNwvaBeI/bciLM0yDOni2+aZwfIIiC7Y6PeWHTAvjHNjphz+XCt01WQmOYWCn0ML6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -5193,6 +5202,7 @@
       "integrity": "sha512-PvLrfa8vkej3qinlebyhLpksJgCF5aiysDMSVhOZqwH5nQLLtDE9WYbnsofGw4r0VVpyw3H/ANCIzYTyCtP9Cg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -5221,6 +5231,7 @@
       "integrity": "sha512-xW+9BtEvoIkkH/Wde9ql4nAFbYLkVINhpgAE7VcBUsuuB34WUbcBl/taOuUYQrPEFQJ4jfXiAJZ2H/rvKjCVnQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13",
@@ -5270,6 +5281,7 @@
       "integrity": "sha512-WEl2tPVYwzYL8OKme6Go2xqiWgKsgxlMwyHabdAU4tXaRwOCnOI7v4021gCcBb9zn/oWwguHuKHmK30Fw2Z/PA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -5413,6 +5425,7 @@
       "integrity": "sha512-qoqtN8LDknm3fJm9nuPygJv30O3vGhSBD2TxrsCnhtOsxKAqVPJtFVdGd/qVuZ8nqQANQmTlfqTiK9mVWQ7MiQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -5427,6 +5440,7 @@
       "integrity": "sha512-Ev+Jjmj1nHYw897z9C3R9dYsPv7S2/nxdgfFb/h8hOwK0Ovd1k/+yYS46A0uj/JCKK0pQk8wOslYBkPwdnLorw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -5444,6 +5458,7 @@
       "integrity": "sha512-05POQaEJVucjTiSGMoH68ZiELc7QqpIpuQlZ2JBbhCV+WCbPFUBcGSmE7w4Jd0E2GvCho/NoMODLwgcVGQA97A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -6186,7 +6201,8 @@
       "version": "0.1.61",
       "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.61.tgz",
       "integrity": "sha512-Xq7QHyxq7NPljgqlzwRp6tWGe5sD49tWTzG41q9+sYsI+DdymJmteezupkfO3NxNxYXJiDD+q2kF0Ai2he1Mcg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@mattermost/components": {
       "resolved": "platform/components",
@@ -7150,6 +7166,7 @@
       "integrity": "sha512-a0CgrW5A5kwuSu5J1RFRoMQaMs9yagvfH2jJMYVw56+/7NRI4KOtu612SG9Y1ERWfY55ZwzyFxtLWvD6LO+Anw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
         "@parcel/cache": "2.16.4",
@@ -9210,6 +9227,7 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.26"
@@ -9461,6 +9479,7 @@
       "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -9532,6 +9551,7 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -9626,6 +9646,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.26.1.tgz",
       "integrity": "sha512-TX9PyPqBoix0qDLjtok/bddtdSy54QhzLVha405C07V+WySOpH3s/pWYkywehZQY0SQtcrcY4MNSCeQjCbA28A==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -9709,6 +9730,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.26.1.tgz",
       "integrity": "sha512-NY7SYqcrqDVYTSWyaNGdSfCims6pOHoRQ2Rh4DEFb/rb8gLVkqbLZhcHzQCVfinlPqgV3xWF6cYMORwmnlBkXQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -9865,6 +9887,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.26.1.tgz",
       "integrity": "sha512-06nOjnyXpzMO8Ys5k3IbYsDsKib1mv2OtaxBYX1/1uvRyOKwUX5tqDLb/qigic0LIANNL73lkNC8Z8XPeG4Tkg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -9957,6 +9980,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.20.0.tgz",
       "integrity": "sha512-vaaMtQ2KnSSr8WVwgWf7NYNzPwrHx/6T0ekA5CxV8qNUEpXIaLXa5+tE7tJHWEdNR2KY3gUJ46D3lfOkxyFrBQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -10036,6 +10060,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.26.1.tgz",
       "integrity": "sha512-PmRaoe6bebTgz/ZQrjmzwZMST1d9js9ZTiKnUXeXl3Fm+V5U/c3TbbKDfqmL63qPQdjtShDMHi9tYuv+c77OFQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -10079,6 +10104,7 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.26.1.tgz",
       "integrity": "sha512-48cJQRbvr9Ux0+IgM1BR5vOLU5hkC+n+uerdQy2JjrIRKpYE/huU8fQFm6PoRppoKYfilklzb29elsQ+n2TA+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-commands": "^1.6.2",
@@ -10655,6 +10681,7 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.64.tgz",
       "integrity": "sha512-MlmPvHgjj2p3vZaxbQgFUQFvD8QiZwACfGqEdDSWou5yISWxDQ4/74nCAwsUiX7UFLKZz3BbVSPj+YxeoGGCfg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -10697,6 +10724,7 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.25.tgz",
       "integrity": "sha512-o/V48vf4MQh7juIKZU2QGDfli6p1+OOi5oXx36Hffpc9adsHeXjVp8rHuPkjd8VT8sOJ2Zp05HR7CdpGTIUFUA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -10914,6 +10942,7 @@
       "integrity": "sha512-DqVpl8R0vbhVSop4120UHtGrFmHuPeoDwF4hDT0kPJTY8ty0SI38RV3VhCMsWigMUXG+kCXu7vMRqMFNy6eQgA==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "*",
         "@types/react": "*",
@@ -11035,6 +11064,7 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -11825,6 +11855,7 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -12845,6 +12876,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -13221,7 +13253,8 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
       "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/clean-css": {
       "version": "5.3.3",
@@ -13672,7 +13705,6 @@
       "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -14177,6 +14209,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
       "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.11"
       },
@@ -14993,6 +15026,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -15274,6 +15308,7 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -16996,6 +17031,7 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
       "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -18396,6 +18432,7 @@
       "integrity": "sha512-Ry+p2+NLk6u8Agh5yVqELfUJvRfV51hhVBRIB5yZPY7mU0DGBmOuFG5GebZbMbm86cdQNK0fhJuDX8/1YorISQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.1.3",
         "@jest/types": "30.0.5",
@@ -20987,7 +21024,8 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -21055,6 +21093,7 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -21542,7 +21581,8 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/monaco-editor-webpack-plugin": {
       "version": "7.1.0",
@@ -22838,6 +22878,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -23012,6 +23053,7 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -23463,6 +23505,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -23583,6 +23626,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -23662,7 +23706,8 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-is-18": {
       "name": "react-is",
@@ -24068,7 +24113,8 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redux-batched-actions": {
       "version": "0.5.0",
@@ -24467,6 +24513,7 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -24794,6 +24841,7 @@
       "integrity": "sha512-TQd2aoQl/+zsxRMEDSxVdpPIqeq9UFc6pr7PzkugiTx3VYCFPUaa3P4RrBQsqok4PO200Vkz0vXQBNlg7W907g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@parcel/watcher": "^2.4.1",
         "chokidar": "^4.0.0",
@@ -24904,6 +24952,7 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -25258,7 +25307,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shallow-equals/-/shallow-equals-1.0.0.tgz",
       "integrity": "sha512-xd/FKcdmfmMbyYCca3QTVEJtqUOGuajNzvAX6nt8dXILwjAIEkfHc4hI8/JMGApAmb7VeULO0Q30NTxnbH/15g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -26109,6 +26159,7 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.7.tgz",
       "integrity": "sha512-JL1b4A79OGqav4TxkrNsuuQfy6ZnrpyQx6hBDQ3Hd3JyuR2IQuVNBpF+FCEWFNZpN5hj+fhkaEVWteVJ18f0tw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -26177,6 +26228,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.1",
         "@csstools/css-tokenizer": "^3.0.1",
@@ -26865,6 +26917,7 @@
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
       "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }
@@ -27075,7 +27128,8 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD"
+      "license": "0BSD",
+      "peer": true
     },
     "node_modules/turndown": {
       "version": "7.2.2",
@@ -27214,6 +27268,7 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -27644,6 +27699,7 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -27692,6 +27748,7 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -28560,6 +28617,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -28741,6 +28799,7 @@
       "version": "26.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -28990,6 +29049,7 @@
       "version": "26.1.0",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Adds an inline plugin metadata line to **Plugin Management** and **individual plugin settings** pages so admins can see plugin identity without switching between pages.

**Format:**

`Display Name` `(plugin-id` 📋 `- v1.2.3)`

- **Display name** links to `homepage_url` when set; falls back to the plugin ID if the name is empty
- **Parenthetical metadata** (ID, copy button, version) is rendered in smaller, muted text to read as secondary technical detail
- **Plugin ID** uses monospace without code-block highlighting; includes a compact copy button
- **Version** is prefixed with `v` when missing, omitted when unknown, and links to `release_notes_url` when set
- On the **plugin settings page**, the line appears at the top of the content area (not the large admin header) and uses the installed runtime version from plugin status when available
- Plugin settings pages retain an `sr-only` page heading for assistive technology while keeping the visual layout unchanged

Introduces a reusable `PluginMetadataPanel` component used in both locations.

#### Screenshots

**Plugin Management:**
<img width="1355" height="973" alt="Screenshot from 2026-07-06 14-36-12" src="https://github.com/user-attachments/assets/cc1c25fb-26aa-4972-8ef6-67811f56ef7b" />




**Plugin settings page:**
<img width="1954" height="1336" alt="Screenshot from 2026-07-06 14-36-01" src="https://github.com/user-attachments/assets/3f681269-82e7-48e8-bf0b-abdd2b2d7b31" />


#### Release Note

```release-note
Added inline plugin metadata to the Plugin Management page and plugin settings page showing the plugin ID, version, and links to the website and release notes when available.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-78471a57-ae29-4f31-8b22-a68ddc0d323a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-78471a57-ae29-4f31-8b22-a68ddc0d323a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: Medium 🟠

**Regression Risk:** UI-focused change spanning multiple admin console components with new shared metadata rendering and interaction (external links + click-to-copy clipboard/tooltip). Redux prop wiring for plugin + version and the copy/tooltip flow introduce edge-case regression potential even though key rendering/formatting is unit-tested.

**QA Recommendation:** Light manual QA for Plugin Management + Plugin Settings pages: verify display name fallback to plugin ID, homepage/release-notes link rendering, version formatting (including unknown/empty), and the plugin-id copy interaction + feedback.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->