### PR TITLE
Fix milestone lookup in docs-needed workflow

### DIFF
--- a/.github/workflows/docs-needed.yml
+++ b/.github/workflows/docs-needed.yml
@@ -509,8 +509,8 @@ jobs:
           # milestone title contains quotes or other special characters.
           NUM=$(gh api 'repos/mattermost/docs/milestones?state=all' \
             --paginate \
-            --jq '.[] | select(.title == $title) | .number' \
-            --arg title "$MILESTONE_TITLE" \
+            | jq -r --arg title "$MILESTONE_TITLE" \
+                '.[] | select(.title == $title) | .number' \
             | head -1)
 
           if [ -z "$NUM" ]; then


### PR DESCRIPTION
## Summary
`gh api` does not support an `--arg` flag — `--arg` is a `jq` flag, not a `gh api` flag, so passing it alongside `--jq` on the same `gh api` invocation doesn't work as intended. Pipes the milestone list into a standalone `jq -r --arg` invocation instead, which correctly applies the `--arg`-bound `$title` variable when filtering `mattermost/docs` milestones by title.

Fixes https://github.com/mattermost/mattermost/actions/runs/28860645358/job/85598096959#logs

## Test plan
- [ ] Trigger the "Sync milestone" step in `docs-needed.yml` (e.g. via the workflow's normal trigger) and confirm it correctly finds an existing milestone by title in `mattermost/docs` instead of always falling through to milestone creation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is an isolated workflow fix in a single GitHub Actions step, with no impact on shared application code, APIs, or data flows. The main risk is limited to milestone matching behavior in the docs-needed automation.

**QA Recommendation:** Light manual verification is sufficient; trigger the workflow once and confirm it reuses an existing milestone title as expected.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->