### PR TITLE
MM-61199: Restore ChannelBookmarks feature flag for mobile compatibility

### DIFF
--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -143,6 +143,8 @@ type FeatureFlags struct {
 
 	// Enable the new mm_blocks Interactive Messages framework
 	MmBlocksEnabled bool
+
+	ChannelBookmarks bool
 }
 
 func (f *FeatureFlags) SetDefaults() {
@@ -203,6 +205,8 @@ func (f *FeatureFlags) SetDefaults() {
 	f.PropertyFieldRank = true
 
 	f.MmBlocksEnabled = true
+
+	f.ChannelBookmarks = true
 }
 
 // IsChannelPermissionPoliciesEnabled reports whether channel-scope


### PR DESCRIPTION
#### Summary
The `ChannelBookmarks` field was removed from `FeatureFlags` in PR #37120. However, the mobile app reads `FeatureFlagChannelBookmarks` via `observeConfigBooleanValue`, which returns `false` when the key is absent — causing bookmarks to be hidden for all mobile users.

This PR temporarily restores the field with `default=true` so mobile clients receive the correct value while the mobile app ships a proper server-version-based check (see companion mobile PR for MM-61199).

This field will be removed again once the mobile fix is released and sufficient version overlap has occurred.

**QA steps:** Connect a mobile client to a server with this change. Verify channel bookmarks are visible.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-61199

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** This updates a shared public feature-flag model that is consumed by mobile clients, so a mismatch in default values or future cleanup could hide or expose bookmarks unexpectedly. The change is narrowly scoped and rollback is straightforward, but it touches a contract used across client/server boundaries.

**QA Recommendation:** Perform targeted manual QA on a mobile client connected to a server with this change to confirm channel bookmarks remain visible and the feature flag resolves as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->