### PR TITLE
Bucket server test-timing cache by date to cut cache churn

### DIFF
--- a/.github/workflows/server-test-merge-template.yml
+++ b/.github/workflows/server-test-merge-template.yml
@@ -79,6 +79,7 @@ jobs:
         id: timing-prep
         run: |
           mkdir -p server
+          echo "date=$(date -u +%Y-%m-%d)" >> "$GITHUB_OUTPUT"
           if [[ -f merged-report.xml && $(stat -c%s merged-report.xml) -gt 1024 ]]; then
             cp merged-report.xml server/prev-report.xml
             cat shards/*/gotestsum.json > server/prev-gotestsum.json 2>/dev/null || true
@@ -100,5 +101,5 @@ jobs:
           path: |
             server/prev-report.xml
             server/prev-gotestsum.json
-          # The v2 prefix matches the v2 restore prefix in server-test-template.yml.
-          key: server-test-timing-v2-master-${{ github.run_id }}
+          # Bucket by UTC date (not run id) so we save at most one cache per day.
+          key: server-test-timing-v2-master-${{ steps.timing-prep.outputs.date }}


### PR DESCRIPTION
#### Summary

Use a date-based key suffix instead of `${{ github.run_id }}` to prevent creating duplicate server-test-timing caches. Most of these are unused, since only the last one is restored.

<img width="2602" height="1324" alt="CleanShot 2026-07-09 at 15 21 45@2x" src="https://github.com/user-attachments/assets/cabf6030-9652-4f88-95e2-5dc3db109a91" />

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** This is a narrowly scoped workflow cache-key adjustment in a single CI file, with no impact on application runtime, shared utilities, or user-facing product behavior. The main risk is limited to cache hit/miss behavior for server timing data, and rollback would be straightforward.

**QA Recommendation:** Minimal manual QA is needed; verify the workflow still saves and restores the server timing cache as expected across daily runs.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->