### PR TITLE
Fix "Unable to write file" on S3 when a FileWillBeUploaded plugin doesn't modify the file

### DIFF
--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -30,8 +30,10 @@ import (
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest"
 	"github.com/mattermost/mattermost/server/public/plugin/utils"
 	"github.com/mattermost/mattermost/server/public/shared/request"
+	"github.com/mattermost/mattermost/server/v8/channels/app/platform"
 	"github.com/mattermost/mattermost/server/v8/channels/utils/testutils"
 	"github.com/mattermost/mattermost/server/v8/einterfaces/mocks"
+	"github.com/mattermost/mattermost/server/v8/platform/shared/filestore"
 )
 
 func SetAppEnvironmentWithPlugins(t *testing.T, pluginCode []string, app *App, apiFunc func(*model.Manifest) plugin.API) (func(), []string, []error) {
@@ -492,6 +494,27 @@ func TestHookMessageHasBeenDeleted(t *testing.T) {
 	require.Nil(t, err)
 }
 
+// spyFileBackend delegates to the wrapped FileBackend while recording the
+// paths passed to WriteFile.
+type spyFileBackend struct {
+	filestore.FileBackend
+	mut          sync.Mutex
+	writtenPaths []string
+}
+
+func (b *spyFileBackend) WriteFile(fr io.Reader, path string) (int64, error) {
+	b.mut.Lock()
+	b.writtenPaths = append(b.writtenPaths, path)
+	b.mut.Unlock()
+	return b.FileBackend.WriteFile(fr, path)
+}
+
+func (b *spyFileBackend) WrittenPaths() []string {
+	b.mut.Lock()
+	defer b.mut.Unlock()
+	return append([]string{}, b.writtenPaths...)
+}
+
 func TestHookFileWillBeUploaded(t *testing.T) {
 	mainHelper.Parallel(t)
 	t.Run("rejected", func(t *testing.T) {
@@ -763,6 +786,78 @@ func TestHookFileWillBeUploaded(t *testing.T) {
 		require.Nil(t, appErr)
 
 		mockAPI.AssertCalled(t, "LogDebug", "connection_id="+connectionID)
+	})
+
+	t.Run("scan-only plugin does not write a temporary file", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		var mockAPI plugintest.API
+		mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"io"
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) FileWillBeUploaded(c *plugin.Context, info *model.FileInfo, file io.Reader, output io.Writer) (*model.FileInfo, string) {
+				return nil, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, func(*model.Manifest) plugin.API { return &mockAPI })
+		defer tearDown()
+
+		// Wrap the file backend to record every WriteFile call made while
+		// uploading through an upload session.
+		service := th.App.Srv().Platform()
+		origBackend := service.FileBackend()
+		spy := &spyFileBackend{FileBackend: origBackend}
+		require.NoError(t, platform.SetFileStore(spy)(service))
+		defer func() {
+			require.NoError(t, platform.SetFileStore(origBackend)(service))
+		}()
+
+		data := []byte("inputfile")
+		us := &model.UploadSession{
+			Id:        model.NewId(),
+			Type:      model.UploadTypeAttachment,
+			UserId:    th.BasicUser.Id,
+			ChannelId: th.BasicChannel.Id,
+			Filename:  "testhook.txt",
+			FileSize:  int64(len(data)),
+		}
+		us, appErr := th.App.CreateUploadSession(th.Context, us)
+		require.Nil(t, appErr)
+		require.NotEmpty(t, us)
+
+		info, appErr := th.App.UploadData(th.Context, us, bytes.NewReader(data))
+		require.Nil(t, appErr)
+		require.NotNil(t, info)
+
+		fileReader, appErr := th.App.FileReader(info.Path)
+		require.Nil(t, appErr)
+		var resultBuf bytes.Buffer
+		_, err := io.Copy(&resultBuf, fileReader)
+		require.NoError(t, err)
+		require.Equal(t, string(data), resultBuf.String())
+
+		// The plugin left the upload untouched, so the only write must be the
+		// upload itself: no ".tmp" replacement file should ever be written.
+		// Writing an empty replacement file breaks S3-compatible backends
+		// that reject empty uploads of unknown size (MM issue #37323).
+		require.Equal(t, []string{us.Path}, spy.WrittenPaths())
 	})
 }
 

--- a/server/channels/app/upload.go
+++ b/server/channels/app/upload.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"bytes"
 	"errors"
 	"io"
 	"mime"
@@ -93,8 +94,26 @@ func (a *App) runPluginsHook(rctx request.CTX, info *model.FileInfo, file io.Rea
 		return nil
 	}
 
+	// A plugin that doesn't write to the output leaves the file unchanged
+// (see FileWillBeUploaded contract). Probe for one byte to distinguish
+// "nothing written" from real content before creating the .tmp replacement,
+// since some S3-compatible backends reject empty, unknown-size writes.
+	probe := make([]byte, 1)
+	n, probeErr := io.ReadFull(r, probe)
+	if probeErr == io.EOF {
+		// No plugin wrote replacement contents, so the uploaded file is kept
+		// as is. The upload may still have been rejected.
+		if err := <-errChan; err != nil {
+			if fileErr := a.RemoveFile(info.Path); fileErr != nil {
+				rctx.Logger().Warn("Failed to remove file", mlog.Err(fileErr))
+			}
+			return err
+		}
+		return nil
+	}
+
 	tmpPath := filePath + ".tmp"
-	written, err := a.WriteFile(r, tmpPath)
+	written, err := a.WriteFile(io.MultiReader(bytes.NewReader(probe[:n]), r), tmpPath)
 	if err != nil {
 		if fileErr := a.RemoveFile(tmpPath); fileErr != nil {
 			rctx.Logger().Warn("Failed to remove file", mlog.Err(fileErr))
@@ -113,16 +132,10 @@ func (a *App) runPluginsHook(rctx request.CTX, info *model.FileInfo, file io.Rea
 		return err
 	}
 
-	if written > 0 {
-		info.Size = written
-		if fileErr := a.MoveFile(tmpPath, info.Path); fileErr != nil {
-			return model.NewAppError("runPluginsHook", "app.upload.run_plugins_hook.move_fail",
-				nil, "", http.StatusInternalServerError).Wrap(fileErr)
-		}
-	} else {
-		if fileErr := a.RemoveFile(tmpPath); fileErr != nil {
-			rctx.Logger().Warn("Failed to remove file", mlog.Err(fileErr))
-		}
+	info.Size = written
+	if fileErr := a.MoveFile(tmpPath, info.Path); fileErr != nil {
+		return model.NewAppError("runPluginsHook", "app.upload.run_plugins_hook.move_fail",
+			nil, "", http.StatusInternalServerError).Wrap(fileErr)
 	}
 
 	return nil

--- a/server/channels/app/upload.go
+++ b/server/channels/app/upload.go
@@ -95,9 +95,9 @@ func (a *App) runPluginsHook(rctx request.CTX, info *model.FileInfo, file io.Rea
 	}
 
 	// A plugin that doesn't write to the output leaves the file unchanged
-// (see FileWillBeUploaded contract). Probe for one byte to distinguish
-// "nothing written" from real content before creating the .tmp replacement,
-// since some S3-compatible backends reject empty, unknown-size writes.
+	// (see FileWillBeUploaded contract). Probe for one byte to distinguish
+	// "nothing written" from real content before creating the .tmp replacement,
+	// since some S3-compatible backends reject empty, unknown-size writes.
 	probe := make([]byte, 1)
 	n, probeErr := io.ReadFull(r, probe)
 	if probeErr == io.EOF {
@@ -134,6 +134,9 @@ func (a *App) runPluginsHook(rctx request.CTX, info *model.FileInfo, file io.Rea
 
 	info.Size = written
 	if fileErr := a.MoveFile(tmpPath, info.Path); fileErr != nil {
+		if removeErr := a.RemoveFile(tmpPath); removeErr != nil {
+			rctx.Logger().Warn("Failed to remove file", mlog.Err(removeErr))
+		}
 		return model.NewAppError("runPluginsHook", "app.upload.run_plugins_hook.move_fail",
 			nil, "", http.StatusInternalServerError).Wrap(fileErr)
 	}


### PR DESCRIPTION
#### Summary
When a `FileWillBeUploaded` plugin (e.g. the antivirus plugin) only scans an upload and never writes to the output, `runPluginsHook` still wrote a zero-byte `.tmp` replacement file of unknown size. Some S3-compatible backends (e.g. Yandex Object Storage) reject such writes with HTTP 400, failing the entire upload.

This PR probes the plugin output pipe for the first byte before creating the temporary file. On immediate EOF — meaning no plugin replaced the file contents — the uploaded file is kept as is and no `.tmp` object is written, while plugin rejections are still honored. If content is received, the probed byte is stitched back with `io.MultiReader` and the existing replace flow runs unchanged. This matches the behavior of the in-memory hook path in `DoUploadFileExpectModification`, which already skips replacement when the plugin writes no bytes.

Also adds a regression test covering the upload-session path (`UploadData` → `runPluginsHook`) with a scan-only plugin, asserting via a spy file backend that the only `WriteFile` call is the upload itself. The test fails on the previous code (it records the extra `.tmp` write) and passes with the fix.

QA steps:
1. Configure S3-compatible file storage that rejects empty uploads of unknown size (or observe filestore writes).
2. Install a scan-only `FileWillBeUploaded` plugin (e.g. mattermost-plugin-antivirus).
3. Upload a clean file — the upload succeeds and no `<path>.tmp` object is written.
4. Upload a file the plugin rejects — the upload fails with the plugin's rejection reason and no orphaned files remain.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/37323

#### Release Note
```release-note
Fixed an error ("Unable to write file") when uploading files to S3-compatible storage with a scan-only FileWillBeUploaded plugin (such as the antivirus plugin) installed.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** This changes upload handling in a core file-transfer path and affects plugin-driven replacement behavior, so regressions could surface in uploads that rely on `FileWillBeUploaded` hooks. The scope is fairly contained to upload sessions and temp-file handling, and the added regression test lowers risk, but the probe-and-stream logic still touches a sensitive persistence flow.

**QA Recommendation:** Moderate manual QA is recommended for plugin-scanned uploads on both standard and S3-compatible storage backends, including scan-only and replacement-write cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->