### PR TITLE
Change resizable LHS/RHS to only drag with left mouse button

### DIFF
--- a/webapp/channels/src/components/resizable_sidebar/resizable_divider.test.tsx
+++ b/webapp/channels/src/components/resizable_sidebar/resizable_divider.test.tsx
@@ -1,0 +1,62 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {fireEvent} from '@testing-library/react';
+import React, {useRef} from 'react';
+
+import {renderWithContext} from 'tests/react_testing_utils';
+
+import {CssVarKeyForResizable, ResizeDirection} from './constants';
+import ResizableDivider from './resizable_divider';
+
+describe('components/resizable_sidebar/ResizableDivider', () => {
+    const dividerId = 'resizable-divider';
+
+    function TestWrapper(props: {onResizeStart: jest.Mock}) {
+        const containerRef = useRef<HTMLDivElement>(null);
+
+        return (
+            <div ref={containerRef}>
+                <ResizableDivider
+                    id={dividerId}
+                    name='test'
+                    defaultWidth={240}
+                    globalCssVar={CssVarKeyForResizable.LHS}
+                    dir={ResizeDirection.LEFT}
+                    containerRef={containerRef}
+                    onResizeStart={props.onResizeStart}
+                />
+            </div>
+        );
+    }
+
+    test('should start resizing when using the left mouse button', () => {
+        const onResizeStart = jest.fn();
+        const {container} = renderWithContext(<TestWrapper onResizeStart={onResizeStart}/>);
+
+        const divider = container.querySelector(`#${dividerId}`)!;
+        fireEvent.mouseDown(divider, {button: 0});
+
+        expect(onResizeStart).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not start resizing when using the middle mouse button', () => {
+        const onResizeStart = jest.fn();
+        const {container} = renderWithContext(<TestWrapper onResizeStart={onResizeStart}/>);
+
+        const divider = container.querySelector(`#${dividerId}`)!;
+        fireEvent.mouseDown(divider, {button: 1});
+
+        expect(onResizeStart).not.toHaveBeenCalled();
+    });
+
+    test('should not start resizing when using the right mouse button', () => {
+        const onResizeStart = jest.fn();
+        const {container} = renderWithContext(<TestWrapper onResizeStart={onResizeStart}/>);
+
+        const divider = container.querySelector(`#${dividerId}`)!;
+        fireEvent.mouseDown(divider, {button: 2});
+
+        expect(onResizeStart).not.toHaveBeenCalled();
+    });
+});

--- a/webapp/channels/src/components/resizable_sidebar/resizable_divider.tsx
+++ b/webapp/channels/src/components/resizable_sidebar/resizable_divider.tsx
@@ -128,6 +128,12 @@ function ResizableDivider({
         if (disabled || !containerRef.current) {
             return;
         }
+
+        // Only resize with the left mouse button
+        if (e.button !== 0) {
+            return;
+        }
+
         previousClientX.current = e.clientX;
 
         const currentWidth = containerRef.current.getBoundingClientRect().width;


### PR DESCRIPTION
#### Summary
Based on some feedback from community

#### Release Note
```release-note
Changed LHS/RHS to only be resizable with the left mouse button
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** The change is isolated to the resizable sidebar divider and only narrows drag initiation to left-click events. The affected behavior is user-facing but localized, with targeted test coverage added for left, middle, and right mouse buttons.

**QA Recommendation:** Light manual QA is sufficient: verify LHS/RHS panel resizing still works with the left mouse button and does not start with middle/right clicks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->