### PR TITLE
[MM-24529] Preserve hyphenated compound words in Postgres search

### DIFF
--- a/server/channels/store/searchtest/file_info_layer.go
+++ b/server/channels/store/searchtest/file_info_layer.go
@@ -131,11 +131,10 @@ var searchFileInfoStoreTests = []searchTest{
 		Tags: []string{EngineAll},
 	},
 	{
-		Name:        "Should support terms with dash",
-		Fn:          testFileInfoSupportTermsWithDash,
-		Tags:        []string{EngineAll},
-		Skip:        true,
-		SkipMessage: "Hyphenated compound matching isn't viable for filenames: PostgreSQL's parser tokenizes a hyphenated name glued to an extension (e.g. \"photo-2024.jpg\") as an opaque host-type token, so a hyphen-preserving query can never match it. See MM-24529.",
+		Name: "Should support terms with dash",
+		Fn:   testFileInfoSupportTermsWithDash,
+		Tags: []string{EngineAll},
+		Skip: true,
 	},
 	{
 		Name: "Should support terms with underscore",
@@ -152,7 +151,7 @@ var searchFileInfoStoreTests = []searchTest{
 		Fn:          testFileInfoSearchTermsWithDashes,
 		Tags:        []string{EngineAll},
 		Skip:        true,
-		SkipMessage: "Hyphenated compound matching isn't viable for filenames: PostgreSQL's parser tokenizes a hyphenated name glued to an extension (e.g. \"photo-2024.jpg\") as an opaque host-type token, so a hyphen-preserving query can never match it. See MM-24529.",
+		SkipMessage: "Not working",
 	},
 	{
 		Name: "Should be able to search terms with dots",

--- a/server/channels/store/searchtest/file_info_layer.go
+++ b/server/channels/store/searchtest/file_info_layer.go
@@ -131,10 +131,11 @@ var searchFileInfoStoreTests = []searchTest{
 		Tags: []string{EngineAll},
 	},
 	{
-		Name: "Should support terms with dash",
-		Fn:   testFileInfoSupportTermsWithDash,
-		Tags: []string{EngineAll},
-		Skip: true,
+		Name:        "Should support terms with dash",
+		Fn:          testFileInfoSupportTermsWithDash,
+		Tags:        []string{EngineAll},
+		Skip:        true,
+		SkipMessage: "Hyphenated compound matching isn't viable for filenames: PostgreSQL's parser tokenizes a hyphenated name glued to an extension (e.g. \"photo-2024.jpg\") as an opaque host-type token, so a hyphen-preserving query can never match it. See MM-24529.",
 	},
 	{
 		Name: "Should support terms with underscore",
@@ -151,7 +152,7 @@ var searchFileInfoStoreTests = []searchTest{
 		Fn:          testFileInfoSearchTermsWithDashes,
 		Tags:        []string{EngineAll},
 		Skip:        true,
-		SkipMessage: "Not working",
+		SkipMessage: "Hyphenated compound matching isn't viable for filenames: PostgreSQL's parser tokenizes a hyphenated name glued to an extension (e.g. \"photo-2024.jpg\") as an opaque host-type token, so a hyphen-preserving query can never match it. See MM-24529.",
 	},
 	{
 		Name: "Should be able to search terms with dots",

--- a/server/channels/store/searchtest/post_layer.go
+++ b/server/channels/store/searchtest/post_layer.go
@@ -143,8 +143,7 @@ var searchPostStoreTests = []searchTest{
 	{
 		Name: "Should support terms with dash",
 		Fn:   testSupportTermsWithDash,
-		Tags: []string{EngineAll},
-		Skip: true,
+		Tags: []string{EnginePostgres},
 	},
 	{
 		Name: "Should support terms with underscore",
@@ -222,11 +221,9 @@ var searchPostStoreTests = []searchTest{
 		Tags: []string{EnginePostgres},
 	},
 	{
-		Name:        "Should be able to search terms with dashes",
-		Fn:          testSearchTermsWithDashes,
-		Tags:        []string{EngineAll},
-		Skip:        true,
-		SkipMessage: "Not working",
+		Name: "Should be able to search terms with dashes",
+		Fn:   testSearchTermsWithDashes,
+		Tags: []string{EnginePostgres},
 	},
 	{
 		Name: "Should be able to search terms with dots",
@@ -1986,6 +1983,36 @@ func testSearchTermsWithDashes(t *testing.T, th *SearchTestHelper) {
 		require.Len(t, results.Posts, 2)
 		th.checkPostInSearchResults(t, p1.Id, results.Posts)
 		th.checkPostInSearchResults(t, p2.Id, results.Posts)
+	})
+
+	t.Run("Search for terms excluding a dashed term", func(t *testing.T) {
+		params := &model.SearchParams{Terms: "message", ExcludedTerms: "with-dash-term"}
+		results, err := th.Store.Post().SearchPostsForUser(th.Context, []*model.SearchParams{params}, th.User.Id, th.Team.Id, 0, 20)
+		require.NoError(t, err)
+
+		require.Len(t, results.Posts, 1)
+		th.checkPostInSearchResults(t, p2.Id, results.Posts)
+	})
+
+	t.Run("Search for a dashed term with a wildcard", func(t *testing.T) {
+		params := &model.SearchParams{Terms: "with-dash-term*"}
+		results, err := th.Store.Post().SearchPostsForUser(th.Context, []*model.SearchParams{params}, th.User.Id, th.Team.Id, 0, 20)
+		require.NoError(t, err)
+
+		require.Len(t, results.Posts, 1)
+		th.checkPostInSearchResults(t, p1.Id, results.Posts)
+	})
+
+	t.Run("Search for a letters-digits dashed term", func(t *testing.T) {
+		p3, err := th.createPost(th.User.Id, th.ChannelBasic.Id, "the code is FX-042", "", model.PostTypeDefault, 0, false)
+		require.NoError(t, err)
+
+		params := &model.SearchParams{Terms: "FX-042"}
+		results, err := th.Store.Post().SearchPostsForUser(th.Context, []*model.SearchParams{params}, th.User.Id, th.Team.Id, 0, 20)
+		require.NoError(t, err)
+
+		require.Len(t, results.Posts, 1)
+		th.checkPostInSearchResults(t, p3.Id, results.Posts)
 	})
 }
 

--- a/server/channels/store/sqlstore/file_info_store.go
+++ b/server/channels/store/sqlstore/file_info_store.go
@@ -630,6 +630,15 @@ func (fs SqlFileInfoStore) Search(rctx request.CTX, paramsList []*model.SearchPa
 			excludedTerms = strings.Replace(excludedTerms, c, " ", -1)
 		}
 
+		// Unlike post message search, filenames commonly have a hyphenated
+		// name glued directly to an extension (e.g. "photo-2024.jpg"), which
+		// PostgreSQL's parser classifies as an opaque "host"-type token that
+		// to_tsquery can never match against a hyphen-preserving compound
+		// query. So, unlike post_store.go, hyphens are still replaced with
+		// spaces here rather than preserved.
+		terms = strings.Replace(terms, "-", " ", -1)
+		excludedTerms = strings.Replace(excludedTerms, "-", " ", -1)
+
 		if terms == "" && excludedTerms == "" {
 			// we've already confirmed that we have a channel or user to search for
 		} else {

--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -2217,6 +2217,12 @@ func (s *SqlPostStore) search(teamId string, userId string, params *model.Search
 		// It also adds complexity as we would only need that index for CJK deployments.
 		baseQuery = s.buildCJKSearchClause(baseQuery, searchType, terms, excludedTerms, params.OrTerms)
 	} else {
+		// Preserve internal hyphens (e.g. "t-shirt") as compound-word searches,
+		// while neutralizing malformed hyphen usage that would otherwise be
+		// passed to to_tsquery.
+		terms = neutralizeNonWordHyphens(terms)
+		excludedTerms = neutralizeNonWordHyphens(excludedTerms)
+
 		// Parse text for wildcards
 		terms = wildCardRegex.ReplaceAllLiteralString(terms, ":* ")
 		excludedTerms = wildCardRegex.ReplaceAllLiteralString(excludedTerms, ":* ")

--- a/server/channels/store/sqlstore/store.go
+++ b/server/channels/store/sqlstore/store.go
@@ -394,7 +394,6 @@ var specialSearchChars = []string{
 	"<",
 	">",
 	"+",
-	"-",
 	"(",
 	")",
 	"~",

--- a/server/channels/store/sqlstore/utils.go
+++ b/server/channels/store/sqlstore/utils.go
@@ -200,6 +200,35 @@ type rowScanner interface {
 	Err() error
 }
 
+// neutralizeNonWordHyphens replaces any '-' that isn't flanked by a word
+// rune (letter or digit) on both sides with a space, so malformed hyphen
+// usage (leading/trailing/standalone/repeated) can't reach to_tsquery, while
+// compound words like "t-shirt" are preserved.
+func neutralizeNonWordHyphens(s string) string {
+	if !strings.ContainsRune(s, '-') {
+		return s
+	}
+	runes := []rune(s)
+	for i, r := range runes {
+		if r != '-' {
+			continue
+		}
+		hasLeft := i > 0 && isWordRune(runes[i-1])
+		hasRight := i < len(runes)-1 && isWordRune(runes[i+1])
+		if !hasLeft || !hasRight {
+			runes[i] = ' '
+		}
+	}
+	return string(runes)
+}
+
+// isWordRune reports whether r can be part of a word for hyphen-flanking
+// purposes. Combining marks (e.g. a decomposed accent) count too, since they
+// attach to the preceding base letter rather than acting as a boundary.
+func isWordRune(r rune) bool {
+	return unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r)
+}
+
 // scanRowsIntoMap scans SQL rows into a map, using a provided scanner function to extract key-value pairs
 func scanRowsIntoMap[K comparable, V any](rows rowScanner, scanner func(rows rowScanner) (K, V, error), defaults map[K]V) (map[K]V, error) {
 	results := make(map[K]V, len(defaults))

--- a/server/channels/store/sqlstore/utils_test.go
+++ b/server/channels/store/sqlstore/utils_test.go
@@ -11,6 +11,32 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func TestNeutralizeNonWordHyphens(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"compound word kept", "t-shirt", "t-shirt"},
+		{"multiple hyphens kept", "a-b-c", "a-b-c"},
+		{"digits kept", "covid-19", "covid-19"},
+		{"unicode letters kept", "café-au-lait", "café-au-lait"},
+		{"NFD combining mark before hyphen kept", "café-au-lait", "café-au-lait"},
+		{"leading hyphen neutralized", "-5", " 5"},
+		{"trailing hyphen neutralized", "foo-", "foo "},
+		{"standalone hyphen neutralized", "-", " "},
+		{"hyphen between spaces neutralized", "a - b", "a   b"},
+		{"repeated bare hyphens neutralized", "--", "  "},
+		{"empty string", "", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, neutralizeNonWordHyphens(tc.input))
+		})
+	}
+}
+
 func TestChunkSlice(t *testing.T) {
 	if enableFullyParallelTests {
 		t.Parallel()


### PR DESCRIPTION
#### Summary
Postgres full-text search stripped every hyphen to a space before building a `to_tsquery`, so an unquoted search for `t-shirt` degraded into a loose "t AND shirt" match instead of the compound-word match the quoted version (`"t-shirt"`) already got.

Elasticsearch use a different tokenizer and query mechanism (`simple_query_string` over an `icu_tokenizer` with no phrase/adjacency handling).  out of scope for this ticket.

Changes:
- Remove `-` from the shared `specialSearchChars` strip list (`store.go`), and add `neutralizeNonWordHyphens` (`utils.go`), which keeps a hyphen only when flanked by a letter/digit on both sides, neutralizing malformed usage (leading/trailing/standalone/repeated hyphens) that would otherwise reach `to_tsquery` as a parse error.
- Wire the new helper into `post_store.go`'s tsquery-building path.
- `file_info_store.go` intentionally **keeps** the old hyphen-to-space behavior: real filenames glue a hyphenated name directly to an extension (e.g. `photo-2024.jpg`), which Postgres's parser tokenizes as an opaque "host"-type token that a hyphen-preserving compound query can never match — verified directly against Postgres. Preserving hyphens there would have been a regression for real uploaded files, so the two FileInfo dash acceptance tests are re-skipped with an accurate reason (replacing the previous vague "Not working").  In other words: this PR is a no-op for postgres. 
- Re-enable the two previously-skipped Postgres post-search dash acceptance tests (`testSupportTermsWithDash`, `testSearchTermsWithDashes`), and extend them with excluded-term, wildcard, and letters-digits-compound (e.g. `FX-042`) cases.
- Add unit tests for `neutralizeNonWordHyphens`, including an NFD-decomposed Unicode edge case.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-24529

#### Screenshots

**Posts**
<img width="808" height="256" alt="Screenshot from 2026-07-06 14-21-06" src="https://github.com/user-attachments/assets/3816b037-8990-4d88-a428-41e6713e767a" />

**Before**

<img width="1757" height="826" alt="Screenshot from 2026-07-06 14-20-15" src="https://github.com/user-attachments/assets/cd2e4d29-f3a3-48bb-88e6-31c83705cf30" />
<img width="1757" height="826" alt="Screenshot from 2026-07-06 14-19-00" src="https://github.com/user-attachments/assets/3458374b-05e1-4ffd-b6c7-38f3e4b76052" />

**After**
<img width="1690" height="605" alt="Screenshot from 2026-07-06 14-22-37" src="https://github.com/user-attachments/assets/18ae88ca-826b-4bf3-a91c-a7a1599095f0" />
<img width="1690" height="605" alt="Screenshot from 2026-07-06 14-22-45" src="https://github.com/user-attachments/assets/554cb38e-7d1d-451b-9e44-75f3bc381e03" />


#### Release Note
```release-note
Fixed unquoted searches for hyphenated compound words (e.g. `t-shirt`) on PostgreSQL to match the compound word instead of the individual words.
```