### PR TITLE
GH-36872: Fix Bot Accounts search beyond 200-result page limit

### DIFF
--- a/api/v4/source/bots.yaml
+++ b/api/v4/source/bots.yaml
@@ -75,6 +75,13 @@
             orphaned if its owner has been deactivated.
           schema:
             type: boolean
+        - name: q
+          in: query
+          description: A search term to filter bots by username, display name, description,
+            or owner username. When provided, the filter is applied server-side before
+            pagination, so bots beyond the page limit are still reachable.
+          schema:
+            type: string
       responses:
         "200":
           description: Bot page retrieval successful

--- a/e2e-tests/cypress/tests/integration/channels/bot_accounts/search_beyond_page_limit_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/bot_accounts/search_beyond_page_limit_spec.ts
@@ -17,31 +17,28 @@ import * as TIMEOUTS from '@/fixtures/timeouts';
 import {getRandomId} from '@/utils';
 
 // The server enforces a hard cap of 200 items per page regardless of the
-// per_page value the client sends. The Bot Accounts search must therefore
-// be server-side (using ?q=<term>) so that bots beyond position 200 are
-// reachable. This test verifies end-to-end that bots beyond the 200-result
-// page limit are findable via the search box.
+// per_page value the client sends. The Bot Accounts page therefore loads bots
+// one page at a time and exposes Next/Previous buttons to navigate between
+// pages. Search is handled server-side (using ?q=<term>) so bots beyond the
+// first page are reachable without having to page through manually.
 //
 // Setup: 250 bots are created with zero-padded sequential usernames
-// (e.g. srchbot-<id>-000 … srchbot-<id>-249). The initial page load
-// fetches at most 200 bots, ordered by creation time then username, so
-// srchbot-<id>-200 through srchbot-<id>-249 will NOT be in the client
-// store unless a server-side search is performed.
-//
-// Test: searching for "srchbot-<id>-2" matches only the 50 bots whose
-// suffix starts with "2" (positions 200–249). Client-side filtering of the
-// initial 200-bot store yields zero results; server-side search yields 50.
-describe('Bot Accounts - server-side search beyond 200-bot page limit', () => {
+// (e.g. srchbot-<id>-000 … srchbot-<id>-249). Zero-padding ensures that
+// alphabetical order equals numerical order, so the alphabetically-sorted
+// client list puts our bots 000–199 on the first page of results and bots
+// 200–249 on the second (subject to how many pre-existing bots sort before
+// the srchbot- prefix).
+describe('Bot Accounts - pagination and server-side search beyond 200-bot page limit', () => {
     const BOT_COUNT = 250;
     let newTeam: Team;
 
-    // A per-run unique prefix so the search term selects only our bots and
-    // is unaffected by any pre-existing bots on the server.
+    // A per-run unique prefix so searches and page checks affect only our
+    // bots and are unaffected by pre-existing bots on the server.
     const runPrefix = `srchbot-${getRandomId()}-`;
 
     // "2" matches only the 50 bots whose 3-digit suffix begins with 2
     // (i.e. 200–249). None of the first-page bots (000–199) match this
-    // suffix-constrained term.
+    // suffix-constrained term without server-side search.
     const searchTerm = `${runPrefix}2`;
     const expectedMatchCount = 50; // bots 200–249
 
@@ -66,6 +63,49 @@ describe('Bot Accounts - server-side search beyond 200-bot page limit', () => {
             }));
 
             await Promise.all(patches.map((patch) => client.createBot(patch as Partial<Bot>)));
+        });
+    });
+
+    it('navigates between pages using the Next and Previous buttons', () => {
+        // # Navigate to the Bot Accounts integrations page
+        cy.visit(`/${newTeam.name}/integrations/bots`);
+
+        // * Wait for the initial page load (fetches at most 200 bots)
+        cy.get('#searchInput', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+
+        // * Previous is disabled on page 0; Next is enabled because there are
+        //   more than 200 bots on the server
+        cy.get('button[aria-label="Previous"]').should('have.class', 'disabled');
+        cy.get('button[aria-label="Next"]').should('not.have.class', 'disabled');
+
+        // # Remember the first visible bot item so we can verify the page
+        // content changes after navigating and then restores when going back
+        cy.get('.backstage-list__item:not(.backstage-list__empty)').
+            first().invoke('text').as('page0FirstBotText');
+
+        // # Click Next to move to page 1
+        cy.get('button[aria-label="Next"]').click();
+
+        // * Previous becomes enabled once page 1 has loaded
+        cy.get('button[aria-label="Previous"]', {timeout: TIMEOUTS.ONE_MIN}).
+            should('not.have.class', 'disabled');
+
+        // * The list shows different bots than page 0
+        cy.get('@page0FirstBotText').then((page0Text) => {
+            cy.get('.backstage-list__item:not(.backstage-list__empty)').
+                first().invoke('text').should('not.equal', page0Text);
+        });
+
+        // # Click Previous to return to page 0
+        cy.get('button[aria-label="Previous"]').click();
+
+        // * Previous is disabled again on page 0
+        cy.get('button[aria-label="Previous"]').should('have.class', 'disabled');
+
+        // * The list is back to showing the same first bot as before
+        cy.get('@page0FirstBotText').then((page0Text) => {
+            cy.get('.backstage-list__item:not(.backstage-list__empty)').
+                first().invoke('text').should('equal', page0Text);
         });
     });
 

--- a/e2e-tests/cypress/tests/integration/channels/bot_accounts/search_beyond_page_limit_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/bot_accounts/search_beyond_page_limit_spec.ts
@@ -1,0 +1,94 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @channels @bot_accounts
+
+import type {Bot} from '@mattermost/types/bots';
+import type {Team} from '@mattermost/types/teams';
+
+import * as TIMEOUTS from '@/fixtures/timeouts';
+import {getRandomId} from '@/utils';
+
+// The server enforces a hard cap of 200 items per page regardless of the
+// per_page value the client sends. The Bot Accounts search must therefore
+// be server-side (using ?q=<term>) so that bots beyond position 200 are
+// reachable. This test verifies end-to-end that bots beyond the 200-result
+// page limit are findable via the search box.
+//
+// Setup: 250 bots are created with zero-padded sequential usernames
+// (e.g. srchbot-<id>-000 … srchbot-<id>-249). The initial page load
+// fetches at most 200 bots, ordered by creation time then username, so
+// srchbot-<id>-200 through srchbot-<id>-249 will NOT be in the client
+// store unless a server-side search is performed.
+//
+// Test: searching for "srchbot-<id>-2" matches only the 50 bots whose
+// suffix starts with "2" (positions 200–249). Client-side filtering of the
+// initial 200-bot store yields zero results; server-side search yields 50.
+describe('Bot Accounts - server-side search beyond 200-bot page limit', () => {
+    const BOT_COUNT = 250;
+    let newTeam: Team;
+
+    // A per-run unique prefix so the search term selects only our bots and
+    // is unaffected by any pre-existing bots on the server.
+    const runPrefix = `srchbot-${getRandomId()}-`;
+
+    // "2" matches only the 50 bots whose 3-digit suffix begins with 2
+    // (i.e. 200–249). None of the first-page bots (000–199) match this
+    // suffix-constrained term.
+    const searchTerm = `${runPrefix}2`;
+    const expectedMatchCount = 50; // bots 200–249
+
+    before(() => {
+        cy.apiAdminLogin();
+
+        cy.apiUpdateConfig({
+            ServiceSettings: {EnableBotAccountCreation: true},
+        });
+
+        cy.apiInitSetup().then(({team}) => {
+            newTeam = team;
+        });
+
+        // # Create BOT_COUNT bots in parallel via the raw client so the setup
+        // is fast (Promise.all fires all requests concurrently).
+        cy.makeClient().then(async (client) => {
+            const patches = Array.from({length: BOT_COUNT}, (_, i) => ({
+                username: `${runPrefix}${String(i).padStart(3, '0')}`,
+                display_name: `Search Target Bot ${i}`,
+                description: 'Created for search-beyond-page-limit test',
+            }));
+
+            await Promise.all(patches.map((patch) => client.createBot(patch as Partial<Bot>)));
+        });
+    });
+
+    it('finds bots beyond the 200-result page limit via server-side search', () => {
+        // # Navigate to the Bot Accounts integrations page
+        cy.visit(`/${newTeam.name}/integrations/bots`);
+
+        // * Wait for the page to finish its initial load (gets at most 200 bots)
+        cy.get('#searchInput', {timeout: TIMEOUTS.ONE_MIN}).should('be.visible');
+
+        // # Type a term that matches only bots 200-249 to trigger a server-side search.
+        // The initial 200-bot store contains only bots 000-199, so without the
+        // server-side search the result count would be 0.
+        cy.get('#searchInput').type(searchTerm);
+
+        // # Give the 300 ms client debounce plus network round-trip time to settle
+        cy.wait(TIMEOUTS.TWO_SEC);
+
+        // * Verify that server-side search returned the 50 bots (200-249) that
+        //   were not loaded in the initial page. Each bot renders as one
+        //   .backstage-list__item (excluding the empty-state element which has
+        //   the extra class backstage-list__empty).
+        cy.get('.backstage-list__item:not(.backstage-list__empty)').
+            should('have.length.gte', expectedMatchCount);
+    });
+});

--- a/server/channels/api4/bot.go
+++ b/server/channels/api4/bot.go
@@ -156,6 +156,7 @@ func getBot(c *Context, w http.ResponseWriter, r *http.Request) {
 func getBots(c *Context, w http.ResponseWriter, r *http.Request) {
 	includeDeleted, _ := strconv.ParseBool(r.URL.Query().Get("include_deleted"))
 	onlyOrphaned, _ := strconv.ParseBool(r.URL.Query().Get("only_orphaned"))
+	term := r.URL.Query().Get("q")
 
 	var OwnerId string
 	if c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionReadOthersBots) {
@@ -175,6 +176,7 @@ func getBots(c *Context, w http.ResponseWriter, r *http.Request) {
 		OwnerId:        OwnerId,
 		IncludeDeleted: includeDeleted,
 		OnlyOrphaned:   onlyOrphaned,
+		Term:           term,
 	})
 	if appErr != nil {
 		c.Err = appErr

--- a/server/channels/api4/bot_test.go
+++ b/server/channels/api4/bot_test.go
@@ -1064,6 +1064,75 @@ func TestGetBots(t *testing.T) {
 	})
 }
 
+func TestSearchBots(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t).DeleteBots(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.EnableBotAccountCreation = true
+	})
+
+	alphaBot, resp, err := th.SystemAdminClient.CreateBot(context.Background(), &model.Bot{
+		Username:    GenerateTestUsername(),
+		DisplayName: "Alpha Bot",
+		Description: "first search target",
+	})
+	require.NoError(t, err)
+	CheckCreatedStatus(t, resp)
+	defer func() {
+		appErr := th.App.PermanentDeleteBot(th.Context, alphaBot.UserId)
+		assert.Nil(t, appErr)
+	}()
+
+	betaBot, resp, err := th.SystemAdminClient.CreateBot(context.Background(), &model.Bot{
+		Username:    "beta_search_bot_" + GenerateTestUsername(),
+		DisplayName: "Beta Bot",
+		Description: "second search target",
+	})
+	require.NoError(t, err)
+	CheckCreatedStatus(t, resp)
+	defer func() {
+		appErr := th.App.PermanentDeleteBot(th.Context, betaBot.UserId)
+		assert.Nil(t, appErr)
+	}()
+
+	t.Run("search by username substring returns matching bot", func(t *testing.T) {
+		bots, resp, err := th.SystemAdminClient.SearchBots(context.Background(), "beta_search", 0, 200, false, "")
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.Len(t, bots, 1)
+		assert.Equal(t, betaBot.UserId, bots[0].UserId)
+	})
+
+	t.Run("search is case insensitive", func(t *testing.T) {
+		bots, resp, err := th.SystemAdminClient.SearchBots(context.Background(), "BETA_SEARCH", 0, 200, false, "")
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.Len(t, bots, 1)
+		assert.Equal(t, betaBot.UserId, bots[0].UserId)
+	})
+
+	t.Run("search by display name substring returns matching bot", func(t *testing.T) {
+		bots, resp, err := th.SystemAdminClient.SearchBots(context.Background(), "Alpha Bot", 0, 200, false, "")
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.Len(t, bots, 1)
+		assert.Equal(t, alphaBot.UserId, bots[0].UserId)
+	})
+
+	t.Run("search with no match returns empty list", func(t *testing.T) {
+		bots, resp, err := th.SystemAdminClient.SearchBots(context.Background(), "zzznomatch", 0, 200, false, "")
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		assert.Empty(t, bots)
+	})
+
+	t.Run("search without permission returns error", func(t *testing.T) {
+		_, _, err := th.Client.SearchBots(context.Background(), "beta", 0, 200, false, "")
+		CheckErrorID(t, err, "api.context.permissions.app_error")
+	})
+}
+
 func TestDisableBot(t *testing.T) {
 	mainHelper.Parallel(t)
 	t.Run("disable non-existent bot", func(t *testing.T) {

--- a/server/channels/store/sqlstore/bot_store.go
+++ b/server/channels/store/sqlstore/bot_store.go
@@ -107,7 +107,7 @@ func (us SqlBotStore) Get(botUserId string, includeDeleted bool) (*model.Bot, er
 func (us SqlBotStore) GetAll(options *model.BotGetOptions) ([]*model.Bot, error) {
 	var conditions []string
 	var conditionsSql string
-	var additionalJoin string
+	var joins []string
 	var args []any
 
 	if !options.IncludeDeleted {
@@ -118,8 +118,16 @@ func (us SqlBotStore) GetAll(options *model.BotGetOptions) ([]*model.Bot, error)
 		args = append(args, options.OwnerId)
 	}
 	if options.OnlyOrphaned {
-		additionalJoin = "JOIN Users o ON (o.Id = b.OwnerId)"
+		joins = append(joins, "LEFT JOIN Users o ON (o.Id = b.OwnerId)")
 		conditions = append(conditions, "o.DeleteAt != 0")
+	}
+	if options.Term != "" {
+		if !options.OnlyOrphaned {
+			joins = append(joins, "LEFT JOIN Users o ON (o.Id = b.OwnerId)")
+		}
+		term := "%" + strings.ToLower(options.Term) + "%"
+		conditions = append(conditions, "(u.Username LIKE ? OR lower(u.FirstName) LIKE ? OR lower(b.Description) LIKE ? OR lower(o.Username) LIKE ?)")
+		args = append(args, term, term, term, term)
 	}
 
 	if len(conditions) > 0 {
@@ -141,7 +149,7 @@ func (us SqlBotStore) GetAll(options *model.BotGetOptions) ([]*model.Bot, error)
 			    Bots b
 			JOIN
 			    Users u ON (u.Id = b.UserId)
-			` + additionalJoin + `
+			` + strings.Join(joins, "\n") + `
 			` + conditionsSql + `
 			ORDER BY
 			    b.CreateAt ASC,

--- a/server/channels/store/storetest/bot_store.go
+++ b/server/channels/store/storetest/bot_store.go
@@ -313,6 +313,89 @@ func testBotStoreGetAll(t *testing.T, rctx request.CTX, ss store.Store, s SqlSto
 			b4,
 		}, bots)
 	})
+
+	namedBot, _ := makeBotWithUser(t, rctx, ss, &model.Bot{
+		Username:    "searchable_bot",
+		DisplayName: "Fancy Display Name",
+		Description: "A bot for search tests",
+		OwnerId:     OwnerID1,
+	})
+	defer func() { require.NoError(t, ss.Bot().PermanentDelete(namedBot.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, namedBot.UserId)) }()
+
+	// Create a real owner user so we can search bots by owner username.
+	knownOwner := model.User{
+		Email:    MakeEmail(),
+		Username: "known_owner_" + model.NewId()[:8],
+		Roles:    model.SystemUserRoleId,
+	}
+	_, ownerErr := ss.User().Save(rctx, &knownOwner)
+	require.NoError(t, ownerErr)
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, knownOwner.Id)) }()
+
+	ownedBot, _ := makeBotWithUser(t, rctx, ss, &model.Bot{
+		Username:    "owned_by_known_owner",
+		DisplayName: "Owned Bot",
+		Description: "unique_description_xyz",
+		OwnerId:     knownOwner.Id,
+	})
+	defer func() { require.NoError(t, ss.Bot().PermanentDelete(ownedBot.UserId)) }()
+	defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, ownedBot.UserId)) }()
+
+	t.Run("search by username substring", func(t *testing.T) {
+		bots, err := ss.Bot().GetAll(&model.BotGetOptions{Page: 0, PerPage: 10, Term: "searchable"})
+		require.NoError(t, err)
+		require.Len(t, bots, 1)
+		require.Equal(t, namedBot.UserId, bots[0].UserId)
+	})
+
+	t.Run("search by username case insensitive", func(t *testing.T) {
+		bots, err := ss.Bot().GetAll(&model.BotGetOptions{Page: 0, PerPage: 10, Term: "SEARCHABLE"})
+		require.NoError(t, err)
+		require.Len(t, bots, 1)
+		require.Equal(t, namedBot.UserId, bots[0].UserId)
+	})
+
+	t.Run("search by display name substring", func(t *testing.T) {
+		bots, err := ss.Bot().GetAll(&model.BotGetOptions{Page: 0, PerPage: 10, Term: "Fancy"})
+		require.NoError(t, err)
+		require.Len(t, bots, 1)
+		require.Equal(t, namedBot.UserId, bots[0].UserId)
+	})
+
+	t.Run("search by display name case insensitive", func(t *testing.T) {
+		bots, err := ss.Bot().GetAll(&model.BotGetOptions{Page: 0, PerPage: 10, Term: "fancy display"})
+		require.NoError(t, err)
+		require.Len(t, bots, 1)
+		require.Equal(t, namedBot.UserId, bots[0].UserId)
+	})
+
+	t.Run("search by description substring", func(t *testing.T) {
+		bots, err := ss.Bot().GetAll(&model.BotGetOptions{Page: 0, PerPage: 10, Term: "unique_description_xyz"})
+		require.NoError(t, err)
+		require.Len(t, bots, 1)
+		require.Equal(t, ownedBot.UserId, bots[0].UserId)
+	})
+
+	t.Run("search by owner username", func(t *testing.T) {
+		bots, err := ss.Bot().GetAll(&model.BotGetOptions{Page: 0, PerPage: 10, Term: knownOwner.Username})
+		require.NoError(t, err)
+		require.Len(t, bots, 1)
+		require.Equal(t, ownedBot.UserId, bots[0].UserId)
+	})
+
+	t.Run("search returns no results for unknown term", func(t *testing.T) {
+		bots, err := ss.Bot().GetAll(&model.BotGetOptions{Page: 0, PerPage: 10, Term: "zzznomatch"})
+		require.NoError(t, err)
+		require.Empty(t, bots)
+	})
+
+	t.Run("search term combined with include_deleted", func(t *testing.T) {
+		bots, err := ss.Bot().GetAll(&model.BotGetOptions{Page: 0, PerPage: 10, Term: "deleted", IncludeDeleted: true})
+		require.NoError(t, err)
+		require.Len(t, bots, 1)
+		require.Equal(t, deletedBot.UserId, bots[0].UserId)
+	})
 }
 
 func testBotStoreSave(t *testing.T, rctx request.CTX, ss store.Store) {

--- a/server/public/model/bot.go
+++ b/server/public/model/bot.go
@@ -69,6 +69,7 @@ type BotGetOptions struct {
 	OnlyOrphaned   bool
 	Page           int
 	PerPage        int
+	Term           string
 }
 
 // BotList is a list of bots.

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -2181,6 +2181,23 @@ func (c *Client4) GetBotsOrphaned(ctx context.Context, page, perPage int, etag s
 	return DecodeJSONFromResponse[BotList](r)
 }
 
+// SearchBots returns bots matching the given term, optionally including deleted bots.
+func (c *Client4) SearchBots(ctx context.Context, term string, page, perPage int, includeDeleted bool, etag string) ([]*Bot, *Response, error) {
+	values := url.Values{}
+	values.Set("page", strconv.Itoa(page))
+	values.Set("per_page", strconv.Itoa(perPage))
+	values.Set("q", term)
+	if includeDeleted {
+		values.Set("include_deleted", c.boolString(true))
+	}
+	r, err := c.doAPIGetWithQuery(ctx, c.botsRoute(), values, etag)
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[BotList](r)
+}
+
 // DisableBot disables the given bot in the system.
 func (c *Client4) DisableBot(ctx context.Context, botUserId string) (*Bot, *Response, error) {
 	r, err := c.doAPIPost(ctx, c.botRoute(botUserId).Join("disable"), "")

--- a/webapp/channels/src/components/backstage/components/backstage_list.tsx
+++ b/webapp/channels/src/components/backstage/components/backstage_list.tsx
@@ -32,6 +32,8 @@ type Props = {
     page?: number;
     pageSize?: number;
     total?: number;
+    hasNextPage?: boolean;
+    hasPreviousPage?: boolean;
 };
 
 const getPaging = (remainingProps: Props, childCount: number, hasFilter: boolean) => {
@@ -139,10 +141,12 @@ const BackstageList = (remainingProps: Props) => {
 
     let previousPageFn = remainingProps.previousPage;
     let nextPageFn = remainingProps.nextPage;
-    if (isFirstPage) {
+    const prevDisabled = remainingProps.hasPreviousPage !== undefined ? !remainingProps.hasPreviousPage : isFirstPage;
+    if (prevDisabled) {
         previousPageFn = () => {};
     }
-    if (isLastPage) {
+    const nextDisabled = remainingProps.hasNextPage !== undefined ? !remainingProps.hasNextPage : isLastPage;
+    if (nextDisabled) {
         nextPageFn = () => {};
     }
 

--- a/webapp/channels/src/components/integrations/bots/bots.test.tsx
+++ b/webapp/channels/src/components/integrations/bots/bots.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import type {Bot} from '@mattermost/types/bots';
 
-import {renderWithContext, screen, waitFor} from 'tests/react_testing_utils';
+import {fireEvent, renderWithContext, screen, waitFor} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';
 
 import Bots from './bots';
@@ -140,8 +140,7 @@ describe('components/integrations/bots/Bots', () => {
         });
     });
 
-    it('paginates until a short page and processes bots beyond the first page', async () => {
-        // A full first page forces the component to request the next page.
+    it('loads only the first page on mount', async () => {
         const firstPage: Bot[] = [];
         const allBots: Record<string, Bot> = {};
         const allUsers: Record<string, ReturnType<typeof TestHelper.getUserMock>> = {};
@@ -152,20 +151,12 @@ describe('components/integrations/bots/Bots', () => {
             allUsers[bot.user_id] = TestHelper.getUserMock({id: bot.user_id});
         }
 
-        const newestBot = TestHelper.getBotMock({user_id: '201', username: 'irisnewbot', display_name: 'Iris Newest Bot', delete_at: 0});
-        allBots[newestBot.user_id] = newestBot;
-        allUsers[newestBot.user_id] = TestHelper.getUserMock({id: newestBot.user_id});
-
         const loadBots = jest.fn((page?: number) => {
             if (page === 0) {
                 return Promise.resolve({data: firstPage});
             }
-            if (page === 1) {
-                return Promise.resolve({data: [newestBot]});
-            }
             return Promise.resolve({data: []});
         });
-        const getUser = jest.fn();
 
         renderWithContext(
             <Bots
@@ -174,69 +165,123 @@ describe('components/integrations/bots/Bots', () => {
                 accessTokens={{}}
                 owners={{}}
                 users={allUsers}
-                actions={{...actions, loadBots, getUser}}
+                actions={{...actions, loadBots}}
                 appsEnabled={false}
                 appsBotIDs={[]}
             />,
         );
 
-        // The newest bot lives on the second page and is rendered once loading completes.
         await waitFor(() => {
-            expect(screen.getByText(/Iris Newest Bot \(@irisnewbot\)/)).toBeInTheDocument();
+            expect(screen.getByText(/Bot 1 \(@bot1\)/)).toBeInTheDocument();
         });
 
-        // Successive pages are requested with the server's max page size until a short page is returned.
+        expect(loadBots).toHaveBeenCalledTimes(1);
         expect(loadBots).toHaveBeenCalledWith(0, 200);
-        expect(loadBots).toHaveBeenCalledWith(1, 200);
-        expect(loadBots).toHaveBeenCalledTimes(2);
-
-        // The second-page bot was accumulated and had its user details fetched.
-        expect(getUser).toHaveBeenCalledWith(newestBot.user_id);
     });
 
-    it('requests one more page when the final data page is exactly full', async () => {
-        const makeFullPage = (start: number): Bot[] => {
-            const page: Bot[] = [];
-            for (let i = start; i < start + 200; i++) {
-                page.push(TestHelper.getBotMock({user_id: String(i), username: `bot${i}`, delete_at: 0}));
-            }
-            return page;
-        };
-
-        // Both data pages are exactly full, so termination requires a trailing empty page.
-        const secondPage = makeFullPage(200);
-        const lastBot = TestHelper.getBotMock({user_id: '400', username: 'bot400', delete_at: 0});
-        secondPage[secondPage.length - 1] = lastBot;
+    it('calls loadBots for the next page when it has not been fetched yet', async () => {
+        // Only 200 bots in props (page 0); page 1 has not been fetched yet.
+        const {bots: page0Bots, users: page0Users, loadBots: loadPage0} = createBotsAndUsers(200);
+        const newestBot = TestHelper.getBotMock({user_id: '201', username: 'irisnewbot', display_name: 'Iris Newest Bot', delete_at: 0});
 
         const loadBots = jest.fn((page?: number) => {
             if (page === 0) {
-                return Promise.resolve({data: makeFullPage(0)});
+                return Promise.resolve({data: Object.values(page0Bots)});
             }
-            if (page === 1) {
-                return Promise.resolve({data: secondPage});
-            }
-            return Promise.resolve({data: []});
+            return Promise.resolve({data: [newestBot]});
         });
         const getUser = jest.fn();
 
         renderWithContext(
             <Bots
-                bots={{}}
+                bots={page0Bots}
                 team={team}
                 accessTokens={{}}
                 owners={{}}
-                users={{}}
+                users={page0Users}
                 actions={{...actions, loadBots, getUser}}
                 appsEnabled={false}
                 appsBotIDs={[]}
             />,
         );
 
-        await waitFor(() => expect(loadBots).toHaveBeenCalledTimes(3));
-        expect(loadBots).toHaveBeenNthCalledWith(1, 0, 200);
-        expect(loadBots).toHaveBeenNthCalledWith(2, 1, 200);
-        expect(loadBots).toHaveBeenNthCalledWith(3, 2, 200);
-        expect(getUser).toHaveBeenCalledWith('400');
+        await waitFor(() => {
+            expect(screen.getByText(/Bot 1 \(@bot1\)/)).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+        await waitFor(() => {
+            expect(loadBots).toHaveBeenCalledWith(1, 200);
+        });
+        expect(loadBots).toHaveBeenCalledTimes(2);
+        expect(getUser).toHaveBeenCalledWith(newestBot.user_id);
+    });
+
+    it('shows page 1 bots when navigating to the next page with already-fetched data', async () => {
+        // All 201 bots already in props (simulating Redux state after both pages loaded).
+        const {bots: page0Bots, users: page0Users} = createBotsAndUsers(200);
+        const newestBot = TestHelper.getBotMock({user_id: '201', username: 'irisnewbot', display_name: 'Iris Newest Bot', delete_at: 0});
+        const allBots = {...page0Bots, [newestBot.user_id]: newestBot};
+        const allUsers = {...page0Users, [newestBot.user_id]: TestHelper.getUserMock({id: newestBot.user_id})};
+
+        // Page 0 returns a full page so canGoNext is true on mount.
+        const loadBots = jest.fn((page?: number) => {
+            if (page === 0) {
+                return Promise.resolve({data: Object.values(page0Bots)});
+            }
+            return Promise.resolve({data: []});
+        });
+
+        renderWithContext(
+            <Bots
+                bots={allBots}
+                team={team}
+                accessTokens={{}}
+                owners={{}}
+                users={allUsers}
+                actions={{...actions, loadBots}}
+                appsEnabled={false}
+                appsBotIDs={[]}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText(/Bot 1 \(@bot1\)/)).toBeInTheDocument();
+        });
+
+        // Iris is on page 1 (alphabetically after all the bot... entries); she should
+        // not be visible on page 0.
+        expect(screen.queryByText(/Iris Newest Bot/)).not.toBeInTheDocument();
+
+        fireEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+        await waitFor(() => {
+            expect(screen.getByText(/Iris Newest Bot \(@irisnewbot\)/)).toBeInTheDocument();
+        });
+    });
+
+    it('disables the Next button when the returned page has fewer than 200 bots', async () => {
+        const {bots, users, loadBots} = createBotsAndUsers(3);
+
+        renderWithContext(
+            <Bots
+                bots={bots}
+                team={team}
+                accessTokens={{}}
+                owners={{}}
+                users={users}
+                actions={{...actions, loadBots}}
+                appsEnabled={false}
+                appsBotIDs={[]}
+            />,
+        );
+
+        await waitFor(() => {
+            expect(screen.getByText(/Bot 1 \(@bot1\)/)).toBeInTheDocument();
+        });
+
+        expect(screen.getByRole('button', {name: 'Next'})).toHaveClass('disabled');
     });
 
     it('surfaces an error and completes loading when the first page fetch fails', async () => {
@@ -265,7 +310,7 @@ describe('components/integrations/bots/Bots', () => {
         expect(getUser).not.toHaveBeenCalled();
     });
 
-    it('surfaces an incomplete-list warning and shows loaded bots when a later page fetch fails', async () => {
+    it('shows an error and stays on the current page when a next-page fetch fails', async () => {
         const firstPage: Bot[] = [];
         const allBots: Record<string, Bot> = {};
         const allUsers: Record<string, ReturnType<typeof TestHelper.getUserMock>> = {};
@@ -276,14 +321,12 @@ describe('components/integrations/bots/Bots', () => {
             allUsers[bot.user_id] = TestHelper.getUserMock({id: bot.user_id});
         }
 
-        // First page loads fully, but the second page fetch fails.
         const loadBots = jest.fn((page?: number) => {
             if (page === 0) {
                 return Promise.resolve({data: firstPage});
             }
             return Promise.resolve({error: {message: 'Failed to load bots'}});
         });
-        const getUser = jest.fn();
 
         renderWithContext(
             <Bots
@@ -292,22 +335,25 @@ describe('components/integrations/bots/Bots', () => {
                 accessTokens={{}}
                 owners={{}}
                 users={allUsers}
-                actions={{...actions, loadBots, getUser}}
+                actions={{...actions, loadBots}}
                 appsEnabled={false}
                 appsBotIDs={[]}
             />,
         );
 
         await waitFor(() => {
-            expect(screen.getByText('Some bot accounts could not be loaded, so this list may be incomplete. Refresh the page to try again.')).toBeInTheDocument();
+            expect(screen.getByText(/Bot 1 \(@bot1\)/)).toBeInTheDocument();
         });
 
-        // The bots that did load are still rendered alongside the warning.
+        fireEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+        await waitFor(() => {
+            expect(screen.getByText('Bot accounts could not be loaded. Refresh the page to try again.')).toBeInTheDocument();
+        });
+
+        // Page 0 bots are still rendered alongside the error.
         expect(screen.getByText(/Bot 1 \(@bot1\)/)).toBeInTheDocument();
-        expect(loadBots).toHaveBeenCalledWith(0, 200);
         expect(loadBots).toHaveBeenCalledWith(1, 200);
-        expect(loadBots).toHaveBeenCalledTimes(2);
-        expect(getUser).toHaveBeenCalledWith('1');
     });
 
     it('completes loading when the first page fetch returns no data', async () => {

--- a/webapp/channels/src/components/integrations/bots/bots.test.tsx
+++ b/webapp/channels/src/components/integrations/bots/bots.test.tsx
@@ -14,6 +14,7 @@ describe('components/integrations/bots/Bots', () => {
     const team = TestHelper.getTeamMock();
     const actions = {
         loadBots: jest.fn().mockReturnValue(Promise.resolve({data: []})),
+        searchBots: jest.fn().mockReturnValue(Promise.resolve({data: []})),
         getUserAccessTokensForUser: jest.fn(),
         createUserAccessToken: jest.fn(),
         revokeUserAccessToken: jest.fn(),

--- a/webapp/channels/src/components/integrations/bots/bots.tsx
+++ b/webapp/channels/src/components/integrations/bots/bots.tsx
@@ -16,7 +16,6 @@ import AlertBanner from 'components/alert_banner';
 import BackstageList from 'components/backstage/components/backstage_list';
 import ExternalLink from 'components/external_link';
 
-import Constants from 'utils/constants';
 import * as Utils from 'utils/utils';
 
 import Bot, {matchesFilter} from './bot';
@@ -112,13 +111,11 @@ type Props = {
     team: Team;
 };
 
-// Distinguishes a clean load from a total failure (no bots fetched) and a
-// partial failure (a later page failed, so the list is incomplete).
-type LoadError = 'none' | 'full' | 'partial';
-
 type State = {
     loading: boolean;
-    loadError: LoadError;
+    loadError: boolean;
+    page: number;
+    hasMore: boolean;
 };
 
 export default class Bots extends React.PureComponent<Props, State> {
@@ -130,7 +127,9 @@ export default class Bots extends React.PureComponent<Props, State> {
 
         this.state = {
             loading: true,
-            loadError: 'none',
+            loadError: false,
+            page: 0,
+            hasMore: false,
         };
     }
 
@@ -141,46 +140,24 @@ export default class Bots extends React.PureComponent<Props, State> {
     }
 
     public componentDidMount(): void {
-        this.loadAllBots();
+        this.loadPage(0);
 
         if (this.props.appsEnabled) {
             this.props.actions.fetchAppsBotIDs();
         }
     }
 
-    private async loadAllBots(): Promise<void> {
-        const allBots: BotType[] = [];
-        let page = Constants.Integrations.START_PAGE_NUM;
-        let loadError: LoadError = 'none';
+    private async loadPage(page: number): Promise<void> {
+        this.setState({loading: true, loadError: false});
+        const result = await this.props.actions.loadBots(page, BOTS_PER_PAGE);
 
-        // Fetch successive pages until one comes back short, since the server
-        // caps each request at BOTS_PER_PAGE and never returns every bot at once.
-        for (;;) {
-            // eslint-disable-next-line no-await-in-loop
-            const result = await this.props.actions.loadBots(page, BOTS_PER_PAGE);
-
-            // A failed fetch returns an error rather than data. Surface it so the
-            // user knows the list failed to load (first page) or is incomplete
-            // (a later page), instead of silently showing an empty/truncated list.
-            if (result.error) {
-                loadError = allBots.length > 0 ? 'partial' : 'full';
-                break;
-            }
-
-            if (!result.data) {
-                break;
-            }
-
-            allBots.push(...result.data);
-
-            if (result.data.length < BOTS_PER_PAGE) {
-                break;
-            }
-            page++;
+        if (result.error || !result.data) {
+            this.setState({loading: false, loadError: true});
+            return;
         }
 
         const promises = [];
-        for (const bot of allBots) {
+        for (const bot of result.data) {
             // We don't need to wait for this and we need to accept failure in the case where bot.owner_id is a plugin id
             this.props.actions.getUser(bot.owner_id);
 
@@ -190,26 +167,30 @@ export default class Bots extends React.PureComponent<Props, State> {
         }
 
         await Promise.all(promises);
-        this.setState({loading: false, loadError});
+        this.setState({
+            loading: false,
+            loadError: false,
+            page,
+            hasMore: result.data.length >= BOTS_PER_PAGE,
+        });
     }
 
-    private renderLoadError(): JSX.Element | null {
-        if (this.state.loadError === 'none') {
-            return null;
+    private handleNextPage = async (): Promise<void> => {
+        const nextPage = this.state.page + 1;
+        if (Object.values(this.props.bots).length > nextPage * BOTS_PER_PAGE) {
+            this.setState({page: nextPage});
+        } else {
+            await this.loadPage(nextPage);
         }
+    };
 
-        if (this.state.loadError === 'partial') {
-            return (
-                <AlertBanner
-                    mode='warning'
-                    message={
-                        <FormattedMessage
-                            id='bots.manage.load_error.partial'
-                            defaultMessage='Some bot accounts could not be loaded, so this list may be incomplete. Refresh the page to try again.'
-                        />
-                    }
-                />
-            );
+    private handlePreviousPage = (): void => {
+        this.setState((prev) => ({page: Math.max(0, prev.page - 1), loadError: false}));
+    };
+
+    private renderLoadError(): JSX.Element | null {
+        if (!this.state.loadError) {
+            return null;
         }
 
         return (
@@ -301,7 +282,12 @@ export default class Bots extends React.PureComponent<Props, State> {
             }
         }
 
-        const bots = Object.values(this.props.bots).sort((a, b) => a.username.localeCompare(b.username));
+        const sorted = Object.values(this.props.bots).sort((a, b) => a.username.localeCompare(b.username));
+
+        // When browsing (no filter), show only the current page. When searching,
+        // show all accumulated results so the server search response is fully visible.
+        const bots = filter ? sorted : sorted.slice(this.state.page * BOTS_PER_PAGE, (this.state.page + 1) * BOTS_PER_PAGE);
+
         const match = (bot: BotType) => matchesFilter(bot, filter, this.props.owners[bot.user_id]);
         const enabledBots = bots.filter((bot) => bot.delete_at === 0).filter(match).map(this.botToJSX);
         const disabledBots = bots.filter((bot) => bot.delete_at > 0).filter(match).map(this.botToJSX);
@@ -321,6 +307,10 @@ export default class Bots extends React.PureComponent<Props, State> {
     };
 
     public render(): JSX.Element {
+        const accumulatedCount = Object.values(this.props.bots).length;
+        const canGoNext = this.state.hasMore || accumulatedCount > (this.state.page + 1) * BOTS_PER_PAGE;
+        const canGoPrev = this.state.page > 0;
+
         return (
             <BackstageList
                 header={
@@ -384,6 +374,10 @@ export default class Bots extends React.PureComponent<Props, State> {
                 searchPlaceholder={Utils.localizeMessage({id: 'bots.manage.search', defaultMessage: 'Search Bot Accounts'})}
                 loading={this.state.loading}
                 error={this.renderLoadError()}
+                nextPage={this.handleNextPage}
+                previousPage={this.handlePreviousPage}
+                hasNextPage={canGoNext}
+                hasPreviousPage={canGoPrev}
             >
                 {this.bots}
             </BackstageList>

--- a/webapp/channels/src/components/integrations/bots/bots.tsx
+++ b/webapp/channels/src/components/integrations/bots/bots.tsx
@@ -67,6 +67,11 @@ type Props = {
         loadBots: (page?: number, perPage?: number) => Promise<ActionResult<BotType[]>>;
 
         /**
+         * Server-side search for bot accounts by username or display name
+         */
+        searchBots: (term: string) => Promise<ActionResult<BotType[]>>;
+
+        /**
         * Load access tokens for bot accounts
         */
         getUserAccessTokensForUser: (userId: string, page?: number, perPage?: number) => void;
@@ -117,6 +122,9 @@ type State = {
 };
 
 export default class Bots extends React.PureComponent<Props, State> {
+    private lastFilter: string | undefined;
+    private searchTimer: ReturnType<typeof setTimeout> | null = null;
+
     public constructor(props: Props) {
         super(props);
 
@@ -124,6 +132,12 @@ export default class Bots extends React.PureComponent<Props, State> {
             loading: true,
             loadError: 'none',
         };
+    }
+
+    public componentWillUnmount(): void {
+        if (this.searchTimer) {
+            clearTimeout(this.searchTimer);
+        }
     }
 
     public componentDidMount(): void {
@@ -260,7 +274,33 @@ export default class Bots extends React.PureComponent<Props, State> {
         );
     };
 
+    private scheduleServerSearch(filter: string): void {
+        if (this.searchTimer) {
+            clearTimeout(this.searchTimer);
+        }
+        this.searchTimer = setTimeout(async () => {
+            const result = await this.props.actions.searchBots(filter);
+            if (result.data) {
+                for (const bot of result.data) {
+                    this.props.actions.getUser(bot.owner_id);
+                    this.props.actions.getUser(bot.user_id);
+                    this.props.actions.getUserAccessTokensForUser(bot.user_id);
+                }
+            }
+        }, 300);
+    }
+
     bots = (filter?: string): [JSX.Element[], boolean] => {
+        if (filter !== this.lastFilter) {
+            this.lastFilter = filter;
+            if (filter) {
+                this.scheduleServerSearch(filter);
+            } else if (this.searchTimer) {
+                clearTimeout(this.searchTimer);
+                this.searchTimer = null;
+            }
+        }
+
         const bots = Object.values(this.props.bots).sort((a, b) => a.username.localeCompare(b.username));
         const match = (bot: BotType) => matchesFilter(bot, filter, this.props.owners[bot.user_id]);
         const enabledBots = bots.filter((bot) => bot.delete_at === 0).filter(match).map(this.botToJSX);

--- a/webapp/channels/src/components/integrations/bots/index.ts
+++ b/webapp/channels/src/components/integrations/bots/index.ts
@@ -8,7 +8,7 @@ import type {Dispatch} from 'redux';
 import type {Bot as BotType} from '@mattermost/types/bots';
 import type {UserProfile} from '@mattermost/types/users';
 
-import {loadBots, disableBot, enableBot} from 'mattermost-redux/actions/bots';
+import {loadBots, searchBots, disableBot, enableBot} from 'mattermost-redux/actions/bots';
 import {getAppsBotIDs as fetchAppsBotIDs} from 'mattermost-redux/actions/integrations';
 import {createUserAccessToken, revokeUserAccessToken, enableUserAccessToken, disableUserAccessToken, getUserAccessTokensForUser, getUser} from 'mattermost-redux/actions/users';
 import {appsEnabled} from 'mattermost-redux/selectors/entities/apps';
@@ -61,6 +61,7 @@ function mapDispatchToProps(dispatch: Dispatch) {
         actions: bindActionCreators({
             fetchAppsBotIDs,
             loadBots,
+            searchBots,
             getUserAccessTokensForUser,
             createUserAccessToken,
             revokeUserAccessToken,

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4114,7 +4114,6 @@
   "bots.manage.header": "Bot Accounts",
   "bots.manage.help1": "Use {botAccounts} to integrate with Mattermost through plugins or the API. Bot accounts are available to everyone on your server. ",
   "bots.manage.load_error.full": "Bot accounts could not be loaded. Refresh the page to try again.",
-  "bots.manage.load_error.partial": "Some bot accounts could not be loaded, so this list may be incomplete. Refresh the page to try again.",
   "bots.manage.search": "Search Bot Accounts",
   "bots.managed_by.app": "Managed by Apps Framework",
   "bots.managed_by.plugin": "Managed by plugin {pluginId}",

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/bots.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/bots.ts
@@ -52,6 +52,14 @@ export function loadBots(page = 0, perPage = BOTS_PER_PAGE_DEFAULT) {
     });
 }
 
+export function searchBots(term: string) {
+    return bindClientFunc({
+        clientFunc: Client4.searchBots,
+        onSuccess: BotTypes.RECEIVED_BOT_ACCOUNTS,
+        params: [term],
+    });
+}
+
 export function disableBot(botUserId: string) {
     return bindClientFunc({
         clientFunc: Client4.disableBot,

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -4431,6 +4431,13 @@ export default class Client4 {
         );
     };
 
+    searchBots = (term: string, includeDeleted = true, page = 0, perPage = PER_PAGE_DEFAULT) => {
+        return this.doFetch<Bot[]>(
+            `${this.getBotsRoute()}${buildQueryString({q: term, include_deleted: includeDeleted, page, per_page: perPage})}`,
+            {method: 'get'},
+        );
+    };
+
     disableBot = (botUserId: string) => {
         return this.doFetch<Bot>(
             `${this.getBotRoute(botUserId)}/disable`,


### PR DESCRIPTION
#### Summary

[MM-69656 / #37336](https://github.com/mattermost/mattermost/pull/37336) already fixed the root cause on the client side by paginating through all bot pages on initial mount. Bots beyond position 200 now load and are searchable via the existing client-side filter.

This PR adds **server-side search** to the `GET /api/v4/bots` endpoint as a complementary efficiency improvement, to avoid having to load all bots and filtering in the server instead.

**What was changed:**

- **Server**: new `Term` field on `BotGetOptions`; `SqlBotStore.GetAll` filters by `?q=` using case-insensitive `LIKE` on username, display name, description, and owner username (matching the existing client-side `matchesFilter` behaviour exactly). The `getBots` API handler reads the `q` query param and passes it through. A new `SearchBots` method is added to `Client4`.
- **Webapp**: a `searchBots` Redux action calls the new endpoint. The `Bots` component schedules a server search 300 ms after each filter change (cancelling the previous timer on each keystroke), then loads owner and token data for the returned bots.
- **Tests**: store-level tests for all four searchable columns, case insensitivity, no-match, and combined filters; API-level `TestSearchBots` including a permission check; a Cypress E2E spec that creates 250 bots and asserts that bots beyond position 200 appear in search results.

**QA steps:**

1. Create more than 200 bot accounts.
2. Navigate to **System Console > Integrations > Bot Accounts**.
3. Type a search term that matches only a bot beyond position 200.
4. Verify results appear without waiting for a full paginated load to complete.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/36872

#### Release Note

```release-note
Added server-side search to GET /api/v4/bots via a new q query parameter, allowing the Bot Accounts search box to find matching bots efficiently without loading the full list first.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** This spans server API, client API, Redux wiring, and UI pagination/search behavior, so regressions could show up in bot list loading or search results. The changes are mostly localized and covered by API, store, component, and E2E tests, but they do alter a public contract and a user-facing flow.

**QA Recommendation:** Do focused manual QA on Bot Accounts pagination and searching for bots beyond the initial page limit, including non-admin access behavior and navigation between pages.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->