### PR TITLE
MM-69340: fix NULL Type scan error in Draft.Get()

### DIFF
--- a/server/channels/store/sqlstore/draft_store.go
+++ b/server/channels/store/sqlstore/draft_store.go
@@ -35,8 +35,15 @@ func draftSliceColumns() []string {
 		"FileIds",
 		"Props",
 		"Priority",
-		"COALESCE(Type, '') AS Type",
+		"Type",
 	}
+}
+
+func draftSelectColumns() []string {
+	cols := make([]string, len(draftSliceColumns()))
+	copy(cols, draftSliceColumns())
+	cols[len(cols)-1] = "COALESCE(Type, '') AS Type"
+	return cols
 }
 
 func draftToSlice(draft *model.Draft) []any {
@@ -65,7 +72,7 @@ func newSqlDraftStore(sqlStore *SqlStore, metrics einterfaces.MetricsInterface) 
 
 func (s *SqlDraftStore) Get(userId, channelId, rootId string, includeDeleted bool) (*model.Draft, error) {
 	query := s.getQueryBuilder().
-		Select(draftSliceColumns()...).
+		Select(draftSelectColumns()...).
 		From("Drafts").
 		Where(sq.Eq{
 			"UserId":    userId,

--- a/server/channels/store/sqlstore/draft_store.go
+++ b/server/channels/store/sqlstore/draft_store.go
@@ -35,7 +35,7 @@ func draftSliceColumns() []string {
 		"FileIds",
 		"Props",
 		"Priority",
-		"Type",
+		"COALESCE(Type, '') AS Type",
 	}
 }
 

--- a/server/channels/store/storetest/draft_store.go
+++ b/server/channels/store/storetest/draft_store.go
@@ -362,6 +362,18 @@ func testGetDraft(t *testing.T, rctx request.CTX, ss store.Store) {
 		assert.Equal(t, draft2.Message, draftResp.Message)
 		assert.Equal(t, draft2.ChannelId, draftResp.ChannelId)
 	})
+
+	t.Run("get draft with NULL type", func(t *testing.T) {
+		_, err := ss.GetInternalMasterDB().Exec(
+			"UPDATE Drafts SET Type = NULL WHERE UserId = $1 AND ChannelId = $2",
+			user.Id, channel.Id,
+		)
+		require.NoError(t, err)
+
+		draftResp, err := ss.Draft().Get(user.Id, channel.Id, "", false)
+		require.NoError(t, err)
+		assert.Equal(t, "", draftResp.Type)
+	})
 }
 
 func testGetDraftsForUser(t *testing.T, rctx request.CTX, ss store.Store) {


### PR DESCRIPTION
#### Summary

Drafts created before the v11.3 migration have `Type = NULL` in the database, which fails with the following when querying a single draft:

```
sql: Scan error on column index 10, name "type": converting NULL to string is unsupported
```

MM-67380 already patched this part of the way: this change completes the coverage.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-69340

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: Low 🟢

**Regression Risk:** The change only affects how `Draft.Get()` reads the `Type` column by converting legacy `NULL` values into an empty string, avoiding a scan-time error. `Upsert` write behavior remains unchanged, so risk of unintended persistence side effects is minimal.

**QA Recommendation:** Minimal manual QA—spot-check `Draft.Get()` for legacy drafts (created pre-migration) to confirm `Type` returns as an empty string and no errors occur; automated test coverage already targets this scenario.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->