### PR TITLE
[MM-69699] Strip metadata from single post consume hooks

### DIFF
--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -2091,6 +2091,104 @@ drainLoop:
 	}
 }
 
+func TestUpdatePostConsumeHooksWithOpenGraphMetadata(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	ogServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html; charset=utf-8")
+		_, _ = io.WriteString(w, `<html><head><meta property="og:title" content="OG Title"><meta property="og:description" content="OG Description"></head><body>ok</body></html>`)
+	}))
+	t.Cleanup(ogServer.Close)
+
+	testCases := []struct {
+		name            string
+		hookImpl        string
+		expectedMessage string
+	}{
+		{
+			name: "MessagesWillBeConsumed",
+			hookImpl: `
+		func (p *MyPlugin) MessagesWillBeConsumed(posts []*model.Post) []*model.Post {
+			for _, post := range posts {
+				if post.Metadata != nil {
+					post.Message = "metadata_leaked:" + post.Message
+					continue
+				}
+				post.Message = "mwbc_plugin:" + post.Message
+			}
+			return posts
+		}
+`,
+			expectedMessage: "mwbc_plugin:",
+		},
+		{
+			name: "MessagesWillBeConsumedWithContext",
+			hookImpl: `
+		func (p *MyPlugin) MessagesWillBeConsumedWithContext(c *plugin.Context, posts []*model.Post) []*model.Post {
+			for _, post := range posts {
+				if post.Metadata != nil {
+					post.Message = "metadata_leaked:" + post.Message
+					continue
+				}
+				post.Message = "mwbcwc_plugin:" + post.Message
+			}
+			return posts
+		}
+`,
+			expectedMessage: "mwbcwc_plugin:",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			th := SetupConfig(t, func(cfg *model.Config) {
+				*cfg.ServiceSettings.EnableLinkPreviews = true
+				*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost,127.0.0.1"
+			}).InitBasic(t)
+
+			var mockAPI plugintest.API
+			mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
+			mockAPI.On("LogDebug", mock.Anything).Return(nil)
+
+			tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{`
+		package main
+
+		import (
+			"github.com/mattermost/mattermost/server/public/plugin"
+			"github.com/mattermost/mattermost/server/public/model"
+		)
+
+		type MyPlugin struct {
+			plugin.MattermostPlugin
+		}
+` + tc.hookImpl + `
+
+		func main() {
+			plugin.ClientMain(&MyPlugin{})
+		}
+	`}, th.App, func(*model.Manifest) plugin.API { return &mockAPI })
+			t.Cleanup(tearDown)
+
+			basePost, _, err := th.App.CreatePost(th.Context, &model.Post{
+				UserId:    th.BasicUser.Id,
+				ChannelId: th.BasicChannel.Id,
+				Message:   "original body",
+			}, th.BasicChannel, model.CreatePostFlags{SetOnline: false})
+			require.Nil(t, err)
+
+			editedMessage := ogServer.URL + " edited body"
+			patchedPost, _, err := th.App.PatchPost(th.Context, basePost.Id, &model.PostPatch{
+				Message: &editedMessage,
+			}, nil)
+			require.Nil(t, err)
+
+			require.NotNil(t, patchedPost.Metadata)
+			require.NotEmpty(t, patchedPost.Metadata.Embeds)
+			require.Equal(t, tc.expectedMessage+editedMessage, patchedPost.Message)
+		})
+	}
+}
+
 func TestUpdatePostNoOpWhenNoPlugin(t *testing.T) {
 	mainHelper.Parallel(t)
 

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -2187,6 +2187,89 @@ func TestUpdatePostConsumeHooksWithOpenGraphMetadata(t *testing.T) {
 			require.Equal(t, tc.expectedMessage+editedMessage, patchedPost.Message)
 		})
 	}
+
+	t.Run("MessagesWillBeConsumed replacement is passed to MessagesWillBeConsumedWithContext", func(t *testing.T) {
+		th := SetupConfig(t, func(cfg *model.Config) {
+			*cfg.ServiceSettings.EnableLinkPreviews = true
+			*cfg.ServiceSettings.AllowedUntrustedInternalConnections = "localhost,127.0.0.1"
+		}).InitBasic(t)
+
+		var mockAPI plugintest.API
+		mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
+		mockAPI.On("LogDebug", mock.Anything).Return(nil)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{`
+		package main
+
+		import (
+			"github.com/mattermost/mattermost/server/public/plugin"
+			"github.com/mattermost/mattermost/server/public/model"
+		)
+
+		type MyPlugin struct {
+			plugin.MattermostPlugin
+		}
+
+		func (p *MyPlugin) MessagesWillBeConsumed(posts []*model.Post) []*model.Post {
+			for _, post := range posts {
+				if post.Metadata != nil {
+					post.Message = "metadata_leaked:" + post.Message
+					continue
+				}
+				post.Message = "mwbc_plugin:" + post.Message
+			}
+			return posts
+		}
+
+		func main() {
+			plugin.ClientMain(&MyPlugin{})
+		}
+	`, `
+		package main
+
+		import (
+			"github.com/mattermost/mattermost/server/public/plugin"
+			"github.com/mattermost/mattermost/server/public/model"
+		)
+
+		type MyPlugin struct {
+			plugin.MattermostPlugin
+		}
+
+		func (p *MyPlugin) MessagesWillBeConsumedWithContext(c *plugin.Context, posts []*model.Post) []*model.Post {
+			for _, post := range posts {
+				if post.Metadata != nil {
+					post.Message = "metadata_leaked:" + post.Message
+					continue
+				}
+				post.Message = "mwbcwc_plugin:" + post.Message
+			}
+			return posts
+		}
+
+		func main() {
+			plugin.ClientMain(&MyPlugin{})
+		}
+	`}, th.App, func(*model.Manifest) plugin.API { return &mockAPI })
+		t.Cleanup(tearDown)
+
+		basePost, _, err := th.App.CreatePost(th.Context, &model.Post{
+			UserId:    th.BasicUser.Id,
+			ChannelId: th.BasicChannel.Id,
+			Message:   "original body",
+		}, th.BasicChannel, model.CreatePostFlags{SetOnline: false})
+		require.Nil(t, err)
+
+		editedMessage := ogServer.URL + " edited body"
+		patchedPost, _, err := th.App.PatchPost(th.Context, basePost.Id, &model.PostPatch{
+			Message: &editedMessage,
+		}, nil)
+		require.Nil(t, err)
+
+		require.NotNil(t, patchedPost.Metadata)
+		require.NotEmpty(t, patchedPost.Metadata.Embeds)
+		require.Equal(t, "mwbcwc_plugin:mwbc_plugin:"+editedMessage, patchedPost.Message)
+	})
 }
 
 func TestUpdatePostNoOpWhenNoPlugin(t *testing.T) {

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -1943,6 +1943,45 @@ func TestApplyPostWillBeConsumedHook(t *testing.T) {
 	})
 }
 
+func TestApplyPostWillBeConsumedHookIgnoresReplacementWithDifferentID(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	th := Setup(t).InitBasic(t)
+
+	var mockAPI plugintest.API
+	mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
+	mockAPI.On("LogDebug", mock.Anything).Return(nil)
+
+	tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{`
+		package main
+
+		import (
+			"github.com/mattermost/mattermost/server/public/plugin"
+			"github.com/mattermost/mattermost/server/public/model"
+		)
+
+		type MyPlugin struct {
+			plugin.MattermostPlugin
+		}
+
+		func (p *MyPlugin) MessagesWillBeConsumed(posts []*model.Post) []*model.Post {
+			return []*model.Post{{
+				Id: model.NewId(),
+				Message: "unexpected replacement",
+			}}
+		}
+
+		func main() {
+			plugin.ClientMain(&MyPlugin{})
+		}
+	`}, th.App, func(*model.Manifest) plugin.API { return &mockAPI })
+	t.Cleanup(tearDown)
+
+	post := &model.Post{Id: model.NewId(), Message: "message"}
+	th.App.applyPostWillBeConsumedHook(th.Context, &post)
+	require.Equal(t, "message", post.Message)
+}
+
 func TestHookMessagesWillBeConsumedWithContext(t *testing.T) {
 	mainHelper.Parallel(t)
 
@@ -2270,6 +2309,101 @@ func TestUpdatePostConsumeHooksWithOpenGraphMetadata(t *testing.T) {
 		require.NotEmpty(t, patchedPost.Metadata.Embeds)
 		require.Equal(t, "mwbcwc_plugin:mwbc_plugin:"+editedMessage, patchedPost.Message)
 	})
+}
+
+func TestApplyPostsWillBeConsumedHookPreservesMetadataAndChainsReplacements(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	th := Setup(t).InitBasic(t)
+
+	var mockAPI plugintest.API
+	mockAPI.On("LoadPluginConfiguration", mock.Anything).Return(nil)
+	mockAPI.On("LogDebug", mock.Anything).Return(nil)
+
+	tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{`
+		package main
+
+		import (
+			"github.com/mattermost/mattermost/server/public/plugin"
+			"github.com/mattermost/mattermost/server/public/model"
+		)
+
+		type MyPlugin struct {
+			plugin.MattermostPlugin
+		}
+
+		func (p *MyPlugin) MessagesWillBeConsumed(posts []*model.Post) []*model.Post {
+			replacements := make([]*model.Post, 0, len(posts))
+			for _, post := range posts {
+				replacement := post.Clone()
+				if replacement.Metadata != nil {
+					replacement.Message = "metadata_leaked:" + replacement.Message
+				} else {
+					replacement.Message = "mwbc_plugin:" + replacement.Message
+				}
+				replacements = append(replacements, replacement)
+			}
+			replacements = append(replacements, &model.Post{Id: model.NewId(), Message: "unexpected replacement"})
+			return replacements
+		}
+
+		func main() {
+			plugin.ClientMain(&MyPlugin{})
+		}
+	`, `
+		package main
+
+		import (
+			"github.com/mattermost/mattermost/server/public/plugin"
+			"github.com/mattermost/mattermost/server/public/model"
+		)
+
+		type MyPlugin struct {
+			plugin.MattermostPlugin
+		}
+
+		func (p *MyPlugin) MessagesWillBeConsumedWithContext(c *plugin.Context, posts []*model.Post) []*model.Post {
+			replacements := make([]*model.Post, 0, len(posts))
+			for _, post := range posts {
+				replacement := post.Clone()
+				if replacement.Metadata != nil {
+					replacement.Message = "metadata_leaked:" + replacement.Message
+				} else {
+					replacement.Message = "mwbcwc_plugin:" + replacement.Message
+				}
+				replacements = append(replacements, replacement)
+			}
+			return replacements
+		}
+
+		func main() {
+			plugin.ClientMain(&MyPlugin{})
+		}
+	`}, th.App, func(*model.Manifest) plugin.API { return &mockAPI })
+	t.Cleanup(tearDown)
+
+	priority := model.PostPriorityUrgent
+	requestedAck := true
+	postID := model.NewId()
+	metadata := &model.PostMetadata{
+		Embeds:     []*model.PostEmbed{{Type: model.PostEmbedImage, URL: "http://example.com/image.png"}},
+		Priority:   &model.PostPriority{Priority: &priority, RequestedAck: &requestedAck},
+		ExpireAt:   12345,
+		Recipients: []string{model.NewId()},
+	}
+	posts := map[string]*model.Post{
+		postID: {
+			Id:       postID,
+			Message:  "message",
+			Metadata: metadata,
+		},
+	}
+
+	th.App.applyPostsWillBeConsumedHook(th.Context, posts)
+
+	require.Equal(t, "mwbcwc_plugin:mwbc_plugin:message", posts[postID].Message)
+	require.Equal(t, metadata, posts[postID].Metadata)
+	require.Len(t, posts, 1)
 }
 
 func TestUpdatePostNoOpWhenNoPlugin(t *testing.T) {

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -1941,6 +1941,27 @@ func TestApplyPostWillBeConsumedHook(t *testing.T) {
 		th.App.applyPostWillBeConsumedHook(th.Context, &post)
 		assert.Equal(t, "message", post.Message)
 	})
+
+	t.Run("post list skips burn-on-read posts", func(t *testing.T) {
+		regularPostID := model.NewId()
+		burnOnReadPostID := model.NewId()
+		posts := map[string]*model.Post{
+			regularPostID: {
+				Id:      regularPostID,
+				Message: "message",
+			},
+			burnOnReadPostID: {
+				Id:      burnOnReadPostID,
+				Message: "burn-on-read message",
+				Type:    model.PostTypeBurnOnRead,
+			},
+		}
+
+		th.App.applyPostsWillBeConsumedHook(th.Context, posts)
+
+		assert.Equal(t, "mwbc_plugin:message", posts[regularPostID].Message)
+		assert.Equal(t, "burn-on-read message", posts[burnOnReadPostID].Message)
+	})
 }
 
 func TestApplyPostWillBeConsumedHookIgnoresReplacementWithDifferentID(t *testing.T) {

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -2928,6 +2928,7 @@ func (a *App) applyPostWillBeConsumedHook(rctx request.CTX, post **model.Post) {
 		}
 		*post = replacements[0]
 		(*post).Metadata = metadata
+		ps = []*model.Post{(*post).ForPlugin()}
 	}
 
 	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -2920,21 +2920,26 @@ func (a *App) applyPostWillBeConsumedHook(rctx request.CTX, post **model.Post) {
 		return
 	}
 
-	ps := []*model.Post{*post}
+	metadata := (*post).Metadata
+	ps := []*model.Post{(*post).ForPlugin()}
+	applyReplacement := func(replacements []*model.Post) {
+		if len(replacements) == 0 || replacements[0] == nil {
+			return
+		}
+		*post = replacements[0]
+		(*post).Metadata = metadata
+	}
+
 	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 		rp := hooks.MessagesWillBeConsumed(ps)
-		if len(rp) > 0 {
-			(*post) = rp[0]
-		}
+		applyReplacement(rp)
 		return true
 	}, plugin.MessagesWillBeConsumedID)
 
 	pluginContext := pluginContext(rctx)
 	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 		rp := hooks.MessagesWillBeConsumedWithContext(pluginContext, ps)
-		if len(rp) > 0 {
-			(*post) = rp[0]
-		}
+		applyReplacement(rp)
 		return true
 	}, plugin.MessagesWillBeConsumedWithContextID)
 }

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -2887,25 +2887,44 @@ func (a *App) applyPostsWillBeConsumedHook(rctx request.CTX, posts map[string]*m
 		return
 	}
 
+	metadataByPostID := make(map[string]*model.PostMetadata, len(posts))
 	postsSlice := make([]*model.Post, 0, len(posts))
-
-	for _, post := range posts {
-		postsSlice = append(postsSlice, post.ForPlugin())
+	rebuildPostsSlice := func() {
+		postsSlice = postsSlice[:0]
+		for _, post := range posts {
+			postsSlice = append(postsSlice, post.ForPlugin())
+		}
 	}
-	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
-		postReplacements := hooks.MessagesWillBeConsumed(postsSlice)
+	for postID, post := range posts {
+		metadataByPostID[postID] = post.Metadata
+	}
+	rebuildPostsSlice()
+	applyReplacements := func(postReplacements []*model.Post) {
 		for _, postReplacement := range postReplacements {
+			if postReplacement == nil {
+				continue
+			}
+			// if the plugin returned a post with a new id, ignore it.
+			metadata, ok := metadataByPostID[postReplacement.Id]
+			if !ok {
+				continue
+			}
+			postReplacement.Metadata = metadata
 			posts[postReplacement.Id] = postReplacement
 		}
+		rebuildPostsSlice()
+	}
+
+	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
+		postReplacements := hooks.MessagesWillBeConsumed(postsSlice)
+		applyReplacements(postReplacements)
 		return true
 	}, plugin.MessagesWillBeConsumedID)
 
 	pluginContext := pluginContext(rctx)
 	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
 		postReplacements := hooks.MessagesWillBeConsumedWithContext(pluginContext, postsSlice)
-		for _, postReplacement := range postReplacements {
-			posts[postReplacement.Id] = postReplacement
-		}
+		applyReplacements(postReplacements)
 		return true
 	}, plugin.MessagesWillBeConsumedWithContextID)
 }
@@ -2921,25 +2940,29 @@ func (a *App) applyPostWillBeConsumedHook(rctx request.CTX, post **model.Post) {
 	}
 
 	metadata := (*post).Metadata
-	ps := []*model.Post{(*post).ForPlugin()}
+	postsSlice := []*model.Post{(*post).ForPlugin()}
 	applyReplacement := func(replacements []*model.Post) {
 		if len(replacements) == 0 || replacements[0] == nil {
 			return
 		}
+		// if the plugin returned a post with a different id, ignore it.
+		if replacements[0].Id != (*post).Id {
+			return
+		}
 		*post = replacements[0]
 		(*post).Metadata = metadata
-		ps = []*model.Post{(*post).ForPlugin()}
+		postsSlice = []*model.Post{(*post).ForPlugin()}
 	}
 
 	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
-		rp := hooks.MessagesWillBeConsumed(ps)
+		rp := hooks.MessagesWillBeConsumed(postsSlice)
 		applyReplacement(rp)
 		return true
 	}, plugin.MessagesWillBeConsumedID)
 
 	pluginContext := pluginContext(rctx)
 	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
-		rp := hooks.MessagesWillBeConsumedWithContext(pluginContext, ps)
+		rp := hooks.MessagesWillBeConsumedWithContext(pluginContext, postsSlice)
 		applyReplacement(rp)
 		return true
 	}, plugin.MessagesWillBeConsumedWithContextID)

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -2891,14 +2891,24 @@ func (a *App) applyPostsWillBeConsumedHook(rctx request.CTX, posts map[string]*m
 	postsSlice := make([]*model.Post, 0, len(posts))
 	rebuildPostsSlice := func() {
 		postsSlice = postsSlice[:0]
-		for _, post := range posts {
+		for postID, post := range posts {
+			if _, ok := metadataByPostID[postID]; !ok {
+				continue
+			}
 			postsSlice = append(postsSlice, post.ForPlugin())
 		}
 	}
 	for postID, post := range posts {
+		if post.Type == model.PostTypeBurnOnRead {
+			continue
+		}
 		metadataByPostID[postID] = post.Metadata
 	}
+	if len(metadataByPostID) == 0 {
+		return
+	}
 	rebuildPostsSlice()
+
 	applyReplacements := func(postReplacements []*model.Post) {
 		for _, postReplacement := range postReplacements {
 			if postReplacement == nil {
@@ -2930,42 +2940,9 @@ func (a *App) applyPostsWillBeConsumedHook(rctx request.CTX, posts map[string]*m
 }
 
 func (a *App) applyPostWillBeConsumedHook(rctx request.CTX, post **model.Post) {
-	if (*post).Type == model.PostTypeBurnOnRead {
-		return
-	}
-
-	env := a.GetPluginsEnvironment()
-	if env == nil || (!env.HasPluginImplementing(plugin.MessagesWillBeConsumedID) && !env.HasPluginImplementing(plugin.MessagesWillBeConsumedWithContextID)) {
-		return
-	}
-
-	metadata := (*post).Metadata
-	postsSlice := []*model.Post{(*post).ForPlugin()}
-	applyReplacement := func(replacements []*model.Post) {
-		if len(replacements) == 0 || replacements[0] == nil {
-			return
-		}
-		// if the plugin returned a post with a different id, ignore it.
-		if replacements[0].Id != (*post).Id {
-			return
-		}
-		*post = replacements[0]
-		(*post).Metadata = metadata
-		postsSlice = []*model.Post{(*post).ForPlugin()}
-	}
-
-	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
-		rp := hooks.MessagesWillBeConsumed(postsSlice)
-		applyReplacement(rp)
-		return true
-	}, plugin.MessagesWillBeConsumedID)
-
-	pluginContext := pluginContext(rctx)
-	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
-		rp := hooks.MessagesWillBeConsumedWithContext(pluginContext, postsSlice)
-		applyReplacement(rp)
-		return true
-	}, plugin.MessagesWillBeConsumedWithContextID)
+	posts := map[string]*model.Post{(*post).Id: *post}
+	a.applyPostsWillBeConsumedHook(rctx, posts)
+	*post = posts[(*post).Id]
 }
 
 func makePostLink(siteURL, teamName, postID string) string {


### PR DESCRIPTION
## Summary
- In load testing the MBE plugin the plugin's connection was shutting down within a minute. Couldn't figure out what was going on. Turns out it was because one of the paths to sending a post through the `MessagesWillBeConsumedWithContext` (and the old `MessagesWillBeConsumed`) hooks were not stripping out the OpenGraph embed.
- So: send single-post consume hook payloads through Post.ForPlugin() so plugin RPC does not gob-encode post metadata/OpenGraph embeds
- restore the original server-side metadata after hook replacement so prepared responses keep their embeds
- add OpenGraph regression coverage for both MessagesWillBeConsumed and MessagesWillBeConsumedWithContext

## Testing
- go test ./channels/app -run TestUpdatePostConsumeHooksWithOpenGraphMetadata|TestUpdatePostFiresConsumeHook|TestHookMessagesWillBeConsumed|TestHookMessagesWillBeConsumedWithContext|TestHookMessageWillBePosted|TestHookMessageWillBeUpdated -count=1 -v

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: Medium 🟡

**Regression Risk:** This alters the core “will be consumed” plugin-hook execution path by switching to `Post.ForPlugin()` and restoring post metadata/embeds on replacements, which changes what hook implementations can observe and how replacements chain. Risk is mitigated by targeted unit/regression tests (including OpenGraph/metadata leakage and burn-on-read skipping), but it still affects a user-facing post-consumption flow exercised across multiple plugins.

**QA Recommendation:** Run focused `go test` for `channels/app` and do a brief manual verification of consumed-post rendering/link preview (OpenGraph embeds preserved) and burn-on-read posts not being passed to consume hooks.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->