### PR TITLE
Fix reaction not added when emoji autocomplete is used (#37351)

### DIFF
--- a/webapp/channels/src/components/suggestion/emoticon_provider.test.tsx
+++ b/webapp/channels/src/components/suggestion/emoticon_provider.test.tsx
@@ -52,7 +52,42 @@ describe('components/EmoticonProvider', () => {
             expect(resultsCallback).toHaveBeenCalled();
         }
     });
+    it.each(['+', '-'])('should complete system emojis in the :name: form for the "%s" reaction shortcut', (prefix) => {
+        const pretext = `${prefix}:thu`;
+        mockedGetEmojiMap.mockReturnValue(emojiMap);
+        mockedGetRecentEmojisNames.mockReturnValue([]);
 
+        emoticonProvider.handlePretextChanged(pretext, resultsCallback);
+        expect(resultsCallback).toHaveBeenCalled();
+
+        const args = resultsCallback.mock.calls[0][0];
+
+        expect(args.matchedPretext).toEqual(':thu');
+
+        const terms: string[] = args.groups[0].terms;
+
+        expect(terms).toContain(':thumbsup:');
+
+        for (const term of terms) {
+            expect(term).toMatch(/^:[^:\s]+:$/);
+        }
+    });
+
+    it('should complete system emojis as the unicode glyph in a regular message', () => {
+        const pretext = ':thu';
+        mockedGetEmojiMap.mockReturnValue(emojiMap);
+        mockedGetRecentEmojisNames.mockReturnValue([]);
+
+        emoticonProvider.handlePretextChanged(pretext, resultsCallback);
+        expect(resultsCallback).toHaveBeenCalled();
+
+        const args = resultsCallback.mock.calls[0][0];
+        const terms: string[] = args.groups[0].terms;
+
+        expect(terms).not.toContain(':thumbsup:');
+
+        expect(terms).toContain(':thumbsdown-custom:');
+    });
     it('should order suggested emojis', () => {
         const pretext = ':thu';
         const recentEmojis = ['smile'];

--- a/webapp/channels/src/components/suggestion/emoticon_provider.tsx
+++ b/webapp/channels/src/components/suggestion/emoticon_provider.tsx
@@ -85,17 +85,19 @@ export default class EmoticonProvider extends Provider {
         }
 
         if (store.getState().entities.general.config.EnableCustomEmoji === 'true') {
-            store.dispatch(autocompleteCustomEmojis(partialName)).then(() => this.findAndSuggestEmojis(text, partialName, resultsCallback));
+            store.dispatch(autocompleteCustomEmojis(partialName)).then(() => this.findAndSuggestEmojis(text, partialName, resultsCallback, prefix));
         } else {
-            this.findAndSuggestEmojis(text, partialName, resultsCallback);
+            this.findAndSuggestEmojis(text, partialName, resultsCallback, prefix);
         }
 
         return true;
     }
 
-    formatEmojis(emojis: EmojiItem[]) {
+    formatEmojis(emojis: EmojiItem[], prefix = '') {
+        const isEmojiReaction = prefix === '+' || prefix === '-';
+
         return emojis.map((item) => {
-            if (isSystemEmoji(item.emoji)) {
+            if (isSystemEmoji(item.emoji) && !isEmojiReaction) {
                 return unifiedToUnicode((item.emoji as SystemEmoji).unified);
             }
             return ':' + item.name + ':';
@@ -112,7 +114,7 @@ export default class EmoticonProvider extends Provider {
     //
     // For now, this behaviour and difference is by design.
     // See https://mattermost.atlassian.net/browse/MM-17320.
-    findAndSuggestEmojis(text: string, partialName: string, resultsCallback: ResultsCallback<EmojiItem>) {
+    findAndSuggestEmojis(text: string, partialName: string, resultsCallback: ResultsCallback<EmojiItem>, prefix = '') {
         const recentMatched: EmojiItem[] = [];
         const matched: EmojiItem[] = [];
         const state = store.getState();
@@ -161,8 +163,8 @@ export default class EmoticonProvider extends Provider {
         matched.sort(sortEmojisHelper);
 
         const terms = [
-            ...this.formatEmojis(recentMatched),
-            ...this.formatEmojis(matched),
+            ...this.formatEmojis(recentMatched, prefix),
+            ...this.formatEmojis(matched, prefix),
         ];
 
         const items = [


### PR DESCRIPTION
#### Summary
The Web UI failed to add a reaction when the emoji name was chosen via autocomplete. Using the `+:name`/`-:name` reaction shortcut and selecting a system emoji from the autocomplete (e.g. `+:explo` then Tab) posted a new message like `+🤯` instead of adding the reaction.

The emoji autocomplete completes system emojis to their raw Unicode glyph, while the reaction-on-submit detector (`REACTION_PATTERN` in `utils/utils.tsx`, used by `onSubmit` in `actions/views/create_comment.tsx`) only recognises the colon form `+:name:`. So the completed message failed the pattern and was sent as a normal message. Custom emojis were unaffected because they always complete as `:name:`, which is why typing the name in full already worked.

Fix: in `EmoticonProvider`, when completing inside a `+`/`-` reaction shortcut, insert the `:name:` colon form for system emojis too. Completions in a normal message still insert the Unicode glyph, so the common case is unchanged. Added unit tests covering both cases.

#### Ticket Link
Fixes https://github.com/mattermost/mattermost/issues/37351

#### Screenshots
N/A — reproduction video is attached to the linked issue.

#### Release Note
```release-note
Fixed an issue where selecting an emoji from the autocomplete when adding a reaction with the `+`/`-` shortcut posted a new message instead of adding the reaction.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change is localized to emoji autocomplete handling in the web UI, but it alters behavior in a user-facing reaction flow that shares logic with normal message autocomplete. Existing tests cover the key reaction and non-reaction cases, which lowers risk, but the prefix-sensitive formatting path could still affect nearby autocomplete scenarios.

**QA Recommendation:** Perform targeted manual QA on `+`/`-` reaction entry with emoji autocomplete, plus a quick check of standard emoji autocomplete in normal message composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->