### PR TITLE
Support per-value actions (e.g. classification banners) via PropertyValue attrs

### DIFF
--- a/server/channels/api4/properties.go
+++ b/server/channels/api4/properties.go
@@ -795,6 +795,7 @@ func patchPropertyValuesCore(c *Context, w http.ResponseWriter, r *http.Request,
 			GroupID:    group.ID,
 			FieldID:    item.FieldID,
 			Value:      item.Value,
+			Attrs:      item.Attrs,
 			CreatedBy:  userID,
 			UpdatedBy:  userID,
 		}

--- a/server/channels/api4/properties_test.go
+++ b/server/channels/api4/properties_test.go
@@ -3034,6 +3034,37 @@ func TestPatchPropertyValues(t *testing.T) {
 		require.Equal(t, json.RawMessage(`"hello"`), values[0].Value)
 	})
 
+	t.Run("attrs on a value round-trips through the patch and get endpoints", func(t *testing.T) {
+		th.LoginBasic(t)
+
+		items := []model.PropertyValuePatchItem{
+			{
+				FieldID: createdMemberField.ID,
+				Value:   json.RawMessage(`"with-attrs"`),
+				Attrs:   model.StringInterface{"actions": []any{"display_banner_top"}},
+			},
+		}
+		values, resp, err := th.Client.PatchPropertyValues(context.Background(), group.Name, "post", targetID, items)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.Len(t, values, 1)
+		require.Equal(t, model.StringInterface{"actions": []any{"display_banner_top"}}, values[0].Attrs)
+
+		// Re-read to confirm the attrs persisted and serialize back to clients.
+		fetched, resp, err := th.Client.GetPropertyValues(context.Background(), group.Name, "post", targetID, model.PropertyValueSearch{PerPage: 100})
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		var found *model.PropertyValue
+		for _, v := range fetched {
+			if v.FieldID == createdMemberField.ID {
+				found = v
+				break
+			}
+		}
+		require.NotNil(t, found)
+		require.Equal(t, model.StringInterface{"actions": []any{"display_banner_top"}}, found.Attrs)
+	})
+
 	t.Run("websocket event should be fired on values update", func(t *testing.T) {
 		th.LoginBasic(t)
 		webSocketClient := th.CreateConnectedWebSocketClient(t)

--- a/server/channels/app/properties/access_control_value_test.go
+++ b/server/channels/app/properties/access_control_value_test.go
@@ -819,6 +819,126 @@ func TestGetPropertyValuesReadAccess(t *testing.T) {
 	})
 }
 
+// TestGetPropertyValues_AttrsSurviveReadAccessControl is a regression test for
+// the value `attrs` bag (used by classification markings to store banner
+// actions on a value). The access-control read hooks must never strip attrs:
+// public values pass through untouched, and shared_only rank values are
+// shallow-copied — so attrs survive even when the value itself is clamped down
+// to the caller's rank. If a future hook reconstructs a PropertyValue
+// field-by-field without carrying Attrs over, these assertions catch it.
+func TestGetPropertyValues_AttrsSurviveReadAccessControl(t *testing.T) {
+	th := Setup(t).RegisterCPAPropertyGroup(t)
+	th.service.setPluginCheckerForTests(func(pluginID string) bool {
+		return pluginID == "test-plugin"
+	})
+
+	rctxSource := RequestContextWithCallerID(th.Context, "test-plugin")
+	wantAttrs := model.StringInterface{"actions": []any{"display_banner_top", "display_banner_bottom"}}
+
+	t.Run("public field: attrs survive read access control", func(t *testing.T) {
+		field, err := th.service.CreatePropertyField(rctxSource, &model.PropertyField{
+			GroupID:    th.CPAGroupID,
+			Name:       "attrs-public",
+			Type:       model.PropertyFieldTypeText,
+			ObjectType: model.PropertyFieldObjectTypeUser,
+			TargetType: string(model.PropertyFieldTargetLevelSystem),
+			Attrs:      model.StringInterface{model.PropertyAttrsAccessMode: model.PropertyAccessModePublic},
+		})
+		require.NoError(t, err)
+
+		created, err := th.service.CreatePropertyValue(rctxSource, &model.PropertyValue{
+			GroupID:    th.CPAGroupID,
+			FieldID:    field.ID,
+			TargetType: "user",
+			TargetID:   model.NewId(),
+			Value:      json.RawMessage(`"hello"`),
+			Attrs:      wantAttrs,
+		})
+		require.NoError(t, err)
+
+		// Read as an unrelated caller through the plural read path.
+		rctxOther := RequestContextWithCallerID(th.Context, model.NewId())
+		retrieved, err := th.service.GetPropertyValues(rctxOther, th.CPAGroupID, []string{created.ID})
+		require.NoError(t, err)
+		require.Len(t, retrieved, 1)
+		assert.Equal(t, wantAttrs, retrieved[0].Attrs)
+	})
+
+	t.Run("shared_only rank: attrs survive on a pass-through value", func(t *testing.T) {
+		field, err := th.service.CreatePropertyField(rctxSource, &model.PropertyField{
+			GroupID:    th.CPAGroupID,
+			Name:       "attrs-rank-passthrough",
+			Type:       model.PropertyFieldTypeRank,
+			ObjectType: model.PropertyFieldObjectTypeUser,
+			TargetType: string(model.PropertyFieldTargetLevelSystem),
+			Attrs: model.StringInterface{
+				model.PropertyAttrsAccessMode:       model.PropertyAccessModeSharedOnly,
+				model.PropertyAttrsProtected:        true,
+				model.PropertyFieldAttributeOptions: rankOptions(),
+			},
+		})
+		require.NoError(t, err)
+
+		// Caller holds Secret (rank 3); target holds Confidential (rank 2) with attrs.
+		callerID := model.NewId()
+		_, err = th.service.CreatePropertyValue(rctxSource, &model.PropertyValue{
+			GroupID: th.CPAGroupID, FieldID: field.ID, TargetType: "user", TargetID: callerID,
+			Value: json.RawMessage(`"opt_secret"`),
+		})
+		require.NoError(t, err)
+
+		target, err := th.service.CreatePropertyValue(rctxSource, &model.PropertyValue{
+			GroupID: th.CPAGroupID, FieldID: field.ID, TargetType: "user", TargetID: model.NewId(),
+			Value: json.RawMessage(`"opt_confidential"`), Attrs: wantAttrs,
+		})
+		require.NoError(t, err)
+
+		retrieved, err := th.service.GetPropertyValues(RequestContextWithCallerID(th.Context, callerID), th.CPAGroupID, []string{target.ID})
+		require.NoError(t, err)
+		require.Len(t, retrieved, 1)
+		assert.Equal(t, json.RawMessage(`"opt_confidential"`), retrieved[0].Value)
+		assert.Equal(t, wantAttrs, retrieved[0].Attrs)
+	})
+
+	t.Run("shared_only rank: attrs survive even when the value is clamped", func(t *testing.T) {
+		field, err := th.service.CreatePropertyField(rctxSource, &model.PropertyField{
+			GroupID:    th.CPAGroupID,
+			Name:       "attrs-rank-clamped",
+			Type:       model.PropertyFieldTypeRank,
+			ObjectType: model.PropertyFieldObjectTypeUser,
+			TargetType: string(model.PropertyFieldTargetLevelSystem),
+			Attrs: model.StringInterface{
+				model.PropertyAttrsAccessMode:       model.PropertyAccessModeSharedOnly,
+				model.PropertyAttrsProtected:        true,
+				model.PropertyFieldAttributeOptions: rankOptions(),
+			},
+		})
+		require.NoError(t, err)
+
+		// Caller holds Confidential (rank 2); target holds TopSecret (rank 4) with attrs.
+		callerID := model.NewId()
+		_, err = th.service.CreatePropertyValue(rctxSource, &model.PropertyValue{
+			GroupID: th.CPAGroupID, FieldID: field.ID, TargetType: "user", TargetID: callerID,
+			Value: json.RawMessage(`"opt_confidential"`),
+		})
+		require.NoError(t, err)
+
+		target, err := th.service.CreatePropertyValue(rctxSource, &model.PropertyValue{
+			GroupID: th.CPAGroupID, FieldID: field.ID, TargetType: "user", TargetID: model.NewId(),
+			Value: json.RawMessage(`"opt_topsecret"`), Attrs: wantAttrs,
+		})
+		require.NoError(t, err)
+
+		retrieved, err := th.service.GetPropertyValues(RequestContextWithCallerID(th.Context, callerID), th.CPAGroupID, []string{target.ID})
+		require.NoError(t, err)
+		require.Len(t, retrieved, 1)
+		// The value is clamped down to the caller's rank...
+		assert.Equal(t, json.RawMessage(`"opt_confidential"`), retrieved[0].Value)
+		// ...but the attrs must still be present.
+		assert.Equal(t, wantAttrs, retrieved[0].Attrs)
+	})
+}
+
 func TestSearchPropertyValuesReadAccess(t *testing.T) {
 	th := Setup(t).RegisterCPAPropertyGroup(t)
 	th.service.setPluginCheckerForTests(func(pluginID string) bool {

--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -399,3 +399,5 @@ channels/db/migrations/postgres/000201_create_property_fields_groupid_updateat_i
 channels/db/migrations/postgres/000201_create_property_fields_groupid_updateat_id_index.up.sql
 channels/db/migrations/postgres/000202_create_property_values_groupid_updateat_id_index.down.sql
 channels/db/migrations/postgres/000202_create_property_values_groupid_updateat_id_index.up.sql
+channels/db/migrations/postgres/000203_add_attrs_to_property_values.down.sql
+channels/db/migrations/postgres/000203_add_attrs_to_property_values.up.sql

--- a/server/channels/db/migrations/postgres/000203_add_attrs_to_property_values.down.sql
+++ b/server/channels/db/migrations/postgres/000203_add_attrs_to_property_values.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE PropertyValues DROP COLUMN IF EXISTS Attrs;

--- a/server/channels/db/migrations/postgres/000203_add_attrs_to_property_values.up.sql
+++ b/server/channels/db/migrations/postgres/000203_add_attrs_to_property_values.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE PropertyValues ADD COLUMN IF NOT EXISTS Attrs jsonb;

--- a/server/channels/store/sqlstore/property_value_store.go
+++ b/server/channels/store/sqlstore/property_value_store.go
@@ -24,7 +24,7 @@ func newPropertyValueStore(sqlStore *SqlStore) store.PropertyValueStore {
 	s := SqlPropertyValueStore{SqlStore: sqlStore}
 
 	s.tableSelectQuery = s.getQueryBuilder().
-		Select("ID", "TargetID", "TargetType", "GroupID", "FieldID", "Value", "CreateAt", "UpdateAt", "DeleteAt", "COALESCE(CreatedBy, '') as CreatedBy", "COALESCE(UpdatedBy, '') as UpdatedBy").
+		Select("ID", "TargetID", "TargetType", "GroupID", "FieldID", "Value", "Attrs", "CreateAt", "UpdateAt", "DeleteAt", "COALESCE(CreatedBy, '') as CreatedBy", "COALESCE(UpdatedBy, '') as UpdatedBy").
 		From("PropertyValues")
 
 	return &s
@@ -48,8 +48,8 @@ func (s *SqlPropertyValueStore) Create(value *model.PropertyValue) (*model.Prope
 
 	builder := s.getQueryBuilder().
 		Insert("PropertyValues").
-		Columns("ID", "TargetID", "TargetType", "GroupID", "FieldID", "Value", "CreateAt", "UpdateAt", "DeleteAt", "CreatedBy", "UpdatedBy").
-		Values(value.ID, value.TargetID, value.TargetType, value.GroupID, value.FieldID, valueJSON, value.CreateAt, value.UpdateAt, value.DeleteAt, value.CreatedBy, value.UpdatedBy)
+		Columns("ID", "TargetID", "TargetType", "GroupID", "FieldID", "Value", "Attrs", "CreateAt", "UpdateAt", "DeleteAt", "CreatedBy", "UpdatedBy").
+		Values(value.ID, value.TargetID, value.TargetType, value.GroupID, value.FieldID, valueJSON, value.Attrs, value.CreateAt, value.UpdateAt, value.DeleteAt, value.CreatedBy, value.UpdatedBy)
 	if _, err := s.GetMaster().ExecBuilder(builder); err != nil {
 		return nil, errors.Wrap(err, "property_value_create_insert")
 	}
@@ -82,8 +82,8 @@ func (s *SqlPropertyValueStore) CreateMany(values []*model.PropertyValue) ([]*mo
 
 		builder := s.getQueryBuilder().
 			Insert("PropertyValues").
-			Columns("ID", "TargetID", "TargetType", "GroupID", "FieldID", "Value", "CreateAt", "UpdateAt", "DeleteAt", "CreatedBy", "UpdatedBy").
-			Values(value.ID, value.TargetID, value.TargetType, value.GroupID, value.FieldID, valueJSON, value.CreateAt, value.UpdateAt, value.DeleteAt, value.CreatedBy, value.UpdatedBy)
+			Columns("ID", "TargetID", "TargetType", "GroupID", "FieldID", "Value", "Attrs", "CreateAt", "UpdateAt", "DeleteAt", "CreatedBy", "UpdatedBy").
+			Values(value.ID, value.TargetID, value.TargetType, value.GroupID, value.FieldID, valueJSON, value.Attrs, value.CreateAt, value.UpdateAt, value.DeleteAt, value.CreatedBy, value.UpdatedBy)
 
 		if _, err := transaction.ExecBuilder(builder); err != nil {
 			return nil, errors.Wrap(err, "property_value_create_many_exec")
@@ -224,6 +224,7 @@ func (s *SqlPropertyValueStore) Update(groupID string, values []*model.PropertyV
 
 	updateTime := model.GetMillis()
 	valueCase := sq.Case("id")
+	attrsCase := sq.Case("id")
 	deleteAtCase := sq.Case("id")
 	updatedByCase := sq.Case("id")
 	ids := make([]string, len(values))
@@ -241,6 +242,7 @@ func (s *SqlPropertyValueStore) Update(groupID string, values []*model.PropertyV
 		}
 
 		valueCase = valueCase.When(sq.Expr("?", value.ID), sq.Expr("?::jsonb", valueJSON))
+		attrsCase = attrsCase.When(sq.Expr("?", value.ID), sq.Expr("?::jsonb", value.Attrs))
 		deleteAtCase = deleteAtCase.When(sq.Expr("?", value.ID), sq.Expr("?::bigint", value.DeleteAt))
 		updatedByCase = updatedByCase.When(sq.Expr("?", value.ID), sq.Expr("?::text", value.UpdatedBy))
 	}
@@ -248,6 +250,7 @@ func (s *SqlPropertyValueStore) Update(groupID string, values []*model.PropertyV
 	builder := s.getQueryBuilder().
 		Update("PropertyValues").
 		Set("Value", valueCase).
+		Set("Attrs", attrsCase).
 		Set("DeleteAt", deleteAtCase).
 		Set("UpdateAt", updateTime).
 		Set("UpdatedBy", updatedByCase).
@@ -310,15 +313,21 @@ func (s *SqlPropertyValueStore) Upsert(values []*model.PropertyValue) (_ []*mode
 
 		builder := s.getQueryBuilder().
 			Insert("PropertyValues").
-			Columns("ID", "TargetID", "TargetType", "GroupID", "FieldID", "Value", "CreateAt", "UpdateAt", "DeleteAt", "CreatedBy", "UpdatedBy").
-			Values(value.ID, value.TargetID, value.TargetType, value.GroupID, value.FieldID, valueJSON, value.CreateAt, value.UpdateAt, value.DeleteAt, value.CreatedBy, value.UpdatedBy)
+			Columns("ID", "TargetID", "TargetType", "GroupID", "FieldID", "Value", "Attrs", "CreateAt", "UpdateAt", "DeleteAt", "CreatedBy", "UpdatedBy").
+			Values(value.ID, value.TargetID, value.TargetType, value.GroupID, value.FieldID, valueJSON, value.Attrs, value.CreateAt, value.UpdateAt, value.DeleteAt, value.CreatedBy, value.UpdatedBy)
 
+		// Only overwrite Attrs on conflict when the caller supplied some, so a
+		// value-only upsert never clobbers attrs written by another writer.
+		setClause := "Value = ?, UpdateAt = ?, DeleteAt = ?, UpdatedBy = ?"
+		suffixArgs := []any{valueJSON, value.UpdateAt, 0, value.UpdatedBy}
+		if value.Attrs != nil {
+			setClause += ", Attrs = ?"
+			suffixArgs = append(suffixArgs, value.Attrs)
+		}
 		builder = builder.SuffixExpr(sq.Expr(
-			"ON CONFLICT (GroupID, TargetID, FieldID) WHERE DeleteAt = 0 DO UPDATE SET Value = ?, UpdateAt = ?, DeleteAt = ?, UpdatedBy = ? RETURNING ID, TargetID, TargetType, GroupID, FieldID, Value, CreateAt, UpdateAt, DeleteAt, COALESCE(CreatedBy, '') as CreatedBy, COALESCE(UpdatedBy, '') as UpdatedBy",
-			valueJSON,
-			value.UpdateAt,
-			0,
-			value.UpdatedBy,
+			"ON CONFLICT (GroupID, TargetID, FieldID) WHERE DeleteAt = 0 DO UPDATE SET "+setClause+
+				" RETURNING ID, TargetID, TargetType, GroupID, FieldID, Value, Attrs, CreateAt, UpdateAt, DeleteAt, COALESCE(CreatedBy, '') as CreatedBy, COALESCE(UpdatedBy, '') as UpdatedBy",
+			suffixArgs...,
 		))
 
 		var values []*model.PropertyValue

--- a/server/channels/store/storetest/property_value_store.go
+++ b/server/channels/store/storetest/property_value_store.go
@@ -95,6 +95,23 @@ func testCreatePropertyValue(t *testing.T, _ request.CTX, ss store.Store) {
 		require.Empty(t, value.CreatedBy)
 		require.Empty(t, value.UpdatedBy)
 	})
+
+	t.Run("should persist and round-trip attrs", func(t *testing.T) {
+		valueWithAttrs := &model.PropertyValue{
+			TargetID:   model.NewId(),
+			TargetType: "test_type",
+			GroupID:    model.NewId(),
+			FieldID:    model.NewId(),
+			Value:      json.RawMessage(`"opt1"`),
+			Attrs:      model.StringInterface{"actions": []any{"display_banner_top"}},
+		}
+		created, err := ss.PropertyValue().Create(valueWithAttrs)
+		require.NoError(t, err)
+
+		fromStore, err := ss.PropertyValue().Get("", created.ID)
+		require.NoError(t, err)
+		require.Equal(t, model.StringInterface{"actions": []any{"display_banner_top"}}, fromStore.Attrs)
+	})
 }
 
 func testCreateManyPropertyValues(t *testing.T, _ request.CTX, ss store.Store) {
@@ -844,6 +861,29 @@ func testUpdatePropertyValue(t *testing.T, _ request.CTX, ss store.Store) {
 		require.Equal(t, user2, fetched2.UpdatedBy)
 		require.Equal(t, creatorUserID, fetched2.CreatedBy)
 	})
+
+	t.Run("should round-trip attrs on update", func(t *testing.T) {
+		value := &model.PropertyValue{
+			TargetID:   model.NewId(),
+			TargetType: "test_type",
+			GroupID:    model.NewId(),
+			FieldID:    model.NewId(),
+			Value:      json.RawMessage(`"opt1"`),
+			Attrs:      model.StringInterface{"actions": []any{"display_banner_top"}},
+		}
+		_, err := ss.PropertyValue().Create(value)
+		require.NoError(t, err)
+
+		value.Value = json.RawMessage(`"opt2"`)
+		value.Attrs = model.StringInterface{"actions": []any{"display_banner_top", "display_banner_bottom"}}
+		_, err = ss.PropertyValue().Update("", []*model.PropertyValue{value})
+		require.NoError(t, err)
+
+		fromStore, err := ss.PropertyValue().Get("", value.ID)
+		require.NoError(t, err)
+		require.Equal(t, json.RawMessage(`"opt2"`), fromStore.Value)
+		require.Equal(t, model.StringInterface{"actions": []any{"display_banner_top", "display_banner_bottom"}}, fromStore.Attrs)
+	})
 }
 
 func testUpsertPropertyValue(t *testing.T, _ request.CTX, ss store.Store, s SqlStore) {
@@ -926,6 +966,90 @@ func testUpsertPropertyValue(t *testing.T, _ request.CTX, ss store.Store, s SqlS
 		require.NoError(t, err)
 		require.Equal(t, json.RawMessage(`"updated value"`), updated.Value)
 		require.Greater(t, updated.UpdateAt, updated.CreateAt)
+	})
+
+	t.Run("should persist attrs on insert via upsert", func(t *testing.T) {
+		value := &model.PropertyValue{
+			TargetID:   model.NewId(),
+			TargetType: "test_type",
+			GroupID:    model.NewId(),
+			FieldID:    model.NewId(),
+			Value:      json.RawMessage(`"opt1"`),
+			Attrs:      model.StringInterface{"actions": []any{"display_banner_top"}},
+		}
+		upserted, err := ss.PropertyValue().Upsert([]*model.PropertyValue{value})
+		require.NoError(t, err)
+		require.Len(t, upserted, 1)
+		require.Equal(t, model.StringInterface{"actions": []any{"display_banner_top"}}, upserted[0].Attrs)
+
+		fromStore, err := ss.PropertyValue().Get("", upserted[0].ID)
+		require.NoError(t, err)
+		require.Equal(t, model.StringInterface{"actions": []any{"display_banner_top"}}, fromStore.Attrs)
+	})
+
+	t.Run("should preserve attrs on a value-only upsert", func(t *testing.T) {
+		targetID := model.NewId()
+		groupID := model.NewId()
+		fieldID := model.NewId()
+
+		// Seed a value carrying attrs.
+		_, err := ss.PropertyValue().Upsert([]*model.PropertyValue{{
+			TargetID:   targetID,
+			TargetType: "test_type",
+			GroupID:    groupID,
+			FieldID:    fieldID,
+			Value:      json.RawMessage(`"opt1"`),
+			Attrs:      model.StringInterface{"actions": []any{"display_banner_top", "display_banner_bottom"}},
+		}})
+		require.NoError(t, err)
+
+		// Upsert the same (group,target,field) with a new value but nil attrs.
+		upserted, err := ss.PropertyValue().Upsert([]*model.PropertyValue{{
+			TargetID:   targetID,
+			TargetType: "test_type",
+			GroupID:    groupID,
+			FieldID:    fieldID,
+			Value:      json.RawMessage(`"opt2"`),
+		}})
+		require.NoError(t, err)
+		require.Len(t, upserted, 1)
+
+		fromStore, err := ss.PropertyValue().Get("", upserted[0].ID)
+		require.NoError(t, err)
+		require.Equal(t, json.RawMessage(`"opt2"`), fromStore.Value)
+		require.Equal(t, model.StringInterface{"actions": []any{"display_banner_top", "display_banner_bottom"}}, fromStore.Attrs)
+	})
+
+	t.Run("should replace attrs when non-nil attrs provided on conflict", func(t *testing.T) {
+		targetID := model.NewId()
+		groupID := model.NewId()
+		fieldID := model.NewId()
+
+		_, err := ss.PropertyValue().Upsert([]*model.PropertyValue{{
+			TargetID:   targetID,
+			TargetType: "test_type",
+			GroupID:    groupID,
+			FieldID:    fieldID,
+			Value:      json.RawMessage(`"opt1"`),
+			Attrs:      model.StringInterface{"actions": []any{"display_banner_top"}},
+		}})
+		require.NoError(t, err)
+
+		// Re-upsert with an explicit empty actions set (non-nil attrs) → replace.
+		upserted, err := ss.PropertyValue().Upsert([]*model.PropertyValue{{
+			TargetID:   targetID,
+			TargetType: "test_type",
+			GroupID:    groupID,
+			FieldID:    fieldID,
+			Value:      json.RawMessage(`"opt1"`),
+			Attrs:      model.StringInterface{"actions": []any{}},
+		}})
+		require.NoError(t, err)
+		require.Len(t, upserted, 1)
+
+		fromStore, err := ss.PropertyValue().Get("", upserted[0].ID)
+		require.NoError(t, err)
+		require.Equal(t, model.StringInterface{"actions": []any{}}, fromStore.Attrs)
 	})
 
 	t.Run("should handle mixed insert and update operations", func(t *testing.T) {

--- a/server/public/model/property_value.go
+++ b/server/public/model/property_value.go
@@ -35,6 +35,7 @@ type PropertyValue struct {
 	GroupID    string          `json:"group_id"`
 	FieldID    string          `json:"field_id"`
 	Value      json.RawMessage `json:"value"`
+	Attrs      StringInterface `json:"attrs,omitempty"`
 	CreateAt   int64           `json:"create_at"`
 	UpdateAt   int64           `json:"update_at"`
 	DeleteAt   int64           `json:"delete_at"`
@@ -198,6 +199,7 @@ type PropertyValueSearch struct {
 type PropertyValuePatchItem struct {
 	FieldID string          `json:"field_id"`
 	Value   json.RawMessage `json:"value"`
+	Attrs   StringInterface `json:"attrs,omitempty"`
 }
 
 // SanitizePropertyValue normalizes a raw property value's JSON:

--- a/server/public/model/property_value_test.go
+++ b/server/public/model/property_value_test.go
@@ -55,6 +55,21 @@ func TestPropertyValue_IsValid(t *testing.T) {
 		require.NoError(t, pv.IsValid())
 	})
 
+	t.Run("valid value with attrs", func(t *testing.T) {
+		pv := &PropertyValue{
+			ID:         NewId(),
+			TargetID:   NewId(),
+			TargetType: "test_type",
+			GroupID:    NewId(),
+			FieldID:    NewId(),
+			Value:      json.RawMessage(`"opt1"`),
+			Attrs:      StringInterface{"actions": []any{"display_banner_top", "display_banner_bottom"}},
+			CreateAt:   GetMillis(),
+			UpdateAt:   GetMillis(),
+		}
+		require.NoError(t, pv.IsValid())
+	})
+
 	t.Run("invalid ID", func(t *testing.T) {
 		pv := &PropertyValue{
 			ID:         "invalid",
@@ -374,5 +389,46 @@ func TestSanitizePropertyValue(t *testing.T) {
 		raw := json.RawMessage(`"hello"`)
 		got := SanitizePropertyValue(raw)
 		assert.Equal(t, &raw[0], &got[0], "expected same backing array when unchanged")
+	})
+}
+
+func TestPropertyValue_AttrsJSON(t *testing.T) {
+	t.Run("attrs round-trips through JSON", func(t *testing.T) {
+		pv := &PropertyValue{
+			ID:         NewId(),
+			TargetID:   NewId(),
+			TargetType: "channel",
+			GroupID:    NewId(),
+			FieldID:    NewId(),
+			Value:      json.RawMessage(`"opt1"`),
+			Attrs:      StringInterface{"actions": []any{"display_banner_top"}},
+			CreateAt:   GetMillis(),
+			UpdateAt:   GetMillis(),
+		}
+
+		b, err := json.Marshal(pv)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), `"attrs"`)
+
+		var got PropertyValue
+		require.NoError(t, json.Unmarshal(b, &got))
+		assert.Equal(t, pv.Attrs, got.Attrs)
+	})
+
+	t.Run("nil attrs is omitted from JSON", func(t *testing.T) {
+		pv := &PropertyValue{
+			ID:         NewId(),
+			TargetID:   NewId(),
+			TargetType: "channel",
+			GroupID:    NewId(),
+			FieldID:    NewId(),
+			Value:      json.RawMessage(`"opt1"`),
+			CreateAt:   GetMillis(),
+			UpdateAt:   GetMillis(),
+		}
+
+		b, err := json.Marshal(pv)
+		require.NoError(t, err)
+		assert.NotContains(t, string(b), `"attrs"`)
 	})
 }

--- a/webapp/channels/src/components/admin_console/classification_markings/classification_markings.test.tsx
+++ b/webapp/channels/src/components/admin_console/classification_markings/classification_markings.test.tsx
@@ -984,8 +984,8 @@ describe('GlobalClassificationIndicators section', () => {
                 }),
             );
 
-            // System value upserted with the resolved option ID.
-            expect(saveUpsertSpy).toHaveBeenCalledWith('linked_field1', 'lvl1');
+            // System value upserted with the resolved option ID and actions.
+            expect(saveUpsertSpy).toHaveBeenCalledWith('linked_field1', 'lvl1', [DISPLAY_BANNER_TOP, DISPLAY_BANNER_BOTTOM]);
         });
         await act(async () => {}); // flush pending React state updates
     });
@@ -1567,6 +1567,7 @@ describe('Custom preset caching and dropdown visibility', () => {
                 expect(saveUpsertSpy).toHaveBeenCalledWith(
                     'linked_field1',
                     serverGeneratedId,
+                    expect.any(Array),
                 );
             });
             await act(async () => {});

--- a/webapp/channels/src/components/admin_console/classification_markings/classification_markings.tsx
+++ b/webapp/channels/src/components/admin_console/classification_markings/classification_markings.tsx
@@ -37,6 +37,7 @@ import {
     DEFAULT_GLOBAL_BANNER,
     DISPLAY_BANNER_TOP,
     actionsToGlobalBanner,
+    placementToActions,
     fetchChannelClassificationField,
     fetchClassificationField,
     fetchLinkedClassificationField,
@@ -404,10 +405,16 @@ export default function ClassificationMarkings({disabled}: Props) {
                 savedLinked = await saveCreateLinkedField(savedTemplate.id, disabledBanner);
             }
 
-            if (resolvedBanner.enabled && resolvedBanner.level_id) {
-                const savedValues = await saveUpsertSystemValue(savedLinked.id, resolvedBanner.level_id);
-                dispatch({type: PropertyTypes.RECEIVED_PROPERTY_VALUES, data: {values: savedValues}});
+            // Always upsert the system value carrying the resolved actions (empty
+            // when the banner is off) and level so value.attrs.actions and
+            // field.attrs.actions never diverge. New clients read value.attrs.actions;
+            // mobile keeps reading field.attrs.actions (mirrored below).
+            const resolvedLevelId = resolvedBanner.enabled ? resolvedBanner.level_id : '';
+            const savedValues = await saveUpsertSystemValue(savedLinked.id, resolvedLevelId, placementToActions(resolvedBanner));
+            dispatch({type: PropertyTypes.RECEIVED_PROPERTY_VALUES, data: {values: savedValues}});
 
+            // Mirror the resolved actions onto the field last (mobile compat path).
+            if (resolvedBanner.enabled) {
                 savedLinked = await savePatchLinkedField(savedLinked.id, resolvedBanner);
             }
 

--- a/webapp/channels/src/components/admin_console/classification_markings/classification_markings.tsx
+++ b/webapp/channels/src/components/admin_console/classification_markings/classification_markings.tsx
@@ -406,17 +406,16 @@ export default function ClassificationMarkings({disabled}: Props) {
             }
 
             // The value is classification's home for actions: always upsert the
-            // system value with the resolved actions (empty when the banner is off)
-            // and level. New clients read value.attrs.actions. We also mirror the
-            // actions onto the field below, so the two never diverge while older
-            // clients still read the field.
+            // system value with the resolved actions (empty when the banner is
+            // off) and level. The webapp reads actions from value.attrs.actions;
+            // the field is mirrored below so both carry the same actions.
             const resolvedLevelId = resolvedBanner.enabled ? resolvedBanner.level_id : '';
             const savedValues = await saveUpsertSystemValue(savedLinked.id, resolvedLevelId, placementToActions(resolvedBanner));
             dispatch({type: PropertyTypes.RECEIVED_PROPERTY_VALUES, data: {values: savedValues}});
 
-            // Temporary back-compat mirror: also write the actions to the field for
-            // clients that still read field.attrs.actions. Dropped once every client
-            // reads from the value.
+            // Mirror the actions onto the field as well: mobile reads banner
+            // actions from field.attrs.actions, so this keeps it in sync. The
+            // field write can be removed once every client reads from the value.
             if (resolvedBanner.enabled) {
                 savedLinked = await savePatchLinkedField(savedLinked.id, resolvedBanner);
             }

--- a/webapp/channels/src/components/admin_console/classification_markings/classification_markings.tsx
+++ b/webapp/channels/src/components/admin_console/classification_markings/classification_markings.tsx
@@ -405,15 +405,18 @@ export default function ClassificationMarkings({disabled}: Props) {
                 savedLinked = await saveCreateLinkedField(savedTemplate.id, disabledBanner);
             }
 
-            // Always upsert the system value carrying the resolved actions (empty
-            // when the banner is off) and level so value.attrs.actions and
-            // field.attrs.actions never diverge. New clients read value.attrs.actions;
-            // mobile keeps reading field.attrs.actions (mirrored below).
+            // The value is classification's home for actions: always upsert the
+            // system value with the resolved actions (empty when the banner is off)
+            // and level. New clients read value.attrs.actions. We also mirror the
+            // actions onto the field below, so the two never diverge while older
+            // clients still read the field.
             const resolvedLevelId = resolvedBanner.enabled ? resolvedBanner.level_id : '';
             const savedValues = await saveUpsertSystemValue(savedLinked.id, resolvedLevelId, placementToActions(resolvedBanner));
             dispatch({type: PropertyTypes.RECEIVED_PROPERTY_VALUES, data: {values: savedValues}});
 
-            // Mirror the resolved actions onto the field last (mobile compat path).
+            // Temporary back-compat mirror: also write the actions to the field for
+            // clients that still read field.attrs.actions. Dropped once every client
+            // reads from the value.
             if (resolvedBanner.enabled) {
                 savedLinked = await savePatchLinkedField(savedLinked.id, resolvedBanner);
             }

--- a/webapp/channels/src/components/admin_console/classification_markings/utils/index.ts
+++ b/webapp/channels/src/components/admin_console/classification_markings/utils/index.ts
@@ -279,12 +279,11 @@ export async function fetchSystemClassificationValue(linkedFieldId: string): Pro
 
 /**
  * Upserts the system classification property value to the given option ID and
- * banner actions. For classification, the value is the home for actions — new
- * clients read value.attrs.actions. The caller separately mirrors them onto the
- * field as a temporary backwards-compatibility measure, which will be dropped
- * once all clients read actions from the value. Uses the dedicated system values
- * endpoint (sentinel target_id 'system'). Returns the saved values for eager
- * store update.
+ * banner actions. For classification, the value is the home for actions: the
+ * webapp reads them from value.attrs.actions. The caller also mirrors them onto
+ * the field, which mobile reads; that mirror can be removed once every client
+ * reads actions from the value. Uses the dedicated system values endpoint
+ * (sentinel target_id 'system'). Returns the saved values for eager store update.
  */
 export async function saveUpsertSystemValue(linkedFieldId: string, optionId: string, actions: string[]): Promise<Array<PropertyValue<string>>> {
     return Client4.patchSystemPropertyValues<string>(CLASSIFICATIONS_GROUP_NAME, [

--- a/webapp/channels/src/components/admin_console/classification_markings/utils/index.ts
+++ b/webapp/channels/src/components/admin_console/classification_markings/utils/index.ts
@@ -278,13 +278,15 @@ export async function fetchSystemClassificationValue(linkedFieldId: string): Pro
 }
 
 /**
- * Upserts the system classification property value to the given option ID.
- * Uses the dedicated system values endpoint (sentinel target_id 'system').
- * Returns the saved property values so callers can eagerly update the store.
+ * Upserts the system classification property value to the given option ID and
+ * banner actions. The actions are written to the value's attrs (new clients
+ * read value.attrs.actions); the caller separately mirrors them onto the field
+ * for mobile backwards-compatibility. Uses the dedicated system values endpoint
+ * (sentinel target_id 'system'). Returns the saved values for eager store update.
  */
-export async function saveUpsertSystemValue(linkedFieldId: string, optionId: string): Promise<Array<PropertyValue<string>>> {
+export async function saveUpsertSystemValue(linkedFieldId: string, optionId: string, actions: string[]): Promise<Array<PropertyValue<string>>> {
     return Client4.patchSystemPropertyValues<string>(CLASSIFICATIONS_GROUP_NAME, [
-        {field_id: linkedFieldId, value: optionId},
+        {field_id: linkedFieldId, value: optionId, attrs: {actions}},
     ]);
 }
 

--- a/webapp/channels/src/components/admin_console/classification_markings/utils/index.ts
+++ b/webapp/channels/src/components/admin_console/classification_markings/utils/index.ts
@@ -279,10 +279,12 @@ export async function fetchSystemClassificationValue(linkedFieldId: string): Pro
 
 /**
  * Upserts the system classification property value to the given option ID and
- * banner actions. The actions are written to the value's attrs (new clients
- * read value.attrs.actions); the caller separately mirrors them onto the field
- * for mobile backwards-compatibility. Uses the dedicated system values endpoint
- * (sentinel target_id 'system'). Returns the saved values for eager store update.
+ * banner actions. For classification, the value is the home for actions — new
+ * clients read value.attrs.actions. The caller separately mirrors them onto the
+ * field as a temporary backwards-compatibility measure, which will be dropped
+ * once all clients read actions from the value. Uses the dedicated system values
+ * endpoint (sentinel target_id 'system'). Returns the saved values for eager
+ * store update.
  */
 export async function saveUpsertSystemValue(linkedFieldId: string, optionId: string, actions: string[]): Promise<Array<PropertyValue<string>>> {
     return Client4.patchSystemPropertyValues<string>(CLASSIFICATIONS_GROUP_NAME, [

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_configuration_tab.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_configuration_tab.tsx
@@ -435,15 +435,15 @@ function ChannelSettingsConfigurationTab({
 
         if (hasClassificationChanges && classification.channelField) {
             if (classificationEnabled && selectedClassificationId) {
+                // Per-channel banner placement lives on the value's attrs. A single
+                // shared channel field is used for all channels, so placement cannot
+                // live on the field. Fixed to top today (matches prior behavior);
+                // per-channel UI can vary it later.
                 try {
                     const values = await Client4.patchPropertyValues(
                         CLASSIFICATIONS_GROUP_NAME,
                         CLASSIFICATIONS_CHANNEL_OBJECT_TYPE,
                         channel.id,
-                        // Per-channel banner placement lives on the value's attrs.
-                        // A single shared channel field is used for all channels, so
-                        // placement cannot live on the field. Fixed to top today
-                        // (matches prior behavior); per-channel UI can vary it later.
                         [{field_id: classification.channelField.id, value: selectedClassificationId, attrs: {actions: [DISPLAY_BANNER_TOP]}}],
                     );
                     dispatch({type: PropertyTypes.RECEIVED_PROPERTY_VALUES, data: {values}});

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_configuration_tab.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_configuration_tab.tsx
@@ -21,6 +21,7 @@ import {ColorSwatch, LevelOptionLabel} from 'components/admin_console/classifica
 import {
     CLASSIFICATIONS_CHANNEL_OBJECT_TYPE,
     CLASSIFICATIONS_GROUP_NAME,
+    DISPLAY_BANNER_TOP,
 } from 'components/admin_console/classification_markings/utils';
 import {classificationPresetDropdownStyles} from 'components/admin_console/classification_markings/utils/preset_dropdown_styles';
 import ColorInput from 'components/color_input';
@@ -439,7 +440,11 @@ function ChannelSettingsConfigurationTab({
                         CLASSIFICATIONS_GROUP_NAME,
                         CLASSIFICATIONS_CHANNEL_OBJECT_TYPE,
                         channel.id,
-                        [{field_id: classification.channelField.id, value: selectedClassificationId}],
+                        // Per-channel banner placement lives on the value's attrs.
+                        // A single shared channel field is used for all channels, so
+                        // placement cannot live on the field. Fixed to top today
+                        // (matches prior behavior); per-channel UI can vary it later.
+                        [{field_id: classification.channelField.id, value: selectedClassificationId, attrs: {actions: [DISPLAY_BANNER_TOP]}}],
                     );
                     dispatch({type: PropertyTypes.RECEIVED_PROPERTY_VALUES, data: {values}});
                 } catch (err) {

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_configuration_tab.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_configuration_tab.tsx
@@ -435,10 +435,12 @@ function ChannelSettingsConfigurationTab({
 
         if (hasClassificationChanges && classification.channelField) {
             if (classificationEnabled && selectedClassificationId) {
-                // Per-channel banner placement lives on the value's attrs. A single
-                // shared channel field is used for all channels, so placement cannot
-                // live on the field. Fixed to top today (matches prior behavior);
-                // per-channel UI can vary it later.
+                // Per-channel banner actions live on the value — the value is
+                // classification's home for actions. The channel field is shared by
+                // all channels, so actions defined there would apply everywhere;
+                // hence there's no field mirror on this path (unlike the system
+                // banner). Fixed to top today to match prior behavior; a per-channel
+                // UI can vary it later.
                 try {
                     const values = await Client4.patchPropertyValues(
                         CLASSIFICATIONS_GROUP_NAME,

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_configuration_tab.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_configuration_tab.tsx
@@ -439,8 +439,8 @@ function ChannelSettingsConfigurationTab({
                 // classification's home for actions. The channel field is shared by
                 // all channels, so actions defined there would apply everywhere;
                 // hence there's no field mirror on this path (unlike the system
-                // banner). Fixed to top today to match prior behavior; a per-channel
-                // UI can vary it later.
+                // banner). The actions are fixed to [top] here; a per-channel UI
+                // could vary them later.
                 try {
                     const values = await Client4.patchPropertyValues(
                         CLASSIFICATIONS_GROUP_NAME,

--- a/webapp/channels/src/components/common/hooks/useChannelClassificationBanner.test.ts
+++ b/webapp/channels/src/components/common/hooks/useChannelClassificationBanner.test.ts
@@ -218,9 +218,9 @@ describe('useChannelClassificationBanner', () => {
         expect(result.current.classificationBanner).toBeUndefined();
     });
 
-    test('renders for legacy values without attrs (defaults to top placement)', () => {
+    test('renders when the value has no attrs (defaults to top placement)', () => {
         mockClassification();
-        const value = makePropertyValue('lvl1'); // no attrs — pre-refactor data
+        const value = makePropertyValue('lvl1'); // no attrs.actions
 
         const {result} = renderHookWithContext(
             () => useChannelClassificationBanner(CHANNEL_ID),

--- a/webapp/channels/src/components/common/hooks/useChannelClassificationBanner.test.ts
+++ b/webapp/channels/src/components/common/hooks/useChannelClassificationBanner.test.ts
@@ -12,6 +12,7 @@ import {
     CLASSIFICATIONS_CHANNEL_OBJECT_TYPE,
     CLASSIFICATIONS_FIELD_TARGET_TYPE,
     CLASSIFICATIONS_GROUP_NAME,
+    DISPLAY_BANNER_TOP,
 } from 'components/admin_console/classification_markings/utils';
 import type {ClassificationLevel} from 'components/admin_console/classification_markings/utils/presets';
 
@@ -48,7 +49,7 @@ function makeChannelField(overrides: Partial<PropertyField> = {}): PropertyField
     };
 }
 
-function makePropertyValue(value: string | null): PropertyValue<string> {
+function makePropertyValue(value: string | null, attrs?: PropertyValue<string>['attrs']): PropertyValue<string> {
     return {
         id: 'value1',
         target_id: CHANNEL_ID,
@@ -56,6 +57,7 @@ function makePropertyValue(value: string | null): PropertyValue<string> {
         group_id: CLASSIFICATIONS_GROUP_NAME,
         field_id: FIELD_ID,
         value: value as string,
+        attrs,
         create_at: 2000,
         update_at: 2000,
         delete_at: 0,
@@ -188,6 +190,45 @@ describe('useChannelClassificationBanner', () => {
             text: '**UNCLASSIFIED**',
             background_color: '#007A33',
         });
+    });
+
+    test('renders the banner when the value actions include display_banner_top', () => {
+        mockClassification();
+        const value = makePropertyValue('lvl1', {actions: [DISPLAY_BANNER_TOP]});
+
+        const {result} = renderHookWithContext(
+            () => useChannelClassificationBanner(CHANNEL_ID),
+            stateWithValue(value),
+        );
+
+        expect(result.current.hasClassification).toBe(true);
+        expect(result.current.classificationId).toBe('lvl1');
+    });
+
+    test('hides the banner when the value has an explicit empty actions set', () => {
+        mockClassification();
+        const value = makePropertyValue('lvl1', {actions: []});
+
+        const {result} = renderHookWithContext(
+            () => useChannelClassificationBanner(CHANNEL_ID),
+            stateWithValue(value),
+        );
+
+        expect(result.current.hasClassification).toBe(false);
+        expect(result.current.classificationBanner).toBeUndefined();
+    });
+
+    test('renders for legacy values without attrs (defaults to top placement)', () => {
+        mockClassification();
+        const value = makePropertyValue('lvl1'); // no attrs — pre-refactor data
+
+        const {result} = renderHookWithContext(
+            () => useChannelClassificationBanner(CHANNEL_ID),
+            stateWithValue(value),
+        );
+
+        expect(result.current.hasClassification).toBe(true);
+        expect(result.current.classificationId).toBe('lvl1');
     });
 
     test('returns hasClassification=false when the referenced level no longer exists', () => {

--- a/webapp/channels/src/components/common/hooks/useChannelClassificationBanner.ts
+++ b/webapp/channels/src/components/common/hooks/useChannelClassificationBanner.ts
@@ -16,6 +16,7 @@ import {getPropertyValueForTargetField} from 'mattermost-redux/selectors/entitie
 import {
     CLASSIFICATIONS_CHANNEL_OBJECT_TYPE,
     CLASSIFICATIONS_GROUP_NAME,
+    DISPLAY_BANNER_TOP,
 } from 'components/admin_console/classification_markings/utils';
 
 import useClassificationMarkings from './useClassificationMarkings';
@@ -84,6 +85,14 @@ export default function useChannelClassificationBanner(channelId: string): Chann
         };
 
         if (!propertyValue || !propertyValue.value) {
+            return noClassification;
+        }
+
+        // Per-channel banner placement lives on the value's attrs.actions.
+        // Absent attrs (pre-refactor values) default to showing the top banner,
+        // preserving legacy behavior. An explicit empty actions set hides it.
+        const actions = (propertyValue.attrs?.actions as string[] | undefined) ?? [DISPLAY_BANNER_TOP];
+        if (!actions.includes(DISPLAY_BANNER_TOP)) {
             return noClassification;
         }
 

--- a/webapp/channels/src/components/common/hooks/useChannelClassificationBanner.ts
+++ b/webapp/channels/src/components/common/hooks/useChannelClassificationBanner.ts
@@ -89,8 +89,8 @@ export default function useChannelClassificationBanner(channelId: string): Chann
         }
 
         // Per-channel banner placement lives on the value's attrs.actions.
-        // Absent attrs (pre-refactor values) default to showing the top banner,
-        // preserving legacy behavior. An explicit empty actions set hides it.
+        // A value with no attrs.actions defaults to showing the top banner; an
+        // explicit empty actions set hides it.
         const actions = (propertyValue.attrs?.actions as string[] | undefined) ?? [DISPLAY_BANNER_TOP];
         if (!actions.includes(DISPLAY_BANNER_TOP)) {
             return noClassification;

--- a/webapp/channels/src/components/global_classification_banner/global_classification_banner.test.tsx
+++ b/webapp/channels/src/components/global_classification_banner/global_classification_banner.test.tsx
@@ -196,7 +196,7 @@ describe('GlobalClassificationBanner', () => {
         expect(screen.queryByTestId('global-classification-banner-top')).not.toBeInTheDocument();
     });
 
-    test('falls back to field actions when the value has no attrs (legacy/mobile-written data)', () => {
+    test('falls back to field actions when the value has no attrs', () => {
         const options = [{id: 'opt1', name: 'SECRET', color: '#C8102E'}];
         const linked = makeLinkedField([DISPLAY_BANNER_TOP], options);
         const value = makeSystemValue('opt1'); // no attrs on the value

--- a/webapp/channels/src/components/global_classification_banner/global_classification_banner.test.tsx
+++ b/webapp/channels/src/components/global_classification_banner/global_classification_banner.test.tsx
@@ -53,8 +53,8 @@ function makeLinkedField(actions: string[], options: Array<{id: string; name: st
     };
 }
 
-function makeSystemValue(optionId: string): PropertyValue<string> {
-    return {
+function makeSystemValue(optionId: string, actions?: string[]): PropertyValue<string> {
+    const value: PropertyValue<string> = {
         id: 'value1',
         target_id: CLASSIFICATIONS_SYSTEM_VALUE_TARGET_ID,
         target_type: CLASSIFICATIONS_SYSTEM_OBJECT_TYPE,
@@ -67,6 +67,10 @@ function makeSystemValue(optionId: string): PropertyValue<string> {
         created_by: 'user1',
         updated_by: 'user1',
     };
+    if (actions) {
+        value.attrs = {actions};
+    }
+    return value;
 }
 
 type StateOptions = {
@@ -163,6 +167,46 @@ describe('GlobalClassificationBanner', () => {
         );
 
         expect(screen.queryByTestId('global-classification-banner-top')).not.toBeInTheDocument();
+    });
+
+    test('prefers value actions over field actions: renders when the value has top but the field is empty', () => {
+        const options = [{id: 'opt1', name: 'SECRET', color: '#C8102E'}];
+        const linked = makeLinkedField([], options); // field carries no actions
+        const value = makeSystemValue('opt1', [DISPLAY_BANNER_TOP]); // value carries top
+
+        renderWithContext(
+            <GlobalClassificationBanner position='top'/>,
+            makeState({linkedField: linked, systemValue: value}),
+        );
+
+        expect(screen.getByTestId('global-classification-banner-top')).toBeInTheDocument();
+        expect(screen.getByText('SECRET')).toBeInTheDocument();
+    });
+
+    test('value actions take precedence: an empty actions set on the value suppresses a field-configured banner', () => {
+        const options = [{id: 'opt1', name: 'SECRET', color: '#C8102E'}];
+        const linked = makeLinkedField([DISPLAY_BANNER_TOP], options); // field would show it
+        const value = makeSystemValue('opt1', []); // value explicitly clears actions
+
+        renderWithContext(
+            <GlobalClassificationBanner position='top'/>,
+            makeState({linkedField: linked, systemValue: value}),
+        );
+
+        expect(screen.queryByTestId('global-classification-banner-top')).not.toBeInTheDocument();
+    });
+
+    test('falls back to field actions when the value has no attrs (legacy/mobile-written data)', () => {
+        const options = [{id: 'opt1', name: 'SECRET', color: '#C8102E'}];
+        const linked = makeLinkedField([DISPLAY_BANNER_TOP], options);
+        const value = makeSystemValue('opt1'); // no attrs on the value
+
+        renderWithContext(
+            <GlobalClassificationBanner position='top'/>,
+            makeState({linkedField: linked, systemValue: value}),
+        );
+
+        expect(screen.getByTestId('global-classification-banner-top')).toBeInTheDocument();
     });
 
     test('does not render when system property value is absent', () => {

--- a/webapp/channels/src/components/global_classification_banner/global_classification_banner.tsx
+++ b/webapp/channels/src/components/global_classification_banner/global_classification_banner.tsx
@@ -78,9 +78,10 @@ export default function GlobalClassificationBanner({position}: Props) {
         }
     }, [featureEnabled, linkedField, systemValue, dispatch]);
 
-    // Display conditions are encoded in attrs.actions. Prefer the system
-    // value's actions (new clients); fall back to the linked field's actions
-    // so mobile-era data and pre-refactor installs still render correctly.
+    // Display conditions are encoded in attrs.actions. Prefer the system value's
+    // actions; fall back to the linked field's actions — the field also carries
+    // the actions (mobile reads them there), and this covers a value that has
+    // none of its own.
     const actions = (systemValue?.attrs?.actions as string[] | undefined) ??
         (linkedField?.attrs?.actions as string[] | undefined) ?? [];
     const shouldRenderTop = actions.includes(DISPLAY_BANNER_TOP);

--- a/webapp/channels/src/components/global_classification_banner/global_classification_banner.tsx
+++ b/webapp/channels/src/components/global_classification_banner/global_classification_banner.tsx
@@ -78,8 +78,11 @@ export default function GlobalClassificationBanner({position}: Props) {
         }
     }, [featureEnabled, linkedField, systemValue, dispatch]);
 
-    // Display conditions are encoded in the linked field's attrs.actions.
-    const actions = (linkedField?.attrs?.actions as string[] | undefined) ?? [];
+    // Display conditions are encoded in attrs.actions. Prefer the system
+    // value's actions (new clients); fall back to the linked field's actions
+    // so mobile-era data and pre-refactor installs still render correctly.
+    const actions = (systemValue?.attrs?.actions as string[] | undefined) ??
+        (linkedField?.attrs?.actions as string[] | undefined) ?? [];
     const shouldRenderTop = actions.includes(DISPLAY_BANNER_TOP);
     const shouldRenderBottom = actions.includes(DISPLAY_BANNER_BOTTOM);
 

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -2225,14 +2225,14 @@ export default class Client4 {
         );
     };
 
-    patchSystemPropertyValues = <T>(groupName: string, items: Array<{field_id: string; value: T}>) => {
+    patchSystemPropertyValues = <T>(groupName: string, items: Array<{field_id: string; value: T; attrs?: Record<string, unknown>}>) => {
         return this.doFetch<Array<PropertyValue<T>>>(
             `${this.getBaseRoute()}/properties/groups/${groupName}/system/values`,
             {method: 'PATCH', body: JSON.stringify(items)},
         );
     };
 
-    patchPropertyValues = <T>(groupName: string, objectType: string, targetId: string, items: Array<{field_id: string; value: T}>) => {
+    patchPropertyValues = <T>(groupName: string, objectType: string, targetId: string, items: Array<{field_id: string; value: T; attrs?: Record<string, unknown>}>) => {
         return this.doFetch<Array<PropertyValue<T>>>(
             `${this.getBaseRoute()}/properties/groups/${groupName}/${objectType}/values/${targetId}`,
             {method: 'PATCH', body: JSON.stringify(items)},

--- a/webapp/platform/types/src/properties.ts
+++ b/webapp/platform/types/src/properties.ts
@@ -55,6 +55,9 @@ export type PropertyValue<T> = {
     group_id: string;
     field_id: string;
     value: T;
+    attrs?: {
+        [key: string]: unknown;
+    };
     create_at: number;
     update_at: number;
     delete_at: number;


### PR DESCRIPTION
### Overview

Classification banners are driven by "actions" (e.g. `display_banner_top`) that, until now, could only be stored on a property *field*. That coupling forced a design choice: to give different channels different banner behavior, you'd have to create a separate classification field per channel. We'd rather share **one** channel classification field across all channels and decide the actions **per channel**.

This is also forward-looking. "Actions" won't stay limited to banners — we expect to attach things like labels or other behaviors to a classification, and we won't always want them applied to every channel/target. Anchoring actions to the individual value (the per-channel selection) rather than the shared field is what makes that selective, per-target control possible.

### Approach

Property *values* already exist per target — a channel's classification is a value keyed by channel ID against the shared field. The core move is to give `PropertyValue` the same free-form `attrs` bag that `PropertyField` already has. Actions then become a **general capability of the property system: both fields and values can carry them**, and which one a feature uses is a per-feature choice.

For the classification feature specifically, the value is the natural home — it's the per-target selection — so that's where classification defines its actions. We *also* write them onto the field, but purely as a **temporary backwards-compatibility mirror**: it exists only so existing clients keep working, and it will be dropped once every client reads actions from the value (see Migration plan). Fields keeping their own actions remains valid in general; classification just won't be one of the features that relies on it.

The constraint driving the mirror is backwards compatibility: existing clients — notably our mobile apps — read banner actions from property **fields** and must keep working unchanged. So this PR is deliberately **additive rather than a move**:

- Actions are **dual-written** — onto the value's `attrs` (where classification will ultimately keep them) and onto the field's `attrs` (a temporary compatibility mirror). Nothing that reads fields today loses anything.
- New web clients read actions **value-first, with the field as fallback**, so they honor per-channel actions while older data and older clients still resolve correctly.
- The system/global banner records its actions on its value too, so system-scope and channel-scope share one consistent model.

Net effect: today's behavior is preserved everywhere (mobile included), but we now have a single shared channel field whose banner behavior can be set per channel — and a place to hang future, non-banner actions without applying them globally.

### Migration plan

This PR is the first, deliberately additive step. The dual-write (value **and** field) and the value-first-with-field-fallback reads exist so nothing breaks while clients catch up. The rollout then continues in stages:

1. **This release** — add `attrs` to `PropertyValue`, dual-write actions onto both the value and the field, and have web read value-first with a field fallback.
2. **A coming release** — update *all* clients (mobile included) to read actions from **both** the field and the value. Once every supported client understands value attrs, the field is no longer needed as a compatibility source.
3. **After clients are updated** — stop dual-writing and set property-value actions only for the classification markings project specifically, dropping the field-level write. A database migration will handle the transition for existing data.

Staging it this way keeps every ESR/client combination working throughout and defers the value-only cutover until it's safe.

### Ticket Link
<!-- No ticket yet. -->

### Screenshots
No UI changes — behavior is identical to today; this enables per-value actions under the hood.

### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** This change updates data persistence (adds a `jsonb` column via migration) and core property upsert/read/write flows across both backend and web clients, so regressions could affect classification banner placement. Backward compatibility is addressed by mirroring actions to field attrs for legacy readers, but any gaps in fallback/round-tripping could impact banner rendering.

**QA Recommendation:** Moderate manual QA is recommended focused on classification banner behavior across web save/load flows (value vs linked field precedence), including top-only and explicitly empty actions scenarios; automated coverage should cover most persistence/round-trip cases.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

