### PR TITLE
Remove some usage of changeCss

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/send_button/send_button.scss
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/send_button.scss
@@ -53,6 +53,10 @@
         &.singleAction {
             border-radius: 4px;
         }
+
+        &:not(.disabled):hover {
+            background: color-mix(in srgb, var(--button-bg) 90%, #000);
+        }
     }
 
     .button_send_post_options {
@@ -60,5 +64,9 @@
         border-radius: 0 4px 4px 0;
         border-left: 1px solid color-mix(in srgb, currentColor 20%, transparent);
         padding-inline: 2px;
+
+        &:not(.disabled):hover {
+            background: color-mix(in srgb, var(--button-bg) 90%, #000);
+        }
     }
 }

--- a/webapp/channels/src/components/audit_table/__snapshots__/audit_table.test.tsx.snap
+++ b/webapp/channels/src/components/audit_table/__snapshots__/audit_table.test.tsx.snap
@@ -27,10 +27,10 @@ exports[`components/audit_table/AuditTable should match snapshot with audits 1`]
     <tbody
       data-testid="auditTableBody"
     >
-      <tr>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+      <tr
+        class="AuditRow"
+      >
+        <td>
           <div>
             <div>
               Aug 11, 1971
@@ -40,31 +40,25 @@ exports[`components/audit_table/AuditTable should match snapshot with audits 1`]
             </div>
           </div>
         </td>
-        <td
-          class="word-break--all"
-        >
+        <td>
           user_id_1
         </td>
         <td
-          class="word-break--all"
+          class="AuditRowDesc"
         >
           Channels yeye
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+        <td>
           ::1
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+        <td>
           hb8febm9ytdiz8zqaxj18efqhy
         </td>
       </tr>
-      <tr>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+      <tr
+        class="AuditRow"
+      >
+        <td>
           <div>
             <div>
               Aug 14, 1971
@@ -74,24 +68,18 @@ exports[`components/audit_table/AuditTable should match snapshot with audits 1`]
             </div>
           </div>
         </td>
-        <td
-          class="word-break--all"
-        >
+        <td>
           user_id_1
         </td>
         <td
-          class="word-break--all"
+          class="AuditRowDesc"
         >
           Successfully logged in
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+        <td>
           ::1
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        />
+        <td />
       </tr>
     </tbody>
   </table>

--- a/webapp/channels/src/components/audit_table/__snapshots__/format_audit.test.tsx.snap
+++ b/webapp/channels/src/components/audit_table/__snapshots__/format_audit.test.tsx.snap
@@ -4,10 +4,10 @@ exports[`components/audit_table/audit_row/AuditRow should match snapshot with ch
 <div>
   <table>
     <tbody>
-      <tr>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+      <tr
+        class="AuditRow"
+      >
+        <td>
           <div>
             <div>
               Aug 11, 1971
@@ -17,24 +17,18 @@ exports[`components/audit_table/audit_row/AuditRow should match snapshot with ch
             </div>
           </div>
         </td>
-        <td
-          class="word-break--all"
-        >
+        <td>
           test@example.com
         </td>
         <td
-          class="word-break--all"
+          class="AuditRowDesc"
         >
           Channels default-name
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+        <td>
           ::1
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+        <td>
           hb8febm9ytdiz8zqaxj18efqhy
         </td>
       </tr>
@@ -47,10 +41,10 @@ exports[`components/audit_table/audit_row/AuditRow should match snapshot with us
 <div>
   <table>
     <tbody>
-      <tr>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+      <tr
+        class="AuditRow"
+      >
+        <td>
           <div>
             <div>
               Aug 14, 1971
@@ -60,24 +54,18 @@ exports[`components/audit_table/audit_row/AuditRow should match snapshot with us
             </div>
           </div>
         </td>
-        <td
-          class="word-break--all"
-        >
+        <td>
           test@example.com
         </td>
         <td
-          class="word-break--all"
+          class="AuditRowDesc"
         >
           Successfully logged in
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+        <td>
           ::1
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        />
+        <td />
       </tr>
     </tbody>
   </table>
@@ -88,10 +76,10 @@ exports[`components/audit_table/audit_row/AuditRow should match snapshot with us
 <div>
   <table>
     <tbody>
-      <tr>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+      <tr
+        class="AuditRow"
+      >
+        <td>
           <div>
             <div>
               Aug 14, 1971
@@ -101,24 +89,18 @@ exports[`components/audit_table/audit_row/AuditRow should match snapshot with us
             </div>
           </div>
         </td>
-        <td
-          class="word-break--all"
-        >
+        <td>
           test@example.com
         </td>
         <td
-          class="word-break--all"
+          class="AuditRowDesc"
         >
           Attempted to register a new OAuth Application with ID client_id
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+        <td>
           ::1
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        />
+        <td />
       </tr>
     </tbody>
   </table>

--- a/webapp/channels/src/components/audit_table/audit_row/__snapshots__/audit_row.test.tsx.snap
+++ b/webapp/channels/src/components/audit_table/audit_row/__snapshots__/audit_row.test.tsx.snap
@@ -4,10 +4,10 @@ exports[`components/audit_table/audit_row/AuditRow should match snapshot with de
 <div>
   <table>
     <tbody>
-      <tr>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+      <tr
+        class="AuditRow"
+      >
+        <td>
           <div>
             <div>
               Aug 11, 1971
@@ -17,24 +17,18 @@ exports[`components/audit_table/audit_row/AuditRow should match snapshot with de
             </div>
           </div>
         </td>
-        <td
-          class="word-break--all"
-        >
+        <td>
           test@example.com
         </td>
         <td
-          class="word-break--all"
+          class="AuditRowDesc"
         >
           Successfully authenticated
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+        <td>
           ::1
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+        <td>
           hb8febm9ytdiz8zqaxj18efqhy
         </td>
       </tr>
@@ -47,10 +41,10 @@ exports[`components/audit_table/audit_row/AuditRow should match snapshot with no
 <div>
   <table>
     <tbody>
-      <tr>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+      <tr
+        class="AuditRow"
+      >
+        <td>
           <div>
             <div>
               Aug 11, 1971
@@ -60,24 +54,18 @@ exports[`components/audit_table/audit_row/AuditRow should match snapshot with no
             </div>
           </div>
         </td>
-        <td
-          class="word-break--all"
-        >
+        <td>
           test@example.com
         </td>
         <td
-          class="word-break--all"
+          class="AuditRowDesc"
         >
           Url yeye
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+        <td>
           ::1
         </td>
-        <td
-          class="whitespace--nowrap word-break--all"
-        >
+        <td>
           hb8febm9ytdiz8zqaxj18efqhy
         </td>
       </tr>

--- a/webapp/channels/src/components/audit_table/audit_row/audit_row.scss
+++ b/webapp/channels/src/components/audit_table/audit_row/audit_row.scss
@@ -1,0 +1,12 @@
+.AuditRow {
+    white-space: nowrap;
+    word-break: break-all;
+
+    .AuditRowDesc {
+        white-space: normal;
+
+        &--error {
+            color: var(--error-text);
+        }
+    }
+}

--- a/webapp/channels/src/components/audit_table/audit_row/audit_row.tsx
+++ b/webapp/channels/src/components/audit_table/audit_row/audit_row.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import classNames from 'classnames';
 import React from 'react';
 import {FormattedDate, FormattedTime, useIntl} from 'react-intl';
 import {useSelector} from 'react-redux';
@@ -15,8 +16,6 @@ import {toTitleCase} from 'utils/utils';
 import './audit_row.scss';
 
 import holders from '../holders';
-
-import classNames from 'classnames';
 
 export type Props = {
     audit: Audit;

--- a/webapp/channels/src/components/audit_table/audit_row/audit_row.tsx
+++ b/webapp/channels/src/components/audit_table/audit_row/audit_row.tsx
@@ -16,6 +16,8 @@ import './audit_row.scss';
 
 import holders from '../holders';
 
+import classNames from 'classnames';
+
 export type Props = {
     audit: Audit;
     actionURL: string;
@@ -107,18 +109,17 @@ export default function AuditRow({
         );
     }
 
-    let descStyle = 'AuditRowDesc';
-    if (desc.toLowerCase().indexOf('fail') !== -1) {
-        descStyle = ' AuditRowDesc--error';
-    }
-
     return (
         <tr className='AuditRow'>
             <td>
                 {timestamp}
             </td>
             {uContent}
-            <td className={descStyle}>{desc}</td>
+            <td
+                className={classNames('AuditRowDesc', {
+                    'AuditRowDesc--error': desc.toLowerCase().indexOf('fail') !== -1,
+                })}
+            >{desc}</td>
             {iContent}
             {sContent}
         </tr>

--- a/webapp/channels/src/components/audit_table/audit_row/audit_row.tsx
+++ b/webapp/channels/src/components/audit_table/audit_row/audit_row.tsx
@@ -12,6 +12,8 @@ import {getUser} from 'mattermost-redux/selectors/entities/users';
 
 import {toTitleCase} from 'utils/utils';
 
+import './audit_row.scss';
+
 import holders from '../holders';
 
 export type Props = {
@@ -84,13 +86,13 @@ export default function AuditRow({
     const userId = auditProfile ? auditProfile.email : audit.user_id;
     let uContent;
     if (showUserId) {
-        uContent = <td className='word-break--all'>{userId}</td>;
+        uContent = <td>{userId}</td>;
     }
 
     let iContent;
     if (showIp) {
         iContent = (
-            <td className='whitespace--nowrap word-break--all'>
+            <td>
                 {ip}
             </td>
         );
@@ -99,24 +101,24 @@ export default function AuditRow({
     let sContent;
     if (showSession) {
         sContent = (
-            <td className='whitespace--nowrap word-break--all'>
+            <td>
                 {sessionId}
             </td>
         );
     }
 
-    let descStyle = '';
+    let descStyle = 'AuditRowDesc';
     if (desc.toLowerCase().indexOf('fail') !== -1) {
-        descStyle = ' color--error';
+        descStyle = ' AuditRowDesc--error';
     }
 
     return (
-        <tr key={audit.id}>
-            <td className='whitespace--nowrap word-break--all'>
+        <tr className='AuditRow'>
+            <td>
                 {timestamp}
             </td>
             {uContent}
-            <td className={'word-break--all' + descStyle}>{desc}</td>
+            <td className={descStyle}>{desc}</td>
             {iContent}
             {sContent}
         </tr>

--- a/webapp/channels/src/components/product_notices_modal/product_notices_modal.scss
+++ b/webapp/channels/src/components/product_notices_modal/product_notices_modal.scss
@@ -44,6 +44,10 @@
         margin: 0 3px;
         background-color: var(--center-channel-color);
         vertical-align: middle;
+
+        &.active {
+            background-color: var(--button-bg);
+        }
     }
 
     svg {

--- a/webapp/channels/src/components/widgets/separator/notification-separator.scss
+++ b/webapp/channels/src/components/widgets/separator/notification-separator.scss
@@ -1,11 +1,11 @@
 .NotificationSeparator {
     .separator__hr {
-        border-color: #ffaf53;
+        border-color: rgba(var(--new-message-separator-rgb), 0.5);
     }
 
     .separator__text {
         display: inline-flex;
-        color: #f80;
+        color: var(--new-message-separator);
         font-weight: normal;
     }
 }

--- a/webapp/channels/src/components/widgets/separator/separator.scss
+++ b/webapp/channels/src/components/widgets/separator/separator.scss
@@ -28,20 +28,6 @@
         top: 0;
     }
 
-    &.hovered--after {
-        &::before {
-            display: block;
-            background: #f5f5f5;
-        }
-    }
-
-    &.hovered--before {
-        &::after {
-            display: block;
-            background: #f5f5f5;
-        }
-    }
-
     .separator__hr {
         position: relative;
         z-index: 5;
@@ -70,22 +56,6 @@
             &::before,
             &::after {
                 background: none !important;
-            }
-        }
-    }
-}
-
-@media screen and (max-width: 768px) {
-    .Separator {
-        &.hovered--after {
-            &::before {
-                background: none;
-            }
-        }
-
-        &.hovered--before {
-            &::after {
-                background: none;
             }
         }
     }

--- a/webapp/channels/src/components/widgets/separator/separator.scss
+++ b/webapp/channels/src/components/widgets/separator/separator.scss
@@ -50,17 +50,6 @@
     }
 }
 
-@media screen and (max-width: 1440px) {
-    .Separator {
-        &.hovered--comment {
-            &::before,
-            &::after {
-                background: none !important;
-            }
-        }
-    }
-}
-
 @media print {
     .Separator .separator__hr {
         top: 1.7em;

--- a/webapp/channels/src/sass/base/_typography.scss
+++ b/webapp/channels/src/sass/base/_typography.scss
@@ -50,7 +50,7 @@ h1 {
 
 label {
     &.has-error {
-        color: variables.$red;
+        color: var(--error-text);
         font-weight: normal;
     }
 }

--- a/webapp/channels/src/sass/components/_buttons.scss
+++ b/webapp/channels/src/sass/components/_buttons.scss
@@ -216,14 +216,13 @@ button {
         background-color: rgb(var(--button-bg-rgb));
         color: rgb(var(--button-color-rgb)) !important;
 
-        // These hover and active values are for things outside the app__body, the correct theme styles for the primary button are applied in utils.jsx
         &:hover, &.btn-force-hover {
-            background-color: #1a51c8;
+            background-color: color-mix(in srgb, var(--button-bg) 90%, #000);
         }
 
         &:active, &.btn-force-active,
         &:focus, &.btn-force-focus {
-            background-color: #184ab6;
+            background-color: color-mix(in srgb, var(--button-bg) 80%, #000);
         }
 
         &:disabled, &.btn-force-disabled,
@@ -381,9 +380,14 @@ button {
             }
         }
 
-        &:hover, &.btn-force-hover,
+        &:hover, &.btn-force-hover {
+            background: color-mix(in srgb, var(--error-text) 90%, #000);
+            color: variables.$white;
+        }
+
         &:focus, &.btn-force-focus,
         &:active, &.btn-force-active {
+            background: color-mix(in srgb, var(--error-text) 80%, #000);
             color: variables.$white;
         }
     }

--- a/webapp/channels/src/sass/components/_buttons.scss
+++ b/webapp/channels/src/sass/components/_buttons.scss
@@ -396,6 +396,11 @@ button {
         padding: 7px 12px;
         border: none;
         background: transparent;
+
+        &:hover,
+        &:active {
+            color: var(--button-color);
+        }
     }
 
     &.btn-inactive {

--- a/webapp/channels/src/sass/components/_buttons.scss
+++ b/webapp/channels/src/sass/components/_buttons.scss
@@ -399,6 +399,7 @@ button {
 
         &:hover,
         &:active {
+            background: var(--button-bg);
             color: var(--button-color);
         }
     }

--- a/webapp/channels/src/sass/components/_day-picker.scss
+++ b/webapp/channels/src/sass/components/_day-picker.scss
@@ -51,6 +51,7 @@
         .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--outside):not(.DayPicker-Day--selected) {
             &:hover {
                 background-color: var(--center-channel-bg) !important;
+                color: var(--button-color) !important;
 
                 &::before {
                     background-color: rgba(var(--center-channel-color-rgb), 0.08) !important;

--- a/webapp/channels/src/sass/components/_day-picker.scss
+++ b/webapp/channels/src/sass/components/_day-picker.scss
@@ -54,7 +54,7 @@
                 color: var(--button-color) !important;
 
                 &::before {
-                    background-color: rgba(var(--center-channel-color-rgb), 0.08) !important;
+                    background-color: var(--button-bg) !important;
                 }
             }
         }

--- a/webapp/channels/src/sass/components/_emoji-picker-tabs.scss
+++ b/webapp/channels/src/sass/components/_emoji-picker-tabs.scss
@@ -28,18 +28,19 @@
         a {
             width: max-content;
             padding-top: 7px !important;
+            border-bottom-color: var(--button-bg) !important;
 
             svg,
             div {
                 color: var(--button-bg);
-                fill: var(--mention-bg-rgb);
+                fill: var(--mention-bg);
             }
 
             &:hover {
                 svg,
                 div {
                     color: var(--button-bg);
-                    fill: var(--mention-bg-rgb);
+                    fill: var(--mention-bg);
                 }
             }
         }

--- a/webapp/channels/src/sass/components/_files.scss
+++ b/webapp/channels/src/sass/components/_files.scss
@@ -647,7 +647,10 @@
             transition: opacity 0.15s ease;
 
             &:hover {
+                border-color: var(--button-bg);
+                background: var(--button-bg);
                 opacity: 1;
+                stroke: var(--button-color);
             }
         }
 

--- a/webapp/channels/src/sass/components/_forms.scss
+++ b/webapp/channels/src/sass/components/_forms.scss
@@ -61,21 +61,6 @@
     font-weight: 600;
 }
 
-.input__help {
-    margin: 10px 0 0 0;
-    color: inherit;
-    opacity: 0.8;
-    word-break: break-word;
-
-    &.dark {
-        opacity: 1;
-    }
-
-    &.error {
-        color: color.adjust(variables.$red, $lightness: -20%);
-    }
-}
-
 .form-horizontal {
     .modal-intro {
         margin: -10px 0 30px;
@@ -109,20 +94,13 @@
     }
 }
 
-.help-block {
-    margin: 10px 0 0;
-    color: variables.$dark-gray;
-    font-size: 0.95em;
-}
-
 .has-error {
-
-    .help-block,
+    .control-label,
     .radio,
     .checkbox,
     .radio-inline,
     .checkbox-inline {
-        color: variables.$red;
+        color: var(--error-text);
     }
 
     .form__label {
@@ -136,9 +114,13 @@
     &.radio-inline,
     &.checkbox-inline {
         label {
-            color: variables.$red;
+            color: var(--error-text);
         }
     }
+}
+
+.error-text {
+    color: var(--error-text);
 }
 
 .multi-select__radio {

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -178,62 +178,6 @@
         outline: none;
         text-align: center;
     }
-
-    .new-messages__button {
-        position: absolute;
-        z-index: 3;
-        bottom: 0;
-        left: 50%;
-        margin: 5px auto;
-        font-size: 13.5px;
-        opacity: 0;
-        text-align: center;
-        transform: translateX(-50%);
-        visibility: hidden;
-
-        .fa {
-            position: relative;
-            top: 1px;
-            margin-right: 0.5rem;
-            font-size: 1.2em;
-            font-weight: bold;
-        }
-
-        .icon {
-            display: inline-flex;
-            align-items: center;
-            justify-content: center;
-            margin-left: 5px;
-        }
-
-        div {
-            display: flex;
-            height: 28px;
-            align-items: center;
-            padding: 0 20px;
-            border-radius: 50px;
-            cursor: pointer;
-        }
-
-        body.enable-animations & {
-            transition-delay: 0s;
-            transition-duration: variables.$transition-quick;
-            transition-property: opacity, visibility;
-            transition-timing-function: ease-in, step-end;
-        }
-
-        &.visible {
-            opacity: 1;
-            visibility: visible;
-
-            body.enable-animations & {
-                transition-delay: 0s;
-                transition-duration: variables.$transition-quick;
-                transition-property: opacity, visibility;
-                transition-timing-function: ease-out, step-start;
-            }
-        }
-    }
 }
 
 .post-list__timestamp {

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -2252,6 +2252,7 @@
     animation-duration: 2s;
     animation-fill-mode: forwards;
     animation-name: postHighlight;
+    background: rgba(var(--mention-highlight-bg-rgb), 0.5);
 }
 
 .post--pinned-or-flagged {

--- a/webapp/channels/src/sass/components/_search.scss
+++ b/webapp/channels/src/sass/components/_search.scss
@@ -365,7 +365,12 @@
 }
 
 .search-highlight {
-    background-color: variables.$yellow;
+    background-color: var(--mention-highlight-bg);
+    color: var(--mention-highlight-link);
+
+    > a {
+        color: inherit;
+    }
 }
 
 .search-hint__title {

--- a/webapp/channels/src/sass/responsive/_desktop.scss
+++ b/webapp/channels/src/sass/responsive/_desktop.scss
@@ -21,22 +21,6 @@
     }
 }
 
-@media screen and (max-width: 1800px) {
-    .inner-wrap {
-        &.move--left {
-            .date-separator,
-            .new-separator {
-                &.hovered--comment {
-                    &::before,
-                    &::after {
-                        background: none;
-                    }
-                }
-            }
-        }
-    }
-}
-
 @media screen and (max-width: 1440px) {
     .inner-wrap {
         &.move--left {

--- a/webapp/channels/src/sass/routes/_print.scss
+++ b/webapp/channels/src/sass/routes/_print.scss
@@ -25,8 +25,7 @@
     pre,
     blockquote,
     code,
-    .post,
-    .date-separator {
+    .post {
         page-break-inside: avoid;
     }
 

--- a/webapp/channels/src/sass/routes/_settings.scss
+++ b/webapp/channels/src/sass/routes/_settings.scss
@@ -193,6 +193,10 @@
             text-decoration: none;
             transition: all 0.15s ease;
 
+            &:hover {
+                color: var(--button-color);
+            }
+
             span {
                 margin-top: -3px;
                 font-size: 22px;

--- a/webapp/channels/src/sass/routes/_settings.scss
+++ b/webapp/channels/src/sass/routes/_settings.scss
@@ -143,6 +143,10 @@
             text-decoration: none;
             transition: all 0.15s ease;
 
+            &:hover {
+                background: var(--button-bg);
+            }
+
             span {
                 margin-top: -3px;
                 font-size: 22px;
@@ -194,6 +198,7 @@
             transition: all 0.15s ease;
 
             &:hover {
+                background: var(--button-bg);
                 color: var(--button-color);
             }
 

--- a/webapp/channels/src/sass/routes/_settings.scss
+++ b/webapp/channels/src/sass/routes/_settings.scss
@@ -606,7 +606,7 @@
                 }
 
                 .has-error {
-                    color: #a94442;
+                    color: var(--error-text);
                 }
 
                 .file-status {

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -394,7 +394,7 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .attachment__body__wrap.btn-close', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('@media(min-width: 768px){.app__body .post.a11y--active, .app__body .modal .settings-modal .settings-table .settings-content .section-min:hover', 'background:' + changeOpacity(theme.centerChannelColor, 0.04));
         changeCss('@media(min-width: 768px){.app__body .post.post--editing', 'background:' + changeOpacity(theme.buttonBg, 0.08));
-        changeCss('.app__body .more-modal__row.more-modal__row--selected, .app__body .date-separator.hovered--before:after, .app__body .date-separator.hovered--after:before, .app__body .new-separator.hovered--after:before, .app__body .new-separator.hovered--before:after', 'background:' + changeOpacity(theme.centerChannelColor, 0.07));
+        changeCss('.app__body .more-modal__row.more-modal__row--selected, .app__body .date-separator.hovered--before:after, .app__body .date-separator.hovered--after:before', 'background:' + changeOpacity(theme.centerChannelColor, 0.07));
         changeCss('@media(min-width: 768px){.app__body .dropdown-menu>li>a:focus, .app__body .dropdown-menu>li>a:hover', 'background:' + changeOpacity(theme.centerChannelColor, 0.15));
         changeCss('.app__body .form-control[disabled], .app__body .form-control[readonly], .app__body fieldset[disabled] .form-control', 'background:' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('.app__body .sidebar--right', 'color:' + theme.centerChannelColor);
@@ -412,11 +412,6 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .emoji-picker .nav-tabs li a', 'fill:' + theme.centerChannelColor);
         changeCss('.app__body .post .post-collapse__show-more-button', `border-color:${changeOpacity(theme.centerChannelColor, 0.1)}`);
         changeCss('.app__body .post .post-collapse__show-more-line', `background-color:${changeOpacity(theme.centerChannelColor, 0.1)}`);
-    }
-
-    if (theme.newMessageSeparator) {
-        changeCss('.app__body .new-separator .separator__text', 'color:' + theme.newMessageSeparator);
-        changeCss('.app__body .new-separator .separator__hr', 'border-color:' + changeOpacity(theme.newMessageSeparator, 0.5));
     }
 
     if (theme.linkColor) {

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -433,7 +433,7 @@ export function applyTheme(theme: Theme) {
     }
 
     if (theme.buttonBg) {
-        changeCss('.app__body .modal .settings-modal .profile-img__remove:hover, .app__body .DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover:before, .app__body .modal .settings-modal .team-img__remove:hover, .app__body .btn.btn-transparent:hover, .app__body .btn.btn-transparent:active, .app__body .post-image__details .post-image__download svg:hover, .app__body .file-view--single .file__download:hover, .app__body .tutorial__circles .circle.active', 'background:' + theme.buttonBg);
+        changeCss('.app__body .modal .settings-modal .profile-img__remove:hover, .app__body .DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover:before, .app__body .modal .settings-modal .team-img__remove:hover, .app__body .btn.btn-transparent:hover, .app__body .btn.btn-transparent:active, .app__body .post-image__details .post-image__download svg:hover, .app__body .tutorial__circles .circle.active', 'background:' + theme.buttonBg);
         changeCss('.app__body .system-notice__logo svg', 'fill:' + theme.buttonBg);
         changeCss('.app__body .post-image__details .post-image__download svg:hover', 'border-color:' + theme.buttonBg);
         changeCss('.app__body .emoji-picker .nav-tabs li.active a, .app__body .emoji-picker .nav-tabs li a:hover', 'fill:' + theme.buttonBg);
@@ -445,7 +445,7 @@ export function applyTheme(theme: Theme) {
 
     if (theme.buttonColor) {
         changeCss('.app__body .DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover, .app__body .modal .settings-modal .team-img__remove:hover, .app__body .btn.btn-transparent:hover, .app__body .btn.btn-transparent:active', 'color:' + theme.buttonColor);
-        changeCss('.app__body .post-image__details .post-image__download svg:hover, .app__body .file-view--single .file__download svg', 'stroke:' + theme.buttonColor);
+        changeCss('.app__body .post-image__details .post-image__download svg:hover', 'stroke:' + theme.buttonColor);
     }
 
     if (!theme.codeTheme) {

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -433,7 +433,7 @@ export function applyTheme(theme: Theme) {
     }
 
     if (theme.buttonBg) {
-        changeCss('.app__body .modal .settings-modal .profile-img__remove:hover, .app__body .DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover:before, .app__body .modal .settings-modal .team-img__remove:hover, .app__body .btn.btn-transparent:hover, .app__body .btn.btn-transparent:active, .app__body .post-image__details .post-image__download svg:hover, .app__body .file-view--single .file__download:hover, .app__body .new-messages__button div, .app__body .tutorial__circles .circle.active', 'background:' + theme.buttonBg);
+        changeCss('.app__body .modal .settings-modal .profile-img__remove:hover, .app__body .DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover:before, .app__body .modal .settings-modal .team-img__remove:hover, .app__body .btn.btn-transparent:hover, .app__body .btn.btn-transparent:active, .app__body .post-image__details .post-image__download svg:hover, .app__body .file-view--single .file__download:hover, .app__body .tutorial__circles .circle.active', 'background:' + theme.buttonBg);
         changeCss('.app__body .system-notice__logo svg', 'fill:' + theme.buttonBg);
         changeCss('.app__body .post-image__details .post-image__download svg:hover', 'border-color:' + theme.buttonBg);
         changeCss('.app__body .emoji-picker .nav-tabs li.active a, .app__body .emoji-picker .nav-tabs li a:hover', 'fill:' + theme.buttonBg);
@@ -444,8 +444,7 @@ export function applyTheme(theme: Theme) {
     }
 
     if (theme.buttonColor) {
-        changeCss('.app__body .DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover, .app__body .modal .settings-modal .team-img__remove:hover, .app__body .btn.btn-transparent:hover, .app__body .btn.btn-transparent:active, .app__body .new-messages__button div', 'color:' + theme.buttonColor);
-        changeCss('.app__body .new-messages__button svg', 'fill:' + theme.buttonColor);
+        changeCss('.app__body .DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover, .app__body .modal .settings-modal .team-img__remove:hover, .app__body .btn.btn-transparent:hover, .app__body .btn.btn-transparent:active', 'color:' + theme.buttonColor);
         changeCss('.app__body .post-image__details .post-image__download svg:hover, .app__body .file-view--single .file__download svg', 'stroke:' + theme.buttonColor);
     }
 

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -431,16 +431,6 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .post .post-collapse__show-more-button:hover', `background-color:${theme.linkColor}`);
     }
 
-    if (theme.buttonBg) {
-        changeCss('.app__body .modal .settings-modal .profile-img__remove:hover, .app__body .DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover:before, .app__body .modal .settings-modal .team-img__remove:hover, .app__body .btn.btn-transparent:hover, .app__body .btn.btn-transparent:active, .app__body .tutorial__circles .circle.active', 'background:' + theme.buttonBg);
-        changeCss('.app__body .system-notice__logo svg', 'fill:' + theme.buttonBg);
-        changeCss('.app__body .emoji-picker .nav-tabs li.active a, .app__body .emoji-picker .nav-tabs li a:hover', 'fill:' + theme.buttonBg);
-        changeCss('.app__body .emoji-picker .nav-tabs > li.active > a', 'border-bottom-color:' + theme.buttonBg + '!important;');
-        changeCss('.app__body .SendMessageButton:not(.disabled):hover', 'background:' + blendColors(theme.buttonBg, '#000000', 0.1));
-        changeCss('.app__body #button_send_post_options:not(.disabled):hover', 'background:' + blendColors(theme.buttonBg, '#000000', 0.1));
-        changeCss('@media(min-width: 768px){.app__body .post.post--compact.same--root.post--comment .post__content', 'border-color:' + changeOpacity(theme.buttonBg, 0.24));
-    }
-
     if (!theme.codeTheme) {
         theme.codeTheme = Constants.DEFAULT_CODE_THEME;
     }

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -433,19 +433,13 @@ export function applyTheme(theme: Theme) {
     }
 
     if (theme.buttonBg) {
-        changeCss('.app__body .modal .settings-modal .profile-img__remove:hover, .app__body .DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover:before, .app__body .modal .settings-modal .team-img__remove:hover, .app__body .btn.btn-transparent:hover, .app__body .btn.btn-transparent:active, .app__body .post-image__details .post-image__download svg:hover, .app__body .tutorial__circles .circle.active', 'background:' + theme.buttonBg);
+        changeCss('.app__body .modal .settings-modal .profile-img__remove:hover, .app__body .DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover:before, .app__body .modal .settings-modal .team-img__remove:hover, .app__body .btn.btn-transparent:hover, .app__body .btn.btn-transparent:active, .app__body .tutorial__circles .circle.active', 'background:' + theme.buttonBg);
         changeCss('.app__body .system-notice__logo svg', 'fill:' + theme.buttonBg);
-        changeCss('.app__body .post-image__details .post-image__download svg:hover', 'border-color:' + theme.buttonBg);
         changeCss('.app__body .emoji-picker .nav-tabs li.active a, .app__body .emoji-picker .nav-tabs li a:hover', 'fill:' + theme.buttonBg);
         changeCss('.app__body .emoji-picker .nav-tabs > li.active > a', 'border-bottom-color:' + theme.buttonBg + '!important;');
         changeCss('.app__body .SendMessageButton:not(.disabled):hover', 'background:' + blendColors(theme.buttonBg, '#000000', 0.1));
         changeCss('.app__body #button_send_post_options:not(.disabled):hover', 'background:' + blendColors(theme.buttonBg, '#000000', 0.1));
         changeCss('@media(min-width: 768px){.app__body .post.post--compact.same--root.post--comment .post__content', 'border-color:' + changeOpacity(theme.buttonBg, 0.24));
-    }
-
-    if (theme.buttonColor) {
-        changeCss('.app__body .DayPicker:not(.DayPicker--interactionDisabled) .DayPicker-Day:not(.DayPicker-Day--disabled):not(.DayPicker-Day--selected):not(.DayPicker-Day--outside):hover, .app__body .modal .settings-modal .team-img__remove:hover, .app__body .btn.btn-transparent:hover, .app__body .btn.btn-transparent:active', 'color:' + theme.buttonColor);
-        changeCss('.app__body .post-image__details .post-image__download svg:hover', 'stroke:' + theme.buttonColor);
     }
 
     if (!theme.codeTheme) {

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -381,8 +381,7 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .attachment-actions button:focus, .app__body .attachment-actions button:hover', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.5));
         changeCss('.app__body .attachment-actions button:focus, .app__body .attachment-actions button:hover', 'background:' + changeOpacity(theme.centerChannelColor, 0.03));
         changeCss('.app__body .input-group-addon, .app__body .webhooks__container', 'background:' + changeOpacity(theme.centerChannelColor, 0.05));
-        changeCss('.app__body .date-separator .separator__text', 'color:' + theme.centerChannelColor);
-        changeCss('.app__body .date-separator .separator__hr, .app__body .modal-footer, .app__body .modal .custom-textarea', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
+        changeCss('.app__body .modal-footer, .app__body .modal .custom-textarea', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('.app__body .search-item-container', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('.app__body .modal .custom-textarea:focus', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.3));
         changeCss('.app__body .channel-intro, .app__body hr, .app__body .modal .settings-modal .settings-table .settings-content .appearance-section .theme-elements__header, .app__body .user-settings .authorized-app:not(:last-child)', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -459,13 +459,7 @@ export function applyTheme(theme: Theme) {
     }
 
     if (theme.mentionHighlightBg) {
-        changeCss('.app__body .search-highlight', 'background:' + theme.mentionHighlightBg);
         changeCss('.app__body .post.post--highlight', 'background:' + changeOpacity(theme.mentionHighlightBg, 0.5));
-    }
-
-    if (theme.mentionHighlightLink) {
-        changeCss('.app__body .search-highlight', 'color:' + theme.mentionHighlightLink);
-        changeCss('.app__body .search-highlight > a', 'color: inherit');
     }
 
     if (!theme.codeTheme) {

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -458,10 +458,6 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .btn-danger:active', 'background:' + blendColors(theme.errorTextColor, '#000000', 0.2));
     }
 
-    if (theme.mentionHighlightBg) {
-        changeCss('.app__body .post.post--highlight', 'background:' + changeOpacity(theme.mentionHighlightBg, 0.5));
-    }
-
     if (!theme.codeTheme) {
         theme.codeTheme = Constants.DEFAULT_CODE_THEME;
     }

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -438,9 +438,6 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .post-image__details .post-image__download svg:hover', 'border-color:' + theme.buttonBg);
         changeCss('.app__body .emoji-picker .nav-tabs li.active a, .app__body .emoji-picker .nav-tabs li a:hover', 'fill:' + theme.buttonBg);
         changeCss('.app__body .emoji-picker .nav-tabs > li.active > a', 'border-bottom-color:' + theme.buttonBg + '!important;');
-        changeCss('.app__body .btn-primary:hover', 'background:' + blendColors(theme.buttonBg, '#000000', 0.1));
-        changeCss('.app__body .btn-primary:active', 'background:' + blendColors(theme.buttonBg, '#000000', 0.2));
-
         changeCss('.app__body .SendMessageButton:not(.disabled):hover', 'background:' + blendColors(theme.buttonBg, '#000000', 0.1));
         changeCss('.app__body #button_send_post_options:not(.disabled):hover', 'background:' + blendColors(theme.buttonBg, '#000000', 0.1));
         changeCss('@media(min-width: 768px){.app__body .post.post--compact.same--root.post--comment .post__content', 'border-color:' + changeOpacity(theme.buttonBg, 0.24));
@@ -454,8 +451,6 @@ export function applyTheme(theme: Theme) {
 
     if (theme.errorTextColor) {
         changeCss('.app__body .error-text, .app__body .modal .settings-modal .settings-table .settings-content .has-error, .app__body .modal .input__help.error, .app__body .color--error, .app__body .has-error .help-block, .app__body .has-error .control-label, .app__body .has-error .radio, .app__body .has-error .checkbox, .app__body .has-error .radio-inline, .app__body .has-error .checkbox-inline, .app__body .has-error.radio label, .app__body .has-error.checkbox label, .app__body .has-error.radio-inline label, .app__body .has-error.checkbox-inline label', 'color:' + theme.errorTextColor);
-        changeCss('.app__body .btn-danger:hover', 'background:' + blendColors(theme.errorTextColor, '#000000', 0.1));
-        changeCss('.app__body .btn-danger:active', 'background:' + blendColors(theme.errorTextColor, '#000000', 0.2));
     }
 
     if (!theme.codeTheme) {

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -394,7 +394,7 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .attachment__body__wrap.btn-close', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('@media(min-width: 768px){.app__body .post.a11y--active, .app__body .modal .settings-modal .settings-table .settings-content .section-min:hover', 'background:' + changeOpacity(theme.centerChannelColor, 0.04));
         changeCss('@media(min-width: 768px){.app__body .post.post--editing', 'background:' + changeOpacity(theme.buttonBg, 0.08));
-        changeCss('.app__body .more-modal__row.more-modal__row--selected, .app__body .date-separator.hovered--before:after, .app__body .date-separator.hovered--after:before', 'background:' + changeOpacity(theme.centerChannelColor, 0.07));
+        changeCss('.app__body .more-modal__row.more-modal__row--selected', 'background:' + changeOpacity(theme.centerChannelColor, 0.07));
         changeCss('@media(min-width: 768px){.app__body .dropdown-menu>li>a:focus, .app__body .dropdown-menu>li>a:hover', 'background:' + changeOpacity(theme.centerChannelColor, 0.15));
         changeCss('.app__body .form-control[disabled], .app__body .form-control[readonly], .app__body fieldset[disabled] .form-control', 'background:' + changeOpacity(theme.centerChannelColor, 0.1));
         changeCss('.app__body .sidebar--right', 'color:' + theme.centerChannelColor);

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -449,10 +449,6 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .post-image__details .post-image__download svg:hover, .app__body .file-view--single .file__download svg', 'stroke:' + theme.buttonColor);
     }
 
-    if (theme.errorTextColor) {
-        changeCss('.app__body .error-text, .app__body .modal .settings-modal .settings-table .settings-content .has-error, .app__body .modal .input__help.error, .app__body .color--error, .app__body .has-error .help-block, .app__body .has-error .control-label, .app__body .has-error .radio, .app__body .has-error .checkbox, .app__body .has-error .radio-inline, .app__body .has-error .checkbox-inline, .app__body .has-error.radio label, .app__body .has-error.checkbox label, .app__body .has-error.radio-inline label, .app__body .has-error.checkbox-inline label', 'color:' + theme.errorTextColor);
-    }
-
     if (!theme.codeTheme) {
         theme.codeTheme = Constants.DEFAULT_CODE_THEME;
     }

--- a/webapp/channels/src/utils/utils.tsx
+++ b/webapp/channels/src/utils/utils.tsx
@@ -392,7 +392,6 @@ export function applyTheme(theme: Theme) {
         changeCss('.app__body .attachment__body__wrap.btn-close', 'background:' + changeOpacity(theme.centerChannelColor, 0.08));
         changeCss('.app__body .attachment__body__wrap.btn-close', 'border-color:' + changeOpacity(theme.centerChannelColor, 0.2));
         changeCss('@media(min-width: 768px){.app__body .post.a11y--active, .app__body .modal .settings-modal .settings-table .settings-content .section-min:hover', 'background:' + changeOpacity(theme.centerChannelColor, 0.04));
-        changeCss('@media(min-width: 768px){.app__body .post.post--editing', 'background:' + changeOpacity(theme.buttonBg, 0.08));
         changeCss('.app__body .more-modal__row.more-modal__row--selected', 'background:' + changeOpacity(theme.centerChannelColor, 0.07));
         changeCss('@media(min-width: 768px){.app__body .dropdown-menu>li>a:focus, .app__body .dropdown-menu>li>a:hover', 'background:' + changeOpacity(theme.centerChannelColor, 0.15));
         changeCss('.app__body .form-control[disabled], .app__body .form-control[readonly], .app__body fieldset[disabled] .form-control', 'background:' + changeOpacity(theme.centerChannelColor, 0.1));


### PR DESCRIPTION
#### Summary
Before we used CSS variables, we used `applyTheme` and `changeCss` to add a bunch of inline style tags that applied theme colours at runtime. CSS variables are easier to use since they live with the corresponding component CSS, so we've slowly been getting rid of `changeCss`. Here's another batch of that.

Note that it's intentional that the `.app__body` wrapping class is being removed from these wherever possible. We used to need that because we only set the CSS variables for the theme when that class was applied, but they're always set to some theme now. Most of the affected elements are only used in the themed part of the app anyway. That will change the specificity of the CSS, but it doesn't seem to have had any visual changes based on my testing.

#### Ticket Link
MM-50188

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** Updates the shared theme/runtime styling path by narrowing/removing several `applyTheme` dynamic CSS injections and shifting styling to component/base SCSS, which can introduce theme-specific visual/specificity regressions (especially around hover/error/separator/datepicker behaviors). Although it’s UI-only (no auth/data/business logic), the changes span multiple themed UI modules and shared SCSS bases.  

**QA Recommendation:** Manual spot-check theme switching (light/dark), buttons (primary/danger/transparent + hover/focus/active), error/form help/error text states, mention/search highlights, separators & date separators (including print), download icon hover, DayPicker hover/disabled interactions, and audit row wrapping/error styling.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->