### PR TITLE
MM-69585: remove AttributeBasedAccessControl feature flag

### DIFF
--- a/e2e-tests/playwright/lib/src/server/default_config.ts
+++ b/e2e-tests/playwright/lib/src/server/default_config.ts
@@ -805,7 +805,6 @@ const defaultServerConfig: AdminConfig = {
         NotificationMonitoring: true,
         ExperimentalAuditSettingsSystemConsoleUI: true,
         CustomProfileAttributes: true,
-        AttributeBasedAccessControl: true,
         AttributeValueMasking: false,
         PermissionPolicies: false,
         ChannelPermissionPolicies: false,

--- a/server/channels/api4/access_control.go
+++ b/server/channels/api4/access_control.go
@@ -18,14 +18,10 @@ import (
 // Masking is attribute-based, not permission-based: system admins who do not hold all values
 // in a policy must also receive redacted raw expressions.
 func shouldRedactExpressions(c *Context) bool {
-	return c.App.Config().FeatureFlags.AttributeBasedAccessControl &&
-		c.App.Config().FeatureFlags.AttributeValueMasking
+	return c.App.Config().FeatureFlags.AttributeValueMasking
 }
 
 func (api *API) InitAccessControlPolicy() {
-	if !api.srv.Config().FeatureFlags.AttributeBasedAccessControl {
-		return
-	}
 	api.BaseRoutes.AccessControlPolicies.Handle("", api.APISessionRequired(createAccessControlPolicy)).Methods(http.MethodPut)
 	api.BaseRoutes.AccessControlPolicies.Handle("/search", api.APISessionRequired(searchAccessControlPolicies)).Methods(http.MethodPost)
 	api.BaseRoutes.AccessControlPolicies.Handle("/activate", api.APISessionRequired(setActiveStatus)).Methods(http.MethodPut)

--- a/server/channels/api4/access_control_local.go
+++ b/server/channels/api4/access_control_local.go
@@ -6,9 +6,6 @@ package api4
 import "net/http"
 
 func (api *API) InitAccessControlPolicyLocal() {
-	if !api.srv.Config().FeatureFlags.AttributeBasedAccessControl {
-		return
-	}
 	api.BaseRoutes.AccessControlPolicies.Handle("", api.APILocal(createAccessControlPolicy)).Methods(http.MethodPut)
 	api.BaseRoutes.AccessControlPolicies.Handle("/search", api.APILocal(searchAccessControlPolicies)).Methods(http.MethodPost)
 	api.BaseRoutes.AccessControlPolicies.Handle("/activate", api.APILocal(setActiveStatus)).Methods(http.MethodPut)

--- a/server/channels/api4/access_control_test.go
+++ b/server/channels/api4/access_control_test.go
@@ -7,7 +7,6 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
-	"os"
 	"testing"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -992,11 +991,7 @@ func TestSearchAccessControlPolicies(t *testing.T) {
 }
 
 func TestSearchTeamAccessControlPolicies(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
 
 	teamSearch := model.AccessControlPolicySearch{TeamID: th.BasicTeam.Id}
 
@@ -1796,11 +1791,7 @@ func TestResponseMaskingOnPolicyEndpoints(t *testing.T) {
 }
 
 func TestCreateAccessControlPolicyTeamAdmin(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
 
 	t.Run("team admin with permission can create parent policy scoped to their team", func(t *testing.T) {
 		mockACS := setupTeamAdminABAC(t, th)
@@ -2019,11 +2010,7 @@ func TestCreateAccessControlPolicyTeamAdmin(t *testing.T) {
 }
 
 func TestGetAccessControlPolicyTeamAdmin(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
 
 	t.Run("team admin can GET a policy scoped to their team", func(t *testing.T) {
 		mockACS := setupTeamAdminABAC(t, th)
@@ -2122,11 +2109,7 @@ func TestGetAccessControlPolicyTeamAdmin(t *testing.T) {
 }
 
 func TestDeleteAccessControlPolicyTeamAdmin(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
 
 	t.Run("team admin can delete their own team-scoped policy", func(t *testing.T) {
 		mockACS := setupTeamAdminABAC(t, th)
@@ -2209,11 +2192,7 @@ func TestDeleteAccessControlPolicyTeamAdmin(t *testing.T) {
 }
 
 func TestAssignAccessPolicyTeamAdmin(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
 
 	t.Run("team admin can assign channels from their own team", func(t *testing.T) {
 		mockACS := setupTeamAdminABAC(t, th)
@@ -2347,11 +2326,7 @@ func TestAssignAccessPolicyTeamAdmin(t *testing.T) {
 }
 
 func TestUnassignAccessPolicyTeamAdmin(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
 
 	t.Run("team admin can unassign channels from their policy", func(t *testing.T) {
 		mockACS := setupTeamAdminABAC(t, th)
@@ -2541,11 +2516,7 @@ func TestUnassignAccessPolicyTeamAdmin(t *testing.T) {
 }
 
 func TestScopeReconciliationCrossTeam(t *testing.T) {
-	os.Setenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL", "true")
 	th := Setup(t).InitBasic(t)
-	t.Cleanup(func() {
-		os.Unsetenv("MM_FEATUREFLAGS_ATTRIBUTEBASEDACCESSCONTROL")
-	})
 
 	// System admin creates a parent policy with channels only from teamA.
 	// After assigning a channel from teamB, scope must be cleared.

--- a/server/channels/api4/team_abac_api_test.go
+++ b/server/channels/api4/team_abac_api_test.go
@@ -17,10 +17,13 @@ import (
 )
 
 // enableTeamABAC turns on the license + config the team ABAC paths require and
-// injects a mock PDP, returning it for per-test stubbing.
+// injects a mock PDP, returning it for per-test stubbing. Feature flags are
+// read-only by default in tests, so unlock them first — otherwise the
+// TeamMembershipAccessControl toggle below is silently dropped.
 func enableTeamABAC(t *testing.T, th *TestHelper) *mocks.AccessControlServiceInterface {
 	t.Helper()
 	require.True(t, th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced)))
+	th.ConfigStore.SetReadOnlyFF(false)
 	th.App.UpdateConfig(func(cfg *model.Config) {
 		*cfg.AccessControlSettings.EnableAttributeBasedAccessControl = true
 		cfg.FeatureFlags.TeamMembershipAccessControl = true
@@ -83,7 +86,7 @@ func doUnassign(t *testing.T, client *model.Client4, policyID string, body assig
 }
 
 func TestAssignAccessPolicyTeamIds(t *testing.T) {
-	th := SetupConfig(t, func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true }).InitBasic(t)
+	th := Setup(t).InitBasic(t)
 
 	parent := &model.AccessControlPolicy{
 		ID:       model.NewId(),
@@ -143,7 +146,7 @@ func TestAssignAccessPolicyTeamIds(t *testing.T) {
 }
 
 func TestUnassignAccessPolicyTeamIds(t *testing.T) {
-	th := SetupConfig(t, func(cfg *model.Config) { cfg.FeatureFlags.AttributeBasedAccessControl = true }).InitBasic(t)
+	th := Setup(t).InitBasic(t)
 
 	policyID := model.NewId()
 
@@ -177,7 +180,6 @@ func TestUnassignAccessPolicyTeamIds(t *testing.T) {
 
 func TestGetTeamAccessControlPolicy(t *testing.T) {
 	th := SetupConfig(t, func(cfg *model.Config) {
-		cfg.FeatureFlags.AttributeBasedAccessControl = true
 		cfg.FeatureFlags.TeamMembershipAccessControl = true
 	}).InitBasic(t)
 
@@ -275,7 +277,6 @@ func TestGetTeamAccessControlPolicy(t *testing.T) {
 
 func TestGetUsersNotInTeamAbacMatchOnly(t *testing.T) {
 	th := SetupConfig(t, func(cfg *model.Config) {
-		cfg.FeatureFlags.AttributeBasedAccessControl = true
 		cfg.FeatureFlags.TeamMembershipAccessControl = true
 	}).InitBasic(t)
 
@@ -328,7 +329,6 @@ func userIDs(users []*model.User) []string {
 // batch; qualifying users in the same batch are still added.
 func TestAddTeamMembersGracefulABACError(t *testing.T) {
 	th := SetupConfig(t, func(cfg *model.Config) {
-		cfg.FeatureFlags.AttributeBasedAccessControl = true
 		cfg.FeatureFlags.TeamMembershipAccessControl = true
 	}).InitBasic(t)
 

--- a/server/channels/api4/team_test.go
+++ b/server/channels/api4/team_test.go
@@ -5065,7 +5065,6 @@ func TestGetTeamMembersForUserRoleDataSanitization(t *testing.T) {
 
 func TestGetAllTeamsDirectoryHiding(t *testing.T) {
 	th := SetupConfig(t, func(cfg *model.Config) {
-		cfg.FeatureFlags.AttributeBasedAccessControl = true
 		cfg.FeatureFlags.TeamMembershipAccessControl = true
 	}).InitBasic(t)
 

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -48,14 +48,10 @@ type FeatureFlags struct {
 
 	CustomProfileAttributes bool
 
-	AttributeBasedAccessControl bool
-
 	// Mask non-held attribute values in the policy editor for delegated admins.
-	// Requires AttributeBasedAccessControl.
 	AttributeValueMasking bool
 
 	// Enable permission policies (file upload/download ABAC policies).
-	// Requires AttributeBasedAccessControl to also be enabled.
 	//
 	// This is the umbrella flag: when off, both ChannelPermissionPolicies
 	// and PolicySimulation are also off regardless of their individual
@@ -138,7 +134,6 @@ type FeatureFlags struct {
 	// rank, and the admin console hides the rank type option.
 	PropertyFieldRank bool
 
-	// Requires AttributeBasedAccessControl to also be enabled.
 	TeamMembershipAccessControl bool
 
 	// Enable the new mm_blocks Interactive Messages framework
@@ -162,7 +157,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.NotificationMonitoring = true
 	f.ExperimentalAuditSettingsSystemConsoleUI = true
 	f.CustomProfileAttributes = true
-	f.AttributeBasedAccessControl = true
 	f.AttributeValueMasking = true
 	f.PermissionPolicies = true
 	f.TeamMembershipAccessControl = false

--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -685,7 +685,6 @@ const AdminDefinition: AdminDefinitionType = {
                 isHidden: it.any(
                     it.not(it.minLicenseTier(LicenseSkus.EnterpriseAdvanced)),
                     it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
-                    it.configIsFalse('FeatureFlags', 'AttributeBasedAccessControl'),
                 ),
                 isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
                 schema: {
@@ -721,10 +720,7 @@ const AdminDefinition: AdminDefinitionType = {
                 url: 'system_attributes/attribute_based_access_control',
                 isDiscovery: true,
                 title: defineMessage({id: 'admin.sidebar.attributeBasedAccessControl', defaultMessage: 'Attribute-Based Access'}),
-                isHidden: it.any(
-                    it.minLicenseTier(LicenseSkus.EnterpriseAdvanced),
-                    it.configIsFalse('FeatureFlags', 'AttributeBasedAccessControl'),
-                ),
+                isHidden: it.minLicenseTier(LicenseSkus.EnterpriseAdvanced),
                 schema: {
                     id: 'AttributeBasedAccessControl',
                     name: defineMessage({id: 'admin.accesscontrol.title', defaultMessage: 'Attribute-Based Access'}),
@@ -779,12 +775,8 @@ const AdminDefinition: AdminDefinitionType = {
                     it.configIsFalse('AccessControlSettings', 'EnableAttributeBasedAccessControl'),
                     it.not(it.minLicenseTier(LicenseSkus.EnterpriseAdvanced)),
                     it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
-                    it.configIsFalse('FeatureFlags', 'AttributeBasedAccessControl'),
                 ),
-                isDisabled: it.any(
-                    it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
-                    it.configIsFalse('FeatureFlags', 'AttributeBasedAccessControl'),
-                ),
+                isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
                 schema: {
                     id: 'AccessControlPolicy',
                     component: PolicyDetails,
@@ -796,7 +788,6 @@ const AdminDefinition: AdminDefinitionType = {
                     it.configIsFalse('AccessControlSettings', 'EnableAttributeBasedAccessControl'),
                     it.not(it.minLicenseTier(LicenseSkus.EnterpriseAdvanced)),
                     it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
-                    it.configIsFalse('FeatureFlags', 'AttributeBasedAccessControl'),
                 ),
                 isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
                 schema: {
@@ -810,7 +801,6 @@ const AdminDefinition: AdminDefinitionType = {
                 isHidden: it.any(
                     it.not(it.minLicenseTier(LicenseSkus.EnterpriseAdvanced)),
                     it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
-                    it.configIsFalse('FeatureFlags', 'AttributeBasedAccessControl'),
                     it.configIsFalse('AccessControlSettings', 'EnableAttributeBasedAccessControl'),
                 ),
                 isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
@@ -848,12 +838,10 @@ const AdminDefinition: AdminDefinitionType = {
                     it.configIsFalse('AccessControlSettings', 'EnableAttributeBasedAccessControl'),
                     it.not(it.minLicenseTier(LicenseSkus.EnterpriseAdvanced)),
                     it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
-                    it.configIsFalse('FeatureFlags', 'AttributeBasedAccessControl'),
                     it.configIsFalse('FeatureFlags', 'PermissionPolicies'),
                 ),
                 isDisabled: it.any(
                     it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
-                    it.configIsFalse('FeatureFlags', 'AttributeBasedAccessControl'),
                     it.configIsFalse('FeatureFlags', 'PermissionPolicies'),
                 ),
                 schema: {
@@ -867,7 +855,6 @@ const AdminDefinition: AdminDefinitionType = {
                     it.configIsFalse('AccessControlSettings', 'EnableAttributeBasedAccessControl'),
                     it.not(it.minLicenseTier(LicenseSkus.EnterpriseAdvanced)),
                     it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
-                    it.configIsFalse('FeatureFlags', 'AttributeBasedAccessControl'),
                     it.configIsFalse('FeatureFlags', 'PermissionPolicies'),
                 ),
                 isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
@@ -882,7 +869,6 @@ const AdminDefinition: AdminDefinitionType = {
                 isHidden: it.any(
                     it.not(it.minLicenseTier(LicenseSkus.EnterpriseAdvanced)),
                     it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.USER_MANAGEMENT.SYSTEM_ROLES)),
-                    it.configIsFalse('FeatureFlags', 'AttributeBasedAccessControl'),
                     it.configIsFalse('FeatureFlags', 'PermissionPolicies'),
                     it.configIsFalse('AccessControlSettings', 'EnableAttributeBasedAccessControl'),
                 ),

--- a/webapp/channels/src/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.tsx.snap
@@ -800,6 +800,76 @@ exports[`components/AdminSidebar should match snapshot 1`] = `
                       </li>
                       <li
                         class="sidebar-category"
+                        data-testid="system_attributes"
+                      >
+                        <div
+                          class="category-title category-title--active"
+                          data-testid="sidebar-category-title"
+                        >
+                          <span
+                            class="category-icon"
+                          >
+                            <svg
+                              fill="currentColor"
+                              height="16"
+                              version="1.1"
+                              viewBox="0 0 24 24"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M4,3h16c1.105,0,2,0.848,2,1.895v14.211C22,20.152,21.105,21,20,21H4c-1.105,0-2-0.848-2-1.895V4.895C2,3.848,2.895,3,4,3 M4,6v3h4V6H4 M10,6v3h10V6H10 M4,11v3h4v-3H4 M4,19h4v-3H4V19 M10,11v3h10v-3H10 M10,19h10v-3H10V19"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="category-title__text"
+                          >
+                            System Attributes
+                          </span>
+                        </div>
+                        <ul
+                          class="sections"
+                          data-testid="sidebar-category-sections"
+                        >
+                          <li
+                            class="sidebar-section"
+                            data-testid="system_attributes.attribute_based_access_control_feature_discovery"
+                          >
+                            <a
+                              class="sidebar-section-title"
+                              href="/admin_console/system_attributes/attribute_based_access_control"
+                              id="system_attributes/attribute_based_access_control"
+                            >
+                              <span
+                                class="sidebar-section-title__text"
+                              >
+                                Attribute-Based Access
+                              </span>
+                              <span
+                                class="sidebar-section-indicator"
+                              >
+                                <span
+                                  class="RestrictedIndicator__icon-tooltip-container"
+                                >
+                                  <div
+                                    class="RestrictedIndicator__content"
+                                  >
+                                    <i
+                                      class="RestrictedIndicator__icon-tooltip icon icon-key-variant"
+                                    />
+                                  </div>
+                                </span>
+                              </span>
+                            </a>
+                            <ul
+                              class="nav nav__sub-menu subsections"
+                            />
+                          </li>
+                        </ul>
+                      </li>
+                      <li
+                        class="sidebar-category"
                         data-testid="environment"
                       >
                         <div
@@ -6235,6 +6305,76 @@ exports[`components/AdminSidebar should match snapshot with license with profess
                       </li>
                       <li
                         class="sidebar-category"
+                        data-testid="system_attributes"
+                      >
+                        <div
+                          class="category-title category-title--active"
+                          data-testid="sidebar-category-title"
+                        >
+                          <span
+                            class="category-icon"
+                          >
+                            <svg
+                              fill="currentColor"
+                              height="16"
+                              version="1.1"
+                              viewBox="0 0 24 24"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M4,3h16c1.105,0,2,0.848,2,1.895v14.211C22,20.152,21.105,21,20,21H4c-1.105,0-2-0.848-2-1.895V4.895C2,3.848,2.895,3,4,3 M4,6v3h4V6H4 M10,6v3h10V6H10 M4,11v3h4v-3H4 M4,19h4v-3H4V19 M10,11v3h10v-3H10 M10,19h10v-3H10V19"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="category-title__text"
+                          >
+                            System Attributes
+                          </span>
+                        </div>
+                        <ul
+                          class="sections"
+                          data-testid="sidebar-category-sections"
+                        >
+                          <li
+                            class="sidebar-section"
+                            data-testid="system_attributes.attribute_based_access_control_feature_discovery"
+                          >
+                            <a
+                              class="sidebar-section-title"
+                              href="/admin_console/system_attributes/attribute_based_access_control"
+                              id="system_attributes/attribute_based_access_control"
+                            >
+                              <span
+                                class="sidebar-section-title__text"
+                              >
+                                Attribute-Based Access
+                              </span>
+                              <span
+                                class="sidebar-section-indicator"
+                              >
+                                <span
+                                  class="RestrictedIndicator__icon-tooltip-container"
+                                >
+                                  <div
+                                    class="RestrictedIndicator__content"
+                                  >
+                                    <i
+                                      class="RestrictedIndicator__icon-tooltip icon icon-key-variant"
+                                    />
+                                  </div>
+                                </span>
+                              </span>
+                            </a>
+                            <ul
+                              class="nav nav__sub-menu subsections"
+                            />
+                          </li>
+                        </ul>
+                      </li>
+                      <li
+                        class="sidebar-category"
                         data-testid="environment"
                       >
                         <div
@@ -7919,6 +8059,76 @@ exports[`components/AdminSidebar should match snapshot with workspace optimizati
                                 class="sidebar-section-title__text"
                               >
                                 Delegated Granular Administration
+                              </span>
+                              <span
+                                class="sidebar-section-indicator"
+                              >
+                                <span
+                                  class="RestrictedIndicator__icon-tooltip-container"
+                                >
+                                  <div
+                                    class="RestrictedIndicator__content"
+                                  >
+                                    <i
+                                      class="RestrictedIndicator__icon-tooltip icon icon-key-variant"
+                                    />
+                                  </div>
+                                </span>
+                              </span>
+                            </a>
+                            <ul
+                              class="nav nav__sub-menu subsections"
+                            />
+                          </li>
+                        </ul>
+                      </li>
+                      <li
+                        class="sidebar-category"
+                        data-testid="system_attributes"
+                      >
+                        <div
+                          class="category-title category-title--active"
+                          data-testid="sidebar-category-title"
+                        >
+                          <span
+                            class="category-icon"
+                          >
+                            <svg
+                              fill="currentColor"
+                              height="16"
+                              version="1.1"
+                              viewBox="0 0 24 24"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M4,3h16c1.105,0,2,0.848,2,1.895v14.211C22,20.152,21.105,21,20,21H4c-1.105,0-2-0.848-2-1.895V4.895C2,3.848,2.895,3,4,3 M4,6v3h4V6H4 M10,6v3h10V6H10 M4,11v3h4v-3H4 M4,19h4v-3H4V19 M10,11v3h10v-3H10 M10,19h10v-3H10V19"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="category-title__text"
+                          >
+                            System Attributes
+                          </span>
+                        </div>
+                        <ul
+                          class="sections"
+                          data-testid="sidebar-category-sections"
+                        >
+                          <li
+                            class="sidebar-section"
+                            data-testid="system_attributes.attribute_based_access_control_feature_discovery"
+                          >
+                            <a
+                              class="sidebar-section-title"
+                              href="/admin_console/system_attributes/attribute_based_access_control"
+                              id="system_attributes/attribute_based_access_control"
+                            >
+                              <span
+                                class="sidebar-section-title__text"
+                              >
+                                Attribute-Based Access
                               </span>
                               <span
                                 class="sidebar-section-indicator"
@@ -9743,6 +9953,76 @@ exports[`components/AdminSidebar should match snapshot, not prevent the console 
                       </li>
                       <li
                         class="sidebar-category"
+                        data-testid="system_attributes"
+                      >
+                        <div
+                          class="category-title category-title--active"
+                          data-testid="sidebar-category-title"
+                        >
+                          <span
+                            class="category-icon"
+                          >
+                            <svg
+                              fill="currentColor"
+                              height="16"
+                              version="1.1"
+                              viewBox="0 0 24 24"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M4,3h16c1.105,0,2,0.848,2,1.895v14.211C22,20.152,21.105,21,20,21H4c-1.105,0-2-0.848-2-1.895V4.895C2,3.848,2.895,3,4,3 M4,6v3h4V6H4 M10,6v3h10V6H10 M4,11v3h4v-3H4 M4,19h4v-3H4V19 M10,11v3h10v-3H10 M10,19h10v-3H10V19"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="category-title__text"
+                          >
+                            System Attributes
+                          </span>
+                        </div>
+                        <ul
+                          class="sections"
+                          data-testid="sidebar-category-sections"
+                        >
+                          <li
+                            class="sidebar-section"
+                            data-testid="system_attributes.attribute_based_access_control_feature_discovery"
+                          >
+                            <a
+                              class="sidebar-section-title"
+                              href="/admin_console/system_attributes/attribute_based_access_control"
+                              id="system_attributes/attribute_based_access_control"
+                            >
+                              <span
+                                class="sidebar-section-title__text"
+                              >
+                                Attribute-Based Access
+                              </span>
+                              <span
+                                class="sidebar-section-indicator"
+                              >
+                                <span
+                                  class="RestrictedIndicator__icon-tooltip-container"
+                                >
+                                  <div
+                                    class="RestrictedIndicator__content"
+                                  >
+                                    <i
+                                      class="RestrictedIndicator__icon-tooltip icon icon-key-variant"
+                                    />
+                                  </div>
+                                </span>
+                              </span>
+                            </a>
+                            <ul
+                              class="nav nav__sub-menu subsections"
+                            />
+                          </li>
+                        </ul>
+                      </li>
+                      <li
+                        class="sidebar-category"
                         data-testid="environment"
                       >
                         <div
@@ -11433,6 +11713,76 @@ exports[`components/AdminSidebar should match snapshot, render plugins without a
                       </li>
                       <li
                         class="sidebar-category"
+                        data-testid="system_attributes"
+                      >
+                        <div
+                          class="category-title category-title--active"
+                          data-testid="sidebar-category-title"
+                        >
+                          <span
+                            class="category-icon"
+                          >
+                            <svg
+                              fill="currentColor"
+                              height="16"
+                              version="1.1"
+                              viewBox="0 0 24 24"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M4,3h16c1.105,0,2,0.848,2,1.895v14.211C22,20.152,21.105,21,20,21H4c-1.105,0-2-0.848-2-1.895V4.895C2,3.848,2.895,3,4,3 M4,6v3h4V6H4 M10,6v3h10V6H10 M4,11v3h4v-3H4 M4,19h4v-3H4V19 M10,11v3h10v-3H10 M10,19h10v-3H10V19"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="category-title__text"
+                          >
+                            System Attributes
+                          </span>
+                        </div>
+                        <ul
+                          class="sections"
+                          data-testid="sidebar-category-sections"
+                        >
+                          <li
+                            class="sidebar-section"
+                            data-testid="system_attributes.attribute_based_access_control_feature_discovery"
+                          >
+                            <a
+                              class="sidebar-section-title"
+                              href="/admin_console/system_attributes/attribute_based_access_control"
+                              id="system_attributes/attribute_based_access_control"
+                            >
+                              <span
+                                class="sidebar-section-title__text"
+                              >
+                                Attribute-Based Access
+                              </span>
+                              <span
+                                class="sidebar-section-indicator"
+                              >
+                                <span
+                                  class="RestrictedIndicator__icon-tooltip-container"
+                                >
+                                  <div
+                                    class="RestrictedIndicator__content"
+                                  >
+                                    <i
+                                      class="RestrictedIndicator__icon-tooltip icon icon-key-variant"
+                                    />
+                                  </div>
+                                </span>
+                              </span>
+                            </a>
+                            <ul
+                              class="nav nav__sub-menu subsections"
+                            />
+                          </li>
+                        </ul>
+                      </li>
+                      <li
+                        class="sidebar-category"
                         data-testid="environment"
                       >
                         <div
@@ -13093,6 +13443,76 @@ exports[`components/AdminSidebar should match snapshot, with license (with all f
                       </li>
                       <li
                         class="sidebar-category"
+                        data-testid="system_attributes"
+                      >
+                        <div
+                          class="category-title category-title--active"
+                          data-testid="sidebar-category-title"
+                        >
+                          <span
+                            class="category-icon"
+                          >
+                            <svg
+                              fill="currentColor"
+                              height="16"
+                              version="1.1"
+                              viewBox="0 0 24 24"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M4,3h16c1.105,0,2,0.848,2,1.895v14.211C22,20.152,21.105,21,20,21H4c-1.105,0-2-0.848-2-1.895V4.895C2,3.848,2.895,3,4,3 M4,6v3h4V6H4 M10,6v3h10V6H10 M4,11v3h4v-3H4 M4,19h4v-3H4V19 M10,11v3h10v-3H10 M10,19h10v-3H10V19"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="category-title__text"
+                          >
+                            System Attributes
+                          </span>
+                        </div>
+                        <ul
+                          class="sections"
+                          data-testid="sidebar-category-sections"
+                        >
+                          <li
+                            class="sidebar-section"
+                            data-testid="system_attributes.attribute_based_access_control_feature_discovery"
+                          >
+                            <a
+                              class="sidebar-section-title"
+                              href="/admin_console/system_attributes/attribute_based_access_control"
+                              id="system_attributes/attribute_based_access_control"
+                            >
+                              <span
+                                class="sidebar-section-title__text"
+                              >
+                                Attribute-Based Access
+                              </span>
+                              <span
+                                class="sidebar-section-indicator"
+                              >
+                                <span
+                                  class="RestrictedIndicator__icon-tooltip-container"
+                                >
+                                  <div
+                                    class="RestrictedIndicator__content"
+                                  >
+                                    <i
+                                      class="RestrictedIndicator__icon-tooltip icon icon-key-variant"
+                                    />
+                                  </div>
+                                </span>
+                              </span>
+                            </a>
+                            <ul
+                              class="nav nav__sub-menu subsections"
+                            />
+                          </li>
+                        </ul>
+                      </li>
+                      <li
+                        class="sidebar-category"
                         data-testid="environment"
                       >
                         <div
@@ -14699,6 +15119,76 @@ exports[`components/AdminSidebar should match snapshot, with license (without an
                                 class="sidebar-section-title__text"
                               >
                                 Delegated Granular Administration
+                              </span>
+                              <span
+                                class="sidebar-section-indicator"
+                              >
+                                <span
+                                  class="RestrictedIndicator__icon-tooltip-container"
+                                >
+                                  <div
+                                    class="RestrictedIndicator__content"
+                                  >
+                                    <i
+                                      class="RestrictedIndicator__icon-tooltip icon icon-key-variant"
+                                    />
+                                  </div>
+                                </span>
+                              </span>
+                            </a>
+                            <ul
+                              class="nav nav__sub-menu subsections"
+                            />
+                          </li>
+                        </ul>
+                      </li>
+                      <li
+                        class="sidebar-category"
+                        data-testid="system_attributes"
+                      >
+                        <div
+                          class="category-title category-title--active"
+                          data-testid="sidebar-category-title"
+                        >
+                          <span
+                            class="category-icon"
+                          >
+                            <svg
+                              fill="currentColor"
+                              height="16"
+                              version="1.1"
+                              viewBox="0 0 24 24"
+                              width="16"
+                              xmlns="http://www.w3.org/2000/svg"
+                            >
+                              <path
+                                d="M4,3h16c1.105,0,2,0.848,2,1.895v14.211C22,20.152,21.105,21,20,21H4c-1.105,0-2-0.848-2-1.895V4.895C2,3.848,2.895,3,4,3 M4,6v3h4V6H4 M10,6v3h10V6H10 M4,11v3h4v-3H4 M4,19h4v-3H4V19 M10,11v3h10v-3H10 M10,19h10v-3H10V19"
+                              />
+                            </svg>
+                          </span>
+                          <span
+                            class="category-title__text"
+                          >
+                            System Attributes
+                          </span>
+                        </div>
+                        <ul
+                          class="sections"
+                          data-testid="sidebar-category-sections"
+                        >
+                          <li
+                            class="sidebar-section"
+                            data-testid="system_attributes.attribute_based_access_control_feature_discovery"
+                          >
+                            <a
+                              class="sidebar-section-title"
+                              href="/admin_console/system_attributes/attribute_based_access_control"
+                              id="system_attributes/attribute_based_access_control"
+                            >
+                              <span
+                                class="sidebar-section-title__text"
+                              >
+                                Attribute-Based Access
                               </span>
                               <span
                                 class="sidebar-section-indicator"

--- a/webapp/channels/src/components/admin_console/admin_sidebar/admin_sidebar.test.tsx
+++ b/webapp/channels/src/components/admin_console/admin_sidebar/admin_sidebar.test.tsx
@@ -398,7 +398,6 @@ describe('components/AdminSidebar', () => {
                     Scope: 'scope',
                 } as Office365Settings,
                 FeatureFlags: {
-                    AttributeBasedAccessControl: true,
                     CustomProfileAttributes: true,
                     CloudDedicatedExportUI: true,
                     ExperimentalAuditSettingsSystemConsoleUI: true,
@@ -533,7 +532,6 @@ describe('components/AdminSidebar', () => {
                     Scope: 'scope',
                 } as Office365Settings,
                 FeatureFlags: {
-                    AttributeBasedAccessControl: true,
                     CustomProfileAttributes: true,
                     CloudDedicatedExportUI: true,
                     ExperimentalAuditSettingsSystemConsoleUI: true,

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/index.ts
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/index.ts
@@ -64,7 +64,7 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     // Channel Groups is only available for Enterprise and above
     const channelGroupsEnabled = isLicensed && isMinimumEnterpriseLicense(license);
 
-    const abacSupported = isLicensed && isMinimumEnterpriseAdvancedLicense(license) && config.FeatureFlagAttributeBasedAccessControl === 'true';
+    const abacSupported = isLicensed && isMinimumEnterpriseAdvancedLicense(license);
 
     const guestAccountsEnabled = config.EnableGuestAccounts === 'true';
     const channelID = ownProps.match.params.channel_id;

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/index.ts
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/details/index.ts
@@ -5,8 +5,6 @@ import {connect} from 'react-redux';
 import {bindActionCreators} from 'redux';
 import type {Dispatch} from 'redux';
 
-import type {GlobalState} from '@mattermost/types/store';
-
 import {getAccessControlPolicy, deleteAccessControlPolicy, assignChannelsToAccessControlPolicy, searchAccessControlPolicies, unassignChannelsFromAccessControlPolicy, createAccessControlPolicy, getAccessControlFields, getVisualAST, validateExpressionAgainstRequester, updateAccessControlPoliciesActive, searchUsersForExpression} from 'mattermost-redux/actions/access_control';
 import {
     addChannelMember,
@@ -39,8 +37,11 @@ import {getScheme} from 'mattermost-redux/selectors/entities/schemes';
 import {getTeam} from 'mattermost-redux/selectors/entities/teams';
 
 import {setNavigationBlocked} from 'actions/admin_actions';
+import {isChannelAccessControlEnabled} from 'selectors/general';
 
 import {isMinimumEnterpriseAdvancedLicense, isMinimumEnterpriseLicense, isMinimumProfessionalLicense} from 'utils/license_utils';
+
+import type {GlobalState} from 'types/store';
 
 import ChannelDetails from './channel_details';
 
@@ -64,7 +65,10 @@ function mapStateToProps(state: GlobalState, ownProps: OwnProps) {
     // Channel Groups is only available for Enterprise and above
     const channelGroupsEnabled = isLicensed && isMinimumEnterpriseLicense(license);
 
-    const abacSupported = isLicensed && isMinimumEnterpriseAdvancedLicense(license);
+    // ABAC must be licensed (Enterprise Advanced) and enabled via the
+    // AccessControlSettings.EnableAttributeBasedAccessControl config setting,
+    // which is now the sole switch for the feature.
+    const abacSupported = isLicensed && isMinimumEnterpriseAdvancedLicense(license) && isChannelAccessControlEnabled(state);
 
     const guestAccountsEnabled = config.EnableGuestAccounts === 'true';
     const channelID = ownProps.match.params.channel_id;

--- a/webapp/channels/src/components/admin_console/team_channel_settings/team/details/index.ts
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/team/details/index.ts
@@ -42,11 +42,10 @@ function mapStateToProps(state: GlobalState, props: OwnProps) {
     const license = getLicense(state);
     const isLicensedForLDAPGroups = license.LDAPGroups === 'true';
 
-    // Team ABAC requires Enterprise Advanced plus both the umbrella ABAC flag
-    // and the team-membership kill switch, mirroring the server enforcement gate.
+    // Team ABAC requires Enterprise Advanced plus the team-membership kill
+    // switch, mirroring the server enforcement gate.
     const abacSupported = license?.IsLicensed === 'true' &&
         isMinimumEnterpriseAdvancedLicense(license) &&
-        config.FeatureFlagAttributeBasedAccessControl === 'true' &&
         config.FeatureFlagTeamMembershipAccessControl === 'true';
 
     return {

--- a/webapp/platform/types/src/config.ts
+++ b/webapp/platform/types/src/config.ts
@@ -128,7 +128,6 @@ export type ClientConfig = {
     FeatureFlagAppsEnabled: string;
     FeatureFlagCallsEnabled: string;
     FeatureFlagCustomProfileAttributes: string;
-    FeatureFlagAttributeBasedAccessControl: string;
     FeatureFlagTeamMembershipAccessControl: string;
     FeatureFlagPermissionPolicies: string;
     FeatureFlagChannelPermissionPolicies: string;


### PR DESCRIPTION
#### Summary
Delete the `AttributeBasedAccessControl` feature flag: this is now exclusively controlled by the `AccessControlSettings.EnableAttributeBasedAccessControl` config setting.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-69585
Relates-to: https://github.com/mattermost/enterprise/pull/2223

#### Release Note
```release-note
Deleted the AttributeBasedAccessControl feature flag. Attribute-based access control is now exclusively controlled by the AccessControlSettings.EnableAttributeBasedAccessControl config setting.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: High 🔴

**Regression Risk:** The changes alter access-control gating across server APIs, config types, and UI navigation, so regressions could affect authorization-related behavior and feature visibility in multiple places. Because the feature flag is being removed and replaced with config-driven control, any mismatched assumptions between backend and frontend could cause unexpected access or hiding of ABAC functionality.

**QA Recommendation:** Perform focused manual QA on ABAC-enabled and ABAC-disabled flows, including API route availability, admin console visibility, and team/permission policy pages.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->