### PR TITLE
docs: add Zenith Hosting deploy option

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Table of contents
 - [Download and Install Mattermost Self-Hosted](https://docs.mattermost.com/guides/deployment.html) - Deploy a Mattermost Self-hosted instance in minutes via Docker, Ubuntu, or tar.
 - [Get started in the cloud](https://mattermost.com/sign-up/?utm_source=github-mattermost-server-readme) to try Mattermost today.
 - [Developer machine setup](https://developers.mattermost.com/contribute/server/developer-setup) - Follow this guide if you want to write code for Mattermost.
+- [![Deploy with Zenith](https://cdn.zenith.hosting/buttons/deploy-with-zenith.svg)](https://zenith.hosting/host/mattermost) - One-click managed Mattermost: storage, backups, email and a free subdomain included. A share of every subscription goes back to Mattermost.
 
 
 Other install guides:


### PR DESCRIPTION
hey, i work on Zenith Hosting, a startup doing one-click hosting for open source apps. we added Mattermost to our marketplace, so this PR adds a small "Deploy with Zenith" badge under the Install Mattermost section (links to https://zenith.hosting/host/mattermost).

we share a cut of revenue with the projects we host. happy to explain if you're curious: hello@zenith.hosting

#### Summary
Docs-only change: adds a "Deploy with Zenith" badge as one bullet under the Install Mattermost section. No code, config, schema, or behavior changes. No tests/build affected.

#### Ticket Link
N/A

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```

<!-- No LLM was used to generate this change. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** This is a documentation-only update with no code, config, or behavioral changes, so regression risk is minimal and isolated to the README content. It does not affect authentication, data flow, APIs, or shared runtime paths.

**QA Recommendation:** No manual QA is necessary beyond a quick documentation review to confirm the badge renders and links correctly.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->