### PR TITLE
Disable Codecov PR comments

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -36,7 +36,4 @@ flags:
   webapp:
     after_n_builds: 1 # 1 merged webapp upload
 
-comment:
-  layout: "condensed_header,diff,flags"
-  behavior: default
-  require_changes: true
+comment: false


### PR DESCRIPTION
#### Summary
This is the third-time I've been burned by an endless stream of CodeCov comments on a PR: https://hub.mattermost.com/private-core/pl/wz64uy1a3tfipfnsmefzobai5c. Let's just disable the comments entirely.

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** This is an isolated CI/configuration change that disables Codecov PR comments and does not touch runtime code, shared utilities, or user-facing product logic. The main risk is limited to losing PR annotation feedback from Codecov, with no expected impact on application behavior.

**QA Recommendation:** Minimal manual QA needed; verify the repository’s Codecov workflow still runs successfully and that PR comments are no longer posted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->