### PR TITLE
Add HCL/Terraform syntax highlighting

### DIFF
--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -1922,6 +1922,7 @@ export const Constants = {
         handlebars: {name: 'Handlebars', extensions: ['handlebars', 'hbs', 'html.hbs', 'html.handlebars'], aliases: ['hbs', 'mustache']},
         haskell: {name: 'Haskell', extensions: ['hs'], aliases: ['hs']},
         haxe: {name: 'Haxe', extensions: ['hx'], aliases: ['hx']},
+        hcl: {name: 'HCL', extensions: ['hcl', 'tf'], aliases: ['terraform', 'tf']},
         java: {name: 'Java', extensions: ['java', 'jsp']},
         javascript: {name: 'JavaScript', extensions: ['js', 'jsx'], aliases: ['js']},
         json: {name: 'JSON', extensions: ['json']},

--- a/webapp/channels/src/utils/hcl_language.ts
+++ b/webapp/channels/src/utils/hcl_language.ts
@@ -1,0 +1,57 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {HLJSApi, Language, Mode} from 'highlight.js';
+
+// highlight.js v11 no longer bundles a grammar for HCL / Terraform, so we vendor a
+// small self-contained definition here instead of pulling in a third-party package.
+// See https://github.com/mattermost/mattermost/issues/33870
+//
+// The default export matches highlight.js' LanguageFn contract, so it can be passed
+// straight to hljs.registerLanguage() by the loader in syntax_highlighting.tsx.
+
+/* eslint-disable new-cap */
+
+export default function hcl(hljs: HLJSApi): Language {
+    const interpolation: Mode = {
+        className: 'subst',
+        begin: /\$\{/,
+        end: /\}/,
+    };
+
+    const stringMode: Mode = {
+        className: 'string',
+        begin: '"',
+        end: '"',
+        contains: [interpolation],
+    };
+
+    const heredocMode: Mode = {
+        className: 'string',
+        begin: /<<-?\s*["']?[A-Za-z][A-Za-z0-9_]*["']?/,
+        end: /^\s*[A-Za-z][A-Za-z0-9_]*/,
+    };
+
+    const attributeMode: Mode = {
+        className: 'attr',
+        begin: /[A-Za-z_][A-Za-z0-9_-]*\s*(?==)/,
+    };
+
+    return {
+        name: 'HCL',
+        aliases: ['terraform', 'tf'],
+        keywords: {
+            keyword: 'resource variable provider output locals module data terraform for_each count depends_on lifecycle dynamic',
+            literal: 'true false null',
+        },
+        contains: [
+            hljs.COMMENT('#', '$'),
+            hljs.COMMENT('//', '$'),
+            hljs.COMMENT('/\\*', '\\*/'),
+            hljs.NUMBER_MODE,
+            stringMode,
+            heredocMode,
+            attributeMode,
+        ],
+    };
+}

--- a/webapp/channels/src/utils/syntax_highlighting.test.ts
+++ b/webapp/channels/src/utils/syntax_highlighting.test.ts
@@ -6,6 +6,7 @@ import javascript from 'highlight.js/lib/languages/javascript';
 import plaintext from 'highlight.js/lib/languages/plaintext';
 import swift from 'highlight.js/lib/languages/swift';
 
+import hcl from './hcl_language';
 import {highlight} from './syntax_highlighting';
 
 jest.mock('highlight.js/lib/core');
@@ -33,5 +34,23 @@ describe('utils/syntax_highlighting.tsx', () => {
         await highlight('vtt', '');
 
         expect(hlJS.registerLanguage).toHaveBeenCalledWith('vtt', plaintext);
+    });
+
+    it('should register the vendored hcl language', async () => {
+        expect.assertions(1);
+
+        await highlight('hcl', '');
+
+        expect(hlJS.registerLanguage).toHaveBeenCalledWith('hcl', hcl);
+    });
+
+    it('should register terraform and tf aliases as hcl', async () => {
+        expect.assertions(2);
+
+        await highlight('terraform', '');
+        expect(hlJS.registerLanguage).toHaveBeenCalledWith('hcl', hcl);
+
+        await highlight('tf', '');
+        expect(hlJS.registerLanguage).toHaveBeenCalledWith('hcl', hcl);
     });
 });

--- a/webapp/channels/src/utils/syntax_highlighting.tsx
+++ b/webapp/channels/src/utils/syntax_highlighting.tsx
@@ -109,6 +109,7 @@ async function registerLanguage(languageName: string) {
         handlebars: () => import('highlight.js/lib/languages/handlebars'),
         haskell: () => import('highlight.js/lib/languages/haskell'),
         haxe: () => import('highlight.js/lib/languages/haxe'),
+        hcl: () => import('./hcl_language'),
         java: () => import('highlight.js/lib/languages/java'),
         javascript: () => import('highlight.js/lib/languages/javascript'),
         json: () => import('highlight.js/lib/languages/json'),


### PR DESCRIPTION
#### Summary
Adds syntax highlighting for HCL / Terraform code blocks.

`highlight.js` v11 (currently used by the web app) no longer bundles a grammar for HCL/Terraform, so this change vendors a small, self-contained grammar (`webapp/channels/src/utils/hcl_language.ts`) and registers it in the code-block syntax highlighter. Fenced code blocks tagged ` ```hcl `, ` ```terraform `, or ` ```tf ` now render with syntax highlighting, and "HCL" appears in the code-block language list.

The grammar covers the common Terraform/HCL constructs: `#`, `//` and `/* */` comments, double-quoted strings with `${...}` interpolation, heredocs, numbers, block/keyword identifiers (`resource`, `variable`, `module`, `data`, …), attribute names, and the `true`/`false`/`null` literals. It was vendored rather than pulled from a third-party package to avoid adding a dependency.

#### Ticket Link
Fixes #33870

#### Screenshots
_Example — the snippet from the issue now renders highlighted:_
```hcl
resource "provider_resource" "example" {
  key = "value"
}
```

#### Release Note
```
Added syntax highlighting for HCL / Terraform code blocks.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** This touches shared syntax-highlighting utilities and a vendored language definition used by the web app, so regressions are possible if language registration or highlighting behavior changes unexpectedly. The scope is limited to code-block rendering and does not affect auth, data, or core messaging flows.

**QA Recommendation:** Run targeted manual checks for fenced code blocks tagged `hcl`, `terraform`, and `tf` in the web app, plus a quick pass on existing syntax highlighting to confirm no unrelated languages were impacted.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->