### PR TITLE
[MM-69693] notify token owners when an expired PAT is deleted

### DIFF
--- a/server/channels/app/expired_access_token_notify.go
+++ b/server/channels/app/expired_access_token_notify.go
@@ -23,12 +23,10 @@ import (
 // swallowed so it never blocks the cleanup. Bot-owned tokens and tokens owned
 // by deactivated users are skipped, matching pat_expiry_notify — GetExpiredBefore
 // returns those too because the cleanup job must still delete them.
-func (a *App) NotifyExpiredAccessTokensDeleted(tokens []*model.UserAccessToken) {
+func (a *App) NotifyExpiredAccessTokensDeleted(rctx request.CTX, tokens []*model.UserAccessToken) {
 	if len(tokens) == 0 {
 		return
 	}
-
-	rctx := request.EmptyContext(a.Log())
 
 	systemBot, appErr := a.GetSystemBot(rctx)
 	if appErr != nil {

--- a/server/channels/app/expired_access_token_notify.go
+++ b/server/channels/app/expired_access_token_notify.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/i18n"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+)
+
+// NotifyExpiredAccessTokensDeleted DMs the owner of each expired personal
+// access token that the cleanup_expired_access_tokens job is about to delete.
+//
+// This is the at-expiry safety net that complements the pre-expiry warning
+// cascade (pat_expiry_notify): it fires from the cleanup job at the moment a
+// token is removed, so an owner whose fire-and-forget integration silently
+// swallowed the rejection error still learns their token stopped working.
+//
+// It is best-effort. It is invoked before the tokens are deleted so the
+// token→owner mapping is still available, and every failure is logged and
+// swallowed so it never blocks the cleanup. Bot-owned tokens and tokens owned
+// by deactivated users are skipped, matching pat_expiry_notify — GetExpiredBefore
+// returns those too because the cleanup job must still delete them.
+func (a *App) NotifyExpiredAccessTokensDeleted(tokens []*model.UserAccessToken) {
+	if len(tokens) == 0 {
+		return
+	}
+
+	rctx := request.EmptyContext(a.Log())
+
+	systemBot, appErr := a.GetSystemBot(rctx)
+	if appErr != nil {
+		rctx.Logger().Error("Failed to get system bot to notify expired personal access token owners", mlog.Err(appErr))
+		return
+	}
+
+	for _, token := range tokens {
+		user, appErr := a.GetUser(token.UserId)
+		if appErr != nil {
+			rctx.Logger().Warn("Failed to get user for expired personal access token notification",
+				mlog.String("user_id", token.UserId),
+				mlog.Err(appErr),
+			)
+			continue
+		}
+
+		// Skip bot accounts and deactivated users, matching pat_expiry_notify.
+		if user.IsBot || user.DeleteAt != 0 {
+			continue
+		}
+
+		channel, appErr := a.GetOrCreateDirectChannel(rctx, token.UserId, systemBot.UserId)
+		if appErr != nil {
+			rctx.Logger().Warn("Failed to get direct channel for expired personal access token notification",
+				mlog.String("user_id", token.UserId),
+				mlog.Err(appErr),
+			)
+			continue
+		}
+
+		T := i18n.GetUserTranslations(user.Locale)
+		post := &model.Post{
+			ChannelId: channel.Id,
+			Message: T("app.user_access_token.expired_deleted_notification", model.StringInterface{
+				"Description": token.Description,
+			}),
+			Type:   model.PostTypeDefault,
+			UserId: systemBot.UserId,
+		}
+
+		if _, _, appErr := a.CreatePost(rctx, post, channel, model.CreatePostFlags{SetOnline: true}); appErr != nil {
+			rctx.Logger().Warn("Failed to send expired personal access token notification",
+				mlog.String("user_id", token.UserId),
+				mlog.Err(appErr),
+			)
+		}
+	}
+}

--- a/server/channels/app/expired_access_token_notify_test.go
+++ b/server/channels/app/expired_access_token_notify_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// dmPostsFromSystemBot returns the posts in the DM channel between the system
+// bot and userID, or nil if no such channel exists yet. NotifyExpiredAccessTokensDeleted
+// posts synchronously, so no polling is required.
+func dmPostsFromSystemBot(t *testing.T, th *TestHelper, botUserID, userID string) []*model.Post {
+	t.Helper()
+
+	channel, err := th.App.Srv().Store().Channel().GetByName("", model.GetDMNameFromIds(botUserID, userID), false)
+	if err != nil {
+		// No DM channel means no notification was ever sent.
+		return nil
+	}
+
+	postList, err := th.App.Srv().Store().Post().GetPosts(th.Context, model.GetPostsOptions{ChannelId: channel.Id, Page: 0, PerPage: 10}, false, map[string]bool{})
+	require.NoError(t, err)
+
+	posts := make([]*model.Post, 0, len(postList.Order))
+	for _, id := range postList.Order {
+		posts = append(posts, postList.Posts[id])
+	}
+	return posts
+}
+
+// notificationPostsFor returns the DM posts authored by the system bot that
+// mention the given token description.
+func notificationPostsFor(t *testing.T, th *TestHelper, botUserID, userID, description string) []*model.Post {
+	t.Helper()
+
+	var matching []*model.Post
+	for _, post := range dmPostsFromSystemBot(t, th, botUserID, userID) {
+		if post.UserId == botUserID && strings.Contains(post.Message, description) {
+			matching = append(matching, post)
+		}
+	}
+	return matching
+}
+
+func TestNotifyExpiredAccessTokensDeleted(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	t.Run("empty token list is a no-op", func(t *testing.T) {
+		th := Setup(t).InitBasic(t)
+
+		require.NotPanics(t, func() {
+			th.App.NotifyExpiredAccessTokensDeleted(nil)
+			th.App.NotifyExpiredAccessTokensDeleted([]*model.UserAccessToken{})
+		})
+	})
+
+	t.Run("happy path DMs the token owner", func(t *testing.T) {
+		th := Setup(t).InitBasic(t)
+
+		bot, appErr := th.App.GetSystemBot(th.Context)
+		require.Nil(t, appErr)
+
+		user := th.CreateUser(t)
+		const description = "ci-integration-token"
+
+		th.App.NotifyExpiredAccessTokensDeleted([]*model.UserAccessToken{
+			{Id: model.NewId(), UserId: user.Id, Description: description},
+		})
+
+		posts := notificationPostsFor(t, th, bot.UserId, user.Id, description)
+		require.Len(t, posts, 1, "the owner should receive exactly one expiry notification")
+		require.Equal(t, bot.UserId, posts[0].UserId)
+	})
+
+	t.Run("bot-owned token is skipped", func(t *testing.T) {
+		th := Setup(t).InitBasic(t)
+
+		systemBot, appErr := th.App.GetSystemBot(th.Context)
+		require.Nil(t, appErr)
+
+		bot := th.CreateBot(t)
+
+		th.App.NotifyExpiredAccessTokensDeleted([]*model.UserAccessToken{
+			{Id: model.NewId(), UserId: bot.UserId, Description: "bot-token"},
+		})
+
+		require.Empty(t, dmPostsFromSystemBot(t, th, systemBot.UserId, bot.UserId))
+	})
+
+	t.Run("deactivated user token is skipped", func(t *testing.T) {
+		th := Setup(t).InitBasic(t)
+
+		bot, appErr := th.App.GetSystemBot(th.Context)
+		require.Nil(t, appErr)
+
+		user := th.CreateUser(t)
+		_, appErr = th.App.UpdateActive(th.Context, user, false)
+		require.Nil(t, appErr)
+
+		th.App.NotifyExpiredAccessTokensDeleted([]*model.UserAccessToken{
+			{Id: model.NewId(), UserId: user.Id, Description: "deactivated-token"},
+		})
+
+		require.Empty(t, dmPostsFromSystemBot(t, th, bot.UserId, user.Id))
+	})
+
+	t.Run("unknown owner is skipped but processing continues", func(t *testing.T) {
+		th := Setup(t).InitBasic(t)
+
+		bot, appErr := th.App.GetSystemBot(th.Context)
+		require.Nil(t, appErr)
+
+		user := th.CreateUser(t)
+
+		// First token references a user that does not exist (GetUser fails);
+		// the second is a valid active user that must still be notified.
+		th.App.NotifyExpiredAccessTokensDeleted([]*model.UserAccessToken{
+			{Id: model.NewId(), UserId: model.NewId(), Description: "orphan-token"},
+			{Id: model.NewId(), UserId: user.Id, Description: "valid-token"},
+		})
+
+		require.Len(t, notificationPostsFor(t, th, bot.UserId, user.Id, "valid-token"), 1)
+	})
+}

--- a/server/channels/app/expired_access_token_notify_test.go
+++ b/server/channels/app/expired_access_token_notify_test.go
@@ -55,8 +55,8 @@ func TestNotifyExpiredAccessTokensDeleted(t *testing.T) {
 		th := Setup(t).InitBasic(t)
 
 		require.NotPanics(t, func() {
-			th.App.NotifyExpiredAccessTokensDeleted(nil)
-			th.App.NotifyExpiredAccessTokensDeleted([]*model.UserAccessToken{})
+			th.App.NotifyExpiredAccessTokensDeleted(th.Context, nil)
+			th.App.NotifyExpiredAccessTokensDeleted(th.Context, []*model.UserAccessToken{})
 		})
 	})
 
@@ -69,7 +69,7 @@ func TestNotifyExpiredAccessTokensDeleted(t *testing.T) {
 		user := th.CreateUser(t)
 		const description = "ci-integration-token"
 
-		th.App.NotifyExpiredAccessTokensDeleted([]*model.UserAccessToken{
+		th.App.NotifyExpiredAccessTokensDeleted(th.Context, []*model.UserAccessToken{
 			{Id: model.NewId(), UserId: user.Id, Description: description},
 		})
 
@@ -86,7 +86,7 @@ func TestNotifyExpiredAccessTokensDeleted(t *testing.T) {
 
 		bot := th.CreateBot(t)
 
-		th.App.NotifyExpiredAccessTokensDeleted([]*model.UserAccessToken{
+		th.App.NotifyExpiredAccessTokensDeleted(th.Context, []*model.UserAccessToken{
 			{Id: model.NewId(), UserId: bot.UserId, Description: "bot-token"},
 		})
 
@@ -103,7 +103,7 @@ func TestNotifyExpiredAccessTokensDeleted(t *testing.T) {
 		_, appErr = th.App.UpdateActive(th.Context, user, false)
 		require.Nil(t, appErr)
 
-		th.App.NotifyExpiredAccessTokensDeleted([]*model.UserAccessToken{
+		th.App.NotifyExpiredAccessTokensDeleted(th.Context, []*model.UserAccessToken{
 			{Id: model.NewId(), UserId: user.Id, Description: "deactivated-token"},
 		})
 
@@ -120,7 +120,7 @@ func TestNotifyExpiredAccessTokensDeleted(t *testing.T) {
 
 		// First token references a user that does not exist (GetUser fails);
 		// the second is a valid active user that must still be notified.
-		th.App.NotifyExpiredAccessTokensDeleted([]*model.UserAccessToken{
+		th.App.NotifyExpiredAccessTokensDeleted(th.Context, []*model.UserAccessToken{
 			{Id: model.NewId(), UserId: model.NewId(), Description: "orphan-token"},
 			{Id: model.NewId(), UserId: user.Id, Description: "valid-token"},
 		})

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -1743,7 +1743,7 @@ func (s *Server) initJobs() {
 
 	s.Jobs.RegisterJobType(
 		model.JobTypeCleanupExpiredAccessTokens,
-		cleanup_expired_access_tokens.MakeWorker(s.Jobs, s.platform.ClearUserSessionCache),
+		cleanup_expired_access_tokens.MakeWorker(s.Jobs, s.platform.ClearUserSessionCache, New(ServerConnector(s.Channels())).NotifyExpiredAccessTokensDeleted),
 		cleanup_expired_access_tokens.MakeScheduler(s.Jobs),
 	)
 

--- a/server/channels/jobs/cleanup_expired_access_tokens/worker.go
+++ b/server/channels/jobs/cleanup_expired_access_tokens/worker.go
@@ -105,8 +105,18 @@ func cleanupExpired(
 
 		// Notify owners before deleting: the token still carries its UserId
 		// here, and deletion right after makes re-notification impossible.
+		// Isolate the notifier with its own recover so a panic inside it can
+		// never abort execute() before DeleteByIds runs — notification is
+		// best-effort and must not block cleanup.
 		if notifyExpired != nil {
-			notifyExpired(expired)
+			func() {
+				defer func() {
+					if r := recover(); r != nil {
+						logger.Error("Recovered from panic while notifying expired token owners", mlog.Any("panic", r))
+					}
+				}()
+				notifyExpired(expired)
+			}()
 		}
 
 		deleted, err := store.DeleteByIds(ids)

--- a/server/channels/jobs/cleanup_expired_access_tokens/worker.go
+++ b/server/channels/jobs/cleanup_expired_access_tokens/worker.go
@@ -35,7 +35,15 @@ type expiredTokenStore interface {
 //
 // clearSessionCache is called for each affected user after their tokens are
 // deleted so that in-memory session caches don't serve stale sessions.
-func MakeWorker(jobServer *jobs.JobServer, clearSessionCache func(userID string)) *jobs.SimpleWorker {
+//
+// notifyExpired is called with each batch of expired tokens immediately before
+// they are deleted, so the owner can be DMed that their token has been removed.
+// It is best-effort: any failure is handled internally and must not block the
+// cleanup. Note that after this change PAT expiry notifications come from two
+// jobs — the pre-expiry warning cascade (pat_expiry_notify) and this
+// at-deletion notice — so a future reader shouldn't be surprised to find an
+// expiry DM originating from the cleanup job.
+func MakeWorker(jobServer *jobs.JobServer, clearSessionCache func(userID string), notifyExpired func(tokens []*model.UserAccessToken)) *jobs.SimpleWorker {
 	isEnabled := func(cfg *model.Config) bool {
 		return *cfg.ServiceSettings.EnableUserAccessTokens
 	}
@@ -46,6 +54,7 @@ func MakeWorker(jobServer *jobs.JobServer, clearSessionCache func(userID string)
 			logger,
 			jobServer.Store.UserAccessToken(),
 			clearSessionCache,
+			notifyExpired,
 			model.GetMillis(),
 			batchLimit,
 			maxBatches,
@@ -61,10 +70,17 @@ func MakeWorker(jobServer *jobs.JobServer, clearSessionCache func(userID string)
 //
 // clearSessionCache is called for each unique user whose tokens were deleted so
 // that in-memory session caches don't continue serving the removed sessions.
+//
+// notifyExpired is called with each batch immediately before deletion so token
+// owners can be notified. It runs best-effort: it is invoked before the delete
+// so the token→owner mapping is still available, and the delete proceeds
+// regardless of what it does. The worst case (a crash between notify and
+// delete) is a single duplicate DM on the next run, which is acceptable.
 func cleanupExpired(
 	logger mlog.LoggerIFace,
 	store expiredTokenStore,
 	clearSessionCache func(userID string),
+	notifyExpired func(tokens []*model.UserAccessToken),
 	cutoff int64,
 	limit int,
 	maxIter int,
@@ -85,6 +101,12 @@ func cleanupExpired(
 		for i, token := range expired {
 			ids[i] = token.Id
 			userIDs[token.UserId] = struct{}{}
+		}
+
+		// Notify owners before deleting: the token still carries its UserId
+		// here, and deletion right after makes re-notification impossible.
+		if notifyExpired != nil {
+			notifyExpired(expired)
 		}
 
 		deleted, err := store.DeleteByIds(ids)

--- a/server/channels/jobs/cleanup_expired_access_tokens/worker.go
+++ b/server/channels/jobs/cleanup_expired_access_tokens/worker.go
@@ -103,20 +103,8 @@ func cleanupExpired(
 			userIDs[token.UserId] = struct{}{}
 		}
 
-		// Notify owners before deleting: the token still carries its UserId
-		// here, and deletion right after makes re-notification impossible.
-		// Isolate the notifier with its own recover so a panic inside it can
-		// never abort execute() before DeleteByIds runs — notification is
-		// best-effort and must not block cleanup.
 		if notifyExpired != nil {
-			func() {
-				defer func() {
-					if r := recover(); r != nil {
-						logger.Error("Recovered from panic while notifying expired token owners", mlog.Any("panic", r))
-					}
-				}()
-				notifyExpired(expired)
-			}()
+			notifyExpired(expired)
 		}
 
 		deleted, err := store.DeleteByIds(ids)

--- a/server/channels/jobs/cleanup_expired_access_tokens/worker.go
+++ b/server/channels/jobs/cleanup_expired_access_tokens/worker.go
@@ -6,6 +6,7 @@ package cleanup_expired_access_tokens
 import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/jobs"
 )
 
@@ -43,7 +44,7 @@ type expiredTokenStore interface {
 // jobs — the pre-expiry warning cascade (pat_expiry_notify) and this
 // at-deletion notice — so a future reader shouldn't be surprised to find an
 // expiry DM originating from the cleanup job.
-func MakeWorker(jobServer *jobs.JobServer, clearSessionCache func(userID string), notifyExpired func(tokens []*model.UserAccessToken)) *jobs.SimpleWorker {
+func MakeWorker(jobServer *jobs.JobServer, clearSessionCache func(userID string), notifyExpired func(rctx request.CTX, tokens []*model.UserAccessToken)) *jobs.SimpleWorker {
 	isEnabled := func(cfg *model.Config) bool {
 		return *cfg.ServiceSettings.EnableUserAccessTokens
 	}
@@ -51,7 +52,7 @@ func MakeWorker(jobServer *jobs.JobServer, clearSessionCache func(userID string)
 	execute := func(logger mlog.LoggerIFace, job *model.Job) error {
 		defer jobServer.HandleJobPanic(logger, job)
 		return cleanupExpired(
-			logger,
+			request.EmptyContext(logger),
 			jobServer.Store.UserAccessToken(),
 			clearSessionCache,
 			notifyExpired,
@@ -75,12 +76,13 @@ func MakeWorker(jobServer *jobs.JobServer, clearSessionCache func(userID string)
 // owners can be notified. It runs best-effort: it is invoked before the delete
 // so the token→owner mapping is still available, and the delete proceeds
 // regardless of what it does. The worst case (a crash between notify and
-// delete) is a single duplicate DM on the next run, which is acceptable.
+// delete) is a single duplicate DM on the next run, which is acceptable. The
+// request context is passed through so the notifier logs under the job's logger.
 func cleanupExpired(
-	logger mlog.LoggerIFace,
+	rctx request.CTX,
 	store expiredTokenStore,
 	clearSessionCache func(userID string),
-	notifyExpired func(tokens []*model.UserAccessToken),
+	notifyExpired func(rctx request.CTX, tokens []*model.UserAccessToken),
 	cutoff int64,
 	limit int,
 	maxIter int,
@@ -104,7 +106,7 @@ func cleanupExpired(
 		}
 
 		if notifyExpired != nil {
-			notifyExpired(expired)
+			notifyExpired(rctx, expired)
 		}
 
 		deleted, err := store.DeleteByIds(ids)
@@ -122,7 +124,7 @@ func cleanupExpired(
 		}
 	}
 
-	logger.Info(
+	rctx.Logger().Info(
 		"Cleaned up expired personal access tokens",
 		mlog.Int("deleted", int(totalDeleted)),
 		mlog.Int("cutoff", int(cutoff)),

--- a/server/channels/jobs/cleanup_expired_access_tokens/worker_test.go
+++ b/server/channels/jobs/cleanup_expired_access_tokens/worker_test.go
@@ -198,15 +198,4 @@ func TestCleanupExpired(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, store.deletedIDs, 1)
 	})
-
-	t.Run("notify panic does not block deletion", func(t *testing.T) {
-		store := &fakeStore{batches: [][]*model.UserAccessToken{makeTokens(2, 1000)}}
-		panicking := func(_ []*model.UserAccessToken) { panic("notify boom") }
-
-		require.NotPanics(t, func() {
-			err := cleanupExpired(logger, store, nopClearSession, panicking, 9999, 1000, 10)
-			require.NoError(t, err)
-		})
-		require.Len(t, store.deletedIDs, 1, "delete must still run after a notify panic")
-	})
 }

--- a/server/channels/jobs/cleanup_expired_access_tokens/worker_test.go
+++ b/server/channels/jobs/cleanup_expired_access_tokens/worker_test.go
@@ -198,4 +198,15 @@ func TestCleanupExpired(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, store.deletedIDs, 1)
 	})
+
+	t.Run("notify panic does not block deletion", func(t *testing.T) {
+		store := &fakeStore{batches: [][]*model.UserAccessToken{makeTokens(2, 1000)}}
+		panicking := func(_ []*model.UserAccessToken) { panic("notify boom") }
+
+		require.NotPanics(t, func() {
+			err := cleanupExpired(logger, store, nopClearSession, panicking, 9999, 1000, 10)
+			require.NoError(t, err)
+		})
+		require.Len(t, store.deletedIDs, 1, "delete must still run after a notify panic")
+	})
 }

--- a/server/channels/jobs/cleanup_expired_access_tokens/worker_test.go
+++ b/server/channels/jobs/cleanup_expired_access_tokens/worker_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 )
 
 // fakeStore implements expiredTokenStore. Each call to GetExpiredBefore pops
@@ -66,16 +67,16 @@ func makeTokens(n int, base int64) []*model.UserAccessToken {
 
 func nopClearSession(_ string) {}
 
-func nopNotify(_ []*model.UserAccessToken) {}
+func nopNotify(_ request.CTX, _ []*model.UserAccessToken) {}
 
 func TestCleanupExpired(t *testing.T) {
-	logger := mlog.CreateConsoleTestLogger(t)
+	rctx := request.EmptyContext(mlog.CreateConsoleTestLogger(t))
 
 	t.Run("happy path single batch", func(t *testing.T) {
 		tokens := makeTokens(3, 1000)
 		store := &fakeStore{batches: [][]*model.UserAccessToken{tokens}}
 
-		err := cleanupExpired(logger, store, nopClearSession, nopNotify, 9999, 1000, 10)
+		err := cleanupExpired(rctx, store, nopClearSession, nopNotify, 9999, 1000, 10)
 		require.NoError(t, err)
 
 		// Exactly one DeleteByIds call with the three token ids. A partial first
@@ -89,7 +90,7 @@ func TestCleanupExpired(t *testing.T) {
 	t.Run("empty result is no-op", func(t *testing.T) {
 		store := &fakeStore{} // no batches, no errors
 
-		err := cleanupExpired(logger, store, nopClearSession, nopNotify, 9999, 1000, 10)
+		err := cleanupExpired(rctx, store, nopClearSession, nopNotify, 9999, 1000, 10)
 		require.NoError(t, err)
 
 		require.Equal(t, 1, store.getCalls)
@@ -102,7 +103,7 @@ func TestCleanupExpired(t *testing.T) {
 		second := makeTokens(2, 2000)    // partial batch -> loop stops
 		store := &fakeStore{batches: [][]*model.UserAccessToken{first, second}}
 
-		err := cleanupExpired(logger, store, nopClearSession, nopNotify, 9999, limit, 10)
+		err := cleanupExpired(rctx, store, nopClearSession, nopNotify, 9999, limit, 10)
 		require.NoError(t, err)
 
 		require.Equal(t, 2, store.getCalls)
@@ -120,7 +121,7 @@ func TestCleanupExpired(t *testing.T) {
 			makeTokens(limit, 3000), // never reached
 		}}
 
-		err := cleanupExpired(logger, store, nopClearSession, nopNotify, 9999, limit, maxIter)
+		err := cleanupExpired(rctx, store, nopClearSession, nopNotify, 9999, limit, maxIter)
 		require.NoError(t, err)
 
 		require.Equal(t, maxIter, store.getCalls, "loop must cap at maxIter")
@@ -135,7 +136,7 @@ func TestCleanupExpired(t *testing.T) {
 			getErr:   wantErr,
 		}
 
-		err := cleanupExpired(logger, store, nopClearSession, nopNotify, 9999, 1000, 10)
+		err := cleanupExpired(rctx, store, nopClearSession, nopNotify, 9999, 1000, 10)
 		require.ErrorIs(t, err, wantErr)
 		require.Empty(t, store.deletedIDs, "delete must not run when get fails")
 	})
@@ -147,7 +148,7 @@ func TestCleanupExpired(t *testing.T) {
 			deleteErr: wantErr,
 		}
 
-		err := cleanupExpired(logger, store, nopClearSession, nopNotify, 9999, 1000, 10)
+		err := cleanupExpired(rctx, store, nopClearSession, nopNotify, 9999, 1000, 10)
 		require.ErrorIs(t, err, wantErr)
 		require.Len(t, store.deletedIDs, 1, "DeleteByIds was called once before failing")
 	})
@@ -162,7 +163,7 @@ func TestCleanupExpired(t *testing.T) {
 		store := &fakeStore{batches: [][]*model.UserAccessToken{tokens}}
 
 		cleared := map[string]int{}
-		err := cleanupExpired(logger, store, func(userID string) { cleared[userID]++ }, nopNotify, 9999, 1000, 10)
+		err := cleanupExpired(rctx, store, func(userID string) { cleared[userID]++ }, nopNotify, 9999, 1000, 10)
 		require.NoError(t, err)
 
 		require.Len(t, cleared, 2, "cache must be cleared for each unique user")
@@ -176,14 +177,14 @@ func TestCleanupExpired(t *testing.T) {
 		store := &fakeStore{batches: [][]*model.UserAccessToken{first, second}}
 
 		var notified [][]*model.UserAccessToken
-		notify := func(tokens []*model.UserAccessToken) {
+		notify := func(_ request.CTX, tokens []*model.UserAccessToken) {
 			// Each batch must be notified before it is deleted: at the Nth
 			// notify call exactly N-1 prior batches should have been deleted.
 			require.Len(t, store.deletedIDs, len(notified), "notify must run before this batch's DeleteByIds")
 			notified = append(notified, tokens)
 		}
 
-		err := cleanupExpired(logger, store, nopClearSession, notify, 9999, limit, 10)
+		err := cleanupExpired(rctx, store, nopClearSession, notify, 9999, limit, 10)
 		require.NoError(t, err)
 
 		require.Len(t, notified, 2, "notify called once per batch")
@@ -194,7 +195,7 @@ func TestCleanupExpired(t *testing.T) {
 	t.Run("nil notify is tolerated", func(t *testing.T) {
 		store := &fakeStore{batches: [][]*model.UserAccessToken{makeTokens(2, 1000)}}
 
-		err := cleanupExpired(logger, store, nopClearSession, nil, 9999, 1000, 10)
+		err := cleanupExpired(rctx, store, nopClearSession, nil, 9999, 1000, 10)
 		require.NoError(t, err)
 		require.Len(t, store.deletedIDs, 1)
 	})

--- a/server/channels/jobs/cleanup_expired_access_tokens/worker_test.go
+++ b/server/channels/jobs/cleanup_expired_access_tokens/worker_test.go
@@ -66,6 +66,8 @@ func makeTokens(n int, base int64) []*model.UserAccessToken {
 
 func nopClearSession(_ string) {}
 
+func nopNotify(_ []*model.UserAccessToken) {}
+
 func TestCleanupExpired(t *testing.T) {
 	logger := mlog.CreateConsoleTestLogger(t)
 
@@ -73,7 +75,7 @@ func TestCleanupExpired(t *testing.T) {
 		tokens := makeTokens(3, 1000)
 		store := &fakeStore{batches: [][]*model.UserAccessToken{tokens}}
 
-		err := cleanupExpired(logger, store, nopClearSession, 9999, 1000, 10)
+		err := cleanupExpired(logger, store, nopClearSession, nopNotify, 9999, 1000, 10)
 		require.NoError(t, err)
 
 		// Exactly one DeleteByIds call with the three token ids. A partial first
@@ -87,7 +89,7 @@ func TestCleanupExpired(t *testing.T) {
 	t.Run("empty result is no-op", func(t *testing.T) {
 		store := &fakeStore{} // no batches, no errors
 
-		err := cleanupExpired(logger, store, nopClearSession, 9999, 1000, 10)
+		err := cleanupExpired(logger, store, nopClearSession, nopNotify, 9999, 1000, 10)
 		require.NoError(t, err)
 
 		require.Equal(t, 1, store.getCalls)
@@ -100,7 +102,7 @@ func TestCleanupExpired(t *testing.T) {
 		second := makeTokens(2, 2000)    // partial batch -> loop stops
 		store := &fakeStore{batches: [][]*model.UserAccessToken{first, second}}
 
-		err := cleanupExpired(logger, store, nopClearSession, 9999, limit, 10)
+		err := cleanupExpired(logger, store, nopClearSession, nopNotify, 9999, limit, 10)
 		require.NoError(t, err)
 
 		require.Equal(t, 2, store.getCalls)
@@ -118,7 +120,7 @@ func TestCleanupExpired(t *testing.T) {
 			makeTokens(limit, 3000), // never reached
 		}}
 
-		err := cleanupExpired(logger, store, nopClearSession, 9999, limit, maxIter)
+		err := cleanupExpired(logger, store, nopClearSession, nopNotify, 9999, limit, maxIter)
 		require.NoError(t, err)
 
 		require.Equal(t, maxIter, store.getCalls, "loop must cap at maxIter")
@@ -133,7 +135,7 @@ func TestCleanupExpired(t *testing.T) {
 			getErr:   wantErr,
 		}
 
-		err := cleanupExpired(logger, store, nopClearSession, 9999, 1000, 10)
+		err := cleanupExpired(logger, store, nopClearSession, nopNotify, 9999, 1000, 10)
 		require.ErrorIs(t, err, wantErr)
 		require.Empty(t, store.deletedIDs, "delete must not run when get fails")
 	})
@@ -145,7 +147,7 @@ func TestCleanupExpired(t *testing.T) {
 			deleteErr: wantErr,
 		}
 
-		err := cleanupExpired(logger, store, nopClearSession, 9999, 1000, 10)
+		err := cleanupExpired(logger, store, nopClearSession, nopNotify, 9999, 1000, 10)
 		require.ErrorIs(t, err, wantErr)
 		require.Len(t, store.deletedIDs, 1, "DeleteByIds was called once before failing")
 	})
@@ -160,10 +162,40 @@ func TestCleanupExpired(t *testing.T) {
 		store := &fakeStore{batches: [][]*model.UserAccessToken{tokens}}
 
 		cleared := map[string]int{}
-		err := cleanupExpired(logger, store, func(userID string) { cleared[userID]++ }, 9999, 1000, 10)
+		err := cleanupExpired(logger, store, func(userID string) { cleared[userID]++ }, nopNotify, 9999, 1000, 10)
 		require.NoError(t, err)
 
 		require.Len(t, cleared, 2, "cache must be cleared for each unique user")
 		require.Equal(t, 1, cleared[sharedUserID], "each user cleared exactly once per batch")
+	})
+
+	t.Run("notify is called with each batch before delete", func(t *testing.T) {
+		const limit = 3
+		first := makeTokens(limit, 1000) // full batch -> loop continues
+		second := makeTokens(1, 2000)    // partial batch -> loop stops
+		store := &fakeStore{batches: [][]*model.UserAccessToken{first, second}}
+
+		var notified [][]*model.UserAccessToken
+		notify := func(tokens []*model.UserAccessToken) {
+			// Each batch must be notified before it is deleted: at the Nth
+			// notify call exactly N-1 prior batches should have been deleted.
+			require.Len(t, store.deletedIDs, len(notified), "notify must run before this batch's DeleteByIds")
+			notified = append(notified, tokens)
+		}
+
+		err := cleanupExpired(logger, store, nopClearSession, notify, 9999, limit, 10)
+		require.NoError(t, err)
+
+		require.Len(t, notified, 2, "notify called once per batch")
+		require.Equal(t, first, notified[0])
+		require.Equal(t, second, notified[1])
+	})
+
+	t.Run("nil notify is tolerated", func(t *testing.T) {
+		store := &fakeStore{batches: [][]*model.UserAccessToken{makeTokens(2, 1000)}}
+
+		err := cleanupExpired(logger, store, nopClearSession, nil, 9999, 1000, 10)
+		require.NoError(t, err)
+		require.Len(t, store.deletedIDs, 1)
 	})
 }

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9671,6 +9671,10 @@
     "translation": "The personal access token has expired."
   },
   {
+    "id": "app.user_access_token.expired_deleted_notification",
+    "translation": "Your personal access token \"{{.Description}}\" has expired and been removed. Open **Profile → Security** to create a new token."
+  },
+  {
     "id": "app.user_access_token.expires_at_in_past.app_error",
     "translation": "The provided expires_at is in the past."
   },


### PR DESCRIPTION
#### Summary

Follow-up from https://github.com/mattermost/mattermost/pull/37272 (proactive pre-expiry warnings) and part of the PAT expiry epic MM-68415.

The pre-expiry warning cascade is best-effort — a user can miss, mute, or never connect the DMs. When a personal access token actually expires, the only remaining signals are the rejection error at point-of-use (returned to the *caller*, not the human owner, so a fire-and-forget integration swallows it) and the passive status badge in Profile → Security. For the silent-integration case the owner can be left unaware their token stopped working.

This closes that gap by sending an at-expiry DM from the existing `cleanup_expired_access_tokens` job at the moment it deletes an expired token.

**Why the cleanup job**
- It already fetches expired tokens (`GetExpiredBefore`) and has the owner (`UserId`) in hand immediately before deleting them — no extra state needed.
- No grace period / tombstone / cleanup-semantics change required; the token→owner mapping is still available at delete time.
- Dedup is inherent: the row is deleted right after, so it can never be re-surfaced or re-notified.
- One job owns both the notification and the deletion, so there is no cross-job race.

**Behavior**
- For each expired token about to be deleted, DM the owner via the system bot, localized to the recipient's locale (matching the pre-expiry job).
- Notify **before** delete, best-effort: send the DM, then delete regardless. A send failure is logged and does not block cleanup. Worst case (crash between send and delete) is a single duplicate DM on the next hourly run.
- Skip bot-account tokens and tokens owned by deactivated users. `GetExpiredBefore` returns those too, and cleanup must still delete them, so the notify step looks up the user and skips `IsBot` / `DeleteAt != 0`.
- Gated on `ServiceSettings.EnableUserAccessTokens` (the cleanup job already is).
- The DM fires at deletion, i.e. 0–60 min after actual expiry (hourly cadence).

**Wiring**
- An app-layer notify callback (`App.NotifyExpiredAccessTokensDeleted`) is injected into the cleanup worker, mirroring how `expirynotify` is wired, so the extracted `cleanupExpired` function stays unit-testable with a fake notifier.

After this change, PAT expiry DMs come from two jobs: pre-expiry from `pat_expiry_notify`, at-deletion from `cleanup_expired_access_tokens`. A code comment notes this so a future reader isn't surprised the expiry notification lives in the cleanup job.

#### Screenshots
<img width="1310" height="165" alt="Screenshot from 2026-07-06 10-34-16" src="https://github.com/user-attachments/assets/2638404d-e74d-4a97-b68a-d9a63c3e6222" />


#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69693

#### Release Note

```release-note
Token owners are now notified by a direct message from the system bot when one of their personal access tokens is removed after expiring.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014Am6a5P8tpkd9AeEHbCBqg)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change is gated by `ServiceSettings.EnableUserAccessTokens` and is best-effort (notification failures don’t block or prevent token deletion), reducing risk to core cleanup behavior. However, it adds new DM/channel creation and localized posting logic within the cleanup worker, so bugs in recipient eligibility/locale/channel creation could cause user-facing notification issues.

**QA Recommendation:** Light manual QA only—verify a real expired non-bot PAT owner receives the system-bot DM in the correct locale, and confirm bot-owned and deactivated-user tokens do not generate DMs.
 
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->