### PR TITLE
[MM-69394] fix for data retention teams endpoint

### DIFF
--- a/server/channels/api4/data_retention.go
+++ b/server/channels/api4/data_retention.go
@@ -229,6 +229,7 @@ func getTeamsForPolicy(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = appErr
 		return
 	}
+	c.App.SanitizeTeams(*c.AppContext.Session(), teams.Teams)
 
 	b, err := json.Marshal(teams)
 	if err != nil {

--- a/server/channels/api4/data_retention_test.go
+++ b/server/channels/api4/data_retention_test.go
@@ -709,12 +709,17 @@ func TestGetTeamsForPolicy(t *testing.T) {
 	// Create and set up the mock
 	mockDataRetentionInterface := &mocks.DataRetentionInterface{}
 
-	// Set up the mock to return sample teams
+	// Set up the mock to return sample teams. team1 carries a secret InviteId and Email,
+	// mirroring an invite-only private team, to verify the endpoint sanitizes them for
+	// callers who lack team-scoped permissions on that team (MM-69394).
 	sampleTeams := &model.TeamsWithCount{
 		Teams: []*model.Team{
 			{
-				Id:   model.NewId(),
-				Name: "team1",
+				Id:       model.NewId(),
+				Name:     "team1",
+				Type:     model.TeamInvite,
+				InviteId: model.NewId(),
+				Email:    "team1-secret@example.com",
 			},
 			{
 				Id:   model.NewId(),
@@ -768,6 +773,23 @@ func TestGetTeamsForPolicy(t *testing.T) {
 		require.Error(t, err)
 		CheckForbiddenStatus(t, resp)
 		assert.Nil(t, teams, "Teams should be nil when user has no permission")
+	})
+
+	t.Run("SanitizesInviteIDAndEmailForUserWithoutTeamAccess", func(t *testing.T) {
+		// A user holding ONLY the read-only Data Retention Policy permission, who is not a
+		// member of the team and holds no team-scoped permissions on it, must not be able to
+		// read the team's secret invite_id or email via this endpoint (MM-69394).
+		th.AddPermissionToRole(t, model.PermissionSysconsoleReadComplianceDataRetentionPolicy.Id, model.SystemUserRoleId)
+		defer th.RemovePermissionFromRole(t, model.PermissionSysconsoleReadComplianceDataRetentionPolicy.Id, model.SystemUserRoleId)
+
+		teams, resp, err := th.Client.GetTeamsForRetentionPolicy(context.Background(), validPolicyId, 0, 100)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.NotNil(t, teams, "Teams should not be nil")
+		require.Len(t, teams.Teams, 2, "Should return 2 teams")
+		assert.Equal(t, "team1", teams.Teams[0].Name, "Non-secret team fields should still be returned")
+		assert.Empty(t, teams.Teams[0].InviteId, "InviteId must be sanitized for a caller without team access")
+		assert.Empty(t, teams.Teams[0].Email, "Email must be sanitized for a caller without team access")
 	})
 
 	t.Run("NotLoggedIn", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
- See the linked ticket for summary and root cause analysis.

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-69394


#### Release Note

```release-note
Fixed an issue where the data retention policy teams endpoint returned more team information than intended.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Medium 🟡

**Regression Risk:** The change is isolated to a single API endpoint, but it alters the response contract by sanitizing team fields based on session context. That creates some risk around authorization-adjacent behavior and could affect consumers expecting the previous payload shape.

**QA Recommendation:** Targeted manual QA is recommended for the data retention teams endpoint across at least two permission scenarios: privileged access and limited/system-user access. Automated coverage is helpful here, but a quick response-shape verification would reduce release risk.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->