### PR TITLE
On successful SAML auth audit log the user's email

### DIFF
--- a/server/channels/web/saml.go
+++ b/server/channels/web/saml.go
@@ -210,6 +210,7 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	auditRec.AddMeta("obtained_user_id", user.Id)
+	auditRec.AddMeta("obtained_user_email", user.Email)
 	c.LogAuditWithUserId(user.Id, "obtained user")
 
 	desktopToken := relayProps["desktop_token"]


### PR DESCRIPTION
#### Summary
In order for a customer's security or compliance team to correlate SAML sign-up events to users in their identity provider they need a common field in the audit log event. In this case we're adding email. Tested locally.

#### Ticket Link
n/a

#### Screenshots
n/a

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note
Added "obtained_user_email" field to "completeSaml" audit log events
```
