### PR TITLE
Bump Playwright v2 CI workers from 10 to 15

### DIFF
--- a/.github/workflows/e2e-tests-playwright.yml
+++ b/.github/workflows/e2e-tests-playwright.yml
@@ -218,7 +218,7 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/e2e-tests-playwright-template-v2.yml
     with:
-      workers: 10
+      workers: 15
       enabled_docker_services: "postgres inbucket"
       commit_sha: ${{ inputs.commit_sha }}
       branch: ${{ needs.generate-build-variables.outputs.branch }}


### PR DESCRIPTION
## Summary
- Increase `playwright-full-v2` worker count from 10 to 15 in `e2e-tests-playwright.yml`
- Will likely bump again next time as we migrate more tests to Playwright

Test run on staging cut Playwright's full duration from 16 min (master) to 11 min:
- Staging: https://staging-test-io.test.mattermost.com/reports/mattermost/master/49b7406/playwright-dispatch-test?gh_run_id=28995734589&gh_run_attempt=1
- Master: https://test-io.test.mattermost.com/reports/mattermost/master/49b7406/playwright-full-enterprise-master?gh_run_id=28986436368

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** This is an isolated CI workflow configuration change that only increases Playwright worker count, so it does not affect application code, shared utilities, or runtime behavior. The main risk is potential CI flakiness or resource contention in the test job itself.

**QA Recommendation:** Automated CI validation is sufficient; no additional manual QA is needed beyond confirming the workflow passes reliably with the updated worker count.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->