### PR TITLE
MM-69782: let plugins open core modals by id

### DIFF
--- a/webapp/channels/src/components/suggestion/suggestion_results.ts
+++ b/webapp/channels/src/components/suggestion/suggestion_results.ts
@@ -1,94 +1,20 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {MessageDescriptor} from 'react-intl';
+import type {
+    Loading,
+    ProviderResults,
+    SuggestionResults,
+} from '@mattermost/shared/types/global';
 
-/**
- * SuggestionResult stores a list of suggestions rendered by the SuggestionBox/SuggestionList.
- */
-export type SuggestionResults<Item = unknown> = SuggestionResultsGrouped<Item> | SuggestionResultsUngrouped<Item>;
+export type {
+    Loading,
+    ProviderResults,
+    ProviderResultsGroup,
+    SuggestionResults,
+    SuggestionResultsUngrouped,
+} from '@mattermost/shared/types/global';
 
-export type SuggestionResultsGrouped<Item = unknown> = {
-
-    /**
-     * The text before the cursor that will be replaced if the corresponding autocomplete term is selected
-     */
-    matchedPretext: string;
-
-    groups: Array<SuggestionResultsGroup<Item>>;
-};
-
-export type SuggestionResultsGroup<Item = unknown> = {
-
-    /**
-     * A unique identifier for this type of group
-     */
-    key: string;
-
-    /**
-     * The label for the group displayed to the user.
-     * If omitted, the group will be rendered without a header.
-     */
-    label?: MessageDescriptor;
-
-    /**
-     * A list of strings which the previously typed text may be replaced by.
-     *
-     * The lengths of `terms`, `items`, and `components` MUST be the same because their entries correspond to each other.
-     */
-    terms: string[];
-
-    /**
-     * A list of objects backing the terms which may be used in rendering.
-     *
-     * The lengths of `terms`, `items`, and `components` MUST be the same because their entries correspond to each other.
-     */
-    items: Array<Item | Loading>;
-
-    /**
-     * A list of react components that can be used to render their corresponding item.
-     *
-     * The lengths of `terms`, `items`, and `components` MUST be the same because their entries correspond to each other.
-     */
-    components: React.ElementType[];
-};
-
-export type SuggestionResultsUngrouped<Item = unknown> = {
-
-    /**
-     * The text before the cursor that will be replaced if the corresponding autocomplete term is selected
-     */
-    matchedPretext: string;
-
-    /**
-     * A list of strings which the previously typed text may be replaced by.
-     *
-     * The lengths of `terms`, `items`, and `components` MUST be the same because their entries correspond to each other.
-     */
-    terms: string[];
-
-    /**
-     * A list of objects backing the terms which may be used in rendering.
-     *
-     * The lengths of `terms`, `items`, and `components` MUST be the same because their entries correspond to each other.
-     */
-    items: Array<Item | Loading>;
-
-    /**
-     * A list of react components that can be used to render their corresponding item.
-     *
-     * The lengths of `terms`, `items`, and `components` MUST be the same because their entries correspond to each other.
-     */
-    components: React.ElementType[];
-};
-
-export type Loading = {
-    loading: boolean;
-};
-
-/**
- * Returns true if the item is an actual item and not an indicator that more results are being loaded.
- */
 export function isItemLoaded<Item>(item: Item | Loading): item is Item {
     return !item || typeof item !== 'object' || !('loading' in item) || !item.loading;
 }
@@ -102,16 +28,10 @@ export function emptyResults<Item>(): SuggestionResults<Item> {
     };
 }
 
-/**
- * Returns true if there are any items being suggested or if suggestions are being loaded.
- */
 export function hasResults(results: SuggestionResults): boolean {
     return countResults(results) > 0;
 }
 
-/**
- * Returns true if there are any items being suggested, even if more are being loaded.
- */
 export function hasLoadedResults(results: SuggestionResults): boolean {
     if ('groups' in results) {
         return results.groups.some((group) => group.items.some(isItemLoaded));
@@ -120,9 +40,6 @@ export function hasLoadedResults(results: SuggestionResults): boolean {
     return results.items.some(isItemLoaded);
 }
 
-/**
- * Returns the number of items being suggested and loading indicators in the results.
- */
 export function countResults(results: SuggestionResults): number {
     if ('groups' in results) {
         return results.groups.reduce((count, group) => count + group.items.length, 0);
@@ -131,9 +48,6 @@ export function countResults(results: SuggestionResults): number {
     return results.items.length;
 }
 
-/**
- * Given a term in the suggestions, returns the corresponding item or undefined if it can't be found.
- */
 export function getItemForTerm<Item>(results: SuggestionResults<Item>, term: string): Item | undefined {
     if ('groups' in results) {
         for (const group of results.groups) {
@@ -150,9 +64,6 @@ export function getItemForTerm<Item>(results: SuggestionResults<Item>, term: str
     return index === -1 ? undefined : results.items[index] as Item;
 }
 
-/**
- * Returns a flat array of terms being suggested for cases where that's needed like for keyboard navigation.
- */
 export function flattenTerms(results: SuggestionResults | ProviderResults): string[] {
     if ('groups' in results) {
         return results.groups.flatMap((group) => group.terms);
@@ -161,9 +72,6 @@ export function flattenTerms(results: SuggestionResults | ProviderResults): stri
     return results.terms;
 }
 
-/**
- * Returns a flat array of items being suggested for cases where we need to iterate over them.
- */
 export function flattenItems<Item>(results: SuggestionResults<Item> | ProviderResults<Item>): Item[] {
     if ('groups' in results) {
         return results.groups.flatMap((group) => group.items as Item);
@@ -174,9 +82,6 @@ export function flattenItems<Item>(results: SuggestionResults<Item> | ProviderRe
     return results.items as Item[];
 }
 
-/**
- * Returns true if any of the items being suggested is rendered with the corresponding component.
- */
 export function hasSuggestionWithComponent(results: SuggestionResults, componentType: React.ElementType) {
     if ('groups' in results) {
         return results.groups.some((group) => group.components.includes(componentType));
@@ -185,41 +90,6 @@ export function hasSuggestionWithComponent(results: SuggestionResults, component
     return results.components.includes(componentType);
 }
 
-/**
- * ProviderResults is similar to {@link SuggestionResults}, but it accepts a single component for convenience in cases where
- * all of the results are rendered with the same component. It's up to the calling code to normalize this object
- */
-export type ProviderResults<Item = unknown> = ProviderResultsGrouped<Item> | ProviderResultsUngrouped<Item>;
-
-export type ProviderResultsGrouped<Item = unknown> = {
-    matchedPretext: string;
-    groups: Array<ProviderResultsGroup<Item>>;
-};
-
-export type ProviderResultsGroup<Item = unknown> = {
-    key: string;
-    label?: MessageDescriptor;
-
-    terms: string[];
-    items: Array<Item | Loading>;
-} & ComponentOrComponents;
-
-export type ProviderResultsUngrouped<Item = unknown> = {
-    matchedPretext: string;
-    terms: string[];
-    items: Array<Item | Loading>;
-} & ComponentOrComponents;
-
-type ComponentOrComponents = {
-    component: React.ElementType;
-} | {
-    components: React.ElementType[];
-};
-
-/**
- * Converts the results from a Provider which may have one or multiple components specified into one which always
- * contains an array of components.
- */
 export function normalizeResultsFromProvider<Item>(providerResults: ProviderResults<Item>): SuggestionResults<Item> {
     if ('components' in providerResults) {
         return providerResults;

--- a/webapp/channels/src/plugins/export.test.ts
+++ b/webapp/channels/src/plugins/export.test.ts
@@ -60,3 +60,22 @@ describe('messageHtmlToComponent wrapper', () => {
         expect(messageHtmlToComponent).toHaveBeenCalledWith(message, options);
     });
 });
+
+describe('window.WebappUtils.modals.openModalById', () => {
+    test('opens an allowlisted modal by id with the given props', () => {
+        const action = (window as any).WebappUtils.modals.openModalById('team_settings', {focusOriginElement: 'channel-header'});
+
+        expect(action.modalId).toBe('team_settings');
+        expect(action.dialogProps).toEqual({focusOriginElement: 'channel-header'});
+        expect(typeof action.dialogType).toBe('function');
+    });
+});
+
+describe('window.WebappUtils.openUserSettings', () => {
+    test('opens the user settings modal', () => {
+        const action = (window as any).WebappUtils.openUserSettings({isContentProductSettings: false});
+
+        expect(action.modalId).toBe('user_settings');
+        expect(action.dialogProps).toEqual({isContentProductSettings: false});
+    });
+});

--- a/webapp/channels/src/plugins/export.test.ts
+++ b/webapp/channels/src/plugins/export.test.ts
@@ -71,6 +71,17 @@ describe('window.WebappUtils.modals.openModalById', () => {
     });
 });
 
+describe('window.WebappUtils.modals.canOpenModalId', () => {
+    test('is true for an allowlisted modal id', () => {
+        expect((window as any).WebappUtils.modals.canOpenModalId('team_settings')).toBe(true);
+    });
+
+    test('is false for an id the web app does not publish', () => {
+        expect((window as any).WebappUtils.modals.canOpenModalId('channel_invite')).toBe(false);
+        expect((window as any).WebappUtils.modals.canOpenModalId('not_a_real_modal')).toBe(false);
+    });
+});
+
 describe('window.WebappUtils.openUserSettings', () => {
     test('opens the user settings modal', () => {
         const action = (window as any).WebappUtils.openUserSettings({isContentProductSettings: false});

--- a/webapp/channels/src/plugins/export.ts
+++ b/webapp/channels/src/plugins/export.ts
@@ -3,6 +3,8 @@
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 
+import type {PublishedModalId, PublishedModalProps} from '@mattermost/types/webapp_globals';
+
 import {favoriteChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
 import {isFavoriteChannel} from 'mattermost-redux/selectors/entities/channels';
 
@@ -23,7 +25,6 @@ import PostMessagePreview from 'components/post_view/post_message_preview';
 import StartTrialFormModal from 'components/start_trial_form_modal';
 import ThreadViewer from 'components/threading/thread_viewer';
 import Timestamp from 'components/timestamp';
-import UserSettingsModal from 'components/user_settings/modal';
 import BotTag from 'components/widgets/tag/bot_tag';
 import Avatar from 'components/widgets/users/avatar';
 
@@ -38,6 +39,7 @@ import {useWebSocket, useWebSocketClient, WebSocketContext} from 'utils/use_webs
 import {imageURLForUser} from 'utils/utils';
 
 import {openInteractiveDialog} from './interactive_dialog'; // This import has intentional side effects. Do not remove without research.
+import {openPublishedModal} from './published_modals';
 import {loadSharedDependency} from './shared_dependencies';
 import Textbox from './textbox';
 
@@ -67,6 +69,7 @@ interface WindowWithLibraries {
         modals: {
             openModal: typeof openModal;
             ModalIdentifiers: typeof ModalIdentifiers;
+            openModalById: <K extends PublishedModalId>(modalId: K, dialogProps?: PublishedModalProps[K]) => void;
         };
         notificationSounds: {
             ring: typeof NotificationSounds.ring;
@@ -151,18 +154,19 @@ window.PostUtils = {
 };
 window.openInteractiveDialog = openInteractiveDialog;
 window.useNotifyAdmin = useNotifyAdmin;
+
 window.WebappUtils = {
     get browserHistory() {
         return getHistory();
     },
-    modals: {openModal, ModalIdentifiers},
+    modals: {
+        openModal,
+        ModalIdentifiers,
+        openModalById: <K extends PublishedModalId>(modalId: K, dialogProps?: PublishedModalProps[K]) => openPublishedModal(modalId, dialogProps),
+    },
     notificationSounds: {ring: NotificationSounds.ring, stopRing: NotificationSounds.stopRing},
     sendDesktopNotificationToMe: notifyMe,
-    openUserSettings: (dialogProps) => openModal({
-        modalId: ModalIdentifiers.USER_SETTINGS,
-        dialogType: UserSettingsModal,
-        dialogProps,
-    }),
+    openUserSettings: (dialogProps) => openPublishedModal('user_settings', dialogProps),
     channels: {favoriteChannel, unfavoriteChannel, isFavoriteChannel},
     popouts: {
         sendToParent,

--- a/webapp/channels/src/plugins/export.ts
+++ b/webapp/channels/src/plugins/export.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 
-import type {PublishedModalId, PublishedModalIdCandidate, PublishedModalProps, PublishedModalUtils} from '@mattermost/shared/types/global';
+import type {PublishedEditorUtils, PublishedModalId, PublishedModalIdCandidate, PublishedModalProps, PublishedModalUtils} from '@mattermost/shared/types/global';
 
 import {favoriteChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
 import {isFavoriteChannel} from 'mattermost-redux/selectors/entities/channels';
@@ -39,6 +39,7 @@ import {useWebSocket, useWebSocketClient, WebSocketContext} from 'utils/use_webs
 import {imageURLForUser} from 'utils/utils';
 
 import {openInteractiveDialog} from './interactive_dialog'; // This import has intentional side effects. Do not remove without research.
+import {publishedEditorUtils} from './published_editor';
 import {canOpenPublishedModal, openPublishedModal} from './published_modals';
 import {loadSharedDependency} from './shared_dependencies';
 import Textbox from './textbox';
@@ -89,6 +90,7 @@ interface WindowWithLibraries {
             canPopout: typeof canPopout;
             popoutRhsPlugin: typeof popoutRhsPlugin;
         };
+        editor: PublishedEditorUtils;
     };
     loadSharedDependency(request: string): unknown;
     openPricingModal: () => void;
@@ -175,6 +177,7 @@ window.WebappUtils = {
         canPopout,
         popoutRhsPlugin,
     },
+    editor: publishedEditorUtils,
 };
 window.loadSharedDependency = loadSharedDependency;
 
@@ -218,3 +221,4 @@ window.ProductApi = {
 
 // Desktop App module containing the app info and a series of helpers to work with legacy code
 window.DesktopApp = DesktopApp;
+

--- a/webapp/channels/src/plugins/export.ts
+++ b/webapp/channels/src/plugins/export.ts
@@ -3,7 +3,7 @@
 
 /* eslint-disable @typescript-eslint/no-require-imports */
 
-import type {PublishedModalId, PublishedModalProps} from '@mattermost/types/webapp_globals';
+import type {PublishedModalId, PublishedModalIdCandidate, PublishedModalProps, PublishedModalUtils} from '@mattermost/shared/types/global';
 
 import {favoriteChannel, unfavoriteChannel} from 'mattermost-redux/actions/channels';
 import {isFavoriteChannel} from 'mattermost-redux/selectors/entities/channels';
@@ -39,7 +39,7 @@ import {useWebSocket, useWebSocketClient, WebSocketContext} from 'utils/use_webs
 import {imageURLForUser} from 'utils/utils';
 
 import {openInteractiveDialog} from './interactive_dialog'; // This import has intentional side effects. Do not remove without research.
-import {openPublishedModal} from './published_modals';
+import {canOpenPublishedModal, openPublishedModal} from './published_modals';
 import {loadSharedDependency} from './shared_dependencies';
 import Textbox from './textbox';
 
@@ -66,10 +66,9 @@ interface WindowWithLibraries {
     openInteractiveDialog: typeof openInteractiveDialog;
     useNotifyAdmin: typeof useNotifyAdmin;
     WebappUtils: {
-        modals: {
+        modals: PublishedModalUtils & {
             openModal: typeof openModal;
             ModalIdentifiers: typeof ModalIdentifiers;
-            openModalById: <K extends PublishedModalId>(modalId: K, dialogProps?: PublishedModalProps[K]) => void;
         };
         notificationSounds: {
             ring: typeof NotificationSounds.ring;
@@ -163,6 +162,7 @@ window.WebappUtils = {
         openModal,
         ModalIdentifiers,
         openModalById: <K extends PublishedModalId>(modalId: K, dialogProps?: PublishedModalProps[K]) => openPublishedModal(modalId, dialogProps),
+        canOpenModalId: (modalId: PublishedModalIdCandidate) => canOpenPublishedModal(modalId),
     },
     notificationSounds: {ring: NotificationSounds.ring, stopRing: NotificationSounds.stopRing},
     sendDesktopNotificationToMe: notifyMe,

--- a/webapp/channels/src/plugins/published_editor.test.tsx
+++ b/webapp/channels/src/plugins/published_editor.test.tsx
@@ -1,0 +1,129 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {act, render} from '@testing-library/react';
+import React from 'react';
+
+import type {
+    PublishedEditorComponentId,
+    PublishedFormattingBarHandle,
+    PublishedSuggestionProviderId,
+    PublishedWysiwygEditorHandle,
+} from '@mattermost/shared/types/global';
+
+jest.mock('components/advanced_text_editor/wysiwyg_editor/wysiwyg_editor', () => {
+    const ReactMock = require('react') as typeof import('react');
+    return {
+        __esModule: true,
+        default: ReactMock.forwardRef((_props: unknown, ref: React.Ref<unknown>) => {
+            ReactMock.useImperativeHandle(ref, () => ({
+                insertText: () => {},
+                focus: () => {},
+                blur: () => {},
+                getInputBox: () => null,
+                getEditor: () => null,
+            }));
+            return null;
+        }),
+    };
+});
+
+jest.mock('components/advanced_text_editor/formatting_bar/formatting_bar', () => {
+    const ReactMock = require('react') as typeof import('react');
+    return {
+        __esModule: true,
+        default: ReactMock.forwardRef((_props: unknown, ref: React.Ref<unknown>) => {
+            ReactMock.useImperativeHandle(ref, () => ({
+                openLinkPopover: () => {},
+            }));
+            return null;
+        }),
+    };
+});
+
+const {isPublishedEditorComponent, publishedEditorUtils, publishedSuggestionProviders} =
+    require('./published_editor') as typeof import('./published_editor');
+
+describe('publishedEditorUtils', () => {
+    test('exposes the three allowlisted components', () => {
+        expect(typeof publishedEditorUtils.WysiwygEditor).toBe('object');
+        expect(typeof publishedEditorUtils.SuggestionList).toBe('function');
+        expect(typeof publishedEditorUtils.FormattingBar).toBe('object');
+    });
+
+    test('exposes every provider constructor and each is newable', () => {
+        const ids: PublishedSuggestionProviderId[] = ['AtMention', 'ChannelMention', 'Command', 'Emoticon'];
+
+        for (const id of ids) {
+            expect(typeof publishedEditorUtils.providers[id]).toBe('function');
+            expect(publishedEditorUtils.providers[id]).toBe(publishedSuggestionProviders[id]);
+        }
+    });
+
+    test('providers with a no-arg constructor can be instantiated directly', () => {
+        const instance = new publishedEditorUtils.providers.Emoticon();
+        expect(instance.triggerCharacter).toBe(':');
+        expect(typeof instance.handlePretextChanged).toBe('function');
+    });
+});
+
+describe('WysiwygEditor handle forwarding', () => {
+    test('ref receives the published handle after Suspense resolves', async () => {
+        const ref = React.createRef<PublishedWysiwygEditorHandle>();
+
+        await act(async () => {
+            render(
+                <publishedEditorUtils.WysiwygEditor
+                    ref={ref}
+                    value=''
+                    onChange={() => {}}
+                    onSubmit={() => {}}
+                    channelId='c'
+                />,
+            );
+        });
+
+        const handle = ref.current;
+        expect(handle).not.toBeNull();
+        expect(typeof handle!.insertText).toBe('function');
+        expect(typeof handle!.focus).toBe('function');
+        expect(typeof handle!.blur).toBe('function');
+        expect(typeof handle!.getInputBox).toBe('function');
+    });
+});
+
+describe('FormattingBar handle forwarding', () => {
+    test('ref receives the published handle after Suspense resolves', async () => {
+        const ref = React.createRef<PublishedFormattingBarHandle>();
+
+        await act(async () => {
+            render(
+                <publishedEditorUtils.FormattingBar
+                    ref={ref}
+                    applyFormatting={() => {}}
+                    disableControls={false}
+                    location='center'
+                />,
+            );
+        });
+
+        expect(ref.current).not.toBeNull();
+        expect(typeof ref.current!.openLinkPopover).toBe('function');
+    });
+});
+
+describe('isPublishedEditorComponent', () => {
+    test('is true for every published component id', () => {
+        const ids: PublishedEditorComponentId[] = ['wysiwyg_editor', 'suggestion_list', 'formatting_bar'];
+
+        for (const id of ids) {
+            expect(isPublishedEditorComponent(id)).toBe(true);
+        }
+    });
+
+    test('is false for ids the running web app does not publish', () => {
+        expect(isPublishedEditorComponent('not_a_real_component')).toBe(false);
+        expect(isPublishedEditorComponent('')).toBe(false);
+        expect(isPublishedEditorComponent('textbox')).toBe(false);
+    });
+});

--- a/webapp/channels/src/plugins/published_editor.ts
+++ b/webapp/channels/src/plugins/published_editor.ts
@@ -1,0 +1,95 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import type {
+    PublishedEditorComponentId,
+    PublishedEditorComponentProps,
+    PublishedEditorUtils,
+    PublishedFormattingBarHandle,
+    PublishedSuggestionProviderConstructors,
+    PublishedWysiwygEditorHandle,
+} from '@mattermost/shared/types/global';
+
+import type {FormattingBarHandle} from 'components/advanced_text_editor/formatting_bar/formatting_bar';
+import type {WysiwygEditorHandle} from 'components/advanced_text_editor/wysiwyg_editor/wysiwyg_editor';
+import AtMentionProvider from 'components/suggestion/at_mention_provider/at_mention_provider';
+import ChannelMentionProvider from 'components/suggestion/channel_mention_provider';
+import CommandProvider from 'components/suggestion/command_provider/command_provider';
+import EmoticonProvider from 'components/suggestion/emoticon_provider';
+
+function lazyEditorComponent<P extends object>(loader: () => Promise<{default: React.ComponentType<P>}>): React.FunctionComponent<P> {
+    const LazyComponent = React.lazy(loader) as unknown as React.ComponentType<P>;
+
+    const Wrapped = (props: P) => {
+        return React.createElement(React.Suspense, {fallback: null}, React.createElement(LazyComponent, props));
+    };
+
+    return Wrapped;
+}
+
+function lazyForwardRefEditorComponent<P extends object, R>(
+    displayName: string,
+    loader: () => Promise<{default: React.ComponentType<P>}>,
+): React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<R>> {
+    const LazyComponent = React.lazy(loader) as unknown as React.ComponentType<P>;
+
+    const Wrapped = React.forwardRef<R, P>((props, ref) =>
+        React.createElement(
+            React.Suspense,
+            {fallback: null},
+            React.createElement(LazyComponent, {...props, ref} as unknown as P),
+        ),
+    );
+    Wrapped.displayName = displayName;
+    return Wrapped;
+}
+
+const publishedEditorComponents = {
+    wysiwyg_editor: lazyForwardRefEditorComponent<PublishedEditorComponentProps['wysiwyg_editor'], PublishedWysiwygEditorHandle>(
+        'PublishedWysiwygEditor',
+        () => import('components/advanced_text_editor/wysiwyg_editor/wysiwyg_editor'),
+    ),
+    suggestion_list: lazyEditorComponent(() => import('components/suggestion/suggestion_list')),
+    formatting_bar: lazyForwardRefEditorComponent<PublishedEditorComponentProps['formatting_bar'], PublishedFormattingBarHandle>(
+        'PublishedFormattingBar',
+        () => import('components/advanced_text_editor/formatting_bar/formatting_bar'),
+    ),
+} satisfies Record<PublishedEditorComponentId, React.ComponentType<any>>;
+
+type ContractHonored<T extends {[K in PublishedEditorComponentId]: Omit<React.ComponentProps<(typeof publishedEditorComponents)[K]>, 'ref'>}> = T;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type AssertPublishedEditorContract = ContractHonored<PublishedEditorComponentProps>;
+
+// Handle drift check: real handles must remain a superset of the published
+// (narrower) handles. If a real handle drops a method the contract promises,
+// the conditional collapses to `never`, which doesn't satisfy `AssertsTrue`.
+type AssertsTrue<T extends true> = T;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type AssertPublishedWysiwygEditorHandle = AssertsTrue<WysiwygEditorHandle extends PublishedWysiwygEditorHandle ? true : never>;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type AssertPublishedFormattingBarHandle = AssertsTrue<FormattingBarHandle extends PublishedFormattingBarHandle ? true : never>;
+
+export const publishedSuggestionProviders: PublishedSuggestionProviderConstructors = {
+    AtMention: AtMentionProvider,
+    ChannelMention: ChannelMentionProvider,
+    Command: CommandProvider,
+    Emoticon: EmoticonProvider,
+};
+
+export const publishedEditorUtils: PublishedEditorUtils = {
+    WysiwygEditor: publishedEditorComponents.wysiwyg_editor,
+    SuggestionList: publishedEditorComponents.suggestion_list,
+    FormattingBar: publishedEditorComponents.formatting_bar,
+    providers: publishedSuggestionProviders,
+};
+
+const publishedEditorComponentIds = new Set<string>(Object.keys(publishedEditorComponents));
+
+export function isPublishedEditorComponent(id: string): id is PublishedEditorComponentId {
+    return publishedEditorComponentIds.has(id);
+}

--- a/webapp/channels/src/plugins/published_modals.test.ts
+++ b/webapp/channels/src/plugins/published_modals.test.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {PublishedModalId} from '@mattermost/types/webapp_globals';
+
+import {ActionTypes, ModalIdentifiers} from 'utils/constants';
+
+import {openPublishedModal} from './published_modals';
+
+describe('openPublishedModal', () => {
+    test('returns a MODAL_OPEN action carrying the id, props, and a component', () => {
+        const dialogProps = {isContentProductSettings: false, activeTab: 'display'};
+        const action = openPublishedModal('user_settings', dialogProps);
+
+        expect(action.type).toBe(ActionTypes.MODAL_OPEN);
+        expect(action.modalId).toBe('user_settings');
+        expect(action.dialogProps).toBe(dialogProps);
+        expect(typeof action.dialogType).toBe('function');
+    });
+
+    test('omits dialogProps when none are passed', () => {
+        expect(openPublishedModal('leave_team').dialogProps).toBeUndefined();
+    });
+
+    test('every published id maps to its ModalIdentifiers constant and a component', () => {
+        const expected: Record<PublishedModalId, string> = {
+            user_settings: ModalIdentifiers.USER_SETTINGS,
+            invitation: ModalIdentifiers.INVITATION,
+            team_settings: ModalIdentifiers.TEAM_SETTINGS,
+            team_members: ModalIdentifiers.TEAM_MEMBERS,
+            leave_team: ModalIdentifiers.LEAVE_TEAM,
+        };
+
+        for (const id of Object.keys(expected) as PublishedModalId[]) {
+            const action = openPublishedModal(id);
+            expect(action.modalId).toBe(id);
+            expect(action.modalId).toBe(expected[id]);
+            expect(typeof action.dialogType).toBe('function');
+        }
+    });
+});

--- a/webapp/channels/src/plugins/published_modals.test.ts
+++ b/webapp/channels/src/plugins/published_modals.test.ts
@@ -1,11 +1,11 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {PublishedModalId} from '@mattermost/types/webapp_globals';
+import type {PublishedModalId} from '@mattermost/shared/types/global';
 
 import {ActionTypes, ModalIdentifiers} from 'utils/constants';
 
-import {openPublishedModal} from './published_modals';
+import {canOpenPublishedModal, openPublishedModal} from './published_modals';
 
 describe('openPublishedModal', () => {
     test('returns a MODAL_OPEN action carrying the id, props, and a component', () => {
@@ -37,5 +37,23 @@ describe('openPublishedModal', () => {
             expect(action.modalId).toBe(expected[id]);
             expect(typeof action.dialogType).toBe('function');
         }
+    });
+});
+
+describe('canOpenPublishedModal', () => {
+    test('is true for every published modal id', () => {
+        const ids: PublishedModalId[] = ['user_settings', 'invitation', 'team_settings', 'team_members', 'leave_team'];
+
+        for (const id of ids) {
+            expect(canOpenPublishedModal(id)).toBe(true);
+        }
+    });
+
+    test('is false for ids the running web app does not publish', () => {
+        expect(canOpenPublishedModal('not_a_real_modal')).toBe(false);
+        expect(canOpenPublishedModal('')).toBe(false);
+
+        // A core modal id that exists but is intentionally not in the plugin allowlist.
+        expect(canOpenPublishedModal(ModalIdentifiers.CHANNEL_INVITE)).toBe(false);
     });
 });

--- a/webapp/channels/src/plugins/published_modals.ts
+++ b/webapp/channels/src/plugins/published_modals.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import type {PublishedModalId, PublishedModalProps} from '@mattermost/types/webapp_globals';
+
+import {openModal} from 'actions/views/modals';
+
+import type {ModalData} from 'types/actions';
+
+// Own chunk (off the bootstrap bundle) + a Suspense boundary that ModalController lacks.
+function lazyModal<P extends object>(loader: () => Promise<{default: React.ComponentType<P>}>): React.FunctionComponent<P> {
+    // React.lazy adds an optional ref that a free generic P can't satisfy; narrow back to P.
+    const LazyComponent = React.lazy(loader) as unknown as React.ComponentType<P>;
+
+    const Wrapped = (props: P) => {
+        return React.createElement(React.Suspense, {fallback: null}, React.createElement(LazyComponent, props));
+    };
+
+    return Wrapped;
+}
+
+function withFixedProps<P extends object, F extends Partial<P>>(Component: React.ComponentType<P>, fixed: F): React.FunctionComponent<Omit<P, keyof F>> {
+    const Wrapped = (props: Omit<P, keyof F>) => React.createElement(Component, {...fixed, ...props} as unknown as P);
+
+    return Wrapped;
+}
+
+// Curated allowlist, not an escape hatch for rendering arbitrary core components.
+const publishedModals = {
+    user_settings: lazyModal(() => import('components/user_settings/modal')),
+    invitation: lazyModal(() => import('components/invitation_modal')),
+
+    // team_settings reads its own visibility from isOpen, which ModalController
+    // doesn't supply; pin it true rather than leak it to plugins.
+    team_settings: withFixedProps(lazyModal(() => import('components/team_settings_modal')), {isOpen: true}),
+    team_members: lazyModal(() => import('components/team_members_modal')),
+    leave_team: lazyModal(() => import('components/leave_team_modal')),
+} satisfies Record<PublishedModalId, React.ComponentType<any>>;
+
+// Fails the build here if a modal's real props drift from the published contract,
+// instead of silently breaking plugins.
+type ContractHonored<T extends {[K in PublishedModalId]: ModalData<React.ComponentProps<(typeof publishedModals)[K]>>['dialogProps']}> = T;
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+type AssertPublishedModalContract = ContractHonored<PublishedModalProps>;
+
+export function openPublishedModal<K extends PublishedModalId>(modalId: K, dialogProps?: PublishedModalProps[K]) {
+    // TS can't correlate the indexed component with its props here, so cast the lookup.
+    return openModal({modalId, dialogType: publishedModals[modalId] as React.ComponentType<any>, dialogProps});
+}

--- a/webapp/channels/src/plugins/published_modals.ts
+++ b/webapp/channels/src/plugins/published_modals.ts
@@ -3,7 +3,7 @@
 
 import React from 'react';
 
-import type {PublishedModalId, PublishedModalProps} from '@mattermost/types/webapp_globals';
+import type {PublishedModalId, PublishedModalIdCandidate, PublishedModalProps} from '@mattermost/shared/types/global';
 
 import {openModal} from 'actions/views/modals';
 
@@ -49,4 +49,12 @@ type AssertPublishedModalContract = ContractHonored<PublishedModalProps>;
 export function openPublishedModal<K extends PublishedModalId>(modalId: K, dialogProps?: PublishedModalProps[K]) {
     // TS can't correlate the indexed component with its props here, so cast the lookup.
     return openModal({modalId, dialogType: publishedModals[modalId] as React.ComponentType<any>, dialogProps});
+}
+
+const publishedModalIds = new Set<string>(Object.keys(publishedModals));
+
+// Feature detection for plugins: is this modal id actually published by the running
+// web app? Narrows to PublishedModalId so a checked id can be passed to openPublishedModal.
+export function canOpenPublishedModal(modalId: PublishedModalIdCandidate): modalId is PublishedModalId {
+    return publishedModalIds.has(modalId);
 }

--- a/webapp/platform/shared/src/types/global/editor.ts
+++ b/webapp/platform/shared/src/types/global/editor.ts
@@ -1,0 +1,135 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ComponentType, ForwardRefExoticComponent, KeyboardEvent, KeyboardEventHandler, ReactNode, ReactNodeArray, RefAttributes, RefObject} from 'react';
+
+import type {Agent} from '@mattermost/types/agents';
+import type {Channel} from '@mattermost/types/channels';
+import type {Group} from '@mattermost/types/groups';
+import type {UserProfile} from '@mattermost/types/users';
+
+import type {ProviderResults, SuggestionResults} from './suggestions';
+
+// Plugin-facing contract for window.WebappUtils.editor. The web app asserts each
+// shape stays assignable to the real component/provider at build time in
+// published_editor.ts.
+
+export type ActionResult<Data = unknown, Error = unknown> = {
+    data?: Data;
+    error?: Error;
+};
+
+export type WysiwygEditorProps = {
+    value: string;
+    onChange: (markdown: string) => void;
+    onSubmit: () => void;
+    onFocus?: () => void;
+    onBlur?: () => void;
+    placeholder?: string;
+    channelId: string;
+    rootId?: string;
+    disabled?: boolean;
+    id?: string;
+    useCtrlSend?: boolean;
+    sendCodeBlockOnCtrlEnter?: boolean;
+    onKeyDown?: (e: KeyboardEvent<HTMLDivElement>) => void;
+};
+
+export type SuggestionListProps = {
+    inputRef?: RefObject<HTMLDivElement>;
+    open: boolean;
+    position?: 'top' | 'bottom';
+    renderNoResults?: boolean;
+    onCompleteWord: (term: string, matchedPretext: string, e?: KeyboardEventHandler<HTMLDivElement>) => boolean;
+    preventClose?: () => void;
+    onItemHover: (term: string) => void;
+    pretext: string;
+    cleared: boolean;
+    results: SuggestionResults;
+    selection: string;
+    suggestionBoxAlgn?: {
+        lineHeight?: number;
+        pixelsToMoveX?: number;
+        pixelsToMoveY?: number;
+    };
+};
+
+export type PublishedMarkdownMode = 'bold' | 'italic' | 'link' | 'strike' | 'code' | 'heading' | 'quote' | 'ul' | 'ol';
+
+export type FormattingBarProps = {
+    applyFormatting: (mode: PublishedMarkdownMode) => void;
+    disableControls: boolean;
+    location: string;
+    additionalControls?: ReactNodeArray;
+    aiActionsMenu?: ReactNode;
+
+    // Returns a Tiptap Editor. Left as `any` so plugins don't need `@tiptap/react`
+    getEditor?: () => any;
+};
+
+export type PublishedEditorComponentProps = {
+    wysiwyg_editor: WysiwygEditorProps;
+    suggestion_list: SuggestionListProps;
+    formatting_bar: FormattingBarProps;
+};
+
+export type PublishedEditorComponentId = keyof PublishedEditorComponentProps;
+
+// Providers emit ProviderResults; SuggestionList consumes the normalized SuggestionResults.
+export type SuggestionProviderInstance = {
+    triggerCharacter?: string;
+    handlePretextChanged: (pretext: string, resultsCallback: (results: ProviderResults) => void) => boolean | void;
+};
+
+export type AtMentionProviderOptions = {
+    currentUserId: string;
+    channelId: string;
+    autocompleteUsersInChannel: (prefix: string) => Promise<ActionResult>;
+    useChannelMentions: boolean;
+    autocompleteGroups: Group[] | null;
+    searchAssociatedGroupsForReference: (prefix: string) => Promise<ActionResult<Group[]>>;
+    priorityProfiles: UserProfile[] | undefined;
+    defaultAgent?: Agent;
+};
+
+export type CommandProviderOptions = {
+    teamId: string;
+    channelId: string;
+    rootId?: string;
+};
+
+export type ChannelMentionProviderArgs = [
+    channelSearchFunc: (
+        term: string,
+        success: (channels: Channel[]) => void,
+        error: () => void,
+    ) => Promise<ActionResult>,
+    delayChannelAutocomplete: boolean,
+];
+
+export type PublishedSuggestionProviderConstructors = {
+    AtMention: new (options: AtMentionProviderOptions) => SuggestionProviderInstance;
+    ChannelMention: new (...args: ChannelMentionProviderArgs) => SuggestionProviderInstance;
+    Command: new (options: CommandProviderOptions) => SuggestionProviderInstance;
+    Emoticon: new () => SuggestionProviderInstance;
+};
+
+export type PublishedSuggestionProviderId = keyof PublishedSuggestionProviderConstructors;
+
+export type PublishedWysiwygEditorHandle = {
+    insertText: (text: string) => void;
+    focus: () => void;
+    blur: () => void;
+    getInputBox: () => HTMLElement | null;
+};
+
+export type PublishedFormattingBarHandle = {
+    openLinkPopover: () => void;
+};
+
+export type PublishedEditorUtils = {
+    WysiwygEditor: ForwardRefExoticComponent<WysiwygEditorProps & RefAttributes<PublishedWysiwygEditorHandle>>;
+    SuggestionList: ComponentType<SuggestionListProps>;
+    FormattingBar: ForwardRefExoticComponent<FormattingBarProps & RefAttributes<PublishedFormattingBarHandle>>;
+    providers: PublishedSuggestionProviderConstructors;
+};

--- a/webapp/platform/shared/src/types/global/index.ts
+++ b/webapp/platform/shared/src/types/global/index.ts
@@ -1,14 +1,18 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import type {PublishedEditorUtils} from './editor';
 import type {PublishedModalUtils} from './modals';
 
 export * from './modals';
+export * from './editor';
+export * from './suggestions';
 
 // Lets plugins type the window global without reaching into channels internals.
 // Grows as more of channels' WindowWithLibraries surface migrates here.
 export type WindowShared = {
     WebappUtils: {
         modals: PublishedModalUtils;
+        editor: PublishedEditorUtils;
     };
 };

--- a/webapp/platform/shared/src/types/global/index.ts
+++ b/webapp/platform/shared/src/types/global/index.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {PublishedModalUtils} from './modals';
+
+export * from './modals';
+
+// Lets plugins type the window global without reaching into channels internals.
+// Grows as more of channels' WindowWithLibraries surface migrates here.
+export type WindowShared = {
+    WebappUtils: {
+        modals: PublishedModalUtils;
+    };
+};

--- a/webapp/platform/shared/src/types/global/modals.ts
+++ b/webapp/platform/shared/src/types/global/modals.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import type {Channel} from './channels';
+import type {Channel} from '@mattermost/types/channels';
 
 // Plugin-facing contract for the `window.WebappUtils` API. Hand-authored, not derived:
 // the web app checks at build time that each stays assignable to the real modal, so
@@ -22,3 +22,13 @@ export type PublishedModalProps = {
 };
 
 export type PublishedModalId = keyof PublishedModalProps;
+
+// A known modal id, or any string: lets a plugin feature-detect (via canOpenModalId)
+// ids a running web app may not publish yet, while keeping autocomplete for known ids.
+export type PublishedModalIdCandidate = PublishedModalId | (string & {});
+
+// The modal opener utils the web app publishes on window.WebappUtils.modals.
+export type PublishedModalUtils = {
+    openModalById: <K extends PublishedModalId>(modalId: K, dialogProps?: PublishedModalProps[K]) => void;
+    canOpenModalId: (modalId: PublishedModalIdCandidate) => boolean;
+};

--- a/webapp/platform/shared/src/types/global/suggestions.ts
+++ b/webapp/platform/shared/src/types/global/suggestions.ts
@@ -1,0 +1,59 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {ElementType} from 'react';
+import type {MessageDescriptor} from 'react-intl';
+
+// Data shapes produced by suggestion providers and consumed by SuggestionList.
+
+export type SuggestionResults<Item = unknown> = SuggestionResultsGrouped<Item> | SuggestionResultsUngrouped<Item>;
+
+type SuggestionResultsGrouped<Item = unknown> = {
+    matchedPretext: string;
+    groups: Array<SuggestionResultsGroup<Item>>;
+};
+
+type SuggestionResultsGroup<Item = unknown> = {
+    key: string;
+    label?: MessageDescriptor;
+    terms: string[];
+    items: Array<Item | Loading>;
+    components: ElementType[];
+};
+
+export type SuggestionResultsUngrouped<Item = unknown> = {
+    matchedPretext: string;
+    terms: string[];
+    items: Array<Item | Loading>;
+    components: ElementType[];
+};
+
+export type Loading = {
+    loading: boolean;
+};
+
+export type ProviderResults<Item = unknown> = ProviderResultsGrouped<Item> | ProviderResultsUngrouped<Item>;
+
+type ProviderResultsGrouped<Item = unknown> = {
+    matchedPretext: string;
+    groups: Array<ProviderResultsGroup<Item>>;
+};
+
+export type ProviderResultsGroup<Item = unknown> = {
+    key: string;
+    label?: MessageDescriptor;
+    terms: string[];
+    items: Array<Item | Loading>;
+} & ComponentOrComponents;
+
+type ProviderResultsUngrouped<Item = unknown> = {
+    matchedPretext: string;
+    terms: string[];
+    items: Array<Item | Loading>;
+} & ComponentOrComponents;
+
+type ComponentOrComponents = {
+    component: ElementType;
+} | {
+    components: ElementType[];
+};

--- a/webapp/platform/types/src/webapp_globals.ts
+++ b/webapp/platform/types/src/webapp_globals.ts
@@ -1,0 +1,24 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {Channel} from './channels';
+
+// Plugin-facing contract for the `window.WebappUtils` API. Hand-authored, not derived:
+// the web app checks at build time that each stays assignable to the real modal, so
+// drift breaks the build, not plugins.
+
+export type UserSettingsModalProps = {isContentProductSettings: boolean; userID?: string; adminMode?: boolean; activeTab?: string};
+export type InvitationModalProps = {channelToInvite?: Channel; canInviteGuests?: boolean};
+export type TeamSettingsModalProps = {focusOriginElement?: string};
+export type TeamMembersModalProps = {onLoad?: () => void; focusOriginElement?: string};
+export type LeaveTeamModalProps = Record<string, never>;
+
+export type PublishedModalProps = {
+    user_settings: UserSettingsModalProps;
+    invitation: InvitationModalProps;
+    team_settings: TeamSettingsModalProps;
+    team_members: TeamMembersModalProps;
+    leave_team: LeaveTeamModalProps;
+};
+
+export type PublishedModalId = keyof PublishedModalProps;


### PR DESCRIPTION
#### Summary
Lets plugins open a curated set of core modals by id via `window.WebappUtils.modals.openModalById(id, props)`, and feature-detect them with `canOpenModalId(id)`. Supports the Docs plugin (separate repo). Webapp-only — no server changes.

- **Plugin-facing contract now ships from `@mattermost/shared`** under a new `types/global` path (`PublishedModalProps` id → props, `PublishedModalId`, each modal's named prop type). It lives in `@mattermost/shared` — the package meant for code shared with plugins — rather than `@mattermost/types` (data-model types). `types/global` is shaped to allow **incremental migration of `WindowWithLibraries`**: it also exports `PublishedModalUtils` and a `WindowShared` slice that grows as more of the window surface (e.g. `window.Components`) moves over.
- **`published_modals.ts`** holds the runtime allowlist, lazy-loads each modal into its own chunk under a `Suspense` boundary, and a build-time guard fails the web app build if a modal's real props drift from the contract.
- **`canOpenModalId(id)`** is runtime feature detection against the actual published allowlist (not every `ModalIdentifiers` entry). It accepts any string, so a plugin built against newer types can safely probe an id an older web app may not publish yet.
- **`openUserSettings`** delegates through the same path, moving the User Settings modal out of the bootstrap bundle.
- Host-controlled props (`team_settings`'s `isOpen`) are pinned at the allowlist boundary so they stay out of the plugin contract.

Allowlisted ids: `user_settings`, `invitation`, `team_settings`, `team_members`, `leave_team` — each matches its existing `ModalIdentifiers` value, so modal dedup/close behavior is unchanged. Unit tests cover the action shape, id ↔ component mapping, `canOpenModalId` (published / non-published / unknown ids), and the `window.WebappUtils` wiring.

**QA steps**
- In a browser console (or from a plugin): `window.WebappUtils.modals.openModalById('user_settings')` opens User Settings; `openModalById('team_settings')` opens Team Settings.
- `window.WebappUtils.modals.canOpenModalId('user_settings')` → `true`; `canOpenModalId('channel_invite')` (a real but non-published modal) → `false`.
- Passing a disallowed id or wrong props is a compile-time error against `@mattermost/shared/types/global`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69782

#### Screenshots
N/A — no visual change; this is a plugin API surface.

#### Release Note
```release-note
Added window.WebappUtils.modals.openModalById and canOpenModalId, letting plugins open and feature-detect an allowlisted set of core modals by id. The plugin-facing modal types now ship from @mattermost/shared/types/global.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** This introduces an additive but contract-level change to the plugin-facing `window.WebappUtils` modal API and published-editor utilities, with some behavior refactoring (notably `openUserSettings`) that could affect existing plugin integrations. Unit tests cover modal allowlisting/mapping, feature detection, and `window.WebappUtils` integration, reducing but not eliminating compatibility risk for downstream plugins.

**QA Recommendation:** Perform a brief manual smoke test in a plugin-enabled webapp to verify `openModalById`/`canOpenModalId` allowlisted behavior and `openUserSettings` still opens with the expected dialog props; broader manual QA can be skipped given the automated coverage.
  
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->