### PR TITLE
ci: auto-build missing buildenv images for in-flight Go version bumps (#37286)

### DIFF
--- a/.github/actions/load-buildenv/action.yml
+++ b/.github/actions/load-buildenv/action.yml
@@ -1,0 +1,66 @@
+name: Load build environment
+description: >
+  Loads build-server images uploaded by setup-buildenv into the local Docker
+  daemon, and resolves the image name from the Go version. Use in jobs that
+  run the container directly (test jobs). For jobs that only need a shell
+  inside the container, use run-in-buildenv instead.
+
+inputs:
+  go-version:
+    description: "Go version used to construct the image tag (e.g. 1.26.3)."
+    required: true
+  fips-enabled:
+    description: "Set to 'true' to resolve the FIPS build image"
+    required: false
+    default: "false"
+
+outputs:
+  image:
+    description: "Fully-qualified build image name (e.g. mattermost/mattermost-build-server:1.26.3)."
+    value: ${{ steps.resolve.outputs.image }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set constants
+      shell: bash
+      run: |
+        echo "BUILDENV_ARTIFACT=buildenv-image" >> "${GITHUB_ENV}"
+        echo "BUILDENV_FIPS_ARTIFACT=buildenv-fips-image" >> "${GITHUB_ENV}"
+        echo "BUILDENV_TMPDIR=/tmp/buildenv-save" >> "${GITHUB_ENV}"
+    - name: Download buildenv artifact
+      id: download
+      if: ${{ inputs.fips-enabled != 'true' }}
+      continue-on-error: true
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      with:
+        name: ${{ env.BUILDENV_ARTIFACT }}
+        path: ${{ env.BUILDENV_TMPDIR }}/
+    - name: Load buildenv from artifact
+      if: ${{ inputs.fips-enabled != 'true' && steps.download.outcome == 'success' }}
+      shell: bash
+      run: docker load -i "${BUILDENV_TMPDIR}/image.tar.gz"
+    - name: Download buildenv-fips artifact
+      id: download-fips
+      if: ${{ inputs.fips-enabled == 'true' }}
+      continue-on-error: true
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      with:
+        name: ${{ env.BUILDENV_FIPS_ARTIFACT }}
+        path: ${{ env.BUILDENV_TMPDIR }}/
+    - name: Load buildenv-fips from artifact
+      if: ${{ inputs.fips-enabled == 'true' && steps.download-fips.outcome == 'success' }}
+      shell: bash
+      run: docker load -i "${BUILDENV_TMPDIR}/image-fips.tar.gz"
+    - name: Resolve image name
+      id: resolve
+      shell: bash
+      env:
+        FIPS: ${{ inputs.fips-enabled }}
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        if [[ "${FIPS}" == 'true' ]]; then
+          echo "image=mattermost/mattermost-build-server-fips:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
+        else
+          echo "image=mattermost/mattermost-build-server:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
+        fi

--- a/.github/actions/run-in-buildenv/action.yml
+++ b/.github/actions/run-in-buildenv/action.yml
@@ -1,0 +1,69 @@
+name: Run in build environment
+description: >
+  Runs a script inside the build-server container. Use for build and check
+  jobs that don't need direct control over the docker run invocation.
+
+  Note the special handling of HEAD_REF, REF_NAME, and RUN_ID. Since the
+  container is not otherwise given access to the runner's environment, we
+  re-export github.head_ref, github.ref_name, and github.run_id as a
+  special case for use in safely building up BUILD_NUMBER. In general,
+  don't extend this: if your use case requires more customization, use
+  load-buildenv and invoke docker run yourself.
+
+inputs:
+  run:
+    description: "Bash script to execute inside the container"
+    required: true
+  go-version:
+    description: "Go version to use (e.g. 1.24.3). Defaults to the version in server/.go-version."
+    required: false
+    default: ""
+  fips-enabled:
+    description: "Set to 'true' to use the FIPS build image"
+    required: false
+    default: "false"
+  working-directory:
+    description: "Working directory inside the container (absolute path under /mattermost/)"
+    required: false
+    default: "/mattermost/server"
+
+runs:
+  using: composite
+  steps:
+    - name: Read Go version
+      shell: bash
+      env:
+        GO_VERSION_INPUT: ${{ inputs.go-version }}
+      run: |
+        if [[ -n "${GO_VERSION_INPUT}" ]]; then
+          echo "GO_VERSION=${GO_VERSION_INPUT}" >> "${GITHUB_ENV}"
+        else
+          echo "GO_VERSION=$(cat server/.go-version)" >> "${GITHUB_ENV}"
+        fi
+    - uses: ./.github/actions/load-buildenv
+      id: buildenv
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        fips-enabled: ${{ inputs.fips-enabled }}
+    - name: Run in buildenv
+      shell: bash
+      env:
+        CMD: ${{ inputs.run }}
+        IMAGE: ${{ steps.buildenv.outputs.image }}
+        WORKING_DIR: ${{ inputs.working-directory }}
+        HEAD_REF: ${{ github.head_ref }}
+        REF_NAME: ${{ github.ref_name }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        SCRIPT=$(mktemp)
+        printf 'git config --global --add safe.directory /mattermost\n' > "${SCRIPT}"
+        printf '%s\n' "${CMD}" >> "${SCRIPT}"
+        docker run --rm \
+          --network host \
+          -e HEAD_REF -e REF_NAME -e RUN_ID \
+          -v "$PWD:/mattermost" \
+          -v "${SCRIPT}:/run-script.sh" \
+          -w "${WORKING_DIR}" \
+          "${IMAGE}" \
+          bash -eo pipefail /run-script.sh
+        rm -f "${SCRIPT}"

--- a/.github/actions/setup-buildenv/action.yml
+++ b/.github/actions/setup-buildenv/action.yml
@@ -1,0 +1,104 @@
+name: Setup build environment
+description: >
+  Builds the mattermost-build-server images if they don't yet exist on Docker
+  Hub (e.g. during a Go version bump), and uploads them as artifacts for
+  downstream jobs. Run once per workflow before any build or test jobs.
+
+inputs:
+  go-version:
+    description: "Go version (e.g. 1.26.3)"
+    required: true
+  dockerfile:
+    description: "Path to Dockerfile.buildenv (relative to workspace root)"
+    required: false
+    default: "server/build/Dockerfile.buildenv"
+  dockerfile-fips:
+    description: "Path to Dockerfile.buildenv-fips (relative to workspace root)"
+    required: false
+    default: "server/build/Dockerfile.buildenv-fips"
+
+runs:
+  using: composite
+  steps:
+    - name: Set constants
+      shell: bash
+      run: |
+        echo "BUILDENV_IMAGE=mattermost/mattermost-build-server" >> "${GITHUB_ENV}"
+        echo "BUILDENV_ARTIFACT=buildenv-image" >> "${GITHUB_ENV}"
+        echo "BUILDENV_DOCKERFILE=${{ inputs.dockerfile }}" >> "${GITHUB_ENV}"
+        echo "BUILDENV_FIPS_IMAGE=mattermost/mattermost-build-server-fips" >> "${GITHUB_ENV}"
+        echo "BUILDENV_FIPS_ARTIFACT=buildenv-fips-image" >> "${GITHUB_ENV}"
+        echo "BUILDENV_FIPS_DOCKERFILE=${{ inputs.dockerfile-fips }}" >> "${GITHUB_ENV}"
+        echo "BUILDENV_TMPDIR=/tmp/buildenv-save" >> "${GITHUB_ENV}"
+    # ── Regular ────────────────────────────────────────────────────────
+    - name: Resolve regular image
+      id: resolve
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        docker manifest inspect "${BUILDENV_IMAGE}:${GO_VERSION}" > /dev/null 2>&1 || \
+          echo "needs-build=true" >> "${GITHUB_OUTPUT}"
+    - name: Build regular image
+      if: ${{ steps.resolve.outputs.needs-build == 'true' }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: docker build -t "${BUILDENV_IMAGE}:${GO_VERSION}" - < "${BUILDENV_DOCKERFILE}"
+    - name: Save and upload regular image
+      if: ${{ steps.resolve.outputs.needs-build == 'true' }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        mkdir -p "${BUILDENV_TMPDIR}"
+        docker save "${BUILDENV_IMAGE}:${GO_VERSION}" | gzip > "${BUILDENV_TMPDIR}/image.tar.gz"
+    - name: Upload regular image artifact
+      if: ${{ steps.resolve.outputs.needs-build == 'true' }}
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ env.BUILDENV_ARTIFACT }}
+        path: ${{ env.BUILDENV_TMPDIR }}/image.tar.gz
+        retention-days: 1
+    # ── FIPS (skipped on fork PRs) ─────────────────────────────────────
+    - name: Docker Hub login
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_TOKEN }}
+    - name: Setup Chainctl
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      uses: chainguard-dev/setup-chainctl@c125f765e82b09a42af3185f3214465314d75c5d # v0.5.0
+      with:
+        identity: ${{ env.CHAINCTL_IDENTITY }}
+    - name: Resolve FIPS image
+      id: resolve-fips
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        docker manifest inspect "${BUILDENV_FIPS_IMAGE}:${GO_VERSION}" > /dev/null 2>&1 || \
+          echo "needs-build=true" >> "${GITHUB_OUTPUT}"
+    - name: Build FIPS image
+      if: ${{ steps.resolve-fips.outputs.needs-build == 'true' }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: docker build -t "${BUILDENV_FIPS_IMAGE}:${GO_VERSION}" - < "${BUILDENV_FIPS_DOCKERFILE}"
+    - name: Save and upload FIPS image
+      if: ${{ steps.resolve-fips.outputs.needs-build == 'true' }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        mkdir -p "${BUILDENV_TMPDIR}"
+        docker save "${BUILDENV_FIPS_IMAGE}:${GO_VERSION}" | gzip > "${BUILDENV_TMPDIR}/image-fips.tar.gz"
+    - name: Upload FIPS image artifact
+      if: ${{ steps.resolve-fips.outputs.needs-build == 'true' }}
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ env.BUILDENV_FIPS_ARTIFACT }}
+        path: ${{ env.BUILDENV_TMPDIR }}/image-fips.tar.gz
+        retention-days: 1

--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -56,19 +56,22 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup BUILD_IMAGE
-        id: build
+      - name: buildenv/load
+        id: buildenv
+        uses: ./.github/actions/load-buildenv
+        with:
+          go-version: ${{ inputs.go-version }}
+          fips-enabled: ${{ inputs.fips-enabled }}
+      - name: Setup log artifact name
+        id: log-artifact
         run: |
           if [[ "$INPUT_FIPS_ENABLED" == 'true' ]]; then
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${INPUT_GO_VERSION}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${INPUT_LOGSARTIFACT}-fips" >> "${GITHUB_OUTPUT}"
           else
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${INPUT_GO_VERSION}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${INPUT_LOGSARTIFACT}" >> "${GITHUB_OUTPUT}"
           fi
 
@@ -90,7 +93,7 @@ jobs:
 
       - name: Run mmctl Tests
         env:
-          BUILD_IMAGE: ${{ steps.build.outputs.BUILD_IMAGE }}
+          BUILD_IMAGE: ${{ steps.buildenv.outputs.image }}
         run: |
           if [[ "$REF_NAME" == 'master' ]]; then
             export TESTFLAGS="-timeout 90m -race"
@@ -120,13 +123,13 @@ jobs:
         with:
           report-path: server/report.xml
           zephyr-api-key: ${{ secrets.MM_E2E_ZEPHYR_API_KEY }}
-          build-image: ${{ steps.build.outputs.BUILD_IMAGE }}
+          build-image: ${{ steps.buildenv.outputs.image }}
 
       - name: Archive logs
         if: ${{ always() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: ${{ steps.build.outputs.LOG_ARTIFACT_NAME }}
+          name: ${{ steps.log-artifact.outputs.LOG_ARTIFACT_NAME }}
           path: |
             server/gotestsum.json
             server/report.xml

--- a/.github/workflows/server-ci-nightly-race.yml
+++ b/.github/workflows/server-ci-nightly-race.yml
@@ -21,8 +21,8 @@ permissions:
   contents: read
 
 jobs:
-  go:
-    name: Compute Go Version
+  buildenv:
+    name: Build Environment
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.calculate.outputs.GO_VERSION }}
@@ -38,7 +38,7 @@ jobs:
 
   test-race:
     name: Race Detector
-    needs: go
+    needs: buildenv
     permissions:
       contents: read
       actions: write
@@ -48,7 +48,7 @@ jobs:
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: race-detector-server-test-logs
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: false
       fullyparallel: false
       race-enabled: true

--- a/.github/workflows/server-ci-weekly.yml
+++ b/.github/workflows/server-ci-weekly.yml
@@ -15,15 +15,15 @@ on:
     - cron: "0 5 * * 1" # Monday 5am UTC (~1am ET)
   push:
     branches:
-      - 'release-*'
+      - "release-*"
   workflow_dispatch: # Allow manual trigger for urgent FIPS/binary verification
 
 permissions:
   contents: read
 
 jobs:
-  go:
-    name: Compute Go Version
+  buildenv:
+    name: Build Environment
     runs-on: ubuntu-22.04
     outputs:
       version: ${{ steps.calculate.outputs.GO_VERSION }}
@@ -39,7 +39,7 @@ jobs:
 
   test-postgres-binary:
     name: Postgres with binary parameters
-    needs: go
+    needs: buildenv
     permissions:
       contents: read
       actions: write
@@ -49,7 +49,7 @@ jobs:
       datasource: postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes
       drivername: postgres
       logsartifact: postgres-binary-server-test-logs
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: false
       # Unsharded run on a single 8-core runner: fullyparallel=true causes
       # resource exhaustion (too many server instances, WebSocket hubs, and
@@ -58,7 +58,7 @@ jobs:
 
   test-postgres-normal-fips:
     name: Postgres FIPS
-    needs: go
+    needs: buildenv
     permissions:
       contents: read
       actions: write
@@ -71,14 +71,14 @@ jobs:
       datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: postgres-server-fips-test-logs
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: true
       # Unsharded run on a single 8-core runner: see note on test-postgres-binary.
       fullyparallel: false
 
   test-mmctl-fips:
     name: Run mmctl tests (FIPS)
-    needs: go
+    needs: buildenv
     permissions:
       contents: read
       actions: write
@@ -92,5 +92,5 @@ jobs:
       datasource: postgres://mmuser:mostest-fips-test@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
       drivername: postgres
       logsartifact: mmctl-fips-test-logs
-      go-version: ${{ needs.go.outputs.version }}
+      go-version: ${{ needs.buildenv.outputs.version }}
       fips-enabled: true

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -69,8 +69,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Generate mocks
         run: make mocks
       - name: Check mocks
@@ -94,8 +92,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Run go mod tidy
         run: make modules-tidy
       - name: Check modules
@@ -103,31 +99,6 @@ jobs:
           git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please tidy up the Go modules using make modules-tidy"
-            git diff
-            exit 1
-          fi
-  check-go-fix:
-    name: Check go fix
-    needs: go
-    runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
-    steps:
-      - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
-      - name: Run go fix
-        run: go fix ./...
-      - name: Check go fix
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
-          if [ -n "$(git status --porcelain)" ]; then
-            echo "Please run 'go fix ./...' and commit the changes"
             git diff
             exit 1
           fi
@@ -144,8 +115,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Run golangci
         run: make check-style
   check-gen-serialized:
@@ -161,8 +130,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Run make-gen-serialized
         run: make gen-serialized
       - name: Check serialized
@@ -186,8 +153,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Run mattermost-vet-api
         run: make vet-api
   check-migrations:
@@ -251,8 +216,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Generate store layers
         run: make store-layers
       - name: Check generated code
@@ -289,8 +252,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Generate default roles permissions
         env:
           IS_CI: "true"
@@ -316,8 +277,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Check docs
         run: |
           echo "Making sure docs are updated"
@@ -505,8 +464,6 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "npm"
           cache-dependency-path: "webapp/package-lock.json"
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Build
         run: |
           make config-reset

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -17,8 +17,6 @@ on:
       - ".github/workflows/server-test-template.yml"
       - ".github/workflows/server-test-merge-template.yml"
       - ".github/workflows/mmctl-test-template.yml"
-      - "!server/build/Dockerfile.buildenv"
-      - "!server/build/Dockerfile.buildenv-fips"
       - "tools/mattermost-govet/**"
       - "!server/**/*.md"
       - "!server/NOTICE.txt"
@@ -38,12 +36,14 @@ jobs:
     permissions:
       contents: read
       pull-requests: read
+      actions: write
+      id-token: write  # for chainguard (FIPS base image pull)
     outputs:
       version: ${{ steps.calculate.outputs.GO_VERSION }}
       gomod-changed: ${{ steps.changed-files.outputs.any_changed }}
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
       - name: Calculate version
@@ -52,28 +52,32 @@ jobs:
         run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
       - name: Check for go.mod changes
         id: changed-files
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323  # v47.0.5
         with:
           files: |
             **/go.mod
+      - name: Setup build environment
+        env:
+          CHAINCTL_IDENTITY: ee399b4c72dd4e58e3d617f78fc47b74733c9557/922f2d48307d6f5f
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/setup-buildenv
+        with:
+          go-version: ${{ steps.calculate.outputs.GO_VERSION }}
   check-mocks:
     name: Check mocks
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Generate mocks
-        run: make mocks
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make mocks
       - name: Check mocks
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the mocks using 'make mocks'"
             git diff
@@ -83,20 +87,16 @@ jobs:
     name: Check go mod tidy
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Run go mod tidy
-        run: make modules-tidy
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make modules-tidy
       - name: Check modules
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please tidy up the Go modules using make modules-tidy"
             git diff
@@ -106,35 +106,28 @@ jobs:
     name: check-style
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Run golangci
-        run: make check-style
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make check-style
   check-gen-serialized:
     name: Check serialization methods for hot structs
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Run make-gen-serialized
-        run: make gen-serialized
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make gen-serialized
       - name: Check serialized
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the serialized files using 'make gen-serialized'"
             git diff
@@ -144,35 +137,28 @@ jobs:
     name: Vet API
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Run mattermost-vet-api
-        run: make vet-api
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make vet-api
   check-migrations:
     name: Check migration files
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Extract migrations files
-        run: make migrations-extract
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make migrations-extract
       - name: Check migration files
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the migrations using make migrations-extract"
             git diff
@@ -182,22 +168,18 @@ jobs:
     name: Generate email templates
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Generate email templates
-        run: |
-          npm install -g mjml@4.9.0
-          make build-templates
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: |
+            npm install -g mjml@4.9.0
+            make build-templates
       - name: Check generated email templates
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the email templates using 'make build-templates'"
             git diff
@@ -207,20 +189,16 @@ jobs:
     name: Check store layers
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Generate store layers
-        run: make store-layers
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make store-layers
       - name: Check generated code
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the store layers using make store-layers"
             git diff
@@ -230,7 +208,6 @@ jobs:
     name: Check default roles permissions
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
     permissions:
       contents: read
     services:
@@ -239,26 +216,27 @@ jobs:
         env:
           POSTGRES_USER: mmuser
           POSTGRES_PASSWORD: mostest
+          POSTGRES_DB: mattermost_test
+        ports:
+          - 5432:5432
         options: >-
           --health-cmd pg_isready
           --health-interval 5s
           --health-timeout 5s
           --health-retries 5
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Generate default roles permissions
-        env:
-          IS_CI: "true"
-        run: make default-roles-permissions
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: |
+            export IS_CI=true
+            export TEST_DATABASE_POSTGRESQL_DSN="postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
+            make default-roles-permissions
       - name: Check generated code
         run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the default roles permissions using make default-roles-permissions"
             git diff
@@ -268,20 +246,16 @@ jobs:
     name: Check mmctl docs
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost-server
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make mmctl-docs
       - name: Check docs
         run: |
-          echo "Making sure docs are updated"
-          make mmctl-docs
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           if [ -n "$(git status --porcelain)" ]; then
             echo "Please update the mmctl docs using make mmctl-docs"
             git diff
@@ -296,7 +270,7 @@ jobs:
     name: Postgres (shard ${{ matrix.shard }})
     needs: go
     strategy:
-      fail-fast: false # Let all shards complete so we get full test results
+      fail-fast: false  # Let all shards complete so we get full test results
       matrix:
         shard: [0, 1, 2, 3]
     permissions:
@@ -446,32 +420,23 @@ jobs:
       contents: read
       actions: write
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
-    env:
-      BUILD_NUMBER: "${GITHUB_HEAD_REF}-${GITHUB_RUN_ID}"
-      FIPS_ENABLED: false
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: ci/setup-node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-          cache-dependency-path: "webapp/package-lock.json"
       - name: Build
-        run: |
-          make config-reset
-          make build-cmd
-          make package
+        uses: ./.github/actions/run-in-buildenv
+        with:
+          run: |
+            export BUILD_NUMBER="$(printf '%s' "${HEAD_REF:-${REF_NAME}}" | tr -c 'A-Za-z0-9._-' '-')-${RUN_ID}"
+            export FIPS_ENABLED=false
+            make config-reset
+            make build-cmd
+            make package
       - name: Persist dist artifacts
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: server-dist-artifact
           path: server/dist/
@@ -480,7 +445,7 @@ jobs:
           retention-days: 2
       - name: Persist build artifacts
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: server-build-artifact
           path: server/build/

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -76,7 +76,7 @@ on:
 
 permissions:
   contents: read
-  actions: write
+  actions: read    # for load-buildenv artifact listing
 
 jobs:
   test:
@@ -110,6 +110,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: buildenv/load
+        id: buildenv
+        uses: ./.github/actions/load-buildenv
+        with:
+          go-version: ${{ inputs.go-version }}
+          fips-enabled: ${{ inputs.fips-enabled }}
 
       - name: Restore test timing data
         if: inputs.shard-total > 1
@@ -131,14 +137,12 @@ jobs:
           restore-keys: |
             server-test-timing-v2-
 
-      - name: Setup BUILD_IMAGE
-        id: build
+      - name: Setup log artifact name
+        id: log-artifact
         run: |
           if [[ "$INPUT_FIPS_ENABLED" == 'true' ]]; then
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${INPUT_GO_VERSION}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${INPUT_LOGSARTIFACT}-fips" >> "${GITHUB_OUTPUT}"
           else
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${INPUT_GO_VERSION}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${INPUT_LOGSARTIFACT}" >> "${GITHUB_OUTPUT}"
           fi
 
@@ -225,7 +229,7 @@ jobs:
 
       - name: Run Tests
         env:
-          BUILD_IMAGE: ${{ steps.build.outputs.BUILD_IMAGE }}
+          BUILD_IMAGE: ${{ steps.buildenv.outputs.image }}
         run: |
           RACE_MODE=""
           if [[ "$INPUT_RACE_ENABLED" == "true" ]]; then
@@ -279,7 +283,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: ${{ steps.build.outputs.LOG_ARTIFACT_NAME }}
+          name: ${{ steps.log-artifact.outputs.LOG_ARTIFACT_NAME }}
           path: |
             server/gotestsum.json
             server/report.xml

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build package run stop run-client run-server run-node run-haserver stop-haserver stop-client stop-server restart restart-server restart-client restart-haserver start-docker update-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-freebsd build-windows package-prep package-linux package-osx package-windows internal-test-web-client vet run-server-for-web-client-tests diff-config prepackaged-plugins prepackaged-binaries test-server test-server-ee test-server-elasticsearch test-server-opensearch test-server-quick test-server-race test-mmctl-unit test-mmctl-e2e test-mmctl test-mmctl-coverage mmctl-build mmctl-docs new-migration migrations-extract test-public mocks-public run-server-faketime default-roles-permissions generated
+.PHONY: build package run stop run-client run-server run-node run-haserver stop-haserver stop-client stop-server restart restart-server restart-client restart-haserver start-docker update-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-freebsd build-windows package-prep package-linux package-osx package-windows internal-test-web-client vet run-server-for-web-client-tests diff-config prepackaged-plugins prepackaged-binaries test-server test-server-ee test-server-elasticsearch test-server-opensearch test-server-quick test-server-race test-mmctl-unit test-mmctl-e2e test-mmctl test-mmctl-coverage mmctl-build mmctl-docs new-migration migrations-extract test-public mocks-public run-server-faketime default-roles-permissions generated check-go-fix
 
 ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -404,7 +404,7 @@ mmctl-mocks: setup-go-work ## Creates mocks for mmctl
 pluginapi: setup-go-work ## Generates api and hooks glue code for plugins
 	cd ./public && $(GO) generate $(GOFLAGS) ./plugin
 
-default-roles-permissions: start-docker ## Generates default_roles_permissions.js by snapshotting a live database.
+default-roles-permissions: setup-go-work start-docker ## Generates default_roles_permissions.js by snapshotting a live database.
 	$(GO) run $(GOFLAGS) ./scripts/default_permissions_generator \
 		-out ../e2e-tests/cypress/tests/support/api/default_roles_permissions.js
 
@@ -439,7 +439,10 @@ ifneq ($(SKIP_SETUP_GO_WORK),true)
 	fi
 endif
 
-check-style: plugin-checker vet golangci-lint ## Runs style/lint checks
+check-go-fix: setup-go-work ## Check if go fix would modify any files.
+	$(GO) fix -diff ./...
+
+check-style: plugin-checker vet golangci-lint check-go-fix ## Runs style/lint checks
 
 gotestsum:
 	$(GO) install gotest.tools/gotestsum@v1.13.0
@@ -451,7 +454,7 @@ test-compile: setup-go-work gotestsum ## Compile tests.
 		$(GO) test $(GOFLAGS) -c $$package; \
 	done
 
-modules-tidy: ## Tidy Go modules
+modules-tidy: setup-go-work ## Tidy Go modules
 	mv enterprise/external_imports.go enterprise/external_imports.go.orig
 	-$(GO) mod tidy
 	-cd public && $(GO) mod tidy
@@ -869,6 +872,7 @@ ifeq ($(BUILD_ENTERPRISE_READY),true)
   endif
 endif
 
+vet-api: setup-go-work
 vet-api: export GO := $(GO)
 vet-api: export GOBIN := $(GOBIN)
 vet-api: export ROOT := $(ROOT)


### PR DESCRIPTION
#### Summary

Cherry-pick of #37286 to release-11.9, in two commits:
1. #37268 (`ci: make setup-go-work a Makefile prereq, remove explicit CI steps`) — a prerequisite that had landed on master but not yet on release-11.9, needed so #37286 applies against the same baseline as master.
2. #37286 itself.

The only remaining intentional divergence from master's `server-ci.yml` is the "Check for renumbered or renamed migrations" step from #37099, which hasn't been backported to release-11.9 and is out of scope here.

Companion enterprise change: https://github.com/mattermost/enterprise/pull/2222

#### Release Note
```release-note
NONE
```
