### PR TITLE
Fix flaky TestSendMailWithEmbeddedFilesUsingConfig

### DIFF
--- a/server/platform/shared/mail/mail_test.go
+++ b/server/platform/shared/mail/mail_test.go
@@ -6,6 +6,7 @@ package mail
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"net"
 	"net/mail"
@@ -207,10 +208,10 @@ func TestSendMailPlainText(t *testing.T) {
 func TestSendMailWithEmbeddedFilesUsingConfig(t *testing.T) {
 	cfg := getConfig()
 
-	var emailTo = "test@example.com"
-	var emailSubject = "Testing this email"
-	var emailBody = "This is a test from autobot"
-	var emailCC = "test@example.com"
+	emailTo := fmt.Sprintf("embedded-files-%d@example.com", time.Now().UnixNano())
+	emailSubject := "Testing this email"
+	emailBody := "This is a test from autobot"
+	emailCC := emailTo
 
 	//Delete all the messages before check the sample email
 	DeleteMailBox(emailTo)
@@ -224,10 +225,26 @@ func TestSendMailWithEmbeddedFilesUsingConfig(t *testing.T) {
 
 	//Check if the email was send to the right email address
 	var resultsMailbox JSONMessageHeaderInbucket
-	err3 := RetryInbucket(5, func() error {
+	var resultsEmail JSONMessageInbucket
+	err3 := RetryInbucket(10, func() error {
 		var err error
 		resultsMailbox, err = GetMailBox(emailTo)
-		return err
+		if err != nil {
+			return err
+		}
+		if len(resultsMailbox) == 0 {
+			return fmt.Errorf("no messages in mailbox")
+		}
+
+		resultsEmail, err = GetMessageFromMailbox(emailTo, resultsMailbox[0].ID)
+		if err != nil {
+			return err
+		}
+		if resultsEmail.Size <= 1500 {
+			return fmt.Errorf("message size %d does not yet reflect embedded attachments", resultsEmail.Size)
+		}
+
+		return nil
 	})
 	if err3 != nil {
 		t.Log(err3)
@@ -235,8 +252,6 @@ func TestSendMailWithEmbeddedFilesUsingConfig(t *testing.T) {
 	} else {
 		if len(resultsMailbox) > 0 {
 			require.Contains(t, resultsMailbox[0].To[0], emailTo, "Wrong To: recipient")
-			resultsEmail, err := GetMessageFromMailbox(emailTo, resultsMailbox[0].ID)
-			require.NoError(t, err, "Could not get message from mailbox")
 			require.Contains(t, emailBody, resultsEmail.Body.Text, "Wrong received message %s", resultsEmail.Body.Text)
 			// Usign the message size because the inbucket API doesn't return embedded attachments through the API
 			require.Greater(t, resultsEmail.Size, 1500, "the file size should be more because the embedded attachments")

--- a/server/platform/shared/mail/mail_test.go
+++ b/server/platform/shared/mail/mail_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const embeddedFileMinSize = 1500
+
 func getConfig() *SMTPConfig {
 	server := os.Getenv("MM_EMAILSETTINGS_SMTPSERVER")
 	if server == "" {
@@ -240,7 +242,7 @@ func TestSendMailWithEmbeddedFilesUsingConfig(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if resultsEmail.Size <= 1500 {
+		if resultsEmail.Size <= embeddedFileMinSize {
 			return fmt.Errorf("message size %d does not yet reflect embedded attachments", resultsEmail.Size)
 		}
 
@@ -254,7 +256,7 @@ func TestSendMailWithEmbeddedFilesUsingConfig(t *testing.T) {
 			require.Contains(t, resultsMailbox[0].To[0], emailTo, "Wrong To: recipient")
 			require.Contains(t, emailBody, resultsEmail.Body.Text, "Wrong received message %s", resultsEmail.Body.Text)
 			// Usign the message size because the inbucket API doesn't return embedded attachments through the API
-			require.Greater(t, resultsEmail.Size, 1500, "the file size should be more because the embedded attachments")
+			require.Greater(t, resultsEmail.Size, embeddedFileMinSize, "the file size should be more because the embedded attachments")
 		}
 	}
 }


### PR DESCRIPTION
#### Summary
Fix flake in `TestSendMailWithEmbeddedFilesUsingConfig` (`platform/shared/mail`). Tests-only change — no production behavior changes.

**Root cause:** The test used the shared `test@example.com` Inbucket mailbox and only polled until any message existed. Under CI load (and when other mail package tests run concurrently), that could return a plain email without embedded attachments (size ~948 instead of >1500) or race Inbucket attachment downloads (`EOF` fetching embedded files), causing intermittent assertion failures.

**Fix:** Scope the test to a unique per-run mailbox address and extend `RetryInbucket` to wait until `GetMessageFromMailbox` succeeds and the message size reflects embedded attachments before asserting.

**Verification:**
- `go test -run '^TestSendMailWithEmbeddedFilesUsingConfig$' -race -count=100 -timeout=20m ./platform/shared/mail/...` — 100/100 green locally.
- Reverted the fix and re-ran under concurrent mail-package load; reproduced failures (`948 is not greater than 1500`, attachment `EOF`) in multiple runs, confirming the test still guards the original behavior.

**Originally introduced in:** 5d85417a8b4 by jsoref (size assertion); e9ecb8fdaa8 by jespino (test body).

cc @marianunez

#### Ticket Link
Flaky test reported here: https://github.com/mattermost/mattermost/pull/37372

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: Low 🟢

**Regression Risk:** The change is confined to `server/platform/shared/mail/mail_test.go` and does not modify production code, APIs, persistence, or shared runtime behavior. The only behavioral effect is making an existing flaky test wait for the correct embedded-attachment state, reducing intermittent CI failures.

**QA Recommendation:** No manual QA needed; rely on automated CI for this test. If troubleshooting persists, rerun the targeted mail test with race-enabled/inbucket settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->