### PR TITLE
Auto-continue markdown lists on Shift+Enter (#30977)

### DIFF
--- a/webapp/channels/src/components/autosize_textarea.tsx
+++ b/webapp/channels/src/components/autosize_textarea.tsx
@@ -120,6 +120,43 @@ const AutosizeTextarea = React.forwardRef<HTMLTextAreaElement, Props>(({
         textarea.current = textareaRef;
     }, [ref]);
 
+    // issue #30977: on Shift+Enter inside a bulleted or numbered list,
+    // continue the list on the next line automatically. The parent's
+    // onKeyDown (from ...otherProps) runs first so QuickInput /
+    // SuggestionBox shortcuts still work; we only take over if the
+    // parent hasn't already consumed the event.
+    const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+        (otherProps as {onKeyDown?: React.KeyboardEventHandler<HTMLTextAreaElement>}).onKeyDown?.(e);
+        if (e.defaultPrevented) {
+            return;
+        }
+
+        if (e.key !== 'Enter' || !e.shiftKey) {
+            return;
+        }
+
+        const target = e.currentTarget;
+        const {value, selectionStart} = target;
+
+        // Grab the current line up to the cursor.
+        const lineStart = value.lastIndexOf('\n', selectionStart - 1) + 1;
+        const currentLine = value.slice(lineStart, selectionStart);
+
+        const bullet = currentLine.match(/^(\s*[-*+])\s+/);
+        const numbered = currentLine.match(/^(\s*)(\d+)\.\s+/);
+
+        if (!bullet && !numbered) {
+            return;
+        }
+
+        const prefix = bullet ?
+            `${bullet[1]} ` :
+            `${numbered![1]}${parseInt(numbered![2], 10) + 1}. `;
+
+        e.preventDefault();
+        document.execCommand('insertText', false, '\n' + prefix);
+    };
+
     useEffect(() => {
         recalculateHeight();
         recalculateWidth();
@@ -163,6 +200,7 @@ const AutosizeTextarea = React.forwardRef<HTMLTextAreaElement, Props>(({
                 disabled={disabled}
                 onChange={onChange}
                 onInput={onInput}
+                onKeyDown={handleKeyDown}
                 value={value}
                 defaultValue={defaultValue}
                 style={showScrollbar ? styles.textAreaWithScroll : styles.textArea}


### PR DESCRIPTION
## Summary

Closes #30977. Related JIRA: MM-64235.

When the cursor sits inside a bulleted (`-`, `*`, `+`) or numbered (`1.`) list item and the user presses **Shift+Enter**, the next line is auto-prefixed with the appropriate marker so the list keeps flowing. Nested lists preserve their indent.

- [x] Bulleted lists (`- `, `* `, `+ `) continue with the same marker
- [x] Numbered lists auto-increment (`1.` → `2.` → `3.`)
- [x] Nested indent is preserved (`  - nested` continues as `  - `)
- [x] Non-list content falls through to the browser's default newline (no behaviour change)
- [x] `Enter` alone still submits the message (no behaviour change)

## Why AutosizeTextarea

`AutosizeTextarea` is the shared textarea primitive used by every Markdown text field in the webapp (main editor, RHS reply, channel purpose, edit-header modal, flag-post reason, etc.). Putting the logic here means the feature ships to all of them at once, rather than only the main message editor.

The parent's `onKeyDown` (if any) is still called for keystrokes we don't handle, so no downstream handler is broken.

## Implementation note

The insertion uses `document.execCommand('insertText', ...)` so the change flows through the browser's normal input pipeline and React's controlled state stays in sync automatically. `execCommand` is deprecated but still widely supported (VS Code, GitHub, Slack all use it for the same purpose); the modern `Selection`/`Range` APIs don't have a clean equivalent for a controlled `<textarea>`. Happy to swap for a `nativeSetter` + synthetic input event pattern if reviewers prefer.

## Test plan

- [ ] `- apples` + Shift+Enter → `- apples\n- ` (cursor after the space)
- [ ] `1. first` + Shift+Enter → `1. first\n2. `
- [ ] `  - nested` + Shift+Enter → `  - nested\n  - ` (indent preserved)
- [ ] Plain text + Shift+Enter → normal newline, no marker
- [ ] Enter alone on `- item` → message sends
- [ ] Confirm in the RHS thread reply box, channel purpose/header fields, and flag-post reason field
- [ ] Confirm nothing breaks in a \`Ctrl+Enter to send\` configuration (Settings → Advanced)

### Release Note
Auto-continues bulleted and numbered markdown lists when users press Shift+Enter inside a list item in any Markdown-capable text field.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change is isolated to the shared `AutosizeTextarea` component, which is used by Markdown-capable textbox inputs, so it can affect multiple user entry points. Risk is moderate because it overrides Shift+Enter handling and relies on `document.execCommand('insertText')`, with no automated coverage for key-interaction edge cases (only an init snapshot test).

**QA Recommendation:** Focused manual testing for Shift+Enter continuation in bulleted/numbered lists (including nested indentation), Shift+Enter in non-list text, and verification that Enter-only submission behavior remains unchanged.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->