### PR TITLE
docs: fix broken admonitions and anchors in product-overview changelog pages

### DIFF
--- a/docs/main/product-overview/desktop-app-changelog.mdx
+++ b/docs/main/product-overview/desktop-app-changelog.mdx
@@ -5,10 +5,12 @@ import Inc0_common_esr_support from './common-esr-support.mdx';
 
 This changelog summarizes updates to Mattermost desktop app releases for [Mattermost](https://mattermost.com).
 
-```{Important}
+<Important>
+
 <Inc0_common_esr_support />
-(release-v6-1)=
-## Release v6.1
+
+</Important>
+## Release v6.1 \{#release-v6-1}
 
 - **v6.1.2, released 2026-04-21**
 
@@ -104,8 +106,7 @@ This changelog summarizes updates to Mattermost desktop app releases for [Matter
 
 - [devinbinnie](https://github.com/devinbinnie), [enahum](https://github.com/enahum), [hmhealey](https://github.com/hmhealey), [lieut-data](https://github.com/lieut-data), [lifeisafractal](https://github.com/lifeisafractal), [NARSimoes](https://github.com/NARSimoes), [wiggin77](https://github.com/wiggin77), [yasserfaraazkhan](https://github.com/yasserfaraazkhan).
 
-(release-v6-0)=
-## Release v6.0
+## Release v6.0 \{#release-v6-0}
 
 - **v6.0.4, released 2026-01-20**
 
@@ -140,9 +141,11 @@ This changelog summarizes updates to Mattermost desktop app releases for [Matter
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/v6.0.4)
 
-```{Note}
+<Note>
+
 Mattermost Desktop App v6.0.0 contains low severity level security fixes. Upgrading is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Compatibility
 
@@ -198,8 +201,7 @@ Mattermost Desktop App v6.0.0 contains low severity level security fixes. Upgrad
 
 - [devinbinnie](https://github.com/devinbinnie), [BenCookie95](https://github.com/BenCookie95).
 
-(release-v5-13)=
-## Release v5.13 (Extended Support Release)
+## Release v5.13 (Extended Support Release) \{#release-v5-13}
 
 - **v5.13.5, released 2026-03-24**
 
@@ -270,8 +272,7 @@ Mattermost Desktop App v6.0.0 contains low severity level security fixes. Upgrad
 
 - [devinbinnie](https://github.com/devinbinnie), [hmhealey](https://github.com/hmhealey), [toffguy77](https://github.com/toffguy77).
 
-(release-v5-12)=
-## Release v5.12
+## Release v5.12 \{#release-v5-12}
 
 - **v5.12.1, released 2025-05-31**
 
@@ -284,9 +285,11 @@ Mattermost Desktop App v6.0.0 contains low severity level security fixes. Upgrad
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/v5.12.1)
 
-```{Note}
+<Note>
+
 Mattermost Desktop App v5.12.0 contains a medium severity level security fix. Upgrading is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Compatibility
 
@@ -330,8 +333,7 @@ Mattermost Desktop App v5.12.0 contains a medium severity level security fix. Up
 
 - [devinbinnie](https://github.com/devinbinnie), [j0794](https://github.com/j0794).
 
-(release-v5-11)=
-## Release v5.11 (Extended Support Release)
+## Release v5.11 (Extended Support Release) \{#release-v5-11}
 
 - **v5.11.3, released 2025-05-23**
 
@@ -355,9 +357,11 @@ Mattermost Desktop App v5.12.0 contains a medium severity level security fix. Up
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/v5.11.3)
 
-```{Note}
+<Note>
+
 Mattermost Desktop App v5.11.0 contains a low severity level security fix. Upgrading is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Compatibility
 
@@ -421,8 +425,7 @@ Mattermost Desktop App v5.11.0 contains a low severity level security fix. Upgra
 
 - [andr-sokolov](https://github.com/andr-sokolov), [devinbinnie](https://github.com/devinbinnie), [jonathan-dove](https://github.com/jonathan-dove), [pvev](https://github.com/pvev), [s1Sharp](https://github.com/s1Sharp), [streamer45](https://github.com/streamer45).
 
-(release-v5-10)=
-## Release v5.10
+## Release v5.10 \{#release-v5-10}
 
 - **v5.10.2, released 2024-12-17**
 
@@ -445,9 +448,11 @@ Mattermost Desktop App v5.11.0 contains a low severity level security fix. Upgra
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/v5.10.2)
 
-```{Note}
+<Note>
+
 Mattermost Desktop App v5.10.0 contains a low severity level security fix. Upgrading is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Compatibility
 
@@ -513,8 +518,7 @@ Mattermost Desktop App v5.10.0 contains a low severity level security fix. Upgra
 
 - [devinbinnie](https://github.com/devinbinnie), [streamer45](https://github.com/streamer45), [theaino](https://github.com/theaino).
 
-(release-v5-9)=
-## Release v5.9 (Extended Support Release)
+## Release v5.9 (Extended Support Release) \{#release-v5-9}
 
 - **v5.9.2, released 2024-12-17**
 
@@ -535,13 +539,17 @@ Mattermost Desktop App v5.10.0 contains a low severity level security fix. Upgra
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/v5.9.2)
 
-```{Note}
-Mattermost v5.9.0 contains low to medium severity level security fixes. Upgrading is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+<Note>
 
-```{Note}
+Mattermost v5.9.0 contains low to medium severity level security fixes. Upgrading is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
+
+</Note>
+
+<Note>
+
 v5.9.0 is the first Extended Support Release for the Desktop App. See more details in [this documentation](https://docs.mattermost.com/about/release-policy.html#extended-support-releases).
-```
+
+</Note>
 
 ### Compatibility
 
@@ -594,8 +602,7 @@ v5.9.0 is the first Extended Support Release for the Desktop App. See more detai
 
 - [enzowritescode](https://github.com/enzowritescode), [devinbinnie](https://github.com/devinbinnie), [mvitale1989](https://github.com/mvitale1989), [Rajat-Dabade](https://github.com/Rajat-Dabade), [streamer45](https://github.com/streamer45), [tnir](https://github.com/tnir), [toninis](https://github.com/toninis), [yasserfaraazkhan](https://github.com/yasserfaraazkhan).
 
-(release-v5-8)=
-## Release v5.8
+## Release v5.8 \{#release-v5-8}
 
 - **v5.8.1, released 2024-06-13**
 
@@ -610,9 +617,11 @@ v5.9.0 is the first Extended Support Release for the Desktop App. See more detai
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/v5.8.1)
 
-```{Note}
+<Note>
+
 Mattermost v5.8.0 contains low to medium severity level security fixes. Upgrading is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Compatibility
 
@@ -663,8 +672,7 @@ Mattermost v5.8.0 contains low to medium severity level security fixes. Upgradin
 
 ----
 
-(release-v5-7)=
-## Release v5.7
+## Release v5.7 \{#release-v5-7}
 
 **Release Date: March 15, 2024**
 
@@ -715,8 +723,7 @@ Mattermost v5.8.0 contains low to medium severity level security fixes. Upgradin
 
 ----
 
-(release-v5-6)=
-## Release v5.6
+## Release v5.6 \{#release-v5-6}
 
 **Release Date: December 15, 2023**
 
@@ -771,8 +778,7 @@ Mattermost v5.8.0 contains low to medium severity level security fixes. Upgradin
 
 ----
 
-(release-v5-5)=
-## Release v5.5
+## Release v5.5 \{#release-v5-5}
 
 - **v5.5.1, released 2023-10-03**
   - Mattermost v5.5.1 contains low severity level security fixes. Upgrading is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -786,9 +792,11 @@ Mattermost v5.8.0 contains low to medium severity level security fixes. Upgradin
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/tag/v5.5.1)
 
-```{Note}
+<Note>
+
 Mattermost v5.5.0 contains a medium severity level security fix. Upgrading is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Compatibility
 
@@ -828,8 +836,7 @@ Mattermost v5.5.0 contains a medium severity level security fix. Upgrading is hi
 
 ----
 
-(release-v5-4)=
-## Release v5.4
+## Release v5.4 \{#release-v5-4}
 
 **Release Day: June 19, 2023**
 
@@ -879,8 +886,7 @@ Mattermost v5.5.0 contains a medium severity level security fix. Upgrading is hi
 
 ----
 
-(release-v5-3)=
-## Release v5.3
+## Release v5.3 \{#release-v5-3}
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/tag/v5.3.1)
 
@@ -892,9 +898,11 @@ Mattermost v5.5.0 contains a medium severity level security fix. Upgrading is hi
 
   - Original v5.3.0 release
 
-```{Note}
+<Note>
+
 Mattermost v5.3.0 contains a medium severity level security fix. Upgrading is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Compatibility
 
@@ -951,8 +959,7 @@ Mattermost v5.3.0 contains a medium severity level security fix. Upgrading is hi
 
 ----
 
-(release-v5-2)=
-## Release v5.2
+## Release v5.2 \{#release-v5-2}
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/tag/v5.2.2)
 
@@ -1045,8 +1052,7 @@ Mattermost v5.3.0 contains a medium severity level security fix. Upgrading is hi
 
 ----
 
-(release-v5-1)=
-## Release v5.1
+## Release v5.1 \{#release-v5-1}
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/tag/v5.1.1)
 
@@ -1063,9 +1069,11 @@ Mattermost v5.3.0 contains a medium severity level security fix. Upgrading is hi
 
   - Original v5.1.0 release
 
-```{Note}
+<Note>
+
 Mattermost v5.1.0 contains a low severity level security fix. Upgrading is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Compatibility
 
@@ -1142,8 +1150,7 @@ Mattermost v5.1.0 contains a low severity level security fix. Upgrading is highl
 
 ----
 
-(release-v5-0)=
-## Release v5.0
+## Release v5.0 \{#release-v5-0}
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/tag/v5.0.4)
 
@@ -1179,9 +1186,11 @@ Mattermost v5.1.0 contains a low severity level security fix. Upgrading is highl
 
  - Original v5.0.0 release
 
-```{Note}
+<Note>
+
 Mattermost v5.0.0 contains a low level security fix. Upgrading is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Compatibility
 
@@ -1247,8 +1256,7 @@ Mattermost v5.0.0 contains a low level security fix. Upgrading is highly recomme
 
 ----
 
-(release-v4-7)=
-## Release v4.7
+## Release v4.7 \{#release-v4-7}
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/tag/v4.7.2)
 
@@ -1272,9 +1280,11 @@ Mattermost v5.0.0 contains a low level security fix. Upgrading is highly recomme
 
   - Original v4.7.0 release
 
-```{Note}
+<Note>
+
 Mattermost v4.7.0 contains low to medium level security fixes. Upgrading is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Compatibility
 
@@ -1358,8 +1368,7 @@ Mattermost v4.7.0 contains low to medium level security fixes. Upgrading is high
 
 ----
 
-(release-v4-6)=
-## Release v4.6
+## Release v4.6 \{#release-v4-6}
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/tag/v4.6.2)
 
@@ -1416,8 +1425,7 @@ Many thanks to all our contributors. In alphabetical order:
 
 ----
 
-(release-v4-5)=
-## Release v4.5
+## Release v4.5 \{#release-v4-5}
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/tag/v4.5.4)
 
@@ -1504,8 +1512,7 @@ Many thanks to all our contributors. In alphabetical order:
 
 ----
 
-(release-v4-4)=
-## Release v4.4
+## Release v4.4 \{#release-v4-4}
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/tag/v4.4.2)
 
@@ -1526,9 +1533,11 @@ Many thanks to all our contributors. In alphabetical order:
 
   - Original v4.4.0 release
 
-```{Note}
+<Note>
+
 Mattermost v4.4.0 contains low to medium level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Breaking Changes
 
@@ -1589,8 +1598,7 @@ Many thanks to all our contributors. In alphabetical order:
 
 ----
 
-(release-v4-3)=
-## Release v4.3
+## Release v4.3 \{#release-v4-3}
 
 **Download Binaries:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/tag/4.3.2)
 
@@ -1611,9 +1619,11 @@ Many thanks to all our contributors. In alphabetical order:
 
   - Original v4.3.0 release
 
-```{Note}
+<Note>
+
 Mattermost v4.3.0 contains medium level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Breaking Change
 
@@ -1688,8 +1698,7 @@ Many thanks to all our contributors. In alphabetical order:
 
 ----
 
-(release-v4-2-3)=
-## Release v4.2.3
+## Release v4.2.3 \{#release-v4-2-3}
 
 This release contains a bug fix for all platforms.
 
@@ -1705,8 +1714,7 @@ This release contains a bug fix for all platforms.
 
 ----
 
-(release-v4-2-2)=
-## Release v4.2.2
+## Release v4.2.2 \{#release-v4-2-2}
 
 This release contains a bug fix for all platforms.
 
@@ -1720,8 +1728,7 @@ This release contains a bug fix for all platforms.
 
 ----
 
-(release-v4-2-1)=
-## Release v4.2.1
+## Release v4.2.1 \{#release-v4-2-1}
 
 This release contains a bug fix for all platforms.
 
@@ -1737,16 +1744,17 @@ This release contains a bug fix for all platforms.
 
 ----
 
-(release-v4-2-0)=
-## Release v4.2.0
+## Release v4.2.0 \{#release-v4-2-0}
 
 - **Release date:** November 27, 2018
 **Download Binary:** [Windows 32-bit](https://releases.mattermost.com/desktop/4.2.0/mattermost-setup-4.2.0-win32.exe) | [Windows 64-bit](https://releases.mattermost.com/desktop/4.2.0/mattermost-setup-4.2.0-win64.exe) | [Mac](https://releases.mattermost.com/desktop/4.2.0/mattermost-desktop-4.2.0-mac.dmg) | [Linux 64-bit](https://releases.mattermost.com/desktop/4.2.0/mattermost-desktop-4.2.0-linux-x64.tar.gz)
 - **View Source Code:** [Mattermost Desktop on GitHub](https://github.com/mattermost/desktop/releases/tag/v4.2.0)
 
-```{Note}
+<Note>
+
 Mattermost v4.2.0 contains a high level security fix. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Improvements
 
@@ -1786,8 +1794,7 @@ Many thanks to all our contributors. In alphabetical order:
 
 ----
 
-(release-v4-1-2)=
-## Release v4.1.2
+## Release v4.1.2 \{#release-v4-1-2}
 
 This release contains a bug fix for all platforms.
 
@@ -1803,8 +1810,7 @@ This release contains a bug fix for all platforms.
 
 ----
 
-(release-v4-1-1)=
-## Release v4.1.1
+## Release v4.1.1 \{#release-v4-1-1}
 
 This release contains multiple bug fixes for Mac due to an incorrect build for v4.1.0. Windows and Linux apps are not affected.
 
@@ -1828,8 +1834,7 @@ Each of the issues listed below are already fixed for Windows and Linux v4.1.0.
 
 ----
 
-(release-v4-1-0)=
-## Release v4.1.0
+## Release v4.1.0 \{#release-v4-1-0}
 
 Release date: May 16, 2018
 
@@ -1907,8 +1912,7 @@ Many thanks to all our contributors. In alphabetical order:
 
 ----
 
-(release-v4-0-1)=
-## Release v4.0.1
+## Release v4.0.1 \{#release-v4-0-1}
 
 Release date: March 28, 2018
 
@@ -1926,8 +1930,7 @@ This release contains multiple security updates for Windows, Mac and Linux, and 
 
 ----
 
-(release-v4-0-0)=
-## Release 4.0.0
+## Release 4.0.0 \{#release-v4-0-0}
 
 Release date: January 29, 2018
 
@@ -2025,8 +2028,7 @@ Many thanks to all our contributors. In alphabetical order:
 
 ----
 
-(release-v3-7-1)=
-## Release 3.7.1
+## Release 3.7.1 \{#release-v3-7-1}
 
 Release date: August 30, 2017
 
@@ -2042,7 +2044,6 @@ This release contains a security update for Windows, Mac and Linux, and it is hi
 
 ----
 
-(release-v3-7-0)=
 Release 3.7.0
 --------------
 
@@ -2120,8 +2121,7 @@ Thanks also to those who reported bugs that benefited the release, in alphabetic
 
 ----
 
-(release-v3-6-0)=
-## Release 3.6.0
+## Release 3.6.0 \{#release-v3-6-0}
 
 Release date: February 28, 2017
 
@@ -2203,8 +2203,7 @@ Many thanks to all our contributors. In alphabetical order:
 
 ----
 
-(release-v3-5-0)=
-## Release v3.5.0
+## Release v3.5.0 \{#release-v3-5-0}
 
 Release date: December 14, 2016
 
@@ -2283,8 +2282,7 @@ Thanks also to those who reported bugs that benefited the release, in alphabetic
 
 ----
 
-(release-v3-4-1)=
-## Release v3.4.1
+## Release v3.4.1 \{#release-v3-4-1}
 
 Release date: September 30, 2016
 
@@ -2389,8 +2387,7 @@ Many thanks to all our contributors. In alphabetical order:
 
 --------------
 
-(release-v1-3-0)=
-## Release v1.3.0
+## Release v1.3.0 \{#release-v1-3-0}
 
 Release date: 2016-07-18
 

--- a/docs/main/product-overview/mattermost-desktop-releases.mdx
+++ b/docs/main/product-overview/mattermost-desktop-releases.mdx
@@ -3,16 +3,21 @@ title: "Desktop Releases"
 ---
 import Inc0_common_esr_support from './common-esr-support.mdx';
 
-```{Important}
+<Important>
+
 <Inc0_common_esr_support />
+
+</Important>
 ## Frequency
 
 Mattermost releases a new desktop app version every 4 months, in February, May, August, and November in [binary form](https://docs.mattermost.com/end-user-guide/access/install-desktop-app.html). See the [Desktop app changelog](/product-overview/desktop-app-changelog) for release details.
 
-```{Important}
+<Important>
+
 - From Mattermost v9.11, Mattermost server extended releases are now paired with Mattermost desktop app extended releases. For an optimal user experience and for the latest security fixes, we strongly recommend updating desktop clients to the latest version your Mattermost server supports. See the table below for server compatibility, and see the [Mattermost extended support releases](#extended-support-releases) documentation to learn more about extended releases.
 - If you prefer to control the server and client releases, we recommend disabling automatic client updates to prevent users from upgrading their desktop client to a version your server doesn't support. See the [install Mattermost desktop app](https://docs.mattermost.com/end-user-guide/access/install-desktop-app.html) documentation for platform-specific details on automatic app updates.
-```
+
+</Important>
 
 ## Latest releases
 

--- a/docs/main/product-overview/mattermost-mobile-releases.mdx
+++ b/docs/main/product-overview/mattermost-mobile-releases.mdx
@@ -3,17 +3,22 @@ title: "Mobile Releases"
 ---
 import Inc0_common_esr_support from './common-esr-support.mdx';
 
-```{Important}
+<Important>
+
 <Inc0_common_esr_support />
+
+</Important>
 ## Frequency
 
 Mattermost releases a new mobile app version every month.
 
 See the [Mobile app changelog](/product-overview/mobile-app-changelog) for release details, and see the [iOS mobile app](/end-user-guide/access/install-ios-app) and the [Android mobile app](/end-user-guide/access/install-android-app) documentation for installation details. 
 
-```{Important}
+<Important>
+
 We strongly recommend using the latest mobile app release available that contains the latest security fixes and user experience enhancements. Mobile app releases are compatible with and tested against [supported Mattermost server and extended support releases](https://docs.mattermost.com/product-overview/mattermost-server-releases.html#latest-releases).
-```
+
+</Important>
 
 ## Latest releases
 

--- a/docs/main/product-overview/mattermost-server-releases.mdx
+++ b/docs/main/product-overview/mattermost-server-releases.mdx
@@ -3,16 +3,11 @@ title: "Server Releases"
 ---
 import Inc0_common_esr_support_upgrade from './common-esr-support-upgrade.mdx';
 
-(mattermost-server-releases)=
+<Important>
 
-{/* TODO: eval-rst block left verbatim, port manually */}
-```
-.. meta::
-    :page_title: Mattermost Server Releases
-```
-
-```{Important}
 <Inc0_common_esr_support_upgrade />
+
+</Important>
 ## Frequency
 Mattermost releases a new server version on the 16th of each month in [binary form](https://docs.mattermost.com/administration-guide/upgrade/upgrading-mattermost-server.html). 
 - See the [v11 changelog](https://docs.mattermost.com/product-overview/mattermost-v11-changelog.html) for details on what's coming and changing in the next major release. 

--- a/docs/main/product-overview/mattermost-v10-changelog.mdx
+++ b/docs/main/product-overview/mattermost-v10-changelog.mdx
@@ -3,28 +3,26 @@ title: "v10 Changelog"
 ---
 import Inc0_common_esr_support_upgrade from './common-esr-support-upgrade.mdx';
 
-{/* TODO: eval-rst block left verbatim, port manually */}
-```
-.. meta::
-  :page_title: Mattermost Server v10 Release Notes
-```
+<Important>
 
-```{Important}
 <Inc0_common_esr_support_upgrade />
+
+</Important>
 <Note>
 
 Platform and OS scope reflects reported and tested environments and may not represent all affected configurations.
 
 </Note>
 
-(release-v10.12-feature-release)=
-## Release v10.12 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types)
+## Release v10.12 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types) \{#release-v10-12-feature-release}
 
 - **10.12.4, released 2025-11-21**
- ```{Attention}
- **Critical Fixes**
+ <Important>
+
+**Critical Fixes**
   - Mattermost v10.12.4 contains a Critical severity level security fix in the Jira plugin. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
- ```
+
+ </Important>
   - Pre-packaged Jira plugin version [v4.4.1](https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v4.4.1).
   - Mattermost v10.12.4 contains no database or functional changes.
 - **10.12.3, released 2025-11-17**
@@ -34,10 +32,12 @@ Platform and OS scope reflects reported and tested environments and may not repr
   - Fixed a configuration retention issue where even active configuration got deleted.
   - Mattermost v10.12.3 contains no database or functional changes.
 - **10.12.2, released 2025-10-28**
- ```{Attention}
- **Critical Fixes**
+ <Important>
+
+**Critical Fixes**
   - Mattermost v10.12.2 contains Critical severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
- ```
+
+ </Important>
   - Pre-packaged Boards plugin [v9.1.7](https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.1.7).
   - Mattermost v10.12.2 contains no database or functional changes.
 - **10.12.1, released 2025-10-15**
@@ -48,9 +48,11 @@ Platform and OS scope reflects reported and tested environments and may not repr
 - **10.12.0, released 2025-09-16**
   - Original 10.12.0 release.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v10.10, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration-guide/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Compatibility
  - Updated minimum Edge and Chrome versions to 138+.
@@ -81,8 +83,7 @@ If you upgrade from a release earlier than v10.10, please read the other [Import
 ### Contributors
  - [abbas-dependable-naqvi](https://github.com/abbas-dependable-naqvi), [adityadav1987](https://github.com/adityadav1987), [agarciamontoro](https://github.com/agarciamontoro), [AhsanSarwar0413](https://github.com/AhsanSarwar0413), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [arush-vashishtha](https://github.com/arush-vashishtha), [asaadmahmood](https://github.com/asaadmahmood), [avasconcelos114](https://github.com/avasconcelos114), [calebroseland](https://github.com/calebroseland), [ctlaltdieliet](https://github.com/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [davidkrauser](https://github.com/davidkrauser), [devinbinnie](https://github.com/devinbinnie), [dgwhited](https://github.com/dgwhited), [DHaussermann](https://github.com/DHaussermann), [DSchalla](https://github.com/DSchalla), [electronicmilk](https://translate.mattermost.com/user/electronicmilk), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [esarafianou](https://github.com/esarafianou), [esethna](https://github.com/esethna), [ewwollesen](https://github.com/ewwollesen), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [fsilye](https://github.com/fsilye), [gabrieljackson](https://github.com/gabrieljackson), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [henriquevmac](https://github.com/henriquevmac), [hmhealey](https://github.com/hmhealey), [isacikgoz](https://github.com/isacikgoz), [jgheithcock](https://github.com/jgheithcock), [jlandells](https://github.com/jlandells), [johnsonbrothers](https://github.com/johnsonbrothers), [jprusch](https://github.com/jprusch), [JulienTant](https://github.com/JulienTant), [jwilander](https://github.com/jwilander), [kaakaa](https://translate.mattermost.com/user/kaakaa), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [mansil](https://github.com/mansil), [master7](https://translate.mattermost.com/user/master7), [matt-w99](https://github.com/matt-w99), [matthew-w](https://translate.mattermost.com/user/matthew-w), [mgdelacroix](https://github.com/mgdelacroix), [Morgansvk](https://github.com/Morgansvk), [neflyte](https://github.com/neflyte), [nickmisasi](https://github.com/nickmisasi), [pvev](https://github.com/pvev), [raghavaggarwal2308](https://github.com/raghavaggarwal2308), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Reinkard](https://translate.mattermost.com/user/Reinkard), [rOt779kVceSgL](https://translate.mattermost.com/user/rOt779kVceSgL), [sadohert](https://github.com/sadohert), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [stafot](https://github.com/stafot), [svelle](https://github.com/svelle), [tnir](https://github.com/tnir), [Victor-Nyagudi](https://github.com/Victor-Nyagudi), [wiersgallak](https://github.com/wiersgallak), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [yasserfaraazkhan](https://github.com/yasserfaraazkhan)
 
-(release-v10.11-extended-support-release)=
-## Release v10.11 - [Extended Support Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types)
+## Release v10.11 - [Extended Support Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types) \{#release-v10-11-extended-support-release}
 
 - **10.11.15, released 2026-04-22**
   - Mattermost v10.11.15 contains medium to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -123,10 +124,12 @@ If you upgrade from a release earlier than v10.10, please read the other [Import
   - Fixed an issue where rate limiting was missing from the login endpoint (5 requests/second, 10 burst).
   - Mattermost v10.11.12 contains no database or functional changes.
 - **10.11.11, released 2026-02-13**
-```{Attention}
+<Important>
+
 **Breaking Changes**
  - Photoshop Document (PSD) files are now no longer inline previewed, they are treated as regular file attachments.
-```
+
+</Important>
   - Mattermost v10.11.11 contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
   - Pre-packaged Boards plugin version [v9.2.2](https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.2.2).
   - Fixed an issue where the channel URL got updated when the channel display name was changed.
@@ -157,10 +160,12 @@ If you upgrade from a release earlier than v10.10, please read the other [Import
   - Fixed an issue where pressing ``Shift+Up`` in the channel textbox to reply to a thread could cause the right‑hand sidebar (RHS) reply textbox to not focus.
   - Mattermost v10.11.9 contains no database or functional changes.
 - **10.11.8, released 2025-11-21**
- ```{Attention}
- **Critical Fixes**
+ <Important>
+
+**Critical Fixes**
   - Mattermost v10.11.8 contains a Critical severity level security fix in the Jira plugin. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
- ```
+
+ </Important>
   - Pre-packaged Jira plugin version [v4.4.1](https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v4.4.1).
   - Mattermost v10.11.8 contains no database or functional changes.
 - **10.11.7, released 2025-11-17**
@@ -176,10 +181,12 @@ If you upgrade from a release earlier than v10.10, please read the other [Import
   - Pre-packaged MS Teams Meeting plugin version [v2.3.0](https://github.com/mattermost/mattermost-plugin-msteams-meetings/releases/tag/v2.3.0).
   - Mattermost v10.11.6 contains no database or functional changes.
 - **10.11.5, released 2025-10-28**
- ```{Attention}
- **Critical Fixes**
+ <Important>
+
+**Critical Fixes**
   - Mattermost v10.11.5 contains Critical severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
- ```
+
+ </Important>
   - Pre-packaged Boards plugin [v9.1.7](https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.1.7).
   - Mattermost v10.11.5 contains no database or functional changes.
 - **10.11.4, released 2025-10-15**
@@ -203,9 +210,11 @@ If you upgrade from a release earlier than v10.10, please read the other [Import
 - **10.11.0, released 2025-08-15**
   - Original 10.11.0 release.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v10.10, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration-guide/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
  - Enabled **System Console** user interface for ``AuditSettings`` by default. 
@@ -285,8 +294,7 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Contributors
  - [abbas-dependable-naqvi](https://github.com/abbas-dependable-naqvi), [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [akeiss](https://translate.mattermost.com/user/akeiss), [alexis](https://translate.mattermost.com/user/alexis), [alirezaalavi87](https://github.com/alirezaalavi87), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [Arusekk](https://github.com/Arusekk), [asaadmahmood](https://github.com/asaadmahmood), [BenCookie95](https://github.com/BenCookie95), [calebroseland](https://github.com/calebroseland), [catalintomai](https://github.com/catalintomai), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://github.com/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [cyrusjc](https://github.com/cyrusjc), [danielsischy](https://github.com/danielsischy), [danilvalov](https://github.com/danilvalov), [davidkrauser](https://github.com/davidkrauser), [devinbinnie](https://github.com/devinbinnie), [DHaussermann](https://github.com/DHaussermann), [DSchalla](https://github.com/DSchalla), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [esarafianou](https://github.com/esarafianou), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [fsilye](https://github.com/fsilye), [gabrieljackson](https://github.com/gabrieljackson), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [hmhealey](https://github.com/hmhealey), [isacikgoz](https://github.com/isacikgoz), [jesperfj](https://translate.mattermost.com/user/jesperfj), [jgheithcock](https://github.com/jgheithcock), [johnsonbrothers](https://github.com/johnsonbrothers), [jprusch](https://github.com/jprusch), [JulienTant](https://github.com/JulienTant), [jwilander](https://github.com/jwilander), [kaakaa](https://github.com/kaakaa), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [lindalumitchell](https://github.com/lindalumitchell), [luca.palomba](https://translate.mattermost.com/user/luca.palomba), [lynn915](https://github.com/lynn915), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [mansil](https://github.com/mansil), [marianunez](https://github.com/marianunez), [master7](https://translate.mattermost.com/user/master7), [matthewbirtch](https://github.com/matthewbirtch), [mgdelacroix](https://github.com/mgdelacroix), [Morgansvk](https://github.com/Morgansvk), [neflyte](https://github.com/neflyte), [neil-karania](https://github.com/neil-karania), [nickmisasi](https://github.com/nickmisasi), [panoramix360](https://github.com/panoramix360), [pineoak-audio](https://github.com/pineoak-audio), [pvev](https://github.com/pvev), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Reinkard](https://github.com/Reinkard), [roberson-io](https://github.com/roberson-io), [rohithchandran-mattermost](https://github.com/rohithchandran-mattermost), [rOt779kVceSgL](https://translate.mattermost.com/user/rOt779kVceSgL), [rtfm98](https://github.com/rtfm98), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [Sharuru](https://translate.mattermost.com/user/Sharuru), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [svelle](https://github.com/svelle), [ThrRip](https://github.com/ThrRip), [tnir](https://translate.mattermost.com/user/tnir), [toffguy77](https://github.com/toffguy77), [vish9812](https://github.com/vish9812), [wiersgallak](https://github.com/wiersgallak), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [yasserfaraazkhan](https://github.com/yasserfaraazkhan)
 
-(release-v10.10-feature-release)=
-## Release v10.10 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+## Release v10.10 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types) \{#release-v10-10-feature-release}
 
 - **10.10.3, released 2025-09-16**
   - Mattermost v10.10.3 contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -309,9 +317,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
  - Added a new column ``LastMembersSyncAt`` to the ``SharedChannelRemotes`` table and added ``LastMembershipSyncAt`` to ``SharedChannelUsers``. No database downtime is expected for this upgrade. See the [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html) for more details.
  - Added a new column ``LastGlobalUserSyncAt`` to the ``RemoteClusters`` table. No database downtime is expected for this upgrade. See the [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html) for more details.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v10.9, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -399,8 +409,7 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Contributors
  - [abbas-dependable-naqvi](https://github.com/abbas-dependable-naqvi), [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [Akhilbisht798](https://github.com/Akhilbisht798), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [Aryakoste](https://github.com/Aryakoste), [AulakhHarsh](https://github.com/AulakhHarsh), [BenCookie95](https://github.com/BenCookie95), [calebroseland](https://github.com/calebroseland), [Carloswaldo](https://translate.mattermost.com/user/Carloswaldo), [catalintomai](https://github.com/catalintomai), [coltoneshaw](https://github.com/coltoneshaw), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [davidkrauser](https://github.com/davidkrauser), [devinbinnie](https://github.com/devinbinnie), [Ekaterine](https://translate.mattermost.com/user/Ekaterine), [EkaterinePapava](https://github.com/EkaterinePapava), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [equalsgibson](https://github.com/equalsgibson), [esarafianou](https://github.com/esarafianou), [ewwollesen](https://github.com/ewwollesen), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [fsilye](https://github.com/fsilye), [gabrieljackson](https://github.com/gabrieljackson), [hannaparks](https://github.com/hannaparks), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [hmhealey](https://github.com/hmhealey), [iamleson98](https://github.com/iamleson98), [irdi-cloud68](https://translate.mattermost.com/user/irdi-cloud68), [isacikgoz](https://github.com/isacikgoz), [johnsonbrothers](https://github.com/johnsonbrothers), [jprusch](https://github.com/jprusch), [JulienTant](https://github.com/JulienTant), [jwilander](https://github.com/jwilander), [kaakaa](https://github.com/kaakaa), [kasyap1234](https://github.com/kasyap1234), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [larkox](https://github.com/larkox), [ldez](https://github.com/ldez), [lieut-data](https://github.com/lieut-data), [lindalumitchell](https://github.com/lindalumitchell), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [mansil](https://github.com/mansil), [marianunez](https://github.com/marianunez), [master7](https://translate.mattermost.com/user/master7), [matt-w99](https://github.com/matt-w99), [matthew-w](https://translate.mattermost.com/user/matthew-w), [matthewbirtch](https://github.com/matthewbirtch), [mgdelacroix](https://github.com/mgdelacroix), [Morgansvk](https://github.com/Morgansvk), [neil-karania](https://github.com/neil-karania), [nickmisasi](https://github.com/nickmisasi), [panoramix360](https://github.com/panoramix360), [polinapianina](https://github.com/polinapianina), [pvev](https://github.com/pvev), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Reinkard](https://github.com/Reinkard), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [Sharuru](https://github.com/Sharuru), [spirosoik](https://github.com/spirosoik), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [svelle](https://github.com/svelle), [uday-rana](https://github.com/uday-rana), [Victor-Nyagudi](https://github.com/Victor-Nyagudi), [wiersgallak](https://github.com/wiersgallak), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [yasserfaraazkhan](https://github.com/yasserfaraazkhan)
 
-(release-v10.9-feature-release)=
-## Release v10.9 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+## Release v10.9 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types) \{#release-v10-9-feature-release}
 
 - **10.9.5, released 2025-08-15**
   - Mattermost v10.9.5 contains a high severity level security fix. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -433,9 +442,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
  - Schema changes in the form of a new materialized view (``AttributeView``) was added that aggregates user attributes into a separate table. No database downtime is expected for this upgrade. See the [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html) for more details.
  - When ``SamlSettings.EnableSyncWithLdap`` is enabled, Mattermost will now check if a user exists on the connected LDAP server during login. If the user doesn't exist on the LDAP server, login will fail. Previously, users not present on the LDAP server could login, but would be deactivated on the next LDAP sync.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v10.8, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -524,8 +535,7 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Contributors
  - [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [AnmiTaliDev](https://translate.mattermost.com/user/AnmiTaliDev), [Aryakoste](https://github.com/Aryakoste), [AshishDhama](https://github.com/AshishDhama), [AulakhHarsh](https://github.com/AulakhHarsh), [BenCookie95](https://github.com/BenCookie95), [bndn](https://translate.mattermost.com/user/bndn), [bshumylo](https://github.com/bshumylo), [calebroseland](https://github.com/calebroseland), [catalintomai](https://github.com/catalintomai), [chicchu4157](https://translate.mattermost.com/user/chicchu4157), [cinlloc](https://github.com/cinlloc), [coltoneshaw](https://github.com/coltoneshaw), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [cyrusjc](https://github.com/cyrusjc), [danilvalov](https://github.com/danilvalov), [davidkrauser](https://github.com/davidkrauser), [devinbinnie](https://github.com/devinbinnie), [enahum](https://github.com/enahum), [esarafianou](https://github.com/esarafianou), [evituzas](https://translate.mattermost.com/user/evituzas), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [fsilye](https://github.com/fsilye), [gabrieljackson](https://github.com/gabrieljackson), [gentcod](https://github.com/gentcod), [Gesare5](https://github.com/Gesare5), [guenjun](https://translate.mattermost.com/user/guenjun), [hannaparks](https://github.com/hannaparks), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [hmhealey](https://github.com/hmhealey), [isacikgoz](https://github.com/isacikgoz), [iyampaul](https://github.com/iyampaul), [jespino](https://github.com/jespino), [johnsonbrothers](https://github.com/johnsonbrothers), [joho1968](https://github.com/joho1968), [jprusch](https://github.com/jprusch), [JulienTant](https://github.com/JulienTant), [jwilander](https://github.com/jwilander), [kaakaa](https://github.com/kaakaa), [kasyap1234](https://github.com/kasyap1234), [kayazeren](https://translate.mattermost.com/user/kayazeren), [Kimbohlovette](https://github.com/Kimbohlovette), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [larkox](https://github.com/larkox), [ldez](https://github.com/ldez), [lieut-data](https://github.com/lieut-data), [lindy65](https://github.com/lindy65), [lynn915](https://github.com/lynn915), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [mansil](https://github.com/mansil), [marcelhintermann](https://github.com/marcelhintermann), [marianunez](https://github.com/marianunez), [master7](https://translate.mattermost.com/user/master7), [matthewbirtch](https://github.com/matthewbirtch), [mgdelacroix](https://github.com/mgdelacroix), [Morgansvk](https://github.com/Morgansvk), [nickmisasi](https://github.com/nickmisasi), [oonid](https://translate.mattermost.com/user/oonid), [panoramix360](https://github.com/panoramix360), [pineoak-audio](https://github.com/pineoak-audio), [pvev](https://github.com/pvev), [raghavaggarwal2308](https://github.com/raghavaggarwal2308), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Reinkard](https://github.com/Reinkard), [rOt779kVceSgL](https://translate.mattermost.com/user/rOt779kVceSgL), [sadohert](https://github.com/sadohert), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [Sharuru](https://translate.mattermost.com/user/Sharuru), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [svelle](https://github.com/svelle), [Theo024](https://github.com/Theo024), [ThrRip](https://github.com/ThrRip), [toninis](https://github.com/toninis), [Vasfed](https://github.com/Vasfed), [vasilybels](https://github.com/vasilybels), [VDALuky](https://github.com/VDALuky), [vish9812](https://github.com/vish9812), [wiersgallak](https://github.com/wiersgallak), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [yasserfaraazkhan](https://github.com/yasserfaraazkhan)
 
-(release-v10.8-feature-release)=
-## Release v10.8 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+## Release v10.8 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types) \{#release-v10-8-feature-release}
 
 - **10.8.4, released 2025-07-22**
   - Mattermost v10.8.4 contains medium to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -555,9 +565,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
  - New tables ``AccessControlPolicies`` and ``AccessControlPolicyHistory`` will be created. The migration is fully backwards-compatible, non-locking, and zero downtime is expected.
  - Support for legacy SKUs E10 and E20 licenses was removed. If you need assistance, [talk to a Mattermost expert](https://mattermost.com/contact-sales/).
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v10.7, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -623,8 +635,7 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Contributors
  - [aboukhal](https://github.com/aboukhal), [acc0mplish-note](https://translate.mattermost.com/user/acc0mplish-note), [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [Arusekk](https://translate.mattermost.com/user/Arusekk), [Aryakoste](https://github.com/Aryakoste), [AshiishKarhade](https://github.com/AshiishKarhade), [AulakhHarsh](https://github.com/AulakhHarsh), [BenCookie95](https://github.com/BenCookie95), [bndn](https://github.com/bndn), [bshumylo](https://github.com/bshumylo), [burakcakirel](https://github.com/burakcakirel), [calebroseland](https://github.com/calebroseland), [catalintomai](https://github.com/catalintomai), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://github.com/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [davidkrauser](https://github.com/davidkrauser), [devinbinnie](https://github.com/devinbinnie), [DSchalla](https://github.com/DSchalla), [Eleferen](https://translate.mattermost.com/user/Eleferen), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [errotu](https://github.com/errotu), [esarafianou](https://github.com/esarafianou), [evituzas](https://translate.mattermost.com/user/evituzas), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [fsilye](https://github.com/fsilye), [gabrieljackson](https://github.com/gabrieljackson), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [hmhealey](https://github.com/hmhealey), [isacikgoz](https://github.com/isacikgoz), [jadrales](https://github.com/jadrales), [JahleelT](https://github.com/JahleelT), [jasonblais](https://github.com/jasonblais), [jeoooo](https://github.com/jeoooo), [jespino](https://github.com/jespino), [johnsonbrothers](https://github.com/johnsonbrothers), [jprusch](https://github.com/jprusch), [JulienTant](https://github.com/JulienTant), [kaakaa](https://github.com/kaakaa), [kasyap1234](https://github.com/kasyap1234), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [KuSh](https://github.com/KuSh), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [lil5](https://github.com/lil5), [lucasvbeek](https://github.com/lucasvbeek), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [marianunez](https://github.com/marianunez), [mariuskarotkis](https://translate.mattermost.com/user/mariuskarotkis), [master7](https://translate.mattermost.com/user/master7), [matt-w99](https://github.com/matt-w99), [matthew-w](https://translate.mattermost.com/user/matthew-w), [matthewbirtch](https://github.com/matthewbirtch), [melroy89](https://github.com/melroy89), [mgdelacroix](https://github.com/mgdelacroix), [mlcuchlu](https://translate.mattermost.com/user/mlcuchlu), [nickmisasi](https://github.com/nickmisasi), [panoramix360](https://github.com/panoramix360), [polinapianina](https://github.com/polinapianina), [pvev](https://github.com/pvev), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Reinkard](https://github.com/Reinkard), [Ricky-Tigg](https://github.com/Ricky-Tigg), [Roy-Orbison](https://github.com/Roy-Orbison), [sadohert](https://github.com/sadohert), [saket-dev01](https://github.com/saket-dev01), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [Sharuru](https://github.com/Sharuru), [spirosoik](https://github.com/spirosoik), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [surya2611](https://github.com/surya2611), [ThrRip](https://github.com/ThrRip), [timstott](https://github.com/timstott), [tnir](https://translate.mattermost.com/user/tnir), [toninis](https://github.com/toninis), [vasilybels](https://translate.mattermost.com/user/vasilybels), [ViKriuVK](https://translate.mattermost.com/user/ViKriuVK), [vish9812](https://github.com/vish9812), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [yasserfaraazkhan](https://github.com/yasserfaraazkhan)
 
-(release-v10.7-feature-release)=
-## Release v10.7 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+## Release v10.7 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types) \{#release-v10-7-feature-release}
 
 - **10.7.4, released 2025-06-18**
   - Mattermost v10.7.4 contains high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -657,9 +668,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
  - Added a new column ``BannerInfo`` in the ``Channels`` table for storing metadata for an upcoming licensed feature. 
  - Added support for cursor-based pagination on the property architecture tables, including SQL migration to create indices. 
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v10.6, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -734,8 +747,7 @@ New setting options were added to ``config.json``. Below is a list of the additi
  - [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [AlexKalopsia](https://github.com/AlexKalopsia), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [anlerandy](https://github.com/anlerandy), [Aryakoste](https://github.com/Aryakoste), [AulakhHarsh](https://github.com/AulakhHarsh), [ayush-chauhan233](https://github.com/ayush-chauhan233), [BenCookie95](https://github.com/BenCookie95), [bndn](https://github.com/bndn), [Boruus](https://github.com/Boruus), [bshumylo](https://github.com/bshumylo), [calebroseland](https://github.com/calebroseland), [capricorni](https://translate.mattermost.com/user/capricorni), [Carloswaldo](https://github.com/Carloswaldo), [CBID2](https://github.com/CBID2), [cfarrell987](https://github.com/cfarrell987), [cinlloc](https://github.com/cinlloc), [Combs7th](https://github.com/Combs7th), [cpoile](https://github.com/cpoile), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), 
 [cwarnermm](https://github.com/cwarnermm), [davidkrauser](https://github.com/davidkrauser), [DeathCamel58](https://github.com/DeathCamel58), [devinbinnie](https://github.com/devinbinnie), [DHaussermann](https://github.com/DHaussermann), [Dschoordsch](https://github.com/Dschoordsch), [Eleferen](https://translate.mattermost.com/user/Eleferen), [enahum](https://github.com/enahum), [equalsgibson](https://github.com/equalsgibson), [esarafianou](https://github.com/esarafianou), [esethna](https://github.com/esethna), [ewwollesen](https://github.com/ewwollesen), [felixerdy](https://github.com/felixerdy), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [fsilye](https://github.com/fsilye), [gabrieljackson](https://github.com/gabrieljackson), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [henrique](https://translate.mattermost.com/user/henrique), [hmhealey](https://github.com/hmhealey), [hpflatorre](https://github.com/hpflatorre), [isacikgoz](https://github.com/isacikgoz), [iyampaul](https://github.com/iyampaul), [j0794](https://github.com/j0794), [jachewz](https://github.com/jachewz), [jaehyun-ko](https://github.com/jaehyun-ko), [jasonblais](https://github.com/jasonblais), [jesperordrup](https://translate.mattermost.com/user/jesperordrup), [jespino](https://github.com/jespino), [jlandells](https://github.com/jlandells), [johnsonbrothers](https://github.com/johnsonbrothers), [jprusch](https://github.com/jprusch), [JulienTant](https://github.com/JulienTant), [kaakaa](https://github.com/kaakaa), [kayazeren](https://github.com/kayazeren), [kondo97](https://github.com/kondo97), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [larkox](https://github.com/larkox), [lathiat](https://github.com/lathiat), [lieut-data](https://github.com/lieut-data), [lynn915](https://github.com/lynn915), [majo](https://translate.mattermost.com/user/majo), [marianunez](https://github.com/marianunez), [master7](https://translate.mattermost.com/user/master7), [matt-w99](https://github.com/matt-w99), [matthew-w](https://translate.mattermost.com/user/matthew-w), [matthewbirtch](https://github.com/matthewbirtch), [mgdelacroix](https://github.com/mgdelacroix), [Michal](https://translate.mattermost.com/user/Michal), [moeenio](https://translate.mattermost.com/user/moeenio), [Morgansvk](https://github.com/Morgansvk), [Movion](https://github.com/Movion), [nickmisasi](https://github.com/nickmisasi), [Nityanand13](https://github.com/Nityanand13), [omerfsen](https://github.com/omerfsen), [pineoak-audio](https://github.com/pineoak-audio), [potatogim](https://translate.mattermost.com/user/potatogim), [pvev](https://github.com/pvev), [raghavaggarwal2308](https://github.com/raghavaggarwal2308), [rahimrahman](https://github.com/rahimrahman), [Reinkard](https://github.com/Reinkard), [ricardogalvao](https://translate.mattermost.com/user/ricardogalvao), [Ricky-Tigg](https://github.com/Ricky-Tigg), [robregonm](https://github.com/robregonm), [Saturate](https://github.com/Saturate), [SaurabhSharma-884](https://github.com/SaurabhSharma-884), [sbishel](https://github.com/sbishel), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [sumitbhanushali](https://github.com/sumitbhanushali), [svelle](https://github.com/svelle), [ThrRip](https://github.com/ThrRip), [tnir](https://github.com/tnir), [trokar](https://translate.mattermost.com/user/trokar), [wiersgallak](https://github.com/wiersgallak), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [yasserfaraazkhan](https://github.com/yasserfaraazkhan)
 
-(release-v10.6-feature-release)=
-## Release v10.6 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+## Release v10.6 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types) \{#release-v10-6-feature-release}
 
 - **10.6.6, released 2025-05-21**
   - Mattermost v10.6.6 contains a Critical severity level security fix. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -768,9 +780,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
  - Support for PostgreSQL v11 and v12 have been removed. The new minimum PostgreSQL version is v13+. See the [minimum supported PostgreSQL version policy](https://docs.mattermost.com/deploy/software-hardware-requirements.html#minimum-postgresql-database-support-policy) documentation for details.
  - System Console statistics now perform faster on PostgreSQL. The ``MaxUsersForStatistics`` configuration setting now only disables the **User counts with posts** chart, while all other stats remain unaffected. The other stats remain unaffected because that configuration value is no longer needed to disable the other queries since they are always fast now. Post and file counts update daily, so they may not always reflect real-time data. Advanced stats, such as line charts and plugin data, are now hidden until clicked, reducing load time. No performance improvements apply to MySQL since it's scheduled for full deprecation in v11. We recommend migrating to PostgreSQL for better performance and long-term support. Migration times: On a system with 12M posts, and 1M fileinfo entries, the migration takes 15s, but could take several minutes depending on the server's table sizes and database specs. This migration is non-locking. Note that there is no migration for MySQL deployments because this optimization is only applicable for PostgreSQL. See the [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html) for more details.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v10.5, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -827,17 +841,18 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Contributors
  - [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [Aryakoste](https://github.com/Aryakoste), [ayush-chauhan233](https://github.com/ayush-chauhan233), [BenCookie95](https://github.com/BenCookie95), [bshumylo](https://github.com/bshumylo), [calebroseland](https://github.com/calebroseland), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://github.com/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [darkcircle](https://translate.mattermost.com/user/darkcircle), [davidkrauser](https://github.com/davidkrauser), [devinbinnie](https://github.com/devinbinnie), [dgwhited](https://github.com/dgwhited), [Eleferen](https://translate.mattermost.com/user/Eleferen), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [equalsgibson](https://github.com/equalsgibson), [esarafianou](https://github.com/esarafianou), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [fsilye](https://github.com/fsilye), [gabrieljackson](https://github.com/gabrieljackson), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [henrique](https://translate.mattermost.com/user/henrique), [hereje](https://github.com/hereje), [hmhealey](https://github.com/hmhealey), [hpflatorre](https://github.com/hpflatorre), [ifoukarakis](https://github.com/ifoukarakis), [isacikgoz](https://github.com/isacikgoz), [jespino](https://github.com/jespino), [jlandells](https://github.com/jlandells), [johnsonbrothers](https://github.com/johnsonbrothers), [jprusch](https://github.com/jprusch), [JulienTant](https://github.com/JulienTant), [jwilander](https://github.com/jwilander), [kaakaa](https://github.com/kaakaa), [kayazeren](https://github.com/kayazeren), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [KuSh](https://github.com/KuSh), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [liul8258](https://github.com/liul8258), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [marianunez](https://github.com/marianunez), [master7](https://translate.mattermost.com/user/master7), [matt-w99](https://github.com/matt-w99), [matthew-w](https://translate.mattermost.com/user/matthew-w), [mgdelacroix](https://github.com/mgdelacroix), [Morgansvk](https://github.com/Morgansvk), [mvitale1989](https://github.com/mvitale1989), [natalie-hub](https://github.com/natalie-hub), [nathanaelhoun](https://github.com/nathanaelhoun), [NCPSNetworks](https://github.com/NCPSNetworks), [nickmisasi](https://github.com/nickmisasi), [panoramix360](https://github.com/panoramix360), [pvev](https://github.com/pvev), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Reinkard](https://github.com/Reinkard), [Ricky-Tigg](https://github.com/Ricky-Tigg), [robregonm](https://github.com/robregonm), [SaurabhSharma-884](https://github.com/SaurabhSharma-884), [sbishel](https://github.com/sbishel), [SorenHolm](https://translate.mattermost.com/user/SorenHolm), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [svelle](https://github.com/svelle), [ThrRip](https://github.com/ThrRip), [tnir](https://translate.mattermost.com/user/tnir), [toninis](https://github.com/toninis), [Victor-Nyagudi](https://github.com/Victor-Nyagudi), [wiersgallak](https://github.com/wiersgallak), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [willypuzzle](https://github.com/willypuzzle), [yasserfaraazkhan](https://github.com/yasserfaraazkhan)
 
-(release-v10.5-extended-support-release)=
-## Release v10.5 - [Extended Support Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+## Release v10.5 - [Extended Support Release](https://docs.mattermost.com/about/release-policy.html#release-types) \{#release-v10-5-extended-support-release}
 
 - **10.5.14, released 2025-10-30**
   - Fixed Go v1.23 incompatibility issues with plugins.
   - Mattermost v10.5.14 contains no database or functional changes.
 - **10.5.13, released 2025-10-28**
- ```{Attention}
- **Critical Fixes**
+ <Important>
+
+**Critical Fixes**
   - Mattermost v10.5.13 contains Critical severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
- ```
+
+ </Important>
   - Pre-packaged Boards plugin [v9.1.7](https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.1.7).
   - Mattermost v10.5.13 contains no database or functional changes.
 - **10.5.12, released 2025-10-15**
@@ -922,9 +937,11 @@ If you have already upgraded to v10.5.0 or v10.5.1, we recommend updating the Ji
 ### Breaking Changes
 - The internal workings of the `PluginLinkComponent` in the web app have been changed to unmount link tooltips from the DOM by default, significantly improving performance. Plugins that register link tooltips using `registerLinkTooltipComponent` will experience changes in how tooltip components are managed—they are now only mounted when a link is hovered over or focused. As a result, plugins may need to update their components to properly handle mounting and unmounting scenarios. For example, changes were made in [mattermost-plugin-jira](https://github.com/mattermost/mattermost-plugin-jira/pull/1145), where componentDidUpdate lifecycle hook was replaced with componentDidMount. If your plugin’s tooltip component is a functional React component, there is a high chance that this behavior will be handled automatically, as it would be managed by useEffect with an empty dependency array.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v10.3, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -986,8 +1003,7 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Contributors
  - [agarciamontoro](https://github.com/agarciamontoro), [agardelein](https://github.com/agardelein), [agnivade](https://github.com/agnivade), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [Aryakoste](https://github.com/Aryakoste), [asaadmahmood](https://github.com/asaadmahmood), [AulakhHarsh](https://github.com/AulakhHarsh), [ayush-chauhan233](https://github.com/ayush-chauhan233), [BenCookie95](https://github.com/BenCookie95), [bshumylo](https://translate.mattermost.com/user/bshumylo), [calebroseland](https://github.com/calebroseland), [code1492](https://github.com/code1492), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [devinbinnie](https://github.com/devinbinnie), [dmanpearl](https://github.com/dmanpearl), [Dschoordsch](https://github.com/Dschoordsch), [ebuildy](https://github.com/ebuildy), [Eleferen](https://translate.mattermost.com/user/Eleferen), [emmapeel2](https://github.com/emmapeel2), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [esarafianou](https://github.com/esarafianou), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [fsilye](https://github.com/fsilye), [fume4mattermost](https://github.com/fume4mattermost), [gabrieljackson](https://github.com/gabrieljackson), [hannaparks](https://github.com/hannaparks), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [henrique](https://translate.mattermost.com/user/henrique), [hmhealey](https://github.com/hmhealey), [Honsei901](https://github.com/Honsei901), [hpflatorre](https://github.com/hpflatorre), [ifoukarakis](https://github.com/ifoukarakis), [isacikgoz](https://github.com/isacikgoz), [jespino](https://github.com/jespino), [johnsonbrothers](https://github.com/johnsonbrothers), [jprusch](https://github.com/jprusch), [juliemanalo](https://github.com/juliemanalo), [JulienTant](https://github.com/JulienTant), [jure](https://translate.mattermost.com/user/jure), [jwilander](https://github.com/jwilander), [kaakaa](https://github.com/kaakaa), [kasyap1234](https://github.com/kasyap1234), [kayazeren](https://translate.mattermost.com/user/kayazeren), [kondo97](https://github.com/kondo97), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [lynn915](https://github.com/lynn915), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [marianunez](https://github.com/marianunez), [master7](https://translate.mattermost.com/user/master7), [matthewbirtch](https://github.com/matthewbirtch), [MattSilvaa](https://github.com/MattSilvaa), [mgdelacroix](https://github.com/mgdelacroix), [Morgansvk](https://github.com/Morgansvk), [mvitale1989](https://github.com/mvitale1989), [NadavTasher](https://github.com/NadavTasher), [narutoxboy](https://translate.mattermost.com/user/narutoxboy), [NCPSNetworks](https://github.com/NCPSNetworks), [nickmisasi](https://github.com/nickmisasi), [otbutz](https://github.com/otbutz), [pvev](https://github.com/pvev), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Reinkard](https://github.com/Reinkard), [robregonm](https://github.com/robregonm), [sarthak0714](https://github.com/sarthak0714), [saturninoabril](https://github.com/saturninoabril), [SaurabhSharma-884](https://github.com/SaurabhSharma-884), [sbishel](https://github.com/sbishel), [Sharuru](https://github.com/Sharuru), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [svelle](https://github.com/svelle), [ThrRip](https://github.com/ThrRip), [toninis](https://github.com/toninis), [tormi](https://translate.mattermost.com/user/tormi), [uday-rana](https://github.com/uday-rana), [unode](https://github.com/unode), [varghesejose2020](https://github.com/varghesejose2020), [Victor-Nyagudi](https://github.com/Victor-Nyagudi), [vish9812](https://github.com/vish9812), [wetneb](https://github.com/wetneb), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [willypuzzle](https://github.com/willypuzzle), [X1Vi](https://github.com/X1Vi), [yasserfaraazkhan](https://github.com/yasserfaraazkhan)
 
-(release-v10.4-feature-release)=
-## Release v10.4 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+## Release v10.4 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types) \{#release-v10-4-feature-release}
 
 - **10.4.5, released 2025-04-15**
   - Mattermost v10.4.5 contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -1019,9 +1035,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
 - **10.4.0, released 2025-01-16**
   - Original 10.4.0 release.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v10.3, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -1088,8 +1106,7 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Contributors
  - [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [akbarkz](https://translate.mattermost.com/user/akbarkz), [amyblais](https://github.com/amyblais), [and-ri](https://github.com/and-ri), [andreabia](https://translate.mattermost.com/user/andreabia), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [Aryakoste](https://github.com/Aryakoste), [AulakhHarsh](https://github.com/AulakhHarsh), [ayush-chauhan233](https://github.com/ayush-chauhan233), [BenCookie95](https://github.com/BenCookie95), [calebroseland](https://github.com/calebroseland), [callmeott](https://github.com/callmeott), [catalintomai](https://github.com/catalintomai), [creeper-0910](https://github.com/creeper-0910), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://github.com/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [davidkrauser](https://github.com/davidkrauser), [Destrosvet](https://translate.mattermost.com/user/Destrosvet), [devinbinnie](https://github.com/devinbinnie), [DHaussermann](https://github.com/DHaussermann), [Eleferen](https://translate.mattermost.com/user/Eleferen), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [esarafianou](https://github.com/esarafianou), [esethna](https://github.com/esethna), [ewwollesen](https://github.com/ewwollesen), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [fsilye](https://github.com/fsilye), [fume4mattermost](https://github.com/fume4mattermost), [fxnm](https://github.com/fxnm), [gabrielctn](https://github.com/gabrielctn), [gabrieljackson](https://github.com/gabrieljackson), [gabsfrancis](https://translate.mattermost.com/user/gabsfrancis), [Gesare5](https://github.com/Gesare5), [Haliax](https://translate.mattermost.com/user/Haliax), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [henrique](https://translate.mattermost.com/user/henrique), [hmhealey](https://github.com/hmhealey), [Honsei901](https://github.com/Honsei901), [hpflatorre](https://github.com/hpflatorre), [ifoukarakis](https://github.com/ifoukarakis), [isacikgoz](https://github.com/isacikgoz), [jespino](https://github.com/jespino), [jessiekahn](https://github.com/jessiekahn), [joakim.rivera](https://translate.mattermost.com/user/joakim.rivera), [johnsonbrothers](https://github.com/johnsonbrothers), [jprusch](https://translate.mattermost.com/user/jprusch), [jwilander](https://github.com/jwilander), [kaakaa](https://github.com/kaakaa), [kayazeren](https://github.com/kayazeren), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [Kuruyia](https://github.com/Kuruyia), [kyrillosisaac2](https://github.com/kyrillosisaac2), [lani009](https://translate.mattermost.com/user/lani009), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [lorumic](https://github.com/lorumic), [lynn915](https://github.com/lynn915), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [marianunez](https://github.com/marianunez), [massimo](https://translate.mattermost.com/user/massimo), [master7](https://translate.mattermost.com/user/master7), [matt-w99](https://github.com/matt-w99), [matthew-w](https://translate.mattermost.com/user/matthew-w), [mh4ckt3mh4ckt1c4s](https://translate.mattermost.com/user/mh4ckt3mh4ckt1c4s), [minchae.lee](https://translate.mattermost.com/user/minchae.lee), [morgancz](https://translate.mattermost.com/user/morgancz), [Morgansvk](https://github.com/Morgansvk), [muratbayan](https://translate.mattermost.com/user/muratbayan), [mvitale1989](https://github.com/mvitale1989), [nbruneau71250](https://translate.mattermost.com/user/nbruneau71250), [nickmisasi](https://github.com/nickmisasi), [nikolaiz](https://translate.mattermost.com/user/nikolaiz), [Nityanand13](https://github.com/Nityanand13), [pmokeev](https://github.com/pmokeev), [potatogim](https://github.com/potatogim), [pvev](https://github.com/pvev), [raghavaggarwal2308](https://github.com/raghavaggarwal2308), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Reinkard](https://github.com/Reinkard), [renaudk](https://github.com/renaudk), [ricardogalvao](https://translate.mattermost.com/user/ricardogalvao), [RS-labhub](https://github.com/RS-labhub), [Rutam21](https://github.com/Rutam21), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [Sharuru](https://github.com/Sharuru), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [sypianski](https://translate.mattermost.com/user/sypianski), [TenGentoppa](https://translate.mattermost.com/user/TenGentoppa), [TheInvincibleRalph](https://github.com/TheInvincibleRalph), [ThrRip](https://github.com/ThrRip), [tnir](https://github.com/tnir), [tokipulan](https://translate.mattermost.com/user/tokipulan), [tomdereub](https://translate.mattermost.com/user/tomdereub), [toninis](https://github.com/toninis), [wetneb](https://github.com/wetneb), [wiggin77](https://github.com/wiggin77), [YahyaHaq](https://github.com/YahyaHaq), [yasserfaraazkhan](https://github.com/yasserfaraazkhan), [yesbhautik](https://github.com/yesbhautik), [zenocode-org](https://translate.mattermost.com/user/zenocode-org)
 
-(release-v10.3-feature-release)=
-## Release v10.3 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+## Release v10.3 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types) \{#release-v10-3-feature-release}
 
 - **10.3.4, released 2025-02-19**
   - Mattermost v10.3.4 contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -1125,9 +1142,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
 
  - Updated minimum Edge and Chrome versions to 130+.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v10.2, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -1188,8 +1207,7 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Contributors
  - [7+7](https://translate.mattermost.com/user/7+7), [abdellani](https://github.com/abdellani), [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [akbarkz](https://translate.mattermost.com/user/akbarkz), [Alenoda](https://github.com/Alenoda), [amyblais](https://github.com/amyblais), [amynicol1985](https://github.com/amynicol1985), [and-ri](https://translate.mattermost.com/user/and-ri), [andr-sokolov](https://github.com/andr-sokolov), [andreabia](https://github.com/andreabia), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [Aryakoste](https://github.com/Aryakoste), [asaadmahmood](https://github.com/asaadmahmood), [AulakhHarsh](https://github.com/AulakhHarsh), [ayusht2810](https://github.com/ayusht2810), [azadDsync](https://github.com/azadDsync), [BenCookie95](https://github.com/BenCookie95), [calebroseland](https://github.com/calebroseland), [callmeott](https://github.com/callmeott), [carlosGuimaraesTc](https://github.com/carlosGuimaraesTc), [catalintomai](https://github.com/catalintomai), [cedric.lamalle](https://translate.mattermost.com/user/cedric.lamalle), [creeper-0910](https://translate.mattermost.com/user/creeper-0910), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [cyberm8](https://github.com/cyberm8), [cyrusjc](https://github.com/cyrusjc), [decke](https://github.com/decke), [devinbinnie](https://github.com/devinbinnie), [Dishika18](https://github.com/Dishika18), [Dzenan](https://translate.mattermost.com/user/Dzenan), [edlerd](https://github.com/edlerd), [Eleferen](https://translate.mattermost.com/user/Eleferen), [enahum](https://github.com/enahum), [esarafianou](https://github.com/esarafianou), [frankps](https://translate.mattermost.com/user/frankps), [fsilye](https://github.com/fsilye), [gabsfrancis](https://translate.mattermost.com/user/gabsfrancis), [Gesare5](https://github.com/Gesare5), [guruprasath-v](https://github.com/guruprasath-v), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [HarshitVashisht11](https://github.com/HarshitVashisht11), [henrique](https://translate.mattermost.com/user/henrique), [hmhealey](https://github.com/hmhealey), [Honsei901](https://github.com/Honsei901), [hpflatorre](https://github.com/hpflatorre), [hun-a](https://github.com/hun-a), [ifoukarakis](https://github.com/ifoukarakis), [isacikgoz](https://github.com/isacikgoz), [Jelmerovereem](https://github.com/Jelmerovereem), [jespino](https://github.com/jespino), [jlandells](https://github.com/jlandells), [johnsonbrothers](https://github.com/johnsonbrothers), [jonathan-dove](https://github.com/jonathan-dove), [jprusch](https://github.com/jprusch), [JulienTant](https://github.com/JulienTant), [jwilander](https://github.com/jwilander), [kaakaa](https://github.com/kaakaa), [kayazeren](https://github.com/kayazeren), [kczpl](https://github.com/kczpl), [Killer2OP](https://github.com/Killer2OP), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [Kuruyia](https://github.com/Kuruyia), [KuSh](https://github.com/KuSh), [kyrillosisaac2](https://github.com/kyrillosisaac2), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [lynn915](https://github.com/lynn915), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [mas-who](https://github.com/mas-who), [master7](https://translate.mattermost.com/user/master7), [matt-w99](https://github.com/matt-w99), [matthew-w](https://translate.mattermost.com/user/matthew-w), [matthewbirtch](https://github.com/matthewbirtch), [mentz](https://translate.mattermost.com/user/mentz), [minkyngkm](https://github.com/minkyngkm), [molejnik88](https://github.com/molejnik88), [morgancz](https://translate.mattermost.com/user/morgancz), [Morgansvk](https://github.com/Morgansvk), [mvitale1989](https://github.com/mvitale1989), [NadavTasher](https://github.com/NadavTasher), [nickmisasi](https://github.com/nickmisasi), [Niharika0104](https://github.com/Niharika0104), [nikolaiz](https://translate.mattermost.com/user/nikolaiz), [NilsArnlund](https://github.com/NilsArnlund), [potatogim](https://translate.mattermost.com/user/potatogim), [pranay-0512](https://github.com/pranay-0512), [pvev](https://github.com/pvev), [raghavaggarwal2308](https://github.com/raghavaggarwal2308), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Reinkard](https://github.com/Reinkard), [ricardogalvao](https://translate.mattermost.com/user/ricardogalvao), [RS-labhub](https://github.com/RS-labhub), [Rutam21](https://github.com/Rutam21), [s1Sharp](https://github.com/s1Sharp), [samarth29jc](https://github.com/samarth29jc), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [Seyifunmi](https://github.com/Seyifunmi), [Sharuru](https://github.com/Sharuru), [sohzm](https://github.com/sohzm), [sparr](https://github.com/sparr), [srisri332](https://github.com/srisri332), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [stylianosrigas](https://github.com/stylianosrigas), [sumedhakoranga](https://github.com/sumedhakoranga), [TheInvincibleRalph](https://github.com/TheInvincibleRalph), [thelizardreborn](https://github.com/thelizardreborn), [theoforger](https://github.com/theoforger), [ThrRip](https://translate.mattermost.com/user/ThrRip), [tokipulan](https://translate.mattermost.com/user/tokipulan), [toninis](https://github.com/toninis), [verdel](https://github.com/verdel), [Victor-Nyagudi](https://github.com/Victor-Nyagudi), [vish9812](https://github.com/vish9812), [wetneb](https://github.com/wetneb), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [willypuzzle](https://github.com/willypuzzle), [yanyiyi](https://github.com/yanyiyi), [yasserfaraazkhan](https://github.com/yasserfaraazkhan), [yesbhautik](https://github.com/yesbhautik)
 
-(release-v10.2-feature-release)=
-## Release v10.2 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+## Release v10.2 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types) \{#release-v10-2-feature-release}
 
 - **10.2.3, released 2025-01-22**
   - Mattermost v10.2.3 contains critical severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -1214,9 +1232,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
 
  - Docker Content Trust (DCT) for signing Docker image artifacts has been replaced by Sigstore Cosign in v10.2 (November, 2024). If you rely on artifact verification using DCT, please [transition to using Cosign](https://edu.chainguard.dev/open-source/sigstore/cosign/how-to-install-cosign/). See the [DCT deprecation Mattermost forum post](https://forum.mattermost.com/t/upcoming-dct-deprecation/19275) for more details. 
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v10.0, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -1284,8 +1304,7 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Contributors
  - [047pegasus](https://github.com/047pegasus), [1510janu](https://github.com/1510janu), [aamfahim](https://github.com/aamfahim), [aditipatelpro](https://github.com/aditipatelpro), [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [amyblais](https://github.com/amyblais), [andreabia](https://translate.mattermost.com/user/andreabia), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [anudhyan](https://github.com/anudhyan), [Arch130](https://github.com/Arch130), [arilloid](https://github.com/arilloid), [Aryakoste](https://github.com/Aryakoste), [asaadmahmood](https://github.com/asaadmahmood), [azadDsync](https://github.com/azadDsync), [azigler](https://github.com/azigler), [belkhoujaons](https://github.com/belkhoujaons), [BenCookie95](https://github.com/BenCookie95), [calebroseland](https://github.com/calebroseland), [Camillarhi](https://github.com/Camillarhi), [CarlssonFilip](https://github.com/CarlssonFilip), [catalintomai](https://github.com/catalintomai), [CBID2](https://github.com/CBID2), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://github.com/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [danielsischy](https://github.com/danielsischy), [devinbinnie](https://github.com/devinbinnie), [DHaussermann](https://github.com/DHaussermann), [diamant3](https://github.com/diamant3), [Dishika18](https://github.com/Dishika18), [Eleferen](https://translate.mattermost.com/user/Eleferen), [emdecr](https://github.com/emdecr), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [esarafianou](https://github.com/esarafianou), [esethna](https://github.com/esethna), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [fsilye](https://github.com/fsilye), [fume4mattermost](https://github.com/fume4mattermost), [gabrieljackson](https://github.com/gabrieljackson), [Gesare5](https://github.com/Gesare5), [Good-Soma](https://github.com/Good-Soma), [grubbins](https://github.com/grubbins), [gvarma28](https://github.com/gvarma28), [hamzawritescode](https://github.com/hamzawritescode), [hannaparks](https://github.com/hannaparks), [hanzei](https://github.com/hanzei), [HarshitVashisht11](https://github.com/HarshitVashisht11), [hereje](https://github.com/hereje), [hmhealey](https://github.com/hmhealey), [ifoukarakis](https://github.com/ifoukarakis), [isacikgoz](https://github.com/isacikgoz), [ja49619](https://translate.mattermost.com/user/ja49619), [jespino](https://github.com/jespino), [jlandells](https://github.com/jlandells), [johnsonbrothers](https://github.com/johnsonbrothers), [jopaleti](https://github.com/jopaleti), [jprusch](https://github.com/jprusch), [jwilander](https://github.com/jwilander), [kaakaa](https://github.com/kaakaa), [kayazeren](https://github.com/kayazeren), [Killer2OP](https://github.com/Killer2OP), [kom-senapati](https://github.com/kom-senapati), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [KuSh](https://github.com/KuSh), [KvngMikey](https://github.com/KvngMikey), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [lynn915](https://github.com/lynn915), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [Malay-dev](https://github.com/Malay-dev), [master7](https://translate.mattermost.com/user/master7), [matthew-w](https://translate.mattermost.com/user/matthew-w), [matthewbirtch](https://github.com/matthewbirtch), [mgdelacroix](https://github.com/mgdelacroix), [mm-prodsec-bot](https://github.com/mm-prodsec-bot), [moda-l10n](https://translate.mattermost.com/user/moda-l10n), [Morgan_svk](https://translate.mattermost.com/user/Morgan_svk), [Movion](https://github.com/Movion), [mvitale1989](https://github.com/mvitale1989), [nickmisasi](https://github.com/nickmisasi), [Niharika0104](https://github.com/Niharika0104), [nikolaiz](https://translate.mattermost.com/user/nikolaiz), [NilsArnlund](https://github.com/NilsArnlund), [panoramix360](https://github.com/panoramix360), [pradeepmurugesan](https://github.com/pradeepmurugesan), [pvev](https://github.com/pvev), [qfrigolac](https://github.com/qfrigolac), [raghavaggarwal2308](https://github.com/raghavaggarwal2308), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Ranjana761](https://github.com/Ranjana761), [raremax](https://translate.mattermost.com/user/raremax), [Reinkard](https://github.com/Reinkard), [RS-labhub](https://github.com/RS-labhub), [Ruhi14](https://github.com/Ruhi14), [Rutam21](https://github.com/Rutam21), [s4kh](https://github.com/s4kh), [sahariardev](https://github.com/sahariardev), [samarth29jc](https://github.com/samarth29jc), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [sedivst](https://translate.mattermost.com/user/sedivst), [Sharuru](https://translate.mattermost.com/user/Sharuru), [shraddha761](https://github.com/shraddha761), [space-w-alker](https://github.com/space-w-alker), [srisri332](https://github.com/srisri332), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [stylianosrigas](https://github.com/stylianosrigas), [svelle](https://github.com/svelle), [swills](https://github.com/swills), [tanmaythole](https://github.com/tanmaythole), [TealWater](https://github.com/TealWater), [TheInvincibleRalph](https://github.com/TheInvincibleRalph), [theoforger](https://github.com/theoforger), [ThrRip](https://github.com/ThrRip), [TomerPacific](https://github.com/TomerPacific), [toninis](https://github.com/toninis), [varghesejose2020](https://github.com/varghesejose2020), [vawaver](https://translate.mattermost.com/user/vawaver), [vhaska](https://translate.mattermost.com/user/vhaska), [Victor-Nyagudi](https://github.com/Victor-Nyagudi), [vish9812](https://github.com/vish9812), [WeBjAnJaN](https://translate.mattermost.com/user/WeBjAnJaN), [wetneb](https://github.com/wetneb), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [yanyiyi](https://github.com/yanyiyi), [yasserfaraazkhan](https://github.com/yasserfaraazkhan), [z44440000z](https://github.com/z44440000z), [ZubairImtiaz3](https://github.com/ZubairImtiaz3)
 
-(release-v10.1-feature-release)=
-## Release v10.1 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+## Release v10.1 - [Feature Release](https://docs.mattermost.com/about/release-policy.html#release-types) \{#release-v10-1-feature-release}
 
 - **10.1.7, released 2025-01-15**
   - Mattermost v10.1.7 contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -1317,9 +1336,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
 - **10.1.0, released 2024-10-16**
   - Original 10.1.0 release.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v10.0, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -1385,8 +1406,7 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Contributors
  - [adityasoni2019](https://github.com/adityasoni2019), [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [algeorgiadis](https://github.com/algeorgiadis), [amyblais](https://github.com/amyblais), [andreabia](https://translate.mattermost.com/user/andreabia), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [armmanvaillancourt](https://github.com/armmanvaillancourt), [Aryakoste](https://github.com/Aryakoste), [ayusht2810](https://github.com/ayusht2810), [azistellar](https://translate.mattermost.com/user/azistellar), [azizthegit](https://github.com/azizthegit), [BenCookie95](https://github.com/BenCookie95), [calebroseland](https://github.com/calebroseland), [catalintomai](https://github.com/catalintomai), [ChinoUkaegbu](https://github.com/ChinoUkaegbu), [Chlbek](https://translate.mattermost.com/user/Chlbek), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [danielsischy](https://github.com/danielsischy), [daveseo901](https://github.com/daveseo901), [devinbinnie](https://github.com/devinbinnie), [DHaussermann](https://github.com/DHaussermann), [Eleferen](https://translate.mattermost.com/user/Eleferen), [emdecr](https://github.com/emdecr), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [esarafianou](https://github.com/esarafianou), [esethna](https://github.com/esethna), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [fsilye](https://github.com/fsilye), [gabrieljackson](https://github.com/gabrieljackson), [Gesare5](https://github.com/Gesare5), [Glandos](https://github.com/Glandos), [grundleborg](https://github.com/grundleborg), [gvarma28](https://github.com/gvarma28), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [hereje](https://github.com/hereje), [hmhealey](https://github.com/hmhealey), [ifoukarakis](https://github.com/ifoukarakis), [isacikgoz](https://github.com/isacikgoz), [ja49619](https://translate.mattermost.com/user/ja49619), [johnsonbrothers](https://github.com/johnsonbrothers), [jones](https://translate.mattermost.com/user/jones), [jprusch](https://github.com/jprusch), [JulienTant](https://github.com/JulienTant), [jwilander](https://github.com/jwilander), [kaakaa](https://github.com/kaakaa), [kaoski](https://github.com/kaoski), [kayazeren](https://github.com/kayazeren), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [L3o-pold](https://github.com/L3o-pold), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [lindalumitchell](https://github.com/lindalumitchell), [lukasMega](https://github.com/lukasMega), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [manujgrover71](https://github.com/manujgrover71), [master7](https://translate.mattermost.com/user/master7), [matt-w99](https://github.com/matt-w99), [matthew-w](https://translate.mattermost.com/user/matthew-w), [matthewbirtch](https://github.com/matthewbirtch), [mgdelacroix](https://github.com/mgdelacroix), [milotype](https://translate.mattermost.com/user/milotype), [Morgan_svk](https://translate.mattermost.com/user/Morgan_svk), [Movion](https://github.com/Movion), [mvitale1989](https://github.com/mvitale1989), [nekodayo2222](https://translate.mattermost.com/user/nekodayo2222), [nickmisasi](https://github.com/nickmisasi), [nikhilskul7](https://github.com/nikhilskul7), [Porma120](https://github.com/Porma120), [pvev](https://github.com/pvev), [raghavaggarwal2308](https://github.com/raghavaggarwal2308), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Rishiii7](https://github.com/Rishiii7), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [Sharuru](https://github.com/Sharuru), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [stylianosrigas](https://github.com/stylianosrigas), [testtomato1230](https://translate.mattermost.com/user/testtomato1230), [TheInvincibleRalph](https://github.com/TheInvincibleRalph), [ThrRip](https://translate.mattermost.com/user/ThrRip), [toninis](https://github.com/toninis), [tsabi](https://github.com/tsabi), [vish9812](https://github.com/vish9812), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [yasserfaraazkhan](https://github.com/yasserfaraazkhan), [yaz](https://translate.mattermost.com/user/yaz), [yuney-worx4you](https://github.com/yuney-worx4you)
 
-(release-v10.0-major-release)=
-## Release v10.0 - [Major Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+## Release v10.0 - [Major Release](https://docs.mattermost.com/about/release-policy.html#release-types) \{#release-v10-0-major-release}
 
 - **10.0.4, released 2024-12-10**
   - Mattermost v10.0.4 contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -1422,9 +1442,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
  - Removed deprecated ``pageSize`` query parameter from most API endpoints.
  - Deprecated the experimental Strict CSRF token enforcement. This feature will be fully removed in Mattermost v11.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v9.11, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 

--- a/docs/main/product-overview/mattermost-v10-changelog.mdx
+++ b/docs/main/product-overview/mattermost-v10-changelog.mdx
@@ -17,12 +17,12 @@ Platform and OS scope reflects reported and tested environments and may not repr
 ## Release v10.12 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types) \{#release-v10-12-feature-release}
 
 - **10.12.4, released 2025-11-21**
- <Important>
+  <Important>
 
-**Critical Fixes**
+  **Critical Fixes**
   - Mattermost v10.12.4 contains a Critical severity level security fix in the Jira plugin. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
 
- </Important>
+  </Important>
   - Pre-packaged Jira plugin version [v4.4.1](https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v4.4.1).
   - Mattermost v10.12.4 contains no database or functional changes.
 - **10.12.3, released 2025-11-17**
@@ -32,12 +32,12 @@ Platform and OS scope reflects reported and tested environments and may not repr
   - Fixed a configuration retention issue where even active configuration got deleted.
   - Mattermost v10.12.3 contains no database or functional changes.
 - **10.12.2, released 2025-10-28**
- <Important>
+  <Important>
 
-**Critical Fixes**
+  **Critical Fixes**
   - Mattermost v10.12.2 contains Critical severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
 
- </Important>
+  </Important>
   - Pre-packaged Boards plugin [v9.1.7](https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.1.7).
   - Mattermost v10.12.2 contains no database or functional changes.
 - **10.12.1, released 2025-10-15**
@@ -160,12 +160,12 @@ If you upgrade from a release earlier than v10.10, please read the other [Import
   - Fixed an issue where pressing ``Shift+Up`` in the channel textbox to reply to a thread could cause the right‑hand sidebar (RHS) reply textbox to not focus.
   - Mattermost v10.11.9 contains no database or functional changes.
 - **10.11.8, released 2025-11-21**
- <Important>
+  <Important>
 
-**Critical Fixes**
+  **Critical Fixes**
   - Mattermost v10.11.8 contains a Critical severity level security fix in the Jira plugin. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
 
- </Important>
+  </Important>
   - Pre-packaged Jira plugin version [v4.4.1](https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v4.4.1).
   - Mattermost v10.11.8 contains no database or functional changes.
 - **10.11.7, released 2025-11-17**
@@ -181,12 +181,12 @@ If you upgrade from a release earlier than v10.10, please read the other [Import
   - Pre-packaged MS Teams Meeting plugin version [v2.3.0](https://github.com/mattermost/mattermost-plugin-msteams-meetings/releases/tag/v2.3.0).
   - Mattermost v10.11.6 contains no database or functional changes.
 - **10.11.5, released 2025-10-28**
- <Important>
+  <Important>
 
-**Critical Fixes**
+  **Critical Fixes**
   - Mattermost v10.11.5 contains Critical severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
 
- </Important>
+  </Important>
   - Pre-packaged Boards plugin [v9.1.7](https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.1.7).
   - Mattermost v10.11.5 contains no database or functional changes.
 - **10.11.4, released 2025-10-15**
@@ -847,12 +847,12 @@ New setting options were added to ``config.json``. Below is a list of the additi
   - Fixed Go v1.23 incompatibility issues with plugins.
   - Mattermost v10.5.14 contains no database or functional changes.
 - **10.5.13, released 2025-10-28**
- <Important>
+  <Important>
 
-**Critical Fixes**
+  **Critical Fixes**
   - Mattermost v10.5.13 contains Critical severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
 
- </Important>
+  </Important>
   - Pre-packaged Boards plugin [v9.1.7](https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.1.7).
   - Mattermost v10.5.13 contains no database or functional changes.
 - **10.5.12, released 2025-10-15**

--- a/docs/main/product-overview/mattermost-v11-changelog.mdx
+++ b/docs/main/product-overview/mattermost-v11-changelog.mdx
@@ -3,22 +3,18 @@ title: "v11 Changelog"
 ---
 import Inc0_common_esr_support_upgrade from './common-esr-support-upgrade.mdx';
 
-{/* TODO: eval-rst block left verbatim, port manually */}
-```
-.. meta::
-  :page_title: Mattermost Server v11 Release Notes
-```
+<Important>
 
-```{Important}
 <Inc0_common_esr_support_upgrade />
+
+</Important>
 <Note>
 
 Platform and OS scope reflects reported and tested environments and may not represent all affected configurations.
 
 </Note>
 
-(release-v11.6-feature-release)=
-## Release v11.6 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types)
+## Release v11.6 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types) \{#release-v11-6-feature-release}
 
 - **11.6.1, released 2026-04-22**
   - Mattermost v11.6.1 contains medium to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -51,9 +47,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
 #### Compatibility
  - Updated minimum supported macOS version to 14+ and minimum Safari version to 26.2+.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v11.5, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration-guide/upgrade/important-upgrade-notes.html). In case of an upgrade failure, please check the [Downgrade Guide](https://docs.mattermost.com/administration-guide/upgrade/downgrading-mattermost-server.html) and the [Recovery Guide](https://docs.mattermost.com/deployment-guide/backup-disaster-recovery.html) for rollback steps and interim mitigation strategy.
-```
+
+</Important>
 
 ### Improvements
 
@@ -151,8 +149,7 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-6-is-now-availab
 ### Contributors
  - [135yshr](https://github.com/135yshr), [Adam-Schildkraut](https://github.com/Adam-Schildkraut), [adityadav1987](https://github.com/adityadav1987), [agarciamontoro](https://github.com/agarciamontoro), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [asaadmahmood](https://github.com/asaadmahmood), [AulakhHarsh](https://github.com/AulakhHarsh), [avasconcelos114](https://github.com/avasconcelos114), [BenCookie95](https://github.com/BenCookie95), [bgardner8008](https://github.com/bgardner8008), [calebroseland](https://github.com/calebroseland), [carlisgg](https://github.com/carlisgg), [cheba](https://translate.mattermost.com/user/cheba), [claude](https://github.com/claude), [coltoneshaw](https://github.com/coltoneshaw), [Combs7th](https://github.com/Combs7th), [cpoile](https://github.com/cpoile), [crazylogic03](https://github.com/crazylogic03), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [DannyDaemonic](https://github.com/DannyDaemonic), [davidkrauser](https://github.com/davidkrauser), [davidpaquin](https://github.com/davidpaquin), [devinbinnie](https://github.com/devinbinnie), [DSchalla](https://github.com/DSchalla), [edgarbellot](https://github.com/edgarbellot), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [esarafianou](https://github.com/esarafianou), [esethna](https://github.com/esethna), [eshamir3](https://github.com/eshamir3), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [hmhealey](https://github.com/hmhealey), [IndushaS](https://github.com/IndushaS), [isacikgoz](https://github.com/isacikgoz), [jgheithcock](https://github.com/jgheithcock), [jprusch](https://translate.mattermost.com/user/jprusch), [JulienTant](https://github.com/JulienTant), [kevrl](https://translate.mattermost.com/user/kevrl), [krotesk](https://translate.mattermost.com/user/krotesk), [larkox](https://github.com/larkox), [LeoVie](https://translate.mattermost.com/user/LeoVie), [lieut-data](https://github.com/lieut-data), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [mansil](https://translate.mattermost.com/user/mansil), [marianunez](https://github.com/marianunez), [maruTA-bis5](https://translate.mattermost.com/user/maruTA-bis5), [master7](https://translate.mattermost.com/user/master7), [mgdelacroix](https://github.com/mgdelacroix), [NARSimoes](https://github.com/NARSimoes), [nevyangelova](https://github.com/nevyangelova), [nickmisasi](https://github.com/nickmisasi), [Parth10P](https://github.com/Parth10P), [pavelzeman](https://github.com/pavelzeman), [pvev](https://github.com/pvev), [quirkoglass-debug](https://translate.mattermost.com/user/quirkoglass-debug), [Rajat-Dabade](https://github.com/Rajat-Dabade), [roberson-io](https://github.com/roberson-io), [Roy-Orbison](https://github.com/Roy-Orbison), [ruturaj-rathod](https://github.com/ruturaj-rathod), [sadohert](https://github.com/sadohert), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [sudip-kumar-prasad](https://github.com/sudip-kumar-prasad), [svelle](https://github.com/svelle), [Umeaboy](https://translate.mattermost.com/user/Umeaboy), [unode](https://github.com/unode), [VertexToEdge](https://github.com/VertexToEdge), [vetash](https://translate.mattermost.com/user/vetash), [Victor-Nyagudi](https://github.com/Victor-Nyagudi), [vish9812](https://github.com/vish9812), [wiersgallak](https://github.com/wiersgallak), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [willypuzzle](https://github.com/willypuzzle), [yasserfaraazkhan](https://github.com/yasserfaraazkhan)
 
-(release-v11.5-feature-release)=
-## Release v11.5 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types)
+## Release v11.5 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types) \{#release-v11-5-feature-release}
 
 - **11.5.4, released 2026-04-22**
   - Mattermost v11.5.4 contains medium to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -213,9 +210,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
 #### Compatibility
  - Updated minimum Edge and Chrome versions to 144+.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v11.4, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration-guide/upgrade/important-upgrade-notes.html). In case of an upgrade failure, please check the [Downgrade Guide](https://docs.mattermost.com/administration-guide/upgrade/downgrading-mattermost-server.html) and the [Recovery Guide](https://docs.mattermost.com/deployment-guide/backup-disaster-recovery.html) for rollback steps and interim mitigation strategy.
-```
+
+</Important>
 
 ### Improvements
 
@@ -281,8 +280,7 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-5-is-now-availab
 ### Contributors
  - [adityadav1987](https://github.com/adityadav1987), [agarciamontoro](https://github.com/agarciamontoro), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [asaadmahmood](https://github.com/asaadmahmood), [avasconcelos114](https://github.com/avasconcelos114), [BenCookie95](https://github.com/BenCookie95), [bgardner8008](https://github.com/bgardner8008), [bshumylo](https://translate.mattermost.com/user/bshumylo), [calebroseland](https://github.com/calebroseland), [carlisgg](https://github.com/carlisgg), [catalintomai](https://github.com/catalintomai), [Combs7th](https://github.com/Combs7th), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [davidkrauser](https://github.com/davidkrauser), [devinbinnie](https://github.com/devinbinnie), [DHaussermann](https://github.com/DHaussermann), [DSchalla](https://github.com/DSchalla), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [esarafianou](https://github.com/esarafianou), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [guenjun](https://translate.mattermost.com/user/guenjun), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [hmhealey](https://github.com/hmhealey), [isacikgoz](https://github.com/isacikgoz), [jgheithcock](https://github.com/jgheithcock), [JOAO-Ethan](https://github.com/JOAO-Ethan), [jprusch](https://translate.mattermost.com/user/jprusch), [JulienTant](https://github.com/JulienTant), [kondo97](https://github.com/kondo97), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [locnnil](https://github.com/locnnil), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [marianunez](https://github.com/marianunez), [master7](https://translate.mattermost.com/user/master7), [matthew-w](https://translate.mattermost.com/user/matthew-w), [matthewbirtch](https://github.com/matthewbirtch), [mgdelacroix](https://github.com/mgdelacroix), [milotype](https://translate.mattermost.com/user/milotype), [NARSimoes](https://github.com/NARSimoes), [nevyangelova](https://github.com/nevyangelova), [nickmisasi](https://github.com/nickmisasi), [ogi-m](https://github.com/ogi-m), [pvev](https://github.com/pvev), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Reinkard](https://translate.mattermost.com/user/Reinkard), [roman.belda](https://translate.mattermost.com/user/roman.belda), [Roy-Orbison](https://translate.mattermost.com/user/Roy-Orbison), [sadohert](https://github.com/sadohert), [salvatorearianna](https://translate.mattermost.com/user/salvatorearianna), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [SharpGoldHawk](https://translate.mattermost.com/user/SharpGoldHawk), [Sharuru](https://translate.mattermost.com/user/Sharuru), [svelle](https://github.com/svelle), [thePanz](https://translate.mattermost.com/user/thePanz), [ThrRip](https://translate.mattermost.com/user/ThrRip), [Umeaboy](https://translate.mattermost.com/user/Umeaboy), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [yasserfaraazkhan](https://github.com/yasserfaraazkhan), [ZeWaren](https://github.com/ZeWaren)
 
-(release-v11.4-feature-release)=
-## Release v11.4 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types)
+## Release v11.4 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types) \{#release-v11-4-feature-release}
 
 - **11.4.5, released 2026-04-22**
   - Mattermost v11.4.5 contains medium to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -326,10 +324,12 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-5-is-now-availab
 
 ### Upgrade Impact
 
-```{Attention}
+<Important>
+
 **Breaking Changes**
  - Photoshop Document (PSD) files are now no longer inline previewed, they are treated as regular file attachments.
-```
+
+</Important>
 
 #### Database Schema Changes
  - Added two new tables, ``Recaps`` and ``RecapChannels``. No database downtime is expected for this upgrade. See the [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html) for more details.
@@ -337,9 +337,11 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-5-is-now-availab
 #### Compatibility
  - Updated minimum Edge and Chrome versions to 142+.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v11.3, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration-guide/upgrade/important-upgrade-notes.html). In case of an upgrade failure, please check the [Downgrade Guide](https://docs.mattermost.com/administration-guide/upgrade/downgrading-mattermost-server.html) and the [Recovery Guide](https://docs.mattermost.com/deployment-guide/backup-disaster-recovery.html) for rollback steps and interim mitigation strategy.
-```
+
+</Important>
 
 ### Improvements
 
@@ -392,8 +394,7 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-4-is-now-availab
 ### Contributors
  - [agarciamontoro](https://github.com/agarciamontoro), [akshat-khosya](https://github.com/akshat-khosya), [Alesia](https://translate.mattermost.com/user/Alesia), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [Aryakoste](https://github.com/Aryakoste), [asaadmahmood](https://github.com/asaadmahmood), [avasconcelos114](https://github.com/avasconcelos114), [BenCookie95](https://github.com/BenCookie95), [bgardner8008](https://github.com/bgardner8008), [Boruus](https://github.com/Boruus), [brandon1024](https://github.com/brandon1024), [bshumylo](https://translate.mattermost.com/user/bshumylo), [calebroseland](https://github.com/calebroseland), [carlisgg](https://github.com/carlisgg), [CIOSAI](https://translate.mattermost.com/user/CIOSAI), [Combs7th](https://github.com/Combs7th), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [danilvalov](https://github.com/danilvalov), [devinbinnie](https://github.com/devinbinnie), [DHaussermann](https://github.com/DHaussermann), [DSchalla](https://github.com/DSchalla), [enahum](https://github.com/enahum), [esarafianou](https://github.com/esarafianou), [esethna](https://github.com/esethna), [ewwollesen](https://github.com/ewwollesen), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [hmhealey](https://github.com/hmhealey), [isacikgoz](https://github.com/isacikgoz), [jgheithcock](https://github.com/jgheithcock), [jprusch](https://translate.mattermost.com/user/jprusch), [JulienTant](https://github.com/JulienTant), [jwilander](https://github.com/jwilander), [Kuruyia](https://github.com/Kuruyia), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [lifeisafractal](https://github.com/lifeisafractal), [lindalumitchell](https://github.com/lindalumitchell), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [marko-matusovic](https://translate.mattermost.com/user/marko-matusovic), [master7](https://translate.mattermost.com/user/master7), [matthewbirtch](https://github.com/matthewbirtch), [merlynadena](https://github.com/merlynadena), [mikhail10](https://translate.mattermost.com/user/mikhail10), [milotype](https://translate.mattermost.com/user/milotype), [Morgan_svk](https://translate.mattermost.com/user/Morgan_svk), [NARSimoes](https://github.com/NARSimoes), [natalie-hub](https://github.com/natalie-hub), [nevyangelova](https://github.com/nevyangelova), [nickmisasi](https://github.com/nickmisasi), [pvev](https://github.com/pvev), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Reinkard](https://translate.mattermost.com/user/Reinkard), [Ricky-Tigg](https://translate.mattermost.com/user/Ricky-Tigg), [roberson-io](https://github.com/roberson-io), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [shawnaym](https://github.com/shawnaym), [svelle](https://github.com/svelle), [ThrRip](https://translate.mattermost.com/user/ThrRip), [tnir](https://github.com/tnir), [tsabi](https://translate.mattermost.com/user/tsabi), [Umeaboy](https://translate.mattermost.com/user/Umeaboy), [vadim.asadchi](https://translate.mattermost.com/user/vadim.asadchi), [varghesejose2020](https://github.com/varghesejose2020), [Victor-Nyagudi](https://github.com/Victor-Nyagudi), [vish9812](https://github.com/vish9812), [wiersgallak](https://github.com/wiersgallak), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [wooki-00](https://translate.mattermost.com/user/wooki-00), [yasserfaraazkhan](https://github.com/yasserfaraazkhan)
 
-(release-v11.3-feature-release)=
-## Release v11.3 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types)
+## Release v11.3 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types) \{#release-v11-3-feature-release}
 
 - **11.3.3, released 2026-03-16**
   - Mattermost v11.3.3 contains medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -408,10 +409,12 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-4-is-now-availab
   - Fixed an issue where rate limiting was missing from the login endpoint (5 requests/second, 10 burst).
   - Mattermost v11.3.2 contains no database or functional changes.
 - **11.3.1, released 2026-02-13**
-```{Attention}
+<Important>
+
 **Breaking Changes**
  - Photoshop Document (PSD) files are now no longer inline previewed, they are treated as regular file attachments.
-```
+
+</Important>
   - Mattermost v11.3.1 contains medium to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
   - Pre-packaged Boards plugin version [v9.2.2](https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.2.2).
   - Pre-packaged Playbooks plugin version [v2.6.2](https://github.com/mattermost/mattermost-plugin-playbooks/releases/tag/v2.6.2).
@@ -450,9 +453,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
 #### Important Upgrade Notes
  - Beginning in Mattermost v11.3, some plugins that register a Right Hand Sidebar (RHS) component using ``registerRightHandSidebarComponent`` will need to implement additional code to support RHS popouts if their RHS component relies on plugin-specific state. See [this forum post](https://forum.mattermost.com/t/rhs-popout-support-for-plugins/25626) for full details.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v11.2, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration-guide/upgrade/important-upgrade-notes.html). In case of an upgrade failure, please check the [Downgrade Guide](https://docs.mattermost.com/administration-guide/upgrade/downgrading-mattermost-server.html) and the [Recovery Guide](https://docs.mattermost.com/deployment-guide/backup-disaster-recovery.html) for rollback steps and interim mitigation strategy.
-```
+
+</Important>
 
 ### Improvements
 
@@ -519,8 +524,7 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-3-is-now-availab
 ### Contributors
  - [agarciamontoro](https://github.com/agarciamontoro), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [avasconcelos114](https://github.com/avasconcelos114), [BenCookie95](https://github.com/BenCookie95), [bgardner8008](https://github.com/bgardner8008), [calebroseland](https://github.com/calebroseland), [carlisgg](https://github.com/carlisgg), [Combs7th](https://github.com/Combs7th), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://github.com/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [devinbinnie](https://github.com/devinbinnie), [DHaussermann](https://github.com/DHaussermann), [enahum](https://github.com/enahum), [esarafianou](https://github.com/esarafianou), [esethna](https://github.com/esethna), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [hmhealey](https://github.com/hmhealey), [isacikgoz](https://github.com/isacikgoz), [jgheithcock](https://github.com/jgheithcock), [jprusch](https://translate.mattermost.com/user/jprusch), [jwilander](https://github.com/jwilander), [KuSh](https://github.com/KuSh), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [mansil](https://translate.mattermost.com/user/mansil), [marianunez](https://github.com/marianunez), [master7](https://translate.mattermost.com/user/master7), [matthew-w](https://translate.mattermost.com/user/matthew-w), [matthewbirtch](https://github.com/matthewbirtch), [mental-space1532](https://github.com/mental-space1532), [minhthanhonly](https://translate.mattermost.com/user/minhthanhonly), [nevyangelova](https://github.com/nevyangelova), [nickmisasi](https://github.com/nickmisasi), [pvev](https://github.com/pvev), [rahimrahman](https://github.com/rahimrahman), [roberson-io](https://github.com/roberson-io), [RyanisyydsTT](https://translate.mattermost.com/user/RyanisyydsTT), [sadohert](https://github.com/sadohert), [saturninoabril](https://github.com/saturninoabril), [Sharuru](https://translate.mattermost.com/user/Sharuru), [Student-coder-web](https://github.com/Student-coder-web), [svelle](https://github.com/svelle), [Taofik01](https://github.com/Taofik01), [tnir](https://github.com/tnir), [Umeaboy](https://translate.mattermost.com/user/Umeaboy), [varghesejose2020](https://github.com/varghesejose2020), [Victor-Nyagudi](https://github.com/Victor-Nyagudi), [vimobe](https://translate.mattermost.com/user/vimobe), [wiersgallak](https://github.com/wiersgallak), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [yasserfaraazkhan](https://github.com/yasserfaraazkhan), [zlv](https://github.com/zlv)
 
-(release-v11.2-feature-release)=
-## Release v11.2 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types)
+## Release v11.2 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types) \{#release-v11-2-feature-release}
 
 - **11.2.4, released 2026-02-23**
   - Mattermost v11.2.4 contains medium to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -529,10 +533,12 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-3-is-now-availab
   - Fixed an issue where rate limiting was missing from the login endpoint (5 requests/second, 10 burst).
   - Mattermost v11.2.4 contains no database or functional changes.
 - **11.2.3, released 2026-02-13**
-```{Attention}
+<Important>
+
 **Breaking Changes**
  - Photoshop Document (PSD) files are now no longer inline previewed, they are treated as regular file attachments.
-```
+
+</Important>
   - Mattermost v11.2.3 contains medium to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
   - Pre-packaged Boards plugin version [v9.2.2](https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.2.2).
   - Pre-packaged Playbooks plugin version [v2.6.2](https://github.com/mattermost/mattermost-plugin-playbooks/releases/tag/v2.6.2).
@@ -572,9 +578,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
  - **Changes to Enterprise plans:**
    - Under ``ServiceSettings`` in ``config.json``, added ``EnableDynamicClientRegistration`` configuration setting to control whether Dynamic Client Registration is enabled in your Mattermost instance. The default value is ``false``.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v11.1, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration-guide/upgrade/important-upgrade-notes.html). In case of an upgrade failure, please check the [Downgrade Guide](https://docs.mattermost.com/administration-guide/upgrade/downgrading-mattermost-server.html) and the [Recovery Guide](https://docs.mattermost.com/deployment-guide/backup-disaster-recovery.html) for rollback steps and interim mitigation strategy.
-```
+
+</Important>
 
 ### Improvements
 
@@ -643,8 +651,7 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-2-is-now-availab
 ### Contributors
  - [abbas-dependable-naqvi](https://github.com/abbas-dependable-naqvi), [agarciamontoro](https://github.com/agarciamontoro), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [Arusekk](https://github.com/Arusekk), [asaadmahmood](https://github.com/asaadmahmood), [AurelienS](https://github.com/AurelienS), [BenCookie95](https://github.com/BenCookie95), [bgardner8008](https://github.com/bgardner8008), [calebroseland](https://github.com/calebroseland), [carlisgg](https://github.com/carlisgg), [catenacyber](https://github.com/catenacyber), [coltoneshaw](https://github.com/coltoneshaw), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [David](https://translate.mattermost.com/user/David), [davidkrauser](https://github.com/davidkrauser), [devinbinnie](https://github.com/devinbinnie), [DHaussermann](https://github.com/DHaussermann), [domibarton](https://github.com/domibarton), [efemonge](https://translate.mattermost.com/user/efemonge), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [esarafianou](https://github.com/esarafianou), [evituzas](https://translate.mattermost.com/user/evituzas), [ferdymercury](https://github.com/ferdymercury), [feyzaozcann](https://github.com/feyzaozcann), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [guenjun](https://translate.mattermost.com/user/guenjun), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [helloinah](https://translate.mattermost.com/user/helloinah), [hmhealey](https://github.com/hmhealey), [iamleson98](https://translate.mattermost.com/user/iamleson98), [isacikgoz](https://github.com/isacikgoz), [itz-Me-Pj](https://github.com/itz-Me-Pj), [j0taD](https://translate.mattermost.com/user/j0taD), [jgheithcock](https://github.com/jgheithcock), [jprusch](https://github.com/jprusch), [JulienTant](https://github.com/JulienTant), [kaakaa](https://translate.mattermost.com/user/kaakaa), [kayazeren](https://translate.mattermost.com/user/kayazeren), [KuSh](https://github.com/KuSh), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [mansil](https://translate.mattermost.com/user/mansil), [marianunez](https://github.com/marianunez), [master7](https://translate.mattermost.com/user/master7), [matthewbirtch](https://github.com/matthewbirtch), [mgdelacroix](https://github.com/mgdelacroix), [Morgan_svk](https://translate.mattermost.com/user/Morgan_svk), [mrckndt](https://github.com/mrckndt), [nevyangelova](https://github.com/nevyangelova), [nickmisasi](https://github.com/nickmisasi), [oberleg](https://translate.mattermost.com/user/oberleg), [pvev](https://github.com/pvev), [quarac](https://translate.mattermost.com/user/quarac), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Reinkard](https://github.com/Reinkard), [RS-labhub](https://github.com/RS-labhub), [sadohert](https://github.com/sadohert), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [Sharuru](https://translate.mattermost.com/user/Sharuru), [svelle](https://github.com/svelle), [TimTin](https://translate.mattermost.com/user/TimTin), [tsakmas](https://translate.mattermost.com/user/tsakmas), [tuladhar](https://github.com/tuladhar), [uright](https://github.com/uright), [vpecinka](https://github.com/vpecinka), [wiersgallak](https://github.com/wiersgallak), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [willypuzzle](https://github.com/willypuzzle), [wooki-00](https://translate.mattermost.com/user/wooki-00), [yasserfaraazkhan](https://github.com/yasserfaraazkhan), [zlv](https://github.com/zlv)
 
-(release-v11.1-feature-release)=
-## Release v11.1 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types)
+## Release v11.1 - [Feature Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types) \{#release-v11-1-feature-release}
 
 - **11.1.3, released 2026-01-15**
   - Mattermost v11.1.3 contains medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -657,10 +664,12 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-2-is-now-availab
   - Fixed an issue where Chrome/Desktop App spell check on Windows often couldn't correct typos.
   - Mattermost v11.1.2 contains no database or functional changes.
 - **11.1.1, released 2025-11-21**
- ```{Attention}
- **Critical Fixes**
+ <Important>
+
+**Critical Fixes**
   - Mattermost v11.1.1 contains a Critical severity level security fix in the Jira plugin. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
- ```
+
+ </Important>
   - Pre-packaged Jira plugin version [v4.4.1](https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v4.4.1).
   - Fixed an issue where thread popouts did not show the current user's status.
   - Fixed an issue where clicking on a permalink to a reply in another thread would not navigate the main window.
@@ -669,10 +678,12 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-2-is-now-availab
 - **11.1.0, released 2025-11-14**
   - Original 11.1.0 release.
 
-```{Attention}
+<Important>
+
 **Breaking Changes**
  - The version of React used by the Mattermost web app has been updated from React 17 to React 18. See more details in [this forum post](https://forum.mattermost.com/t/upgrading-the-mattermost-web-app-to-react-18-v11/25000).
-```
+
+</Important>
 
 ### Upgrade Impact
 
@@ -687,9 +698,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Compatibility
  - Updated minimum required Edge, Firefox and Chrome versions to v140+ and updated minimum supported Windows version to v11+.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v11.0, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration-guide/upgrade/important-upgrade-notes.html). In case of an upgrade failure, please check the [Downgrade Guide](https://docs.mattermost.com/administration-guide/upgrade/downgrading-mattermost-server.html) and the [Recovery Guide](https://docs.mattermost.com/deployment-guide/backup-disaster-recovery.html) for rollback steps and interim mitigation strategy.
-```
+
+</Important>
 
 ### Improvements
 
@@ -742,17 +755,18 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-1-is-now-availab
 ### Contributors
  - [abbas-dependable-naqvi](https://github.com/abbas-dependable-naqvi), [abhijit-singh](https://github.com/abhijit-singh), [agarciamontoro](https://github.com/agarciamontoro), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [Arusekk](https://translate.mattermost.com/user/Arusekk), [asaadmahmood](https://github.com/asaadmahmood), [BenCookie95](https://github.com/BenCookie95), [bgardner8008](https://github.com/bgardner8008), [buzzyboy](https://github.com/buzzyboy), [calebroseland](https://github.com/calebroseland), [codiphile](https://github.com/codiphile), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [davidkrauser](https://github.com/davidkrauser), [devinbinnie](https://github.com/devinbinnie), [DHaussermann](https://github.com/DHaussermann), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [esarafianou](https://github.com/esarafianou), [esethna](https://github.com/esethna), [ewwollesen](https://github.com/ewwollesen), [fmartingr](https://github.com/fmartingr), [franklinferre](https://translate.mattermost.com/user/franklinferre), [frankps](https://translate.mattermost.com/user/frankps), [fsilye](https://github.com/fsilye), [grubbins](https://github.com/grubbins), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [hereje](https://github.com/hereje), [hmhealey](https://github.com/hmhealey), [homerCOD](https://github.com/homerCOD), [isacikgoz](https://github.com/isacikgoz), [itz-Me-Pj](https://github.com/itz-Me-Pj), [iyampaul](https://github.com/iyampaul), [jgheithcock](https://github.com/jgheithcock), [johnsonbrothers](https://github.com/johnsonbrothers), [jprusch](https://github.com/jprusch), [jsedy7](https://translate.mattermost.com/user/jsedy7), [JulienTant](https://github.com/JulienTant), [kaakaa](https://github.com/kaakaa), [kayazeren](https://github.com/kayazeren), [KohheiAdachi](https://github.com/KohheiAdachi), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [l-ra](https://github.com/l-ra), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [lindy65](https://github.com/lindy65), [lynn915](https://github.com/lynn915), [majo](https://translate.mattermost.com/user/majo), [mansil](https://github.com/mansil), [marianunez](https://github.com/marianunez), [master7](https://translate.mattermost.com/user/master7), [matt-w99](https://github.com/matt-w99), [matthew-w](https://translate.mattermost.com/user/matthew-w), [matthewbirtch](https://github.com/matthewbirtch), [mental-space1532](https://translate.mattermost.com/user/mental-space1532), [mgdelacroix](https://github.com/mgdelacroix), [moi90](https://github.com/moi90), [neflyte](https://github.com/neflyte), [nickmisasi](https://github.com/nickmisasi), [Omar8345](https://github.com/Omar8345), [pavelzeman](https://github.com/pavelzeman), [pnaskardev](https://github.com/pnaskardev), [polyacedev](https://translate.mattermost.com/user/polyacedev), [pvev](https://github.com/pvev), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [Reinkard](https://github.com/Reinkard), [roberson-io](https://github.com/roberson-io), [roskee](https://github.com/roskee), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [Sharuru](https://translate.mattermost.com/user/Sharuru), [shawnaym](https://github.com/shawnaym), [svelle](https://github.com/svelle), [thejoeejoee](https://translate.mattermost.com/user/thejoeejoee), [ThrRip](https://github.com/ThrRip), [tnir](https://github.com/tnir), [Victor-Nyagudi](https://github.com/Victor-Nyagudi), [vpecinka](https://translate.mattermost.com/user/vpecinka), [wiersgallak](https://github.com/wiersgallak), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [yairsz](https://github.com/yairsz), [Yash-Chakerverti](https://github.com/Yash-Chakerverti), [yasserfaraazkhan](https://github.com/yasserfaraazkhan)
 
-(release-v11.0-major-release)=
-## Release v11.0 - [Major Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types)
+## Release v11.0 - [Major Release](https://docs.mattermost.com/product-overview/release-policy.html#release-types) \{#release-v11-0-major-release}
 
 - **11.0.7, released 2025-12-17**
   - Mattermost v11.0.7 contains medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
   - Mattermost v11.0.7 contains no database or functional changes.
 - **11.0.6, released 2025-11-21**
- ```{Attention}
- **Critical Fixes**
+ <Important>
+
+**Critical Fixes**
   - Mattermost v11.0.6 contains a Critical severity level security fix in the Jira plugin. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
- ```
+
+ </Important>
   - Pre-packaged Jira plugin version [v4.4.1](https://github.com/mattermost/mattermost-plugin-jira/releases/tag/v4.4.1).
   - Mattermost v11.0.6 contains no database or functional changes.
 - **11.0.5, released 2025-11-17**
@@ -763,10 +777,12 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-1-is-now-availab
   - Fixed an issue where plugins could not receive 3rd-party authorization headers.
   - Mattermost v11.0.5 contains no database or functional changes.
 - **11.0.4, released 2025-10-28**
- ```{Attention}
- **Critical Fixes**
+ <Important>
+
+**Critical Fixes**
   - Mattermost v11.0.4 contains Critical severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release as soon as possible is highly recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
- ```
+
+ </Important>
   - Fixed an issue where plugin configuration settings were incorrectly sanitized, causing API endpoints and plugins to receive masked values instead of actual configuration values.
   - Pre-packaged Boards plugin [v9.1.7](https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.1.7).
   - Mattermost v11.0.4 contains no database or functional changes.
@@ -777,7 +793,8 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-1-is-now-availab
 - **11.0.1, released 2025-10-16**
   - Original 11.0.1 release.
 
-```{Attention}
+<Important>
+
 **Breaking Changes**
  - GitLab SSO has been deprecated from Team Edition. Deployments using GitLab SSO can remain on v10.11 ESR (with 12 months of security updates), transition to our new free offering Mattermost Entry, or can explore commercial/nonprofit options. See more details in [this forum post](https://forum.mattermost.com/t/mattermost-v11-changes-in-free-offerings/25126). 
  - The ``TeamSettings.ExperimentalViewArchivedChannels`` setting has been deprecated. Archived channels will always be accessible, subject to normal channel membership. The server will fail to start if this setting is set to ``false``. To deny access to archived channels, mark them as private and remove affected channel members. See more details in [this forum post](https://forum.mattermost.com/t/viewing-accessing-archived-channels-v11/22626).
@@ -806,7 +823,8 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-1-is-now-availab
  - Separate notification log file has been deprecated. If admins want to continue using a separate log file for notification logs, they can use the ``AdvancedLoggingJSON`` configuration. See the [Important Upgrade Notes](https://docs.mattermost.com/administration-guide/upgrade/important-upgrade-notes.html) for an example configuration.
  - Stopped supporting manually installed plugins as per https://forum.mattermost.com/t/deprecation-notice-manual-plugin-deployment/21192
  - Support for PostgreSQL v13 has been removed. The new minimum PostgreSQL version is v14+. See the [minimum supported PostgreSQL version policy](https://docs.mattermost.com/deployment-guide/software-hardware-requirements.html#minimum-postgresql-database-support-policy) documentation for details.
-```
+
+</Important>
 
 ### Upgrade Impact
 
@@ -820,9 +838,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
  - **Changes to Enterprise and Enterprise Advanced plans:**
    - Removed ``ClientSideCertCheck`` as part of removing the experimental certificate-based authentication feature.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v10.10, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration-guide/upgrade/important-upgrade-notes.html). In case of an upgrade failure, please check the [Downgrade Guide](https://docs.mattermost.com/administration-guide/upgrade/downgrading-mattermost-server.html) and the [Recovery Guide](https://docs.mattermost.com/deployment-guide/backup-disaster-recovery.html) for rollback steps and interim mitigation strategy.
-```
+
+</Important>
 
 ### Improvements
 

--- a/docs/main/product-overview/mobile-app-changelog.mdx
+++ b/docs/main/product-overview/mobile-app-changelog.mdx
@@ -5,10 +5,12 @@ import Inc0_common_esr_support from './common-esr-support.mdx';
 
 This changelog summarizes updates to Mattermost mobile apps releases for [Mattermost](https://mattermost.com).
 
-```{Important}
+<Important>
+
 <Inc0_common_esr_support />
-(release-v2-39-0)=
-## 2.39.0 Release
+
+</Important>
+## 2.39.0 Release \{#release-v2-39-0}
  - Release Date: April 16, 2026
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -35,8 +37,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-38-3)=
-## 2.38.3 Release
+## 2.38.3 Release \{#release-v2-38-3}
  - Release Date: April 10, 2026
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -52,8 +53,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-38-2)=
-## 2.38.2 Release
+## 2.38.2 Release \{#release-v2-38-2}
  - Release Date: April 1, 2026
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -69,8 +69,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-38-1)=
-## 2.38.1 Release
+## 2.38.1 Release \{#release-v2-38-1}
  - Release Date: March 25, 2026
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -86,8 +85,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-38-0)=
-## 2.38.0 Release
+## 2.38.0 Release \{#release-v2-38-0}
  - Release Date: March 16, 2026
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -117,8 +115,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-37-2)=
-## 2.37.2 Release
+## 2.37.2 Release \{#release-v2-37-2}
  - Release Date: February 26, 2026
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -134,8 +131,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-37-1)=
-## 2.37.1 Release
+## 2.37.1 Release \{#release-v2-37-1}
  - Release Date: February 23, 2026
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -150,8 +146,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-37-0)=
-## 2.37.0 Release
+## 2.37.0 Release \{#release-v2-37-0}
  - Release Date: February 16, 2026
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -177,8 +172,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-36-4)=
-## 2.36.4 Release
+## 2.36.4 Release \{#release-v2-36-4}
  - Release Date: January 22, 2026
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -195,8 +189,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-36-3)=
-## 2.36.3 Release
+## 2.36.3 Release \{#release-v2-36-3}
  - Release Date: January 21, 2026
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -213,8 +206,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-36-2)=
-## 2.36.2 Release
+## 2.36.2 Release \{#release-v2-36-2}
  - Release Date: January 20, 2026
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -231,8 +223,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-36-1)=
-## 2.36.1 Release
+## 2.36.1 Release \{#release-v2-36-1}
  - Release Date: January 20, 2026
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -249,8 +240,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-36-0)=
-## 2.36.0 Release
+## 2.36.0 Release \{#release-v2-36-0}
  - Release Date: January 16, 2026
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -279,8 +269,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-35-0)=
-## 2.35.0 Release
+## 2.35.0 Release \{#release-v2-35-0}
  - Release Date: December 16, 2025
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -300,8 +289,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-34-0)=
-## 2.34.0 Release
+## 2.34.0 Release \{#release-v2-34-0}
  - Release Date: November 14, 2025
  - Server Versions Supported: Server v10.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -333,8 +321,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-33-1)=
-## 2.33.1 Release
+## 2.33.1 Release \{#release-v2-33-1}
  - Release Date: October 21, 2025
  - Server Versions Supported: Server v10.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -346,8 +333,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
 ### Bug Fixes
  - Fixed an issue where links would change colors when navigating to a channel with a channel banner.
 
-(release-v2-33-0)=
-## 2.33.0 Release
+## 2.33.0 Release \{#release-v2-33-0}
  - Release Date: October 16, 2025
  - Server Versions Supported: Server v10.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -375,8 +361,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-32-0)=
-## 2.32.0 Release
+## 2.32.0 Release \{#release-v2-32-0}
  - Release Date: September 16, 2025
  - Server Versions Supported: Server v10.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -401,8 +386,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-31-0)=
-## 2.31.0 Release
+## 2.31.0 Release \{#release-v2-31-0}
  - Release Date: August 15, 2025
  - Server Versions Supported: Server v10.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -429,8 +413,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-30-0)=
-## 2.30.0 Release
+## 2.30.0 Release \{#release-v2-30-0}
  - Release Date: July 16, 2025
  - Server Versions Supported: Server v10.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -454,8 +437,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-29-1)=
-## 2.29.1 Release
+## 2.29.1 Release \{#release-v2-29-1}
  - Release Date: June 18, 2025
  - Server Versions Supported: Server v10.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -468,8 +450,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Fixed an issue where an unread thread on a Direct/Group Message would mark all teams as unread.
  - Fixed an issue with the **Report a Problem** screen not showing all the buttons on small screens.
 
-(release-v2-29-0)=
-## 2.29.0 Release
+## 2.29.0 Release \{#release-v2-29-0}
  - Release Date: June 16, 2025
  - Server Versions Supported: Server v10.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -503,8 +484,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-28-1)=
-## 2.28.1 Release
+## 2.28.1 Release \{#release-v2-28-1}
  - Release Date: June 4, 2025
  - Server Versions Supported: Server v10.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -516,8 +496,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
 ### Bug Fixes
  - Fixed an issue with some flickering on the tooltip in the drafts screen.
 
-(release-v2-28-0)=
-## 2.28.0 Release
+## 2.28.0 Release \{#release-v2-28-0}
  - Release Date: May 16, 2025
  - Server Versions Supported: Server v10.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -546,8 +525,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-27-1)=
-## 2.27.1 Release
+## 2.27.1 Release \{#release-v2-27-1}
  - Release Date: April 30, 2025
  - Server Versions Supported: Server v9.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -559,8 +537,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
 ### Bug Fixes
  - Calls: fixed a regression that caused unmuting to fail when running the latest app against an older plugin version (earlier than v1.7.0).
 
-(release-v2-27-0)=
-## 2.27.0 Release
+## 2.27.0 Release \{#release-v2-27-0}
  - Release Date: April 16, 2025
  - Server Versions Supported: Server v9.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -587,8 +564,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-26-2)=
-## 2.26.2 Release
+## 2.26.2 Release \{#release-v2-26-2}
  - Release Date: March 25, 2025
  - Server Versions Supported: Server v9.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -600,8 +576,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
 ### Bug Fixes
  - Fixed an issue where the autocomplete area was too small on Android devices.
 
-(release-v2-26-1)=
-## 2.26.1 Release
+## 2.26.1 Release \{#release-v2-26-1}
  - Release Date: March 21, 2025
  - Server Versions Supported: Server v9.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -613,8 +588,7 @@ This changelog summarizes updates to Mattermost mobile apps releases for [Matter
 ### Bug Fixes
  - Fixed issues where app bindings and message attachments would not show properly.
 
-(release-v2-26-0)=
-## 2.26.0 Release
+## 2.26.0 Release \{#release-v2-26-0}
  - Release Date: March 14, 2025
  - Server Versions Supported: Server v9.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -642,8 +616,7 @@ Note: Mattermost Mobile App v2.26.0 contains a low level security fix. Updating 
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-25-1)=
-## 2.25.1 Release
+## 2.25.1 Release \{#release-v2-25-1}
  - Release Date: February 21, 2025
  - Server Versions Supported: Server v9.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -654,8 +627,7 @@ Note: Mattermost Mobile App v2.26.0 contains a low level security fix. Updating 
 
 Note: Mattermost Mobile App v2.25.1 contains a medium level security fix. Updating is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the Mattermost Responsible Disclosure Policy.
 
-(release-v2-25-0)=
-## 2.25.0 Release
+## 2.25.0 Release \{#release-v2-25-0}
  - Release Date: February 14, 2025
  - Server Versions Supported: Server v9.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -684,8 +656,7 @@ Note: Mattermost Mobile App v2.25.1 contains a medium level security fix. Updati
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-24-1)=
-## 2.24.1 Release
+## 2.24.1 Release \{#release-v2-24-1}
  - Release Date: January 17, 2025
  - Server Versions Supported: Server v9.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -697,8 +668,7 @@ Note: Mattermost Mobile App v2.25.1 contains a medium level security fix. Updati
 ### Bug Fixes
  - Fixed a crash when using certain timezones.
 
-(release-v2-24-0)=
-## 2.24.0 Release
+## 2.24.0 Release \{#release-v2-24-0}
  - Release Date: January 16, 2025
  - Server Versions Supported: Server v9.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -717,8 +687,7 @@ Note: Mattermost Mobile App v2.25.1 contains a medium level security fix. Updati
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-23-1)=
-## 2.23.1 Release
+## 2.23.1 Release \{#release-v2-23-1}
  - Release Date: December 19, 2024
  - Server Versions Supported: Server v9.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -731,8 +700,7 @@ Note: Mattermost Mobile App v2.25.1 contains a medium level security fix. Updati
  - Fixed an issue with the number field validation on interactive dialogs.
  - Fixed an issue with interactive dialogs not showing all the elements.
 
-(release-v2-23-0)=
-## 2.23.0 Release
+## 2.23.0 Release \{#release-v2-23-0}
  - Release Date: December 16, 2024
  - Server Versions Supported: Server v9.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -771,8 +739,7 @@ Note: Mattermost Mobile App v2.23.0 contains medium level security fixes. Updati
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-22-0)=
-## 2.22.0 Release
+## 2.22.0 Release \{#release-v2-22-0}
  - Release Date: November 15, 2024
  - Server Versions Supported: Server v9.11.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -798,8 +765,7 @@ Note: Mattermost Mobile App v2.22.0 contains a medium level security fix. Updati
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-21-0)=
-## 2.21.0 Release
+## 2.21.0 Release \{#release-v2-21-0}
  - Release Date: October 16, 2024
  - Server Versions Supported: Server v9.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -820,8 +786,7 @@ Note: Mattermost Mobile App v2.22.0 contains a medium level security fix. Updati
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-20-1)=
-## 2.20.1 Release
+## 2.20.1 Release \{#release-v2-20-1}
  - Release Date: October 9, 2024
  - Server Versions Supported: Server v9.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -833,8 +798,7 @@ Note: Mattermost Mobile App v2.22.0 contains a medium level security fix. Updati
 ### Improvements
  - Added a configuration setting ``NativeAppSettings > MobileExternalBrowser`` that tells the Mobile app to perform SSO Authentication using the external default browser.
 
-(release-v2-20-0)=
-## 2.20.0 Release
+## 2.20.0 Release \{#release-v2-20-0}
  - Release Date: September 16, 2024
  - Server Versions Supported: Server v9.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -862,8 +826,7 @@ Note: Mattermost Mobile App v2.22.0 contains a medium level security fix. Updati
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-19-2)=
-## 2.19.2 Release
+## 2.19.2 Release \{#release-v2-19-2}
  - Release Date: August 29, 2024
  - Server Versions Supported: Server v9.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -876,8 +839,7 @@ Note: Mattermost Mobile App v2.22.0 contains a medium level security fix. Updati
  - Added a new message to the SSO login screen when the login is successful.
  - Fixed an issue that prevented live captions for Calls to show.
 
-(release-v2-19-1)=
-## 2.19.1 Release
+## 2.19.1 Release \{#release-v2-19-1}
  - Release Date: August 27, 2024
  - Server Versions Supported: Server v9.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -890,8 +852,7 @@ Note: Mattermost Mobile App v2.22.0 contains a medium level security fix. Updati
  - Fixed an issue where the iPad hardware keyboard did not work as intended.
  - Fixed an issue where the Android keyboard did not autocapitalize the first letter of a sentence by default when writing a post.
 
-(release-v2-19-0)=
-## 2.19.0 Release
+## 2.19.0 Release \{#release-v2-19-0}
  - Release Date: August 16, 2024
  - Server Versions Supported: Server v9.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -918,8 +879,7 @@ Note: Mattermost Mobile App v2.22.0 contains a medium level security fix. Updati
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-18-1)=
-## 2.18.1 Release
+## 2.18.1 Release \{#release-v2-18-1}
  - Release Date: July 17, 2024
  - Server Versions Supported: Server v9.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -931,8 +891,7 @@ Note: Mattermost Mobile App v2.22.0 contains a medium level security fix. Updati
 ### Bug Fixes
  - Fixed an issue with the server list modal displayed on tablet devices.
 
-(release-v2-18-0)=
-## 2.18.0 Release
+## 2.18.0 Release \{#release-v2-18-0}
  - Release Date: July 16, 2024
  - Server Versions Supported: Server v9.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -959,8 +918,7 @@ Note: Mattermost Mobile App v2.22.0 contains a medium level security fix. Updati
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-17-1)=
-## 2.17.1 Release
+## 2.17.1 Release \{#release-v2-17-1}
  - Release Date: June 25, 2024
  - Server Versions Supported: Server v9.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -984,7 +942,7 @@ Note: Mattermost Mobile App v2.22.0 contains a medium level security fix. Updati
 Note: Mattermost Mobile App v2.17.0 contains low to medium level security fixes. Updating is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the Mattermost Responsible Disclosure Policy.
 
 ### Breaking Changes
- - **IMPORTANT:** The iPhone Deployment Target was updated to 13.4. Old devices may not be able to update the app (<1GB RAM and <iPhone6s).
+ - **IMPORTANT:** The iPhone Deployment Target was updated to 13.4. Old devices may not be able to update the app (&lt;1GB RAM and &lt;iPhone6s).
 
 ### Improvements
  - Calls: Added a **Participants** list to the call screen.
@@ -1012,8 +970,7 @@ Note: Mattermost Mobile App v2.17.0 contains low to medium level security fixes.
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-16-0)=
-## 2.16.0 Release
+## 2.16.0 Release \{#release-v2-16-0}
  - Release Date: May 16, 2024
  - Server Versions Supported: Server v9.5.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1035,8 +992,7 @@ Note: Mattermost Mobile App v2.17.0 contains low to medium level security fixes.
 
 ----
 
-(release-v2-15-0)=
-## 2.15.0 Release
+## 2.15.0 Release \{#release-v2-15-0}
  - Release Date: April 16, 2024
  - Server Versions Supported: Server v8.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1056,8 +1012,7 @@ Note: Mattermost Mobile App v2.17.0 contains low to medium level security fixes.
  - Users are unable to adjust the font size via the OS font size setting.
  - Some Google Pixel phones on Android 12+ might not continue past the login screen. This is a known issue with the OS, and the current workaround is to restart the device.
 
-(release-v2-14-0)=
-## 2.14.0 Release
+## 2.14.0 Release \{#release-v2-14-0}
  - Release Date: March 15, 2024
  - Server Versions Supported: Server v8.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1078,8 +1033,7 @@ Note: Mattermost Mobile App v2.14.0 contains a low level security fix. Updating 
 
 ----
 
-(release-v2-13-0)=
-## 2.13.0 Release
+## 2.13.0 Release \{#release-v2-13-0}
  - Release Date: February 16, 2024
  - Server Versions Supported: Server v8.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1107,8 +1061,7 @@ Note: Mattermost Mobile App v2.13.0 contains low level security fixes. Updating 
 
 ----
 
-(release-v2-12-2)=
-## 2.12.2 Release
+## 2.12.2 Release \{#release-v2-12-2}
  - Release Date: February 5, 2024
  - Server Versions Supported: Server v8.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1123,8 +1076,7 @@ Note: Mattermost Mobile App v2.13.0 contains low level security fixes. Updating 
 
 ----
 
-(release-v2-12-1)=
-## 2.12.1 Release
+## 2.12.1 Release \{#release-v2-12-1}
  - Release Date: January 30, 2024
  - Server Versions Supported: Server v8.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1138,8 +1090,7 @@ Note: Mattermost Mobile App v2.12.1 contains a medium level security fix. Updati
 ### Bug Fixes
  - Fixed an issue where various menus and popovers were non-functional when the phone had accessibility settings related to removing animations enabled.
 
-(release-v2-12-0)=
-## 2.12.0 Release
+## 2.12.0 Release \{#release-v2-12-0}
  - Release Date: January 16, 2024
  - Server Versions Supported: Server v8.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1176,8 +1127,7 @@ Note: Mattermost Mobile App v2.12.1 contains a medium level security fix. Updati
 
 ----
 
-(release-v2-11-0)=
-## 2.11.0 Release
+## 2.11.0 Release \{#release-v2-11-0}
 - Release Date: December 15, 2023
 - Server Versions Supported: Server v8.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1205,8 +1155,7 @@ Note: Mattermost Mobile App v2.12.1 contains a medium level security fix. Updati
 
 ----
 
-(release-v2-10-1)=
-## 2.10.1 Release
+## 2.10.1 Release \{#release-v2-10-1}
 - Release Date: November 29, 2023
 - Server Versions Supported: Server v8.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1219,8 +1168,7 @@ Note: Mattermost Mobile App v2.10.1 contains a high level security fix. Updating
 
 ----
 
-(release-v2-10-0)=
-## 2.10.0 Release
+## 2.10.0 Release \{#release-v2-10-0}
 - Release Date: November 16, 2023
 - Server Versions Supported: Server v8.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1247,8 +1195,7 @@ Note: Mattermost Mobile App v2.10.1 contains a high level security fix. Updating
 
 ----
 
-(release-v2-9-1)=
-## 2.9.1 Release
+## 2.9.1 Release \{#release-v2-9-1}
 - Release Date: November 1, 2023
 - Server Versions Supported: Server v7.8.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1262,8 +1209,7 @@ Note: Mattermost Mobile App v2.10.1 contains a high level security fix. Updating
 
 ----
 
-(release-v2-9-0)=
-## 2.9.0 Release
+## 2.9.0 Release \{#release-v2-9-0}
 - Release Date: October 16, 2023
 - Server Versions Supported: Server v7.8.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1292,8 +1238,7 @@ Note: Mattermost Mobile App v2.10.1 contains a high level security fix. Updating
 
 ----
 
-(release-v2-8-2)=
-## 2.8.2 Release
+## 2.8.2 Release \{#release-v2-8-2}
 - Release Date: Oct 10, 2023
 - Server Versions Supported: Server v7.8.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1305,8 +1250,7 @@ Note: Mattermost Mobile App v2.10.1 contains a high level security fix. Updating
 
 ----
 
-(release-v2-8-1)=
-## 2.8.1 Release
+## 2.8.1 Release \{#release-v2-8-1}
 - Release Date: October 2, 2023
 - Server Versions Supported: Server v7.8.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1316,9 +1260,11 @@ Note: Mattermost Mobile App v2.10.1 contains a high level security fix. Updating
  - iPhone 5s devices and later with iOS 13.4+ is required.
  - Bumped the iOS minimum supported version to v13.4.
 
-```{Note} 
+<Note>
+
 Mattermost Mobile App v2.8.1 contains a high level security fix. Updating is recommended. Details will be posted on our security updates page 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Improvements
  - Added an alert showing when a deeplink is invalid.
@@ -1329,8 +1275,7 @@ Mattermost Mobile App v2.8.1 contains a high level security fix. Updating is rec
 
 ----
 
-(release-v2-8-0)=
-## 2.8.0 Release
+## 2.8.0 Release \{#release-v2-8-0}
 - Release Date: September 15, 2023
 - Server Versions Supported: Server v7.8.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1339,9 +1284,11 @@ Mattermost Mobile App v2.8.1 contains a high level security fix. Updating is rec
  - Android operating system 7+ [is required by Google](https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html).	
  - iPhone 5s devices and later with iOS 12.1+ is required.
 
-```{Note} 
+<Note>
+
 Mattermost Mobile App v2.8.0 contains a medium level security fix. Updating is recommended. Details will be posted on our security updates page 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Improvements
  - Calls: Added incoming call notifications for Direct Message and Group Message calls.
@@ -1365,8 +1312,7 @@ Mattermost Mobile App v2.8.0 contains a medium level security fix. Updating is r
 
 ----
 
-(release-v2-7-0)=
-## 2.7.0 Release
+## 2.7.0 Release \{#release-v2-7-0}
 - Release Date: August 16, 2023
 - Server Versions Supported: Server v7.8.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1398,8 +1344,7 @@ Mattermost Mobile App v2.8.0 contains a medium level security fix. Updating is r
 
 ----
 
-(release-v2-6-0)=
-## 2.6.0 Release
+## 2.6.0 Release \{#release-v2-6-0}
 - Release Date: July 14, 2023
 - Server Versions Supported: Server v7.8.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1431,8 +1376,7 @@ Mattermost Mobile App v2.8.0 contains a medium level security fix. Updating is r
 
 ----
 
-(release-v2-5-1)=
-## 2.5.1 Release
+## 2.5.1 Release \{#release-v2-5-1}
 - Release Date: June 23, 2023
 - Server Versions Supported: Server v7.8.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1441,8 +1385,11 @@ Mattermost Mobile App v2.8.0 contains a medium level security fix. Updating is r
  - Android operating system 7+ [is required by Google](https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html).	
  - iPhone 5s devices and later with iOS 12.1+ is required.
 
-```{Note} Mattermost Mobile App v2.5.1 contains a high level security fix. Upgrading is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+<Note>
+
+Mattermost Mobile App v2.5.1 contains a high level security fix. Upgrading is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
+
+</Note>
 
 ### Bug Fixes
  - Fixed an issue where reading a thread could lead to the phone and server to overwork.
@@ -1450,8 +1397,7 @@ Mattermost Mobile App v2.8.0 contains a medium level security fix. Updating is r
 
 ----
 
-(release-v2-5-0)=
-## 2.5.0 Release
+## 2.5.0 Release \{#release-v2-5-0}
 - Release Date: June 16, 2023
 - Server Versions Supported: Server v7.8.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1485,8 +1431,7 @@ Mattermost Mobile App v2.8.0 contains a medium level security fix. Updating is r
 
 ----
 
-(release-v2-4-0)=
-## 2.4.0 Release
+## 2.4.0 Release \{#release-v2-4-0}
 - Release Date: May 17, 2023
 - Server Versions Supported: Server v7.8.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1526,8 +1471,7 @@ Mattermost Mobile App v2.8.0 contains a medium level security fix. Updating is r
 
 ----
 
-(release-v2-3-0)=
-## 2.3.0 Release
+## 2.3.0 Release \{#release-v2-3-0}
 - Release Date: April 14, 2023
 - Server Versions Supported: Server v7.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1564,8 +1508,7 @@ Mattermost Mobile App v2.8.0 contains a medium level security fix. Updating is r
 
 ----
 
-(release-v2-2-0)=
-## 2.2.0 Release
+## 2.2.0 Release \{#release-v2-2-0}
 - Release Date: March 17, 2023
 - Server Versions Supported: Server v7.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1607,8 +1550,7 @@ Mattermost Mobile App v2.8.0 contains a medium level security fix. Updating is r
 
 ----
 
-(release-v2-1-0)=
-## 2.1.0 Release
+## 2.1.0 Release \{#release-v2-1-0}
 - Release Date: February 16, 2023
 - Server Versions Supported: Server v7.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1646,8 +1588,7 @@ Mattermost Mobile App v2.8.0 contains a medium level security fix. Updating is r
 
 ----
 
-(release-v2-0-1)=
-## 2.0.1 Release
+## 2.0.1 Release \{#release-v2-0-1}
 - Release Date: February 7, 2023
 - Server Versions Supported: Server v7.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1690,8 +1631,7 @@ Mattermost Mobile App v2.8.0 contains a medium level security fix. Updating is r
 
 ----
 
-(release-v2-0-0)=
-## 2.0.0 Release
+## 2.0.0 Release \{#release-v2-0-0}
 - Release Date: January 16, 2023
 - Server Versions Supported: Server v7.1.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1724,8 +1664,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-55-1)=
-## 1.55.1 Release
+## 1.55.1 Release \{#release-v1-55-1}
 - Release Date: September 15, 2022
 - Server Versions Supported: Server v6.3.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1745,8 +1684,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-55-0)=
-## 1.55.0 Release
+## 1.55.0 Release \{#release-v1-55-0}
 - Release Date: August 16, 2022
 - Server Versions Supported: Server v6.3.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1770,8 +1708,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-54-0)=
-## 1.54.0 Release
+## 1.54.0 Release \{#release-v1-54-0}
 - Release Date: July 15, 2022
 - Server Versions Supported: Server v6.3.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1795,8 +1732,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-53-0)=
-## 1.53.0 Release
+## 1.53.0 Release \{#release-v1-53-0}
 - Release Date: June 15, 2022
 - Server Versions Supported: Server v6.3.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1816,8 +1752,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-52-0)=
-## 1.52.0 Release
+## 1.52.0 Release \{#release-v1-52-0}
 - Release Date: May 16, 2022
 - Server Versions Supported: Server v6.3.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1836,8 +1771,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-51-2)=
-## 1.51.2 Release
+## 1.51.2 Release \{#release-v1-51-2}
 - Release Date: May 5, 2022
 - Server Versions Supported: Server v6.3.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1853,8 +1787,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-51-1)=
-## 1.51.1 Release
+## 1.51.1 Release \{#release-v1-51-1}
 - Release Date: April 22, 2022
 - Server Versions Supported: Server v6.3.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1870,8 +1803,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-51-0)=
-## 1.51.0 Release
+## 1.51.0 Release \{#release-v1-51-0}
 - Release Date: April 16, 2022
 - Server Versions Supported: Server v6.3.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1909,8 +1841,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-50-1)=
-## 1.50.1 Release
+## 1.50.1 Release \{#release-v1-50-1}
 - Release Date: March 21, 2022
 - Server Versions Supported: Server v5.37.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1926,8 +1857,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-50-0)=
-## 1.50.0 Release
+## 1.50.0 Release \{#release-v1-50-0}
 - Release Date: March 16, 2022
 - Server Versions Supported: Server v5.37.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1953,8 +1883,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-49-1)=
-## 1.49.1 Release
+## 1.49.1 Release \{#release-v1-49-1}
 - Release Date: February 23, 2022.
 - Server Versions Supported: Server v5.37.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -1970,8 +1899,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-49-0)=
-## 1.49.0 Release
+## 1.49.0 Release \{#release-v1-49-0}
 - Release Date: February 16, 2022
 - Server Versions Supported: Server v5.37.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -2001,8 +1929,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-48-2)=
-## 1.48.2 Release
+## 1.48.2 Release \{#release-v1-48-2}
 - Release Date: January 6, 2022
 - Server Versions Supported: Server v5.37.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -2026,8 +1953,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-48-1)=
-## 1.48.1 Release
+## 1.48.1 Release \{#release-v1-48-1}
 - Release Date: December 15, 2021
 - Server Versions Supported: Server v5.37.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -2053,8 +1979,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-48-0)=
-## 1.48.0 Release
+## 1.48.0 Release \{#release-v1-48-0}
 - Release Date: November 16, 2021
 - Server Versions Supported: Server v5.37.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -2095,8 +2020,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-47-2)=
-## 1.47.2 Release
+## 1.47.2 Release \{#release-v1-47-2}
 - Release Date: October 25, 2021
 - Server Versions Supported: Server v5.37.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -2116,8 +2040,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-47-1)=
-## 1.47.1 Release
+## 1.47.1 Release \{#release-v1-47-1}
 - Release Date: October 19, 2021
 - Server Versions Supported: Server v5.37.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -2138,8 +2061,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-47-0)=
-## 1.47.0 Release
+## 1.47.0 Release \{#release-v1-47-0}
 - Release Date: October 13, 2021
 - Server Versions Supported: Server v5.37.0+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -2207,8 +2129,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-46-0)=
-## 1.46.0 Release
+## 1.46.0 Release \{#release-v1-46-0}
 - Release Date: August 16, 2021
 - Server Versions Supported: Server v5.31.3+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -2269,8 +2190,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-45-1)=
-## 1.45.1 Release
+## 1.45.1 Release \{#release-v1-45-1}
 - Release Date: July 20, 2021
 - Server Versions Supported: Server v5.31.3+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -2289,8 +2209,7 @@ Users now gain a more reliable and feature-rich application, improving their exp
 
 ----
 
-(release-v1-45-0)=
-## 1.45.0 Release
+## 1.45.0 Release \{#release-v1-45-0}
 - Release Date: July 16, 2021
 - Server Versions Supported: Server v5.31.3+ is required. Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device.
 
@@ -2304,9 +2223,11 @@ Users now gain a more reliable and feature-rich application, improving their exp
 #### Emoji Enhancements with Skin Tone Selection
  - Added support for emoji standard v13.0 with Mattermost server v5.37. 
 
-```{Note} 
+<Note>
+
 Due to the upgrade to Emoji 13.0, some emojis may be missing on Android older than 11 and iOS older than 14.2.
-```
+
+</Note>
 
 #### English-Australian Language Support
  - Mattermost is now available in English-Australian.
@@ -2339,8 +2260,7 @@ Due to the upgrade to Emoji 13.0, some emojis may be missing on Android older th
 
 ----
 
-(release-v1-44-1)=
-## 1.44.1 Release
+## 1.44.1 Release \{#release-v1-44-1}
 - Release Date: June 28, 2021
 - Server Versions Supported: Server v5.31.3+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2364,8 +2284,7 @@ Due to the upgrade to Emoji 13.0, some emojis may be missing on Android older th
 
 ----
 
-(release-v1-44-0)=
-## 1.44.0 Release
+## 1.44.0 Release \{#release-v1-44-0}
 - Release Date: June 16, 2021
 - Server Versions Supported: Server v5.31.3+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2374,9 +2293,11 @@ Due to the upgrade to Emoji 13.0, some emojis may be missing on Android older th
  - Android operating system 7+ [is required by Google](https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html).	
  - iPhone 5s devices and later with iOS 11+ is required.
 
-```{Note} 
+<Note>
+
 Mattermost Mobile App v1.44.0 contains low to high level security fixes. Upgrading is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
 
 ### Highlights
 
@@ -2405,8 +2326,7 @@ Mattermost Mobile App v1.44.0 contains low to high level security fixes. Upgradi
 
 ----
 
-(release-v1-43-0)=
-## 1.43.0 Release
+## 1.43.0 Release \{#release-v1-43-0}
 - Release Date: May 16, 2021
 - Server Versions Supported: Server v5.31.3+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2448,8 +2368,7 @@ Mattermost Mobile App v1.44.0 contains low to high level security fixes. Upgradi
 
 ----
 
-(release-v1-42-1)=
-## 1.42.1 Release
+## 1.42.1 Release \{#release-v1-42-1}
 - Release Date: April 19, 2021
 - Server Versions Supported: Server v5.31.3+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2468,8 +2387,7 @@ Mattermost Mobile App v1.44.0 contains low to high level security fixes. Upgradi
 
 ----
 
-(release-v1-42-0)=
-## 1.42.0 Release
+## 1.42.0 Release \{#release-v1-42-0}
 - Release Date: April 16, 2021
 - Server Versions Supported: Server v5.31.3+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2506,8 +2424,7 @@ Mattermost Mobile App v1.44.0 contains low to high level security fixes. Upgradi
 
 ----
 
-(release-v1-41-1)=
-## 1.41.1 Release
+## 1.41.1 Release \{#release-v1-41-1}
 - Release Date: April 7, 2021
 - Server Versions Supported: Server v5.25+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2521,8 +2438,7 @@ Mattermost Mobile App v1.44.0 contains low to high level security fixes. Upgradi
 
 ----
 
-(release-v1-41-0)=
-## 1.41.0 Release
+## 1.41.0 Release \{#release-v1-41-0}
 - Release Date: March 16, 2021
 - Server Versions Supported: Server v5.25+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2554,8 +2470,7 @@ Mattermost Mobile App v1.41.0 contains a high level security fix. Upgrading is r
 
 ----
 
-(release-v1-40-0)=
-## 1.40.0 Release
+## 1.40.0 Release \{#release-v1-40-0}
 - Release Date: February 25, 2021
 - Server Versions Supported: Server v5.25+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2595,8 +2510,7 @@ Mattermost Mobile App v1.40.0 contains a low level security fix. Upgrading is re
 
 ----
 
-(release-v1-39-0)=
-## 1.39.0 Release
+## 1.39.0 Release \{#release-v1-39-0}
 - Release Date: January 16, 2021
 - Server Versions Supported: Server v5.25+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2630,8 +2544,7 @@ Mattermost Mobile App v1.40.0 contains a low level security fix. Upgrading is re
 
 ----
 
-(release-v1-38-1)=
-## 1.38.1 Release
+## 1.38.1 Release \{#release-v1-38-1}
 - Release Date: December 18, 2020
 - Server Versions Supported: Server v5.25+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2646,8 +2559,7 @@ Mattermost Mobile App v1.40.0 contains a low level security fix. Upgrading is re
 
 ----
 
-(release-v1-38-0)=
-## 1.38.0 Release
+## 1.38.0 Release \{#release-v1-38-0}
 - Release Date: December 16, 2020
 - Server Versions Supported: Server v5.25+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2656,9 +2568,11 @@ Mattermost Mobile App v1.40.0 contains a low level security fix. Upgrading is re
  - Android operating system 7+ [is required by Google](https://android-developers.googleblog.com/2017/12/improving-app-security-and-performance.html).
  - iPhone 5s devices and later with iOS 11+ is required.
  
-```{Note} 
+<Note>
+
 Support for landscape orientation was removed for non-tablet devices.
-```
+
+</Note>
 
 ### Improvements
  - Added gallery user interface improvements.
@@ -2685,8 +2599,7 @@ Support for landscape orientation was removed for non-tablet devices.
 
 ----
 
-(release-v1-37-0)=
-## 1.37.0 Release
+## 1.37.0 Release \{#release-v1-37-0}
 - Release Date: November 16, 2020
 - Server Versions Supported: Server v5.25+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2716,8 +2629,7 @@ Support for landscape orientation was removed for non-tablet devices.
 
 ----
 
-(release-v1-36-0)=
-## 1.36.0 Release
+## 1.36.0 Release \{#release-v1-36-0}
 - Release Date: October 16, 2020
 - Server Versions Supported: Server v5.25+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2753,8 +2665,7 @@ Support for landscape orientation was removed for non-tablet devices.
 
 ----
 
-(release-v1-35-1)=
-## 1.35.1 Release
+## 1.35.1 Release \{#release-v1-35-1}
 - Release Date: September 21, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2768,8 +2679,7 @@ Support for landscape orientation was removed for non-tablet devices.
 
 ----
 
-(release-v1-35-0)=
-## 1.35.0 Release
+## 1.35.0 Release \{#release-v1-35-0}
 - Release Date: September 16, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2811,8 +2721,7 @@ Support for landscape orientation was removed for non-tablet devices.
 
 ----
 
-(release-v1-34-1)=
-## 1.34.1 Release
+## 1.34.1 Release \{#release-v1-34-1}
 - Release Date: August 27, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2828,8 +2737,7 @@ Support for landscape orientation was removed for non-tablet devices.
 
 ----
 
-(release-v1-34-0)=
-## 1.34.0 Release
+## 1.34.0 Release \{#release-v1-34-0}
 - Release Date: August 16, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2870,8 +2778,7 @@ Support for landscape orientation was removed for non-tablet devices.
 
 ----
 
-(release-v1-33-1)=
-## 1.33.1 Release
+## 1.33.1 Release \{#release-v1-33-1}
 - Release Date: July 15, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2885,8 +2792,7 @@ Support for landscape orientation was removed for non-tablet devices.
 
 ----
 
-(release-v1-33-0)=
-## 1.33.0 Release
+## 1.33.0 Release \{#release-v1-33-0}
 - Release Date: July 16, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2898,9 +2804,11 @@ Support for landscape orientation was removed for non-tablet devices.
 ### Breaking Changes
  - Starting with mobile app v1.33.0, users on server versions below v5.19 may experience issues with how attachments, link previews, reactions and embed data are displayed. Updating your server to v5.19 or later is required.
  
-```{Note} 
+<Note>
+
 Mattermost Mobile App v1.33.0 contains a low level security fix. Upgrading is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
-```
+
+</Note>
  
 ### Highlights
  -  System admins will now receive an in-app notification to upgrade their server version if they are running versions v5.18 and below.
@@ -2939,8 +2847,7 @@ Mattermost Mobile App v1.33.0 contains a low level security fix. Upgrading is re
 
 ----
 
-(release-v1-32-2)=
-## 1.32.2 Release
+## 1.32.2 Release \{#release-v1-32-2}
 - Release Date: June 26, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2955,8 +2862,7 @@ Mattermost Mobile App v1.33.0 contains a low level security fix. Upgrading is re
 
 ----
 
-(release-v1-32-1)=
-## 1.32.1 Release
+## 1.32.1 Release \{#release-v1-32-1}
 - Release Date: June 25, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -2970,8 +2876,7 @@ Mattermost Mobile App v1.33.0 contains a low level security fix. Upgrading is re
 
 ----
 
-(release-v1-32-0)=
-## 1.32.0 Release
+## 1.32.0 Release \{#release-v1-32-0}
 - Release Date: June 16, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3020,8 +2925,7 @@ Mattermost Mobile App v1.33.0 contains a low level security fix. Upgrading is re
 
 ----
 
-(release-v1-31-2)=
-## 1.31.2 Release
+## 1.31.2 Release \{#release-v1-31-2}
 - Release Date: May 27, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3037,8 +2941,7 @@ Mattermost Mobile App v1.31.2 contains a high level security fix. [Upgrading](ht
 
 ----
 
-(release-v1-31-1)=
-## 1.31.1 Release
+## 1.31.1 Release \{#release-v1-31-1}
 - Release Date: May 22, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3052,8 +2955,7 @@ Mattermost Mobile App v1.31.2 contains a high level security fix. [Upgrading](ht
 
 ----
 
-(release-v1-31-0)=
-## 1.31.0 Release
+## 1.31.0 Release \{#release-v1-31-0}
 - Release Date: May 16, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3086,8 +2988,7 @@ Mattermost Mobile App v1.31.2 contains a high level security fix. [Upgrading](ht
 
 ----
 
-(release-v1-30-1)=
-## 1.30.1 Release
+## 1.30.1 Release \{#release-v1-30-1}
 - Release Date: April 24, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3113,8 +3014,7 @@ Mattermost Mobile App v1.31.2 contains a high level security fix. [Upgrading](ht
 
 ----
 
-(release-v1-30-0)=
-## 1.30.0 Release
+## 1.30.0 Release \{#release-v1-30-0}
 - Release Date: April 16, 2020
 - Server Versions Supported: Server v5.19+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3159,8 +3059,7 @@ Mattermost Mobile App v1.30.0 contains a high level security fix. [Upgrading](ht
 
 ----
 
-(release-v1-29-0)=
-## 1.29.0 Release
+## 1.29.0 Release \{#release-v1-29-0}
 - Release Date: March 16, 2020
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3199,8 +3098,7 @@ Mattermost Mobile App v1.30.0 contains a high level security fix. [Upgrading](ht
 
 ----
 
-(release-v1-28-0)=
-## 1.28.0 Release
+## 1.28.0 Release \{#release-v1-28-0}
 - Release Date: February 16, 2020
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3242,8 +3140,7 @@ Mattermost Mobile App v1.30.0 contains a high level security fix. [Upgrading](ht
 
 ----
 
-(release-v1-27-1)=
-## 1.27.1 Release
+## 1.27.1 Release \{#release-v1-27-1}
 - Release Date: January 21, 2020
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3257,8 +3154,7 @@ Mattermost Mobile App v1.30.0 contains a high level security fix. [Upgrading](ht
 
 ----
 
-(release-v1-27-0)=
-## 1.27.0 Release
+## 1.27.0 Release \{#release-v1-27-0}
 - Release Date: January 16, 2020
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3284,8 +3180,7 @@ Mattermost Mobile App v1.30.0 contains a high level security fix. [Upgrading](ht
 
 ----
 
-(release-v1-26-2)=
-## 1.26.2 Release
+## 1.26.2 Release \{#release-v1-26-2}
 - Release Date: January 7, 2020
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3298,8 +3193,7 @@ Mattermost Mobile App v1.30.0 contains a high level security fix. [Upgrading](ht
 
 ----
 
-(release-v1-26-1)=
-## 1.26.1 Release
+## 1.26.1 Release \{#release-v1-26-1}
 - Release Date: December 20, 2019
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3313,8 +3207,7 @@ Mattermost Mobile App v1.30.0 contains a high level security fix. [Upgrading](ht
 
 ----
 
-(release-v1-26-0)=
-## 1.26.0 Release
+## 1.26.0 Release \{#release-v1-26-0}
 - Release Date: December 16, 2019
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3369,8 +3262,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-25-1)=
-## 1.25.1 Release
+## 1.25.1 Release \{#release-v1-25-1}
 - Release Date: November 22, 2019
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3386,8 +3278,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-25-0)=
-## 1.25.0 Release
+## 1.25.0 Release \{#release-v1-25-0}
 - Release Date: November 16, 2019
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3421,8 +3312,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-24-0)=
-## 1.24.0 Release
+## 1.24.0 Release \{#release-v1-24-0}
 - Release Date: October 16, 2019
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3477,8 +3367,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-23-1)=
-## 1.23.1 Release
+## 1.23.1 Release \{#release-v1-23-1}
 - Release Date: September 27, 2019
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3491,8 +3380,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-23-0)=
-## 1.23.0 Release
+## 1.23.0 Release \{#release-v1-23-0}
 - Release Date: September 16, 2019
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3525,8 +3413,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-22-1)=
-## 1.22.1 Release
+## 1.22.1 Release \{#release-v1-22-1}
 - Release Date: August 23, 2019
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3542,8 +3429,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-22-0)=
-## 1.22.0 Release
+## 1.22.0 Release \{#release-v1-22-0}
 - Release Date: August 16, 2019
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3586,8 +3472,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-21-2)=
-## 1.21.2 Release
+## 1.21.2 Release \{#release-v1-21-2}
 - Release Date: August 1, 2019
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3600,8 +3485,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-21-1)=
-## 1.21.1 Release
+## 1.21.1 Release \{#release-v1-21-1}
 - Release Date: July 22, 2019
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3614,8 +3498,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-21-0)=
-## 1.21.0 Release
+## 1.21.0 Release \{#release-v1-21-0}
 - Release Date: July 16, 2019
 - Server Versions Supported: Server v5.9+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3646,8 +3529,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-20-2)=
-## 1.20.2 Release
+## 1.20.2 Release \{#release-v1-20-2}
 - Release Date: July 10, 2019
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3662,8 +3544,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-20-1)=
-## 1.20.1 Release
+## 1.20.1 Release \{#release-v1-20-1}
 - Release Date: June 21, 2019
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3678,8 +3559,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-20-0)=
-## 1.20.0 Release
+## 1.20.0 Release \{#release-v1-20-0}
 - Release Date: June 16, 2019
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3726,8 +3606,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
  
  ----
 
-(release-v1-19-0)=
-## 1.19.0 Release
+## 1.19.0 Release \{#release-v1-19-0}
 - Release Date: May 16, 2019
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3752,8 +3631,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-18-1)=
-## 1.18.1 Release
+## 1.18.1 Release \{#release-v1-18-1}
 - Release Date: April 18, 2019
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3768,8 +3646,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-18-0)=
-## 1.18.0 Release
+## 1.18.0 Release \{#release-v1-18-0}
 - Release Date: April 16, 2019
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3808,8 +3685,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-17-0)=
-## 1.17.0 Release
+## 1.17.0 Release \{#release-v1-17-0}
 - Release Date: March 20, 2019
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3839,8 +3715,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-16-1)=
-## 1.16.1 Release
+## 1.16.1 Release \{#release-v1-16-1}
 - Release Date: February 21, 2019
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3854,8 +3729,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-16-0)=
-## 1.16.0 Release
+## 1.16.0 Release \{#release-v1-16-0}
 - Release Date: February 16, 2019
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3884,8 +3758,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-15-2)=
-## 1.15.2 Release
+## 1.15.2 Release \{#release-v1-15-2}
 - Release Date: January 16, 2019
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3907,8 +3780,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-15-1)=
-## 1.15.1 Release
+## 1.15.1 Release \{#release-v1-15-1}
 - Release Date: December 28, 2018
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3922,8 +3794,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-15-0)=
-## 1.15.0 Release
+## 1.15.0 Release \{#release-v1-15-0}
 - Release Date: December 16, 2018
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3960,8 +3831,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-14-0)=
-## 1.14.0 Release
+## 1.14.0 Release \{#release-v1-14-0}
 - Release Date: November 16, 2018
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported unless the user installs the CA certificate on their device
 
@@ -3984,8 +3854,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-13-1)=
-## 1.13.1 Release
+## 1.13.1 Release \{#release-v1-13-1}
 - Release Date: October 18, 2018
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported
 
@@ -3996,8 +3865,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-13-0)=
-## v1.13.0 Release
+## v1.13.0 Release \{#release-v1-13-0}
 - Release Date: October 16, 2018
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4037,8 +3905,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-12-0)=
-## v1.12.0 Release
+## v1.12.0 Release \{#release-v1-12-0}
 - Release Date: September 16, 2018
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4064,8 +3931,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-11-0)=
-## v1.11.0 Release
+## v1.11.0 Release \{#release-v1-11-0}
 - Release Date: August 16, 2018
 - Server Versions Supported: Server v4.10+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4102,8 +3968,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-10-0)=
-## v1.10.0 Release
+## v1.10.0 Release \{#release-v1-10-0}
 - Release Date: July 16, 2018
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4146,8 +4011,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-9-3)=
-## 1.9.3 Release
+## 1.9.3 Release \{#release-v1-9-3}
 - Release Date: July 04, 2018
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4158,8 +4022,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-9-2)=
-## 1.9.2 Release
+## 1.9.2 Release \{#release-v1-9-2}
 - Release Date: June 27, 2018
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4177,8 +4040,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-9-1)=
-## 1.9.1 Release
+## 1.9.1 Release \{#release-v1-9-1}
 - Release Date: June 23, 2018
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4189,8 +4051,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-9-0)=
-## v1.9.0 Release
+## v1.9.0 Release \{#release-v1-9-0}
 - Release Date: June 16, 2018
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4229,8 +4090,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-8-0)=
-## v1.8.0 Release
+## v1.8.0 Release \{#release-v1-8-0}
 - Release Date: April 27, 2018
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4264,8 +4124,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-7-1)=
-## v1.7.1 Release
+## v1.7.1 Release \{#release-v1-7-1}
 - Release Date: April 3, 2018
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4275,8 +4134,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-7-0)=
-## v1.7.0 Release
+## v1.7.0 Release \{#release-v1-7-0}
 - Release Date: March 26, 2018
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4315,8 +4173,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-6-1)=
-## v1.6.1 Release
+## v1.6.1 Release \{#release-v1-6-1}
 - Release Date: February 13, 2018
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4327,8 +4184,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-6-0)=
-## v1.6.0 Release
+## v1.6.0 Release \{#release-v1-6-0}
 - Release Date: February 6, 2018
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4355,16 +4211,14 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-5-3)=
-## v1.5.3 Release
+## v1.5.3 Release \{#release-v1-5-3}
 - Release Date: February 1, 2018
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
 - Fixed a login issue when connecting to servers running a Data Retention policy 
 
 ----
 
-(release-v1-5-2)=
-## v1.5.2 Release
+## v1.5.2 Release \{#release-v1-5-2}
 - Release Date: January 12, 2018
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
 
@@ -4381,8 +4235,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-5-1)=
-## v1.5.1 Release
+## v1.5.1 Release \{#release-v1-5-1}
 
 - Release Date: December 7, 2017
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
@@ -4394,8 +4247,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-5)=
-## v1.5 Release 
+## v1.5 Release  \{#release-v1-5}
 
 - Release Date: December 6, 2017
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
@@ -4429,8 +4281,7 @@ Mattermost Mobile App v1.26.0 contains low to medium level security fixes. [Upgr
 
 ----
 
-(release-v1-4-1)=
-## v1.4.1 Release
+## v1.4.1 Release \{#release-v1-4-1}
 
 Release Date: Nov 15, 2017
 Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
@@ -4444,8 +4295,7 @@ Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificate
 
 ----
 
-(release-v1-4)=
-## v1.4 Release 
+## v1.4 Release  \{#release-v1-4}
 
 - Release Date: November 6, 2017
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
@@ -4461,8 +4311,7 @@ Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificate
 
 ----
 
-(release-v1-3)=
-## v1.3 Release 
+## v1.3 Release  \{#release-v1-3}
 
 - Release Date: October 5, 2017
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
@@ -4498,8 +4347,7 @@ Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificate
 
 ----
 
-(release-v1-2)=
-## v1.2 Release
+## v1.2 Release \{#release-v1-2}
 
 - Release Date: September 5, 2017 
 - Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificates are not supported
@@ -4528,8 +4376,7 @@ Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificate
 
 ----
 
-(release-v1-1)=
-## v1.1 Release
+## v1.1 Release \{#release-v1-1}
 
 - Release Date: August 2017 
 - Server Versions Supported: Server v3.10+ is required, Self-Signed SSL Certificates are not supported
@@ -4575,8 +4422,7 @@ Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificate
 
 ----
 
-(release-v1-0-1)=
-## v1.0.1 Release 
+## v1.0.1 Release  \{#release-v1-0-1}
 
 - Release Date: July 20, 2017 
 - Server Versions Supported: Server v3.8+ is required, Self-Signed SSL Certificates are not yet supported
@@ -4588,8 +4434,7 @@ Server Versions Supported: Server v4.0+ is required, Self-Signed SSL Certificate
 
 ----
 
-(release-v1-0)=
-## v1.0 Release 
+## v1.0 Release  \{#release-v1-0}
 
 - Release Date: July 10, 2017 
 - Server Versions Supported: Server v3.8+ is required, Self-Signed SSL Certificates are not supported
@@ -4633,8 +4478,7 @@ Many thanks to all our contributors. In alphabetical order:
 
 ----
 
-(mobile-beta-release)=
-## Beta Release
+## Beta Release \{#mobile-beta-release}
 
 - Release Date: March 29, 2017
 - Server Versions Supported: Server v3.7+ is required, Self-Signed SSL Certificates are not yet supported

--- a/docs/main/product-overview/release-policy.mdx
+++ b/docs/main/product-overview/release-policy.mdx
@@ -8,8 +8,7 @@ To ensure a secure, functional, performant, and efficient Mattermost deployment,
 - considering the use of [extended support releases](#extended-support-releases) for longer-term stability, and
 - keeping both server and client applications updated.
 
-(release-types)=
-## Release Types
+## Release Types \{#release-types}
 
 Mattermost releases include feature, extended support, and major releases. Each release has a specified life cycle start and end date, and life cycles depend on the release type. 
 
@@ -21,8 +20,7 @@ With multiple release types, you can plan the upgrade path that best suits your 
 
 See the full list of all Mattermost Server and desktop app releases and life cycles.
 
-(extended-support-releases)=
-## Extended Support Releases
+## Extended Support Releases \{#extended-support-releases}
 
 Mattermost Extended Support Releases (ESRs) are a strategic choice for organizations looking for stability and reduced frequency of updates. Using ESRs can minimize disruptions associated with frequent upgrades, making them an attractive option for environments where stability is paramount.
 
@@ -36,11 +34,13 @@ ESRs don’t include changes to product functionality or new features. ESRs are 
 
 To install extended support releases, follow our [install and upgrade](/administration-guide/upgrade/enterprise-install-upgrade) documentation. To restore a previous ESR, restore the database and previous version if you need to revert an upgrade. Previous ESR versions continue remain subject to a [life cycle end date](/product-overview/mattermost-server-releases).
 
-```{Important}
+<Important>
+
 - We strongly recommend reviewing [upgrade best practices](https://docs.mattermost.com/administration-guide/upgrade/prepare-to-upgrade-mattermost.html#upgrade-best-practices) for upgrading, and [important upgrade notes](/upgrade/important-upgrade-notes) for all the versions beyond the current ESR version you have currently installed. See the [Mattermost v9 changelog](https://docs.mattermost.com/product-overview/mattermost-v9-changelog.html) for a list of database, API, and `config.json` updates for all v9.x releases.
 - Your license key is decoupled from the Mattermost server version, so you can upgrade to the latest ESR using a legacy license.
 We highly recommend working with your Mattermost Account Team to plan for a migration to our new plans, and to access the latest features such as persistent notifications, advanced compliance features, call recordings, and more.
-```
+
+</Important>
 
 ```{mermaid}
 
@@ -67,8 +67,7 @@ The chart above shows both release dates and end-of-life dates for each version.
 - 🔵 **Blue bars**: Regular feature releases (monthly releases with standard support lifecycle)
 - 🔴 **Red bars**: Extended Support Releases (ESRs) - Released every 6-9 months with extended 9-12 month support
 
-(esr-notifications)=
-### ESR Notifications
+### ESR Notifications \{#esr-notifications}
 
 When an ESR is at the end of its life cycle, there will be announcements ahead of time to provide time for people to test, certify, and deploy a newer ESR version before support ends. After a release reaches its end-of-life, no further updates will be provided for that version. 
 
@@ -82,10 +81,12 @@ For deprecated ESRs, an email announcement is sent 3 months in advance. We also 
 
 The following table lists all releases across Mattermost v7.0, v8.0, and v9.0, including ESRs. See the [unsupported legacy releases](https://docs.mattermost.com/product-overview/unsupported-legacy-releases.html) documentation for comprehensive changelog details for these legacy releases.
 
-```{Important}
+<Important>
+
 - If you're on a legacy Mattermost release prior to v7.1, in order to take advantage of newer Mattermost releases, you must upgrade to [v7.1 ESR](https://docs.mattermost.com/product-overview/unsupported-legacy-releases.html#release-v7-1-extended-support-release) at a minimum.
 - Upgrading from one Extended Support Release (ESR) to the next ESR (``major`` -> ``major_next``) is fully supported and tested. However, upgrading across multiple ESR versions (``major`` to ``major+2``) is supported, but not tested. If you plan to skip versions, we strongly recommend upgrading only between ESR releases. For example, if you're upgrading from v8.1 ESR, upgrade to the v9.5 ESR or the v9.11 ESR before attempting to upgrade to the [v10.5 ESR](https://docs.mattermost.com/product-overview/mattermost-v10-changelog.html#release-v10-5-extended-support-release) or the [v10.11 ESR](https://docs.mattermost.com/product-overview/mattermost-v10-changelog.html#release-v10-11-extended-support-release).
-```
+
+</Important>
 
 | **Release** | **Release Type** | **Support ended** | 
 |:---|:---|:---|

--- a/docs/main/product-overview/unsupported-legacy-releases.mdx
+++ b/docs/main/product-overview/unsupported-legacy-releases.mdx
@@ -6,10 +6,12 @@ import Inc1_common_esr_support_upgrade from './common-esr-support-upgrade.mdx';
 
 This documentation contains comprehensive changelog details for all legacy Mattermost releases including v9.x, v8.x, and v7.x versions that have reached their end of support lifecycle.
 
-```{Important}
+<Important>
+
 <Inc0_common_esr_support_upgrade />
-(release-v9-11-extended-support-release)=
-## Release v9.11 - [Extended Support Release](https://docs.mattermost.com/about/release-policy.html#release-types)
+
+</Important>
+## Release v9.11 - [Extended Support Release](https://docs.mattermost.com/about/release-policy.html#release-types) \{#release-v9-11-extended-support-release}
 
 - **9.11.18, released 2025-07-22**
   - Mattermost v9.11.18 contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -110,7 +112,8 @@ This documentation contains comprehensive changelog details for all legacy Matte
  - Mattermost supports Elasticsearch v7.17+. However, we recommend upgrading your Elasticsearch v7 instance to v8.x. See the [Elasticsearch upgrade](https://www.elastic.co/guide/en/elasticsearch/reference/current/setup-upgrade.html) documentation for details.
  - When using Elasticsearch v8, ensure you set ``action.destructive_requires_name`` to ``false`` in ``elasticsearch.yml`` to allow for wildcard operations to work.
 
-```{Important}
+<Important>
+
 **AWS Elasticsearch**
 
 If you're using AWS Elasticsearch, you must:
@@ -119,15 +122,18 @@ If you're using AWS Elasticsearch, you must:
 3. Upgrade Mattermost server.
 4. Update the Mattermost `ElasticsearchSettings.Backend` configuration setting value from `elasticsearch` to `opensearch` manually or using [mmctl](https://docs.mattermost.com/manage/mmctl-command-line-tool.html#mmctl-config-set). This value cannot be changed using the System Console. See the Mattermost [Elasticsearch backend type](https://docs.mattermost.com/configure/environment-configuration-settings.html#elastic-backendtype) documentation for additional details.
 5. Restart the Mattermost server.
-```
+
+</Important>
 
 ### Compatibility
  - Updated minimum Edge and Chrome versions to 126+.
  - Added Ubuntu Noble support.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v9.5, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -216,8 +222,7 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Contributors
  - [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [amyblais](https://github.com/amyblais), [andreabia](https://translate.mattermost.com/user/andreabia), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [Aryakoste](https://github.com/Aryakoste), [asaadmahmood](https://github.com/asaadmahmood), [AshishDhama](https://github.com/AshishDhama), [ayusht2810](https://github.com/ayusht2810), [bbodenmiller](https://github.com/bbodenmiller), [BenCookie95](https://github.com/BenCookie95), [BrandonS09](https://github.com/BrandonS09), [calebroseland](https://github.com/calebroseland), [Camillarhi](https://github.com/Camillarhi), [catalintomai](https://github.com/catalintomai), [Celeo](https://github.com/Celeo), [chessmadridista](https://github.com/chessmadridista), [ckaznable](https://github.com/ckaznable), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [danielsischy](https://github.com/danielsischy), [devinbinnie](https://github.com/devinbinnie), [Eleferen](https://translate.mattermost.com/user/Eleferen), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [ewwollesen](https://github.com/ewwollesen), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [gabrieljackson](https://github.com/gabrieljackson), [Gesare5](https://github.com/Gesare5), [grinapo](https://github.com/grinapo), [hanzei](https://github.com/hanzei), [harmeet01singh](https://github.com/harmeet01singh), [harshilsharma63](https://github.com/harshilsharma63), [hmhealey](https://github.com/hmhealey), [ifoukarakis](https://github.com/ifoukarakis), [imanmagomedov.said](https://translate.mattermost.com/user/imanmagomedov.said), [isacikgoz](https://github.com/isacikgoz), [jespino](https://github.com/jespino), [jprusch](https://github.com/jprusch), [JulienTant](https://github.com/JulienTant), [jwilander](https://github.com/jwilander), [kaakaa](https://translate.mattermost.com/user/kaakaa), [kalil0321](https://github.com/kalil0321), [KellieSue](https://github.com/KellieSue), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [marianunez](https://github.com/marianunez), [master7](https://translate.mattermost.com/user/master7), [matt-w99](https://github.com/matt-w99), [matthewbirtch](https://github.com/matthewbirtch), [matthew-w](https://translate.mattermost.com/user/matthew-w), [MeHow25](https://github.com/MeHow25), [mgdelacroix](https://github.com/mgdelacroix), [mickmister](https://github.com/mickmister), [milotype](https://translate.mattermost.com/user/milotype), [Mohamed-sobhi95](https://translate.mattermost.com/user/Mohamed-sobhi95), [mvitale1989](https://github.com/mvitale1989), [natalie-hub](https://github.com/natalie-hub), [nickmisasi](https://github.com/nickmisasi), [ningthoujamSwamikumar](https://github.com/ningthoujamSwamikumar), [Pawel1894](https://github.com/Pawel1894), [phoinixgrr](https://github.com/phoinixgrr), [poppfredslund](https://translate.mattermost.com/user/poppfredslund), [pvev](https://github.com/pvev), [raghavaggarwal2308](https://github.com/raghavaggarwal2308), [rahimrahman](https://github.com/rahimrahman), [Rajat-Dabade](https://github.com/Rajat-Dabade), [recontech404](https://github.com/recontech404), [rOt779kVceSgL](https://translate.mattermost.com/user/rOt779kVceSgL), [sadohert](https://github.com/sadohert), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [shaon72](https://github.com/shaon72), [Sharuru](https://translate.mattermost.com/user/Sharuru), [shieldsjared](https://github.com/shieldsjared), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [suraj-anthwal](https://github.com/suraj-anthwal), [svelle](https://github.com/svelle), [ThrRip](https://translate.mattermost.com/user/ThrRip), [tnir](https://github.com/tnir), [toninis](https://github.com/toninis), [varghesejose2020](https://github.com/varghesejose2020), [vhaska](https://translate.mattermost.com/user/vhaska), [wiersgallak](https://github.com/wiersgallak), [wiggin77](https://github.com/wiggin77), [yasserfaraazkhan](https://github.com/yasserfaraazkhan), [yomiadetutu1](https://github.com/yomiadetutu1), [ythosa](https://github.com/ythosa), [zenocode-org](https://translate.mattermost.com/user/zenocode-org), [ZubairImtiaz3](https://github.com/ZubairImtiaz3)
 
-(release-v9-10-feature-release)=
-## Release v9.10 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release)
+## Release v9.10 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release) \{#release-v9-10-feature-release}
 
 - **9.10.3, released 2024-09-26**
   - Mattermost v9.10.3 contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -235,9 +240,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
 - **9.10.0, released 2024-07-16**
   - Original 9.10.0 release.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v9.5, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -299,8 +306,7 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Contributors
  - [abhijit-singh](https://github.com/abhijit-singh), [aeomin](https://translate.mattermost.com/user/aeomin), [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [ahmadJT](https://github.com/ahmadJT), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [apshada](https://github.com/apshada), [Aryakoste](https://github.com/Aryakoste), [asaadmahmood](https://github.com/asaadmahmood), [AshishDhama](https://github.com/AshishDhama), [BenCookie95](https://github.com/BenCookie95), [BillAnderson304](https://github.com/BillAnderson304), [Boruus](https://translate.mattermost.com/user/Boruus), [BrandonS09](https://github.com/BrandonS09), [bruno-keiko](https://github.com/bruno-keiko), [calebroseland](https://github.com/calebroseland), [Camillarhi](https://github.com/Camillarhi), [catalintomai](https://github.com/catalintomai), [chessmadridista](https://github.com/chessmadridista), [ckaznable](https://github.com/ckaznable), [coltoneshaw](https://github.com/coltoneshaw), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [devinbinnie](https://github.com/devinbinnie), [DHaussermann](https://github.com/DHaussermann), [DSchalla](https://github.com/DSchalla), [Eleferen](https://translate.mattermost.com/user/Eleferen), [emdecr](https://github.com/emdecr), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [esarafianou](https://github.com/esarafianou), [EyeCantCU](https://github.com/EyeCantCU), [ezekielchow](https://github.com/ezekielchow), [fmartingr](https://github.com/fmartingr), [frankps](https://translate.mattermost.com/user/frankps), [gabrieljackson](https://github.com/gabrieljackson), [Gesare5](https://github.com/Gesare5), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [hmhealey](https://github.com/hmhealey), [homerCOD](https://translate.mattermost.com/user/homerCOD), [ifoukarakis](https://github.com/ifoukarakis), [isacikgoz](https://github.com/isacikgoz), [jasonblais](https://github.com/jasonblais), [jespino](https://github.com/jespino), [johnsonbrothers](https://github.com/johnsonbrothers), [jprusch](https://github.com/jprusch), [JtheBAB](https://github.com/JtheBAB), [JulienTant](https://github.com/JulienTant), [kaakaa](https://github.com/kaakaa), [kayazeren](https://github.com/kayazeren), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [lindalumitchell](https://github.com/lindalumitchell), [lynn915](https://github.com/lynn915), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [marianunez](https://github.com/marianunez), [maruTA-bis5](https://translate.mattermost.com/user/maruTA-bis5), [master7](https://translate.mattermost.com/user/master7), [matt-w99](https://github.com/matt-w99), [matthew-w](https://translate.mattermost.com/user/matthew-w), [matthewbirtch](https://github.com/matthewbirtch), [MattSilvaa](https://github.com/MattSilvaa), [mgdelacroix](https://github.com/mgdelacroix), [mickmister](https://github.com/mickmister), [mojahani](https://translate.mattermost.com/user/mojahani), [mvitale1989](https://github.com/mvitale1989), [nbruneau71250](https://github.com/nbruneau71250), [nickmisasi](https://github.com/nickmisasi), [phoinixgrr](https://github.com/phoinixgrr), [pvev](https://github.com/pvev), [raghavaggarwal2308](https://github.com/raghavaggarwal2308), [Rajat-Dabade](https://github.com/Rajat-Dabade), [sadohert](https://github.com/sadohert), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [sri-byte](https://github.com/sri-byte), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [ThrRip](https://github.com/ThrRip), [tnir](https://github.com/tnir), [toninis](https://github.com/toninis), [varghesejose2020](https://github.com/varghesejose2020), [wiggin77](https://github.com/wiggin77), [willypuzzle](https://github.com/willypuzzle), [yasserfaraazkhan](https://github.com/yasserfaraazkhan), [yomiadetutu1](https://github.com/yomiadetutu1), [zenocode-org](https://github.com/zenocode-org)
 
-(release-v9-9-feature-release)=
-## Release v9.9 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release)
+## Release v9.9 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release) \{#release-v9-9-feature-release}
 
 - **9.9.3, released 2024-08-27**
   - Mattermost v9.9.3 contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -323,9 +329,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Compatibility
  - Updated minimum macOS version to 12+ and minimum Safari version to 17+.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v9.5, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -419,8 +427,7 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Contributors
  - [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [arush-vashishtha](https://github.com/arush-vashishtha), [asaadmahmood](https://github.com/asaadmahmood), [ayusht2810](https://github.com/ayusht2810), [azigler](https://github.com/azigler), [BenCookie95](https://github.com/BenCookie95), [bndn](https://translate.mattermost.com/user/bndn), [calebroseland](https://github.com/calebroseland), [coltoneshaw](https://github.com/coltoneshaw), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [devinbinnie](https://github.com/devinbinnie), [DHaussermann](https://github.com/DHaussermann), [Eleferen](https://translate.mattermost.com/user/Eleferen), [emdecr](https://github.com/emdecr), [enahum](https://github.com/enahum), [enzowritescode](https://github.com/enzowritescode), [fasal26](https://github.com/fasal26), [fmartingr](https://github.com/fmartingr), [gabrieljackson](https://github.com/gabrieljackson), [grundleborg](https://github.com/grundleborg), [hanzei](https://github.com/hanzei), [harshilsharma63](https://github.com/harshilsharma63), [hmhealey](https://github.com/hmhealey), [ifoukarakis](https://github.com/ifoukarakis), [isacikgoz](https://github.com/isacikgoz), [jespino](https://github.com/jespino), [joakim.rivera](https://translate.mattermost.com/user/joakim.rivera), [johnsonbrothers](https://github.com/johnsonbrothers), [jprusch](https://github.com/jprusch), [JulienTant](https://github.com/JulienTant), [kaakaa](https://github.com/kaakaa), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [majo](https://translate.mattermost.com/user/majo), [marianunez](https://github.com/marianunez), [marlenekoh](https://github.com/marlenekoh), [master7](https://translate.mattermost.com/user/master7), [matt-w99](https://github.com/matt-w99), [matthew-w](https://translate.mattermost.com/user/matthew-w), [matthewbirtch](https://github.com/matthewbirtch), [MeHow25](https://github.com/MeHow25), [mgdelacroix](https://github.com/mgdelacroix), [mickmister](https://github.com/mickmister), [mojahani](https://translate.mattermost.com/user/mojahani), [morgancz](https://github.com/morgancz), [mvitale1989](https://github.com/mvitale1989), [nickmisasi](https://github.com/nickmisasi), [nixusUM](https://github.com/nixusUM), [orimaimon](https://github.com/orimaimon), [phoinixgrr](https://github.com/phoinixgrr), [piotr-lasota](https://github.com/piotr-lasota), [pjenicot](https://translate.mattermost.com/user/pjenicot), [pmokeev](https://github.com/pmokeev), [rOt779kVceSgL](https://translate.mattermost.com/user/rOt779kVceSgL), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [spirosoik](https://github.com/spirosoik), [sri-byte](https://github.com/sri-byte), [stafot](https://github.com/stafot), [streamer45](https://github.com/streamer45), [stylianosrigas](https://github.com/stylianosrigas), [svelle](https://github.com/svelle), [tarrow](https://github.com/tarrow), [ThrRip](https://github.com/ThrRip), [tnir](https://github.com/tnir), [toninis](https://github.com/toninis), [umrkhn](https://github.com/umrkhn), [varghesejose2020](https://github.com/varghesejose2020), [vish9812](https://github.com/vish9812), [wiggin77](https://github.com/wiggin77), [yasserfaraazkhan](https://github.com/yasserfaraazkhan), [yomiadetutu1](https://github.com/yomiadetutu1), [zsrv](https://github.com/zsrv)
 
-(release-v9-8-feature-release)=
-## Release v9.8 - Feature Release
+## Release v9.8 - Feature Release \{#release-v9-8-feature-release}
 
 - **9.8.3, released 2024-07-22**
   - Mattermost v9.8.3 contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -440,9 +447,11 @@ New setting options were added to ``config.json``. Below is a list of the additi
 ### Compatibility
  - Updated minimum required Edge and Chrome versions to 122+.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v9.7, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -541,8 +550,7 @@ New setting option were added to ``config.json``. Below is a list of the additio
 
 ----
 
-(release-v9-7-feature-release)=
-## Release v9.7 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release)
+## Release v9.7 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release) \{#release-v9-7-feature-release}
 
 - **9.7.6, released 2024-07-02**
   - Mattermost v9.7.6 contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -570,9 +578,11 @@ New setting option were added to ``config.json``. Below is a list of the additio
 - **9.7.0, released 2024-04-16**
   - Original 9.7.0 release.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v9.6, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -647,8 +657,7 @@ A new setting option was added to ``config.json``. Below is a list of the additi
 
 ----
 
-(release-v9-6-feature-release)=
-## Release v9.6 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release)
+## Release v9.6 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release) \{#release-v9-6-feature-release}
 
 - **9.6.3, released 2024-06-03**
   - Mattermost v9.6.3 contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -669,9 +678,11 @@ A new setting option was added to ``config.json``. Below is a list of the additi
 ### Compatibility
  - Updated minimum required Edge and Chrome versions to 120+.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v9.5, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -735,8 +746,7 @@ See [this walkthrough video](https://mattermost.com/video/changelog-v9-6/) on so
 
 ----
 
-(release-v9-5-extended-support-release)=
-## Release v9.5 - [Extended Support Release](https://docs.mattermost.com/upgrade/release-definitions.html#extended-support-release-esr)
+## Release v9.5 - [Extended Support Release](https://docs.mattermost.com/upgrade/release-definitions.html#extended-support-release-esr) \{#release-v9-5-extended-support-release}
 
 - **9.5.14, released 2025-05-09**
   - Upgraded logr dependency to v2.0.22 for multiple improvements and bug fixes.
@@ -804,9 +814,11 @@ See [this walkthrough video](https://mattermost.com/video/changelog-v9-6/) on so
 ### Important Upgrade Notes
  - We have stopped supporting MySQL v5.7 since it's at the end of life. We urge customers to upgrade their MySQL instance at their earliest convenience.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v9.4, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -904,8 +916,7 @@ See [this walkthrough video](https://www.youtube.com/watch?v=b1M2BGGF578&feature
 
 ----
 
-(release-v9-4-feature-release)=
-## Release v9.4 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release)
+## Release v9.4 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release) \{#release-v9-4-feature-release}
 
 - **9.4.5, released 2024-03-26**
   - Mattermost v9.4.5 contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -929,9 +940,11 @@ See [this walkthrough video](https://www.youtube.com/watch?v=b1M2BGGF578&feature
 ### Important Upgrade Notes
  - MySQL v5.7 is at end of life. We recommend all customers to upgrade to at least 8.x. For now, we are logging a warning. From Mattermost v9.5, which is the next Extended Support Release, we will stop supporting MySQL v5.7 altogether.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v9.3, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Compatibility
  - Updated the minimum required Edge version to v118+.
@@ -1001,8 +1014,7 @@ See [this walkthrough video](https://www.youtube.com/watch?v=bEMp4vYLi6c&feature
 
 ----
 
-(release-v9-3-feature-release)=
-## Release v9.3 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release)
+## Release v9.3 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release) \{#release-v9-3-feature-release}
 
 - **9.3.3, released 2024-03-06**
   - Mattermost v9.3.3 contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -1117,8 +1129,7 @@ See [this walkthrough video](https://www.youtube.com/watch?v=eXA8emM97Bo) on som
 
 ----
 
-(release-v9-2-feature-release)=
-## Release v9.2 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release)
+## Release v9.2 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release) \{#release-v9-2-feature-release}
 
 - **9.2.6, released 2024-02-14**
     - Mattermost v9.2.6 contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -1147,9 +1158,11 @@ See [this walkthrough video](https://www.youtube.com/watch?v=eXA8emM97Bo) on som
 ### Important Upgrade Notes
  - Fixed data retention policies to run jobs when any custom retention policy is enabled even when the global retention policy is set to **keep-forever**. Before this fix, the enabled custom data retention policies wouldn’t run as long as the global data retention policy was set to **keep-forever** or was disabled. After the fix, the custom data retention policies will run automatically even when the global data retention policy is set to **keep-forever**. Once the server is upgraded, posts may unintentionally be deleted. Admins should make sure to disable all custom data retention policies before upgrading, and then re-enable them again after upgrading.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v9.1, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Compatibility
  - Updated minimum required Edge version to 116+.
@@ -1213,8 +1226,7 @@ See [this walkthrough video](https://www.youtube.com/watch?v=udC2OCTGooc&feature
 
 ----
 
-(release-v9-1-feature-release)=
-## Release v9.1 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release)
+## Release v9.1 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release) \{#release-v9-1-feature-release}
 
 - **9.1.5, released 2024-01-09**
   - Mattermost v9.1.5 contains medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -1245,9 +1257,11 @@ See [this walkthrough video](https://www.youtube.com/watch?v=udC2OCTGooc&feature
  - Improved performance on data retention ``DeleteOrphanedRows`` queries. See the [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html) for notes on a new migration that was added. Removed feature flag ``DataRetentionConcurrencyEnabled``. Data retention now runs without concurrency in order to avoid any performance degradation. Added a new configuration setting ``DataRetentionSettings.RetentionIdsBatchSize``, which allows admins to to configure how many batches of IDs will be fetched at a time when deleting orphaned reactions. The default value is 100.
  - Minimum supported Desktop App version is now v5.3. OAuth/SAML flows were modified to include ``desktop_login`` which makes earlier versions incompatible.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v9.0, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Compatibility
  - Updated Chromium minimum supported version to 116+.
@@ -1345,8 +1359,7 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 ----
 
-(release-v9-0-major-release)=
-## Release v9.0 - [Major Release](https://docs.mattermost.com/upgrade/release-definitions.html#major-release)
+## Release v9.0 - [Major Release](https://docs.mattermost.com/upgrade/release-definitions.html#major-release) \{#release-v9-0-major-release}
 
 - **9.0.5, released 2023-11-29**
   - Mattermost v9.0.5 contains medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -1377,9 +1390,11 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
  - Mattermost Boards and various other plugins have transitioned to being fully community supported. See this [forum post](https://forum.mattermost.com/t/upcoming-product-changes-to-boards-and-various-plugins/16669) for more details.
  - The ``channel_viewed`` websocket event was changed to ``multiple_channels_viewed``, and is now only triggered for channels that actually have unread messages.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v8.1, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -1466,11 +1481,13 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 ### Contributors
  - [abdulsmapara](https://github.com/abdulsmapara), [agarciamontoro](https://github.com/agarciamontoro), [agnivade](https://github.com/agnivade), [akaravashkin](https://github.com/akaravashkin), [amyblais](https://github.com/amyblais), [andrleite](https://github.com/andrleite), [angeloskyratzakos](https://github.com/angeloskyratzakos), [apollo13](https://github.com/apollo13), [aqurilla](https://github.com/aqurilla), [ayusht2810](https://github.com/ayusht2810), [azigler](https://github.com/azigler), [bbodenmiller](https://github.com/bbodenmiller), [BenCookie95](https://github.com/BenCookie95), [Benjamin-Loison](https://github.com/Benjamin-Loison), [calebroseland](https://github.com/calebroseland), [cdmwebs](https://github.com/cdmwebs), [chumano](https://github.com/chumano), [CI-YU](https://github.com/CI-YU), [Coelho](https://translate.mattermost.com/user/Coelho), [cpoile](https://github.com/cpoile), [crspeller](https://github.com/crspeller), [ctlaltdieliet](https://translate.mattermost.com/user/ctlaltdieliet), [cwarnermm](https://github.com/cwarnermm), [danielsischy](https://github.com/danielsischy), [deivisonrpg](https://github.com/deivisonrpg), [devinbinnie](https://github.com/devinbinnie), [djanda97](https://github.com/djanda97), [douglasstasiak](https://github.com/douglasstasiak), [Eleferen](https://translate.mattermost.com/user/Eleferen), [enahum](https://github.com/enahum), [esarafianou](https://github.com/esarafianou), [esethna](https://github.com/esethna), [gabrieljackson](https://github.com/gabrieljackson), [gary-sixgen](https://github.com/gary-sixgen), [Gobbit69](https://translate.mattermost.com/user/Gobbit69), [grubbins](https://github.com/grubbins), [guneshsji](https://github.com/guneshsji), [hannaparks](https://github.com/hannaparks), [hanzei](https://github.com/hanzei), [harshal2030](https://github.com/harshal2030), [harshilsharma63](https://github.com/harshilsharma63), [hmhealey](https://github.com/hmhealey), [hpkhanh1610](https://github.com/hpkhanh1610), [ifoukarakis](https://github.com/ifoukarakis), [isacikgoz](https://github.com/isacikgoz), [it33](https://github.com/it33), [ivakorin](https://github.com/ivakorin), [jasonblais](https://github.com/jasonblais), [jespino](https://github.com/jespino), [johndavidlugtu](https://github.com/johndavidlugtu), [johnsonbrothers](https://github.com/johnsonbrothers), [jprusch](https://github.com/jprusch), [JulienTant](https://github.com/JulienTant), [kaakaa](https://github.com/kaakaa), [kayazeren](https://github.com/kayazeren), [Kshitij-Katiyar](https://github.com/Kshitij-Katiyar), [kyeongsoosoo](https://github.com/kyeongsoosoo), [larkox](https://github.com/larkox), [lieut-data](https://github.com/lieut-data), [LimJiAn](https://github.com/LimJiAn), [lindalumitchell](https://github.com/lindalumitchell), [lindy65](https://github.com/lindy65), [lynn915](https://github.com/lynn915), [M-ZubairAhmed](https://github.com/M-ZubairAhmed), [mahmoudfarouq](https://github.com/mahmoudfarouq), [majo](https://translate.mattermost.com/user/majo), [manojmalik20](https://github.com/manojmalik20), [marianunez](https://github.com/marianunez), [maruTA-bis5](https://translate.mattermost.com/user/maruTA-bis5), [master7](https://translate.mattermost.com/user/master7), [matt-w99](https://github.com/matt-w99), [matthew-w](https://translate.mattermost.com/user/matthew-w), [matthewbirtch](https://github.com/matthewbirtch), [MatthewDorner](https://github.com/MatthewDorner), [mgdelacroix](https://github.com/mgdelacroix), [mickmister](https://github.com/mickmister), [milotype](https://translate.mattermost.com/user/milotype), [mvitale1989](https://github.com/mvitale1989), [nickmisasi](https://github.com/nickmisasi), [panoramix360](https://github.com/panoramix360), [Partizann](https://github.com/Partizann), [penghao_chn](https://translate.mattermost.com/user/penghao_chn), [phoinixgrr](https://github.com/phoinixgrr), [pjenicot](https://translate.mattermost.com/user/pjenicot), [pvev](https://github.com/pvev), [raghavaggarwal2308](https://github.com/raghavaggarwal2308), [RichardScottOZ](https://github.com/RichardScottOZ), [robinsdm](https://github.com/robinsdm), [saturninoabril](https://github.com/saturninoabril), [sbishel](https://github.com/sbishel), [Sharuru](https://github.com/Sharuru), [ShrootBuck](https://github.com/ShrootBuck), [sinansonmez](https://github.com/sinansonmez), [sri-byte](https://github.com/sri-byte), [stafot](https://github.com/stafot), [StreakInTheSky](https://github.com/StreakInTheSky), [streamer45](https://github.com/streamer45), [stylianosrigas](https://github.com/stylianosrigas), [svelle](https://github.com/svelle), [tasawar-hussain](https://github.com/tasawar-hussain), [TealWater](https://github.com/TealWater), [thinkGeist](https://github.com/thinkGeist), [ThrRip](https://translate.mattermost.com/user/ThrRip), [timmycheng](https://translate.mattermost.com/user/timmycheng), [toninis](https://github.com/toninis), [tschuyebuhl](https://github.com/tschuyebuhl), [wiggin77](https://github.com/wiggin77), [Willyfrog](https://github.com/Willyfrog), [y4aniv](https://translate.mattermost.com/user/y4aniv), [yash2189](https://github.com/yash2189), [yasserfaraazkhan](https://github.com/yasserfaraazkhan), [yomiadetutu1](https://github.com/yomiadetutu1), [ZubairImtiaz3](https://github.com/ZubairImtiaz3)
 
-(release-v8-1-extended-support-release)=
-## Release v8.1 - [Extended Support Release](https://docs.mattermost.com/upgrade/release-definitions.html#extended-support-release-esr)
+## Release v8.1 - [Extended Support Release](https://docs.mattermost.com/upgrade/release-definitions.html#extended-support-release-esr) \{#release-v8-1-extended-support-release}
 
-```{Important}
+<Important>
+
 <Inc1_common_esr_support_upgrade />
+
+</Important>
 - **8.1.13, released 2024-04-25**
   - Mattermost v8.1.13 contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
   - Mattermost v8.1.13 contains no database or functional changes.
@@ -1620,12 +1637,13 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 ----
 
-(release-v8-0-major-release)=
-## Release v8.0 - [Major Release](https://docs.mattermost.com/upgrade/release-definitions.html#major-release)
+## Release v8.0 - [Major Release](https://docs.mattermost.com/upgrade/release-definitions.html#major-release) \{#release-v8-0-major-release}
 
-```{Important}
+<Important>
+
 Support for Mattermost Server v8.0 [Major Release](https://docs.mattermost.com/about/release-policy.html#release-types) has come to the end of its life cycle on October 15, 2023. [Upgrading Mattermost Server](https://docs.mattermost.com/about/mattermost-server-releases.html#latest-releases) is required.
-```
+
+</Important>
 
 - **8.0.4, released 2023-10-06**
   - Mattermost v8.0.4 contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -1681,9 +1699,11 @@ Support for Mattermost Server v8.0 [Major Release](https://docs.mattermost.com/a
    - On a PostgreSQL 12.14 DB with 1731 rows in FileInfo and 11M posts, it took around 0.27s
    - On a MySQL 8.0.31 DB with 1405 rows in FileInfo and 11M posts, it took around 0.3s
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v7.10, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -1850,8 +1870,7 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
   - The Mattermost v7.11 release has been canceled as we are working on architectural changes for the Mattermost platform. The next scheduled release is v8.0 this summer.
 
-(release-v7-10-feature-release)=
-## Release v7.10 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release)
+## Release v7.10 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release) \{#release-v7-10-feature-release}
 
 - **v7.10.5, released 2023-07-26**
   - Mattermost v7.10.5 contains medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -1887,9 +1906,11 @@ Mattermost v7.10.0 contains low to medium severity level security fixes. [Upgrad
 
  - In the next release, v7.11, the following repositories will be merged into one: ``mattermost-server``, ``mattermost-webapp``, ``focalboard`` and ``mattermost-plugin-playbooks``. Developers should read the updated [Developer Guide](https://developers.mattermost.com/contribute/developer-setup/) for details. **Playbooks and Boards will be core parts of the product that cannot be disabled**.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v7.9, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
 
@@ -1962,8 +1983,7 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 ----
 
-(release-v7-9-feature-release)=
-## Release v7.9 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release)
+## Release v7.9 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release) \{#release-v7-9-feature-release}
 
 - **v7.9.6, released 2023-07-12**
   - Mattermost v7.9.6 contains medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -2002,9 +2022,11 @@ Mattermost v7.9.0 contains a low severity level security fix. [Upgrading](https:
 - In PostgreSQL databases, the ``Posts`` table will be locked during index creation. To avoid locking this table, admins can create the index manually before performing the upgrade using the following non-blocking query: ``CREATE INDEX CONCURRENTLY idx_posts_original_id ON Posts(OriginalId);``. 
 - Admins managing PostgreSQL deployments containing fewer posts may prefer that the migration process creates the index, and accept that ``Posts`` table will remain locked until the migration is complete.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v7.8, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Compatibility
  - Updated Firefox minimum supported version to 102+.
@@ -2095,12 +2117,13 @@ If you upgrade from a release earlier than v7.8, please read the other [Importan
 
 ----
 
-(release-v7-8-extended-support-release)=
-## Release v7.8 - [Extended Support Release](https://docs.mattermost.com/upgrade/release-definitions.html#extended-support-release-esr)
+## Release v7.8 - [Extended Support Release](https://docs.mattermost.com/upgrade/release-definitions.html#extended-support-release-esr) \{#release-v7-8-extended-support-release}
 
-```{Important}
+<Important>
+
 Support for Mattermost Server v7.8 [Extended Support Release](https://docs.mattermost.com/about/release-policy.html#extended-support-releases) has come to the end of its life cycle on November 15, 2023. [Upgrading Mattermost Server](https://docs.mattermost.com/about/mattermost-server-releases.html#latest-releases) is required.
-```
+
+</Important>
 
 - **7.8.15 released 2023-11-13**
   - Mattermost v7.8.15 contains low to high severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -2183,9 +2206,11 @@ Mattermost v7.8.0 contains low to high severity level security fixes. [Upgrading
 
  - [Message Priority & Acknowledgement](https://docs.mattermost.com/configure/site-configuration-settings.html#message-priority) is now enabled by default for all instances. You may disable this feature in the System Console by going to **Posts > Message Priority** or via the config ``PostPriority`` setting.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v7.5, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -2306,8 +2331,7 @@ If you upgrade from a release earlier than v7.5, please read the other [Importan
 
 ----
 
-(release-v7-7-feature-release)=
-## Release v7.7 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release)
+## Release v7.7 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release) \{#release-v7-7-feature-release}
 
 - **v7.7.4, released 2023-04-12**
   - Mattermost v7.7.4 contains medium level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -2336,9 +2360,11 @@ Mattermost v7.7.0 contains low severity level security fixes. [Upgrading](https:
  - Denormalized ``Threads`` table by adding the ``ThreadTeamId`` column. See details for schema changes in the [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
  - Starting with the Calls version shipping with v7.7, there's now a minimum version requirement when using the external RTCD service. This means that if Calls is configured to use the external service, customers need to upgrade RTCD first to at least version 0.8.0 or the plugin will fail to start.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v7.5, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Compatibility
  - Updated the minimum version of MacOS to 11+.
@@ -2529,9 +2555,11 @@ Mattermost v7.5.0 contains a medium severity level security fix. [Upgrading](htt
  - Adds a new schema migration to ensure ``ParentId`` column is dropped from the ``Posts`` table. Depending on the table size, if the column is not dropped before, a significant spike in database CPU usage is expected on MySQL databases. Writes to the table will be limited during the migration.
  - For ``PluginRegistry.registerCustomRoute``, when you register a custom route component, you must specify a CSS ``grid-area`` in order for it to be placed properly into the root layout (recommended: ``grid-area: center``).
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v7.4, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Compatibility
  - Updated the minimum version of Chrome and Edge to v106+.
@@ -2648,8 +2676,7 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 ----
 
-(release-v7-4-feature-release)=
-## Release v7.4 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release)
+## Release v7.4 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release) \{#release-v7-4-feature-release}
 
 - **v7.4.1, released 2022-12-21**
   - Mattermost v7.4.1 contains low to medium severity level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -2751,9 +2778,11 @@ Mattermost v7.3.0 contains a medium severity level security fix. [Upgrading](htt
 ### Important Upgrade Notes
  - Boards is moving from a channel-based to a role-based permissions system. The migration will happen automatically, but your administrator should perform a backup prior to the upgrade. We removed workspaces, so if you were a member of many boards prior to migration, they will now all appear under the same sidebar. Please see [this document](https://docs.mattermost.com/welcome/whats-new-in-v72.html) for more details.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v7.2, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -2884,9 +2913,11 @@ Several schema changes impose additional database constraints to make the data m
 - ``ALTER TABLE Teams MODIFY COLUMN Type ENUM("I", "O");`` took 0.04 seconds
 - ``ALTER TABLE UploadSessions MODIFY COLUMN Type ENUM("attachment", "import");`` took 0.03 seconds
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v7.1, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -2981,9 +3012,11 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 ## Release v7.1 - [Extended Support Release](https://docs.mattermost.com/upgrade/release-definitions.html#extended-support-release-esr)
 
-```{Important}
+<Important>
+
 Support for Mattermost Server v7.1 [Extended Support Release](https://docs.mattermost.com/about/release-policy.html#extended-support-releases) has come to the end of its life cycle on May 15, 2023. [Upgrading Mattermost Server](https://docs.mattermost.com/about/mattermost-server-releases.html#latest-releases) is required.
-```
+
+</Important>
 
 - **v7.1.9, released 2023-04-27**
   - Mattermost v7.1.9 contains a medium severity level security fix. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -3039,9 +3072,11 @@ Mattermost v7.1.0 contains low severity level security fixes. [Upgrading](https:
       - ``UPDATE reactions SET channelid = COALESCE((select channelid from posts where posts.id = reactions.postid), '') WHERE channelid='';`` 
       - ``CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_reactions_channel_id on reactions (channelid);`` 
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v7.0, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -3129,9 +3164,11 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 ## Release v7.0 - [Major Release](https://docs.mattermost.com/upgrade/release-definitions.html#major-release)
 
-```{Important}
+<Important>
+
 Support for Mattermost Server v7.0 [Major Release](https://docs.mattermost.com/about/release-policy.html#release-types) has come to the end of its life cycle on September 15, 2022. [Upgrading Mattermost Server](https://docs.mattermost.com/about/mattermost-server-releases.html#latest-releases) is required.
-```
+
+</Important>
 
 - **v7.0.2, released 2022-08-23**
   - Mattermost v7.0.2 contains a medium severity level security fix. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -3156,9 +3193,11 @@ Mattermost v7.0.0 contains medium severity level security fixes. [Upgrading](htt
  - The value of ``ServiceSettings.TrustedProxyIPHeader`` defaults to empty from now on. A previous bug prevented this from happening in certain conditions. Customers are requested to check for these values in their config and set them to nil if necessary. See more details [here](https://docs.mattermost.com/configure/configuration-settings.html#trusted-proxy-ip-header).
  - Upgrading the Microsoft Teams Calling plugin to v2.0.0 requires users to reconnect their accounts.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v6.7, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -3255,8 +3294,7 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 ----
 
-(release-v6-7-feature-release)=
-## Release v6.7 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release)
+## Release v6.7 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html#feature-release) \{#release-v6-7-feature-release}
 
 - **v6.7.2, released 2022-06-15**
   - Fixed an issue with Compliance Exports where the zip file creation failed when adding attachments to a post [MM-40179](https://mattermost.atlassian.net/browse/MM-40179).
@@ -3281,9 +3319,11 @@ Mattermost v6.7.0 contains low severity level security fixes. [Upgrading](https:
     - For MySQL: `CREATE INDEX idx_posts_create_at_id on Posts(CreateAt, Id) LOCK=NONE;`
     - For Postgres: `CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_posts_create_at_id on posts(createat, id);`
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v6.6, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -3406,9 +3446,11 @@ Mattermost v6.6.0 contains a low severity level security fix. [Upgrading](https:
 ### Important Upgrade Notes
  - The Apps Framework protocol for binding/form submissions has changed, by separating the single `call` into separate `submit`, `form`, `refresh` and `lookup` calls. If any users have created their own Apps, they have to be updated to the new system.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v6.5, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
- ```
+
+</Important>
 
 ### Highlights
 
@@ -3549,9 +3591,11 @@ Mattermost v6.5.0 contains low to medium severity level security fixes. [Upgradi
 ### Important Upgrade Notes
  - The ``mattermost version`` CLI command does not interact with the database anymore. Therefore the database version is not going to be printed. Also, the database migrations are not going to be applied with the version sub command. [A new db migrate sub command](https://docs.mattermost.com/manage/command-line-tools.html#mattermost-db-migrate) is added to enable administrators to trigger migrations.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v6.4, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -3689,9 +3733,11 @@ Mattermost v6.4.0 contains low severity level security fixes. [Upgrading](https:
  - It has been commonly observed on MySQL 8+ systems to have an error ``Error 1267: Illegal mix of collations`` when upgrading due to changing the default collation. This is caused by the database and the tables having different collations. If you get this error, please change the collations to have the same value with, for example, ``ALTER DATABASE <db_name> COLLATE = '&lt;collation&gt;'``.
  - The new migration system requires the MySQL database user to have additional *EXECUTE*, *CREATE ROUTINE*, *ALTER ROUTINE* and *REFERENCES* privileges to run schema migrations.                   
 
-```{Important} 
+<Important>
+
 If you upgrade from a release earlier than v6.3, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -3927,9 +3973,11 @@ IMPORTANT: If you upgrade from a release earlier than v6.2, please read the othe
  -  Channel results in the channel autocomplete will include private channels. Customers using [Bleve](https://docs.mattermost.com/configure/bleve-search.html) or [Elasticsearch](https://docs.mattermost.com/scale/elasticsearch.html) for autocomplete will have to reindex their data to get the new results. Since this can take a long time, we suggest disabling autocomplete and running indexing in the background. When this is complete, re-enable autocomplete. Note that only channel members will see private channel names in autocomplete results.
  -  [Collapsed Reply Threads](https://docs.mattermost.com/messaging/organizing-conversations.html), available in beta, are known to have a negative impact on server performance. If you cannot easily scale up and tune your database, or if you are running the Mattermost application server and database server on the same machine, we recommended disabling [``ThreadAutoFollow``](https://docs.mattermost.com/configure/configuration-settings.html#automatically-follow-threads) and [``CollapsedThreads``](https://docs.mattermost.com/configure/configuration-settings.html#collapsed-reply-threads-beta) until Collapsed Reply Threads is promoted to general availability in Q2 2022. Learn more about these [performance considerations here](https://support.mattermost.com/hc/en-us/articles/4413183568276-What-to-expect-when-enabling-Collapsed-Reply-Threads-Beta).
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v6.1, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -4061,9 +4109,11 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
    - For MySQL: ``create index idx_jobs_status_type on Jobs (Status,Type);``
  - [Collapsed Reply Threads](https://docs.mattermost.com/messaging/organizing-conversations.html), available in beta, are known to have a negative impact on server performance. If you cannot easily scale up and tune your database, or if you are running the Mattermost application server and database server on the same machine, we recommended disabling [``ThreadAutoFollow``](https://docs.mattermost.com/configure/configuration-settings.html#automatically-follow-threads) and [``CollapsedThreads``](https://docs.mattermost.com/configure/configuration-settings.html#collapsed-reply-threads-beta) until Collapsed Reply Threads is promoted to general availability in Q2 2022. Learn more about these [performance considerations here](https://support.mattermost.com/hc/en-us/articles/4413183568276-What-to-expect-when-enabling-Collapsed-Reply-Threads-Beta).
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v6.0, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -4195,8 +4245,7 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 
 ----
 
-(release-v6-0-feature-release)=
-## Release v6.0 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html)
+## Release v6.0 - [Feature Release](https://docs.mattermost.com/upgrade/release-definitions.html) \{#release-v6-0-feature-release}
 
 - **v6.0.4, released 2021-12-17**
   - Mattermost v6.0.4 contains medium level security fixes. [Upgrading](https://docs.mattermost.com/upgrade/upgrading-mattermost-server.html) to this release is recommended. Details will be posted on our [security updates page](https://mattermost.com/security-updates/) 30 days after release as per the [Mattermost Responsible Disclosure Policy](https://mattermost.com/security-vulnerability-report/).
@@ -4274,9 +4323,11 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
    - Converted the "Executables" field in the plugin manifest to a map.
  -  [Collapsed Reply Threads](https://docs.mattermost.com/messaging/organizing-conversations.html), available in beta, are known to have a negative impact on server performance. If you cannot easily scale up and tune your database, or if you are running the Mattermost application server and database server on the same machine, we recommended disabling [``ThreadAutoFollow``](https://docs.mattermost.com/configure/configuration-settings.html#automatically-follow-threads) and [``CollapsedThreads``](https://docs.mattermost.com/configure/configuration-settings.html#collapsed-reply-threads-beta) until Collapsed Reply Threads is promoted to general availability in Q2 2022. Learn more about these [performance considerations here](https://support.mattermost.com/hc/en-us/articles/4413183568276-What-to-expect-when-enabling-Collapsed-Reply-Threads-Beta).
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v5.39, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -4625,9 +4676,11 @@ Mattermost v5.38.0 contains low to medium level security fixes. [Upgrading](http
  - v5.38 adds fixes for some of the incorrect mention counts and unreads around threads and channels since the introduction of Collapsed Reply Threads (Beta). This fix is done through a SQL migration, and it may take several minutes to complete for large databases. The ``fixCRTChannelMembershipCounts`` fix takes 1 minute and 20 seconds for a database containing approximately 4 million channel memberships and about 130,000 channels. The ``fixCRTThreadCountsAndUnreads`` fix takes about 3 minutes and 30 seconds for a database containing 56367 threads, 124587 thread memberships, and 220801 channel memberships. These are on MySQL v5.6.51.
  - Focalboard v0.8.2 (released with Mattermost v5.38.0) requires Mattermost v5.37+ due to the new database connection system.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v5.37, please read the other [Important Upgrade Notes](https://docs.mattermost.com/upgrade/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -4821,9 +4874,11 @@ The following deprecations are planned for the Mattermost v6.0 release, which is
  - Support for Mattermost Server v5.31 [Extended Support Release](https://docs.mattermost.com/administration/extended-support-release.html) will come to the end of its life cycle on October 15, 2021. Upgrading to Mattermost Server v5.37 or later is required.
  - [Collapsed Reply Threads](https://docs.mattermost.com/messaging/organizing-conversations.html), available in beta, are known to have a negative impact on server performance. If you cannot easily scale up and tune your database, or if you are running the Mattermost application server and database server on the same machine, we recommended disabling [``ThreadAutoFollow``](https://docs.mattermost.com/configure/configuration-settings.html#automatically-follow-threads) and [``CollapsedThreads``](https://docs.mattermost.com/configure/configuration-settings.html#collapsed-reply-threads-beta) until Collapsed Reply Threads is promoted to general availability in Q2 2022. Learn more about these [performance considerations here](https://support.mattermost.com/hc/en-us/articles/4413183568276-What-to-expect-when-enabling-Collapsed-Reply-Threads-Beta).
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v5.36, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -4966,9 +5021,11 @@ Mattermost v5.36.0 contains a high level security fix. [Upgrading](https://docs.
 ### Important Upgrade Notes
  - Gossip clustering mode is now in General Availability and is no longer available as an option. All cluster traffic will always use the gossip protocol. The config setting ``UseExperimentalGossip`` has no effect and has only been kept for compatibility purposes. The setting to use gossip has been removed from the System Console. **Note:** For High Availability upgrades, all nodes in the cluster must use a single protocol. If an existing system is not currently using gossip, one node in a cluster can't be upgraded while other nodes in the cluster use an older version. Customers must either use gossip for their High Availability upgrade, or customers must shut down all nodes, perform the upgrade, and then bring all nodes back up.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v5.35, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -5162,9 +5219,11 @@ Mattermost v5.35.0 contains low and medium level security fixes. [Upgrading](htt
 - The existing password generation logic used during the bulk user import process was comparatively weak. Hence it's advised for admins to immediately reset the passwords for all the users who were generated during the bulk import process and whose password has not been changed even once.
 - In the v5.38 release (August 16, 2021), we will deprecate "config watcher" (the mechanism that automatically reloads the ``config.json file``), in favor of an mmctl command that will need to be run to apply configuration changes after they are made. This change will improve configuration performance and robustness.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v5.34, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -5415,9 +5474,11 @@ Mattermost v5.33.0 contains low-level security fixes. [Upgrading](https://docs.m
  - Deleting a reaction is now a soft delete in the ``Reactions`` table. A schema update is required and may take up to 15 seconds on first run with large data sets.
  - WebSocket handshakes done with an HTTP version lower than 1.1 will result in a warning, and the server will transparently upgrade the version to 1.1 to comply with the WebSocket RFC. This is done to work around incorrect Nginx (and other proxy) configs that do not set the ``proxy_http_version`` directive to 1.1. This facility will be removed in a future Mattermost version. It is strongly recommended to fix the proxy configuration to correctly use the WebSocket protocol.
  
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v5.32, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -5553,9 +5614,11 @@ Mattermost v5.32.0 contains low level security fixes. [Upgrading](https://docs.m
  - Breaking changes to the Golang client API were introduced: ``GetPostThread``, ``GetPostsForChannel``, ``GetPostsSince``, ``GetPostsAfter``, ``GetPostsBefore``, and ``GetPostsAroundLastUnread`` now require an additional collapsedThreads parameter to be passed. Any client making use of these functions will need to update them when upgrading its dependencies.
  - [A breaking change was introduced when upgrading the Go version to v1.15.5](https://go.dev/doc/go1.15) where user logins fail with AD/LDAP Sync when the certificate of the LDAP Server has no Subject Alternative Name (SAN) in it. Creating a new certificate on the AD/LDAP Server with the SAN inside fixes this.
  
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v5.31, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -5887,9 +5950,11 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 ### Compatibility
  - A new configuration setting ``ThreadAutoFollow`` has been added to support [Collapsed Reply Threads](https://docs.google.com/presentation/d/1QSrPws3N8AMSjVyOKp15FKT7O0fGMSx8YidjSDS4Wng/edit#slide=id.g2f0aecc189_0_245) releasing in beta in Q1 2021. This setting is enabled by default and may affect server performance. It is recommended to review our [documentation on hardware requirements](https://docs.mattermost.com/install/requirements.html#hardware-requirements) to ensure your servers are appropriately scaled for the size of your user base.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v5.28, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -5987,9 +6052,11 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 ### Breaking Changes
  - Now when the service crashes, it will generate a coredump instead of just dumping the stack trace to the console. This allows us to preserve the full information of the crash to help with debugging it. For more information about coredumps, please see: https://man7.org/linux/man-pages/man5/core.5.html.  
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than v5.27, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -6222,9 +6289,11 @@ Mattermost v5.27.0 contains a low level security fix. [Upgrading](https://docs.m
  - In v5.26, Elasticsearch indexes needed to be recreated. Admins should re-index Elasticsearch using the **Purge index** and then **Index now** button so that all the changes will be included in the index. Systems may be left with a limited search during the indexing, so it should be done during a time when there is little to no activity because it may take several hours.
  - An ``EnableExperimentalGossipEncryption`` option was added under ``ClusterSettings``. If this is set to ``true``, and ``UseExperimentalGossip`` is also ``true``, all communication through the cluster using the gossip protocol will be encrypted. The encryption uses ``AES-256`` by default, and it is not kept configurable by design. However, if one wishes, they can set the value in Systems table manually for the ``ClusterEncryptionKey`` row. A key is a byte array converted to base64. It should be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256. To update the key, one can execute ``UPDATE Systems SET Value='&lt;value&gt;' WHERE Name='ClusterEncryptionKey';`` in MySQL and ``UPDATE systems SET value='&lt;value&gt;' WHERE name='ClusterEncryptionKey'`` for PostgreSQL. For any change in this config setting to take effect, the whole cluster must be shutdown first. Then the config change made, and then restarted. In a cluster, all servers either will completely use encryption or not. There cannot be any partial usage.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than 5.25, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -6416,9 +6485,11 @@ Mattermost v5.25.0 contains a low level security fix. [Upgrading](https://docs.m
 ### Breaking Changes
  - Some incorrect instructions regarding SAML setup with Active Directory ADFS for setting the “Relying party trust identifier” were corrected. Although the settings will continue to work, it is encouraged to [modify those settings](https://docs.mattermost.com/deployment/sso-saml-adfs-msws2016.html#add-a-relying-party-trust).
  
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than 5.24, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Improvements
  - Added the ability for admins to request a 30-day E20 trial license directly in the System Console.
@@ -6508,9 +6579,11 @@ Mattermost v5.24.0 contains low level security fixes. [Upgrading](https://docs.m
  - Due to fixing performance issues related to emoji reactions, the performance of the upgrade has been affected in that the schema upgrade now takes more time in environments with lots of reactions in their database. These environments are recommended to perform the schema migration during low usage times and potentially in advance of the upgrade. Since this migration happens before the Mattermost Server is fully launched, non-High Availability installs will be unreachable during this time. Please see the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html) for full details.
  - On mobile apps, users will not be able to see LDAP group mentions (E20 feature) in the autocomplete dropdown. Users will still receive notifications if they are part of an LDAP group. However, the group mention keyword will not be highlighted.
  
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than 5.23, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -6752,9 +6825,11 @@ Mattermost v5.22.0 contains a low level security fix. [Upgrading](https://docs.m
  - The Channel Moderation Settings feature is supported on mobile app versions v1.30 and later. In earlier versions of the mobile app, users who attempt to post or react to posts without proper permissions will see an error.
  - Direct access to the ``Props`` field in the ``model.Post`` structure has been deprecated. The available ``GetProps()`` and ``SetProps()`` methods should now be used. Also, direct copy of the ``model.Post`` structure must be avoided in favor of the provided ``Clone()`` method.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than 5.21, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -6930,9 +7005,11 @@ Mattermost v5.20.0 contains a low level security fix. [Upgrading](https://docs.m
  - Any [pre-packaged plugin](https://docs.mattermost.com/administration/plugins.html#pre-packaged-plugins) that is not enabled in the ``config.json`` will no longer install automatically, but can continue to be installed via the [plugin marketplace](https://docs.mattermost.com/administration/plugins.html#plugin-marketplace).
  - Boolean elements from interactive dialogs are no longer serialized as strings. While we try to avoid breaking changes, this change was necessary to allow both the web and mobile apps to work with the boolean elements introduced with v5.16.
  
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than 5.19, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -7074,9 +7151,11 @@ Mattermost v5.19.0 contains low to high level security fixes. [Upgrading](https:
 #### Breaking Changes
  - ``LockTeammateNameDisplay`` setting was moved to Enterprise Edition E20 as it was erroneously available in Team Edition and Enterprise Edition E10.
  
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than 5.18, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Bug Fixes
  - Fixed an issue where email notifications were still sent in some cases while disabled in the user interface.
@@ -7148,9 +7227,11 @@ Mattermost v5.18.0 contains low to high level security fixes. [Upgrading](https:
  - Removed ``Team.InviteId`` from the related Websocket event and sanitized it on all team API endpoints for users without invite permissions.
  - Removed the ability to change the type of a channel using the ``PUT /channels/&#123;channel_id&#125;`` API endpoint. The new ``PUT /channels/&#123;channel_id&#125;/privacy`` endpoint should be used for that purpose.
  
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than 5.17, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
  
@@ -7651,9 +7732,11 @@ Mattermost v5.14.0 contains a medium level security fix. [Upgrading](https://doc
  - Webhooks are now only displayed if the user is the creator of the webhook or a system administrator.
  - With the update from Google+ to Google People, system admins need to ensure the ``GoogleSettings.Scope`` config.json setting is set to ``profile email`` and ``UserAPIEndpoint`` setting should be set to ``https://people.googleapis.com/v1/people/me?personFields=names,emailAddresses,nicknames,metadata`` per [updated documentation](https://docs.mattermost.com/deployment/sso-google.html).
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than 5.13, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -7942,9 +8025,11 @@ Mattermost v5.12.0 contains low to medium level security fixes. [Upgrading](http
  - Image link and YouTube previews do not display unless **System Console > Enable Link Previews** is enabled. Please ensure that your Mattermost server is connected to the internet and has network access to the websites from which previews are expected to appear. [Learn more here](https://docs.mattermost.com/administration/config-settings.html#enable-link-previews).
  - ``ExperimentalEnablePostMetadata`` setting was removed. Post metadata, including post dimensions, is now stored in the database to correct scroll position and eliminate scroll jumps as content loads in a channel.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than 5.11, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -8107,9 +8192,11 @@ Mattermost v5.11.0 contains low level security fixes. [Upgrading](https://docs.m
 
  - If your integration uses ``Update.Props == nil`` to clear ``Props``, this will no longer work in 5.11+. Instead, use ``Update.Props == &#123;&#125;`` to clear properties. This change was made because ``Update.Props == nil`` unintentionally cleared all ``Props``, such as the profile picture, instead of preserving them.
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than 5.10, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Bug Fixes
  - Fixed an issue where plugin settings link didn't appear until refresh after uploading a plugin in the System Console.
@@ -8171,9 +8258,11 @@ Mattermost v5.10.0 contains medium to high level security fixes. [Upgrading](htt
 
  - ``SupportedTimezonesPath`` setting in config.json and changes to timezones in the UI based on the timezones.json file was removed. This was made to support [storing configurations in the database](https://docs.mattermost.com/administration/config-in-database.html#configuration-in-a-database).
 
-```{Important}
+<Important>
+
 If you upgrade from a release earlier than 5.9, please read the other [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
  
@@ -8334,9 +8423,11 @@ Mattermost v5.9.0 contains low to medium level security fixes. [Upgrading](https
  - If **DisableLegacyMfa** setting in ``config.json`` is set to ``true`` and multi-factor authentication is enabled, ensure your users have upgraded to mobile app version 1.17 or later. Otherwise, users who have MFA enabled may not be able to log in successfully. See [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html) for more details.
  - The public IP of the Mattermost application server is considered a reserved IP for additional security hardening in the context of untrusted external requests such as Open Graph metadata, webhooks or slash commands. See [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html) for more details.
 
-```{Important}
+<Important>
+
 If you upgrade from another release than 5.8, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Bug Fixes
 
@@ -8407,9 +8498,11 @@ Mattermost v5.8.0 contains low to high level security fixes. [Upgrading](https:/
 
 - The local image proxy has been added, and images displayed within the client are now affected by the ``AllowUntrustedInternalConnections`` setting. See [documentation](https://docs.mattermost.com/administration/image-proxy.html#local-image-proxy) for more details if you have trouble loading images.
 
-```{Important}
+<Important>
+
 If you upgrade from another release than 5.7, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -8582,9 +8675,11 @@ Mattermost v5.7.0 contains low to medium level security fixes. [Upgrading](https
  - Removed support for IE11 Mobile View due to low usage and instability in order to invest that effort in maintaining a high quality experience on other more used browsers. End users on IE11 will thus have an increased minimum screen size.
  - If EnablePublicChannelsMaterialization setting in config.json is set to false, an offline migration prior to upgrade may be required to synchronize the materialized table for public channels to increase channel search performance in the channel switcher (CTRL/CMD+K), channel autocomplete (~) and elsewhere in the UI. See [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html) for more details.
  
-```{Important}
+<Important>
+
 If you upgrade from another release than 5.5, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -8807,9 +8902,11 @@ Release date: 2018-10-16
  - Mattermost mobile app version 1.13+ is required. File uploads will fail on earlier mobile app versions.
  - In certain upgrade scenarios the new Allow Team Administrators to edit others posts setting under General then Users and Teams may be set to True while the Mattermost default in 5.1 and earlier and with new 5.4+ installations is False.
 
-```{Important}
+<Important>
+
 If you upgrade from another release than 5.3, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -8926,9 +9023,11 @@ Mattermost v5.3.0 contains a high level security fix. [Upgrading](https://docs.m
 
  - Those servers with Elasticsearch enabled will notice that hashtag search is case-sensitive.
 
-```{Important}
+<Important>
+
 If you upgrade from another release than 5.2, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -9017,9 +9116,11 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 
  - Those servers upgrading from v4.1 - v4.4 directly to v5.2 or later and have JIRA enabled will need to re-enable the JIRA plugin after an upgrade.
 
-```{Important}
+<Important>
+
 If you upgrade from another release than 5.1, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -9149,9 +9250,11 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 
  - ``mattermost export`` CLI command is renamed to ``mattermost export schedule``. Make sure to update your scripts if you use this command.
 
-```{Important}
+<Important>
+
 If you upgrade from another release than 5.0, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 
@@ -9258,9 +9361,11 @@ Multiple setting options were added to `config.json`. Below is a list of the add
 - A new `config.json` setting to disable the [permanent APIv4 delete team parameter](https://api.mattermost.com/#tag/teams%2Fpaths%2F~1teams~1%7Bteam_id%7D%2Fput) has been added. The setting is off by default for all new and existing installs, except those deployed on GitLab Omnibus. A System Administrator can enable the API v4 endpoint from the config.json file. [Ticket #9916](https://mattermost.atlassian.net/browse/MM-9916).
 - An unused `ExtraUpdateAt` field has been removed from the channel model. [Ticket #9739](https://mattermost.atlassian.net/browse/MM-9739).
 
-```{Important}
+<Important>
+
 If you upgrade from another release than 4.10, please read the [Important Upgrade Notes](https://docs.mattermost.com/administration/important-upgrade-notes.html).
-```
+
+</Important>
 
 ### Highlights
 


### PR DESCRIPTION
#### Summary
The Sphinx → Docusaurus migration script (docs-experimental/docs-site/scripts/migrate-main-docs.mjs) only converted lowercase admonition directives (e.g. ```{note}). Capitalized, indented, or same-line variants (```{Important}, ```{Attention}) were left as literal text, causing entire sections of these pages to render as one broken raw code block instead of styled callouts.

The PR converts all remaining directive variants into proper <Important>, <Note>, <Warning>, <Tip> MDX components, removes dead leftover .. meta:: eval-rst blocks, and turns MyST (label)= anchors into escaped MDX heading ids (\{#id}) so existing release-note cross-links keep resolving to the right heading.

Fixes 9 pages: mattermost-v10-changelog, mattermost-v11-changelog, mattermost-server-releases, unsupported-legacy-releases, release-policy, mobile-app-changelog, desktop-app-changelog, mattermost-mobile-releases, mattermost-desktop-releases.

Also fixes one pre-existing unescaped < (<1GB) in mobile-app-changelog.mdx that separately broke MDX compilation.


#### Screenshots

Sample screenshots

**Before**
<img width="1258" height="620" alt="Screenshot 2026-07-09 at 19 56 11" src="https://github.com/user-attachments/assets/2d0d5978-01e7-4b59-9cc6-92eb03950233" />

<img width="1273" height="544" alt="Screenshot 2026-07-09 at 19 56 48" src="https://github.com/user-attachments/assets/7ea2d2ff-9afd-430c-9173-de7da150d63b" />



**After**

<img width="1277" height="568" alt="Screenshot 2026-07-09 at 19 56 24" src="https://github.com/user-attachments/assets/0edcb28c-2f18-4775-9315-58291677eebf" />

<img width="1269" height="573" alt="Screenshot 2026-07-09 at 19 57 27" src="https://github.com/user-attachments/assets/50517a6d-e749-4acd-995c-3fb5a6952510" />


#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** These are documentation-only MDX/Sphinx-to-Docusaurus formatting changes across multiple pages, so runtime behavior shouldn’t change, but incorrect anchor/callout syntax can break the docs build or internal cross-references. The changes touch several shared heading/id and callout patterns, increasing the chance of widespread rendering issues if any one conversion is off.

**QA Recommendation:** Run/verify the documentation build (MDX compilation) and then spot-check the affected pages for correct callout rendering and working cross-reference links; minimal manual review is sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->