### PR TITLE
Update timezone metadata

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -102,7 +102,7 @@
     "smooth-scroll-into-view-if-needed": "2.0.2",
     "stream-browserify": "3.0.0",
     "styled-components": "5.3.7",
-    "timezones.json": "1.7.1",
+    "timezones.json": "1.7.2",
     "tinycolor2": "1.6.0",
     "turndown": "7.2.2",
     "web-vitals": "5.0.3",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -150,7 +150,7 @@
         "smooth-scroll-into-view-if-needed": "2.0.2",
         "stream-browserify": "3.0.0",
         "styled-components": "5.3.7",
-        "timezones.json": "1.7.1",
+        "timezones.json": "1.7.2",
         "tinycolor2": "1.6.0",
         "turndown": "7.2.2",
         "web-vitals": "5.0.3",
@@ -26866,9 +26866,9 @@
       "license": "MIT"
     },
     "node_modules/timezones.json": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/timezones.json/-/timezones.json-1.7.1.tgz",
-      "integrity": "sha512-4dB58ulcrRWfiGufzlofLG45RIoalCTZiFUc7tnj0g8za0CpNTyIOVlspg1JD7OFyDeW5up3ntlkukizwB0IJA==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/timezones.json/-/timezones.json-1.7.2.tgz",
+      "integrity": "sha512-+5rRB7XCNeQ1ShJIIY+xrsupjWNHXGdraXE4ji6MDZjuzbm+Mt8n791PHeo1k0dndVG5Fp+qeOhgboSZN+zPgA==",
       "license": "MIT"
     },
     "node_modules/timm": {


### PR DESCRIPTION
#### Summary

Updates `timezones.json` from `1.7.1` to `1.7.2`.

#### Ticket Link

[#37432](https://github.com/mattermost/mattermost/issues/37432)

#### Release Note

```release-note
Updated timezone metadata used for timezone labels in user settings.
```

#### Details

The previous timezone metadata package contains outdated labels and offsets for some IANA timezone mappings. Mattermost uses this package to render timezone labels in the user settings UI, while browser timezone detection and timestamp calculations use separate APIs/libraries.

Updating to `timezones.json@1.7.2` refreshes these labels and offsets without changing Mattermost timezone handling logic.

#### Testing

Not run locally. This is a dependency metadata update only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** This is a narrow dependency metadata update limited to timezone label data, so behavior changes are unlikely and the blast radius is isolated to user settings display. It does not affect authentication, persistence, APIs, or core business logic.

**QA Recommendation:** Minimal QA is needed; a quick spot-check of timezone labels in user settings is sufficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->