### PR TITLE
[MM-69721] Fix empty text/plain part in transactional emails

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/hashicorp/memberlist v0.5.4
 	github.com/icrowley/fake v0.0.0-20240710202011-f797eb4a99c0
 	github.com/isacikgoz/prompt v0.1.0
+	github.com/jaytaylor/html2text v0.0.0-20260303211410-1a4bdc82ecec
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/klauspost/compress v1.18.6
 	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
@@ -153,7 +154,6 @@ require (
 	github.com/hashicorp/yamux v0.1.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/isacikgoz/fuzzy v0.2.0 // indirect
-	github.com/jaytaylor/html2text v0.0.0-20260303211410-1a4bdc82ecec // indirect
 	github.com/jonboulle/clockwork v0.5.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.3.0 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect

--- a/server/platform/shared/mail/mail.go
+++ b/server/platform/shared/mail/mail.go
@@ -13,10 +13,9 @@ import (
 	"net/mail"
 	"net/smtp"
 	"slices"
-	"strings"
 	"time"
 
-	"code.sajari.com/docconv/v2"
+	"github.com/jaytaylor/html2text"
 	"github.com/pkg/errors"
 	gomail "gopkg.in/mail.v2"
 
@@ -294,7 +293,7 @@ func sendMail(c smtpClient, mail mailData, date time.Time, config *SMTPConfig) e
 	mlog.Info("sending mail", mlog.String("to", mail.smtpTo))
 
 	htmlMessage := mail.htmlBody
-	text, _, err := docconv.ConvertHTML(strings.NewReader(htmlMessage), true)
+	text, err := html2text.FromString(htmlMessage)
 	if err != nil {
 		mlog.Warn("Unable to convert html body to text", mlog.Err(err))
 		text = ""

--- a/server/platform/shared/mail/mail_test.go
+++ b/server/platform/shared/mail/mail_test.go
@@ -173,6 +173,20 @@ func TestSendMailPlainText(t *testing.T) {
 			emailBodyHTML:    "<p><strong>Strong</strong> and <a href='https://example.com'>link</a>",
 			expectedBodyText: "*Strong* and link ( https://example.com )",
 		},
+		{
+			// Regression for MM-69721: a link-only body previously yielded an
+			// empty text/plain part (docconv readability returned "MAIN: P is nil").
+			name:             "Link-only body",
+			emailBodyHTML:    "<a href='https://example.com/reset'>Reset your password</a>",
+			expectedBodyText: "Reset your password ( https://example.com/reset )",
+		},
+		{
+			// Regression for MM-69721: templated transactional emails previously
+			// yielded an empty text/plain part (docconv readability extracted no paragraphs).
+			name:             "Templated email",
+			emailBodyHTML:    "<h1>Reset Your Password</h1><p>Click the link below to reset your password.</p><p><a href='https://example.com/reset?token=abc'>Reset Password</a></p>",
+			expectedBodyText: "Reset Password ( https://example.com/reset?token=abc )",
+		},
 	}
 
 	for _, test := range tests {
@@ -198,6 +212,7 @@ func TestSendMailPlainText(t *testing.T) {
 				resultsEmail, err := GetMessageFromMailbox(emailTo, resultsMailbox[0].ID)
 				require.NoError(t, err, "Could not get message from mailbox")
 				require.Contains(t, test.emailBodyHTML, resultsEmail.Body.HTML, "Wrong received message %s", resultsEmail.Body.Text)
+				require.NotEmpty(t, resultsEmail.Body.Text, "text/plain part should not be empty (MM-69721)")
 				require.Contains(t, resultsEmail.Body.Text, test.expectedBodyText, "Wrong message plain text conversion %s", resultsEmail.Body.Text)
 			}
 		})


### PR DESCRIPTION
#### Summary

Restore the `jaytaylor/html2text` dependency now that the upstream tablewriter issue is resolved: https://github.com/jaytaylor/html2text/issues/67.

This also addresses a regression in our `plain/text` mail sending which has been spamming `Unable to convert html body to text: "MAIN: P is nil"` for a while now.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-69721

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The mail plain-text conversion path is a shared utility used during email sending, so behavior changes can affect multiple email flows. The added regression tests reduce risk, but the dependency swap and conversion logic update still warrant caution around edge-case HTML bodies.

**QA Recommendation:** Perform targeted manual verification of plain-text email rendering for link-only and multi-paragraph HTML messages, plus a quick smoke test of standard mail sending.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->