### PR TITLE
Filter property field options in websocket events

### DIFF
--- a/server/channels/app/property_field.go
+++ b/server/channels/app/property_field.go
@@ -44,6 +44,21 @@ func propertyFieldBroadcastParams(rctx request.CTX, field *model.PropertyField) 
 	}
 }
 
+func propertyFieldBroadcastPayload(field *model.PropertyField) *model.PropertyField {
+	if field == nil || !field.Type.SupportsOptions() || field.GetAccessMode() == model.PropertyAccessModePublic {
+		return field
+	}
+
+	filtered := *field
+	filtered.Attrs = make(model.StringInterface, len(field.Attrs)+1)
+	for k, v := range field.Attrs {
+		filtered.Attrs[k] = v
+	}
+	filtered.Attrs[model.PropertyFieldAttributeOptions] = []any{}
+
+	return &filtered
+}
+
 func (a *App) publishPropertyFieldEvent(rctx request.CTX, eventType model.WebsocketEventType, field *model.PropertyField, connectionID string) {
 	if field == nil || field.IsPSAv1() {
 		return
@@ -52,7 +67,7 @@ func (a *App) publishPropertyFieldEvent(rctx request.CTX, eventType model.Websoc
 	if !ok {
 		return
 	}
-	fieldJSON, err := json.Marshal(field)
+	fieldJSON, err := json.Marshal(propertyFieldBroadcastPayload(field))
 	if err != nil {
 		rctx.Logger().Warn("Failed to encode property field to JSON", mlog.Err(err))
 		return

--- a/server/channels/app/property_field_test.go
+++ b/server/channels/app/property_field_test.go
@@ -746,6 +746,72 @@ func TestPropertyFieldBroadcastParams(t *testing.T) {
 	})
 }
 
+func TestPropertyFieldBroadcastPayload(t *testing.T) {
+	options := []any{
+		map[string]any{"id": "opt1", "value": "Option 1"},
+		map[string]any{"id": "opt2", "value": "Option 2"},
+	}
+
+	t.Run("public field keeps options", func(t *testing.T) {
+		field := &model.PropertyField{
+			Type: model.PropertyFieldTypeSelect,
+			Attrs: model.StringInterface{
+				model.PropertyFieldAttributeOptions: options,
+			},
+		}
+
+		payload := propertyFieldBroadcastPayload(field)
+
+		assert.Same(t, field, payload)
+		assert.Equal(t, options, payload.Attrs[model.PropertyFieldAttributeOptions])
+	})
+
+	t.Run("source-only field omits options without mutating original", func(t *testing.T) {
+		field := &model.PropertyField{
+			Type: model.PropertyFieldTypeSelect,
+			Attrs: model.StringInterface{
+				model.PropertyAttrsAccessMode:       model.PropertyAccessModeSourceOnly,
+				model.PropertyFieldAttributeOptions: options,
+			},
+		}
+
+		payload := propertyFieldBroadcastPayload(field)
+
+		require.NotSame(t, field, payload)
+		assert.Empty(t, payload.Attrs[model.PropertyFieldAttributeOptions])
+		assert.Equal(t, options, field.Attrs[model.PropertyFieldAttributeOptions])
+	})
+
+	t.Run("shared-only field omits options without mutating original", func(t *testing.T) {
+		field := &model.PropertyField{
+			Type: model.PropertyFieldTypeMultiselect,
+			Attrs: model.StringInterface{
+				model.PropertyAttrsAccessMode:       model.PropertyAccessModeSharedOnly,
+				model.PropertyFieldAttributeOptions: options,
+			},
+		}
+
+		payload := propertyFieldBroadcastPayload(field)
+
+		require.NotSame(t, field, payload)
+		assert.Empty(t, payload.Attrs[model.PropertyFieldAttributeOptions])
+		assert.Equal(t, options, field.Attrs[model.PropertyFieldAttributeOptions])
+	})
+
+	t.Run("non-option field is unchanged", func(t *testing.T) {
+		field := &model.PropertyField{
+			Type: model.PropertyFieldTypeText,
+			Attrs: model.StringInterface{
+				model.PropertyAttrsAccessMode: model.PropertyAccessModeSourceOnly,
+			},
+		}
+
+		payload := propertyFieldBroadcastPayload(field)
+
+		assert.Same(t, field, payload)
+	})
+}
+
 func TestGetPropertyField(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)


### PR DESCRIPTION
#### Summary

Filters option data from non-public property fields before serializing `property_field_created` and `property_field_updated` websocket payloads. Public fields and non-option field types keep their existing payloads; callers can still fetch fields through the existing read paths for caller-specific option filtering.

QA:
- `docker run --rm -v "$PWD":/repo -w /repo golang:1.26.4-bookworm gofmt -w server/channels/app/property_field.go server/channels/app/property_field_test.go`
- `docker run --rm --network host -v "$PWD":/repo -w /repo golang:1.26.4-bookworm sh -c 'rm -f go.work go.work.sum; go work init ./server ./server/public; cd server; go test ./channels/app -run TestPropertyFieldBroadcastPayload -count=1; cd /repo; rm -f go.work go.work.sum'`

#### Release Note
```release-note
Updated property field websocket events to omit options for fields that require caller-specific filtering.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change is isolated to websocket payload construction for property fields, but it alters the event contract for non-public option fields and could affect clients that consume these broadcasts. Existing read paths remain unchanged, and the added test coverage reduces risk, though behavior changes in a shared notification path warrant caution.

**QA Recommendation:** Perform targeted manual QA for property field create/update websocket events across public, source-only, and shared-only option fields to confirm payload contents and client handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->