### PR TITLE
Rename the daily e2e npm cache to avoid potential prefix collisions

### DIFF
--- a/.github/actions/restore-e2e-npm-cache/action.yml
+++ b/.github/actions/restore-e2e-npm-cache/action.yml
@@ -8,6 +8,6 @@ runs:
       uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: ~/.npm
-        key: node-cache-${{ runner.os }}-${{ runner.arch }}-npm-e2e-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}
+        key: e2e-npm-registry-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}
         restore-keys: |
-          node-cache-${{ runner.os }}-${{ runner.arch }}-npm-e2e-
+          e2e-npm-registry-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/workflows/e2e-ci-cache-warm.yml
+++ b/.github/workflows/e2e-ci-cache-warm.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.npm
-          key: node-cache-${{ runner.os }}-${{ runner.arch }}-npm-e2e-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}
+          key: e2e-npm-registry-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}
           lookup-only: true
 
       - name: ci/setup-node
@@ -75,4 +75,4 @@ jobs:
         uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.npm
-          key: node-cache-${{ runner.os }}-${{ runner.arch }}-npm-e2e-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}
+          key: e2e-npm-registry-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}


### PR DESCRIPTION
#### Summary

The daily e2e npm cache was keyed under `node-cache-<os>-<arch>-npm-e2e-*`, sharing the `node-cache-<os>-<arch>-npm-` prefix that `actions/setup-node`'s built-in npm cache uses. Two buckets under one prefix is a future hazard: a broad restore-key could cross-restore one's `~/.npm` into the other.

Prevent a future issue by preemptively renaming it to `e2e-npm-registry-<os>-<arch>-*`, a distinct namespace matching the repo's other e2e cache keys. Key name only; old entries age out and the daily warm job repopulates.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** This is an isolated CI cache key namespace change affecting only the daily e2e npm cache warm/restore path. Behavior, cache contents, and cache locations remain the same, so the main risk is limited to a temporary cache miss while the new key repopulates.

**QA Recommendation:** Minimal manual QA is needed; verify the warm job and e2e cache restore step populate and reuse the new key successfully in one CI run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->