### PR TITLE
ci: add docs PR preview workflows

### DIFF
--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -1,0 +1,38 @@
+name: docs-preview-cleanup
+
+on:
+  pull_request_target:
+    types: [closed]
+    paths:
+      - 'docs/**'
+      - 'api/**'
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  cleanup:
+    name: Delete preview from S3
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_DOCS_PR_PREVIEW_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DOCS_PR_PREVIEW_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Delete preview prefix from S3
+        run: |
+          aws s3 rm \
+            s3://${{ vars.DOCS_PREVIEW_BUCKET_NAME }}/mattermost/pr-${{ github.event.number }}/ \
+            --recursive
+
+      - name: Comment on closed PR
+        uses: peter-evans/create-or-update-comment@7dfe4b0aa0c4bbd06d172692ff8a9e18381d6979 # v3.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.number }}
+          body: |
+            Docs preview for PR #${{ github.event.number }} has been removed from S3.

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -24,15 +24,17 @@ jobs:
           aws-region: us-east-1
 
       - name: Delete preview prefix from S3
+        env:
+          PR_NUMBER: ${{ github.event.number }}
+          BUCKET_NAME: ${{ vars.DOCS_PREVIEW_BUCKET_NAME }}
         run: |
-          aws s3 rm \
-            s3://${{ vars.DOCS_PREVIEW_BUCKET_NAME }}/mattermost/pr-${{ github.event.number }}/ \
-            --recursive
+          aws s3 rm "s3://${BUCKET_NAME}/mattermost/pr-${PR_NUMBER}/" --recursive
 
       - name: Comment on closed PR
-        uses: peter-evans/create-or-update-comment@7dfe4b0aa0c4bbd06d172692ff8a9e18381d6979 # v3.0.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ github.event.number }}
-          body: |
-            Docs preview for PR #${{ github.event.number }} has been removed from S3.
+        # Plain gh CLI instead of a third-party action -- see docs-preview-template.yml.
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.number }}
+        run: |
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" \
+            --body "Docs preview for PR #${PR_NUMBER} has been removed from S3."

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -1,7 +1,7 @@
 name: docs-preview-cleanup
 
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
     paths:
       - 'docs/**'
@@ -15,6 +15,10 @@ jobs:
   cleanup:
     name: Delete preview from S3
     runs-on: ubuntu-latest
+    # Fork PRs don't get secrets on plain pull_request events, so this would
+    # just fail for them -- a separate scheduled sweep handles fork preview
+    # cleanup instead of switching this to pull_request_target.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
@@ -31,7 +35,6 @@ jobs:
           aws s3 rm "s3://${BUCKET_NAME}/mattermost/pr-${PR_NUMBER}/" --recursive
 
       - name: Comment on closed PR
-        # Plain gh CLI instead of a third-party action -- see docs-preview-template.yml.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.number }}

--- a/.github/workflows/docs-preview-fork.yml
+++ b/.github/workflows/docs-preview-fork.yml
@@ -16,6 +16,11 @@ on:
         required: true
         description: "Full commit SHA to build"
 
+permissions:
+  contents: read
+  statuses: write
+  pull-requests: write
+
 jobs:
   update-initial-status:
     runs-on: ubuntu-latest
@@ -33,7 +38,9 @@ jobs:
 
   preview:
     uses: ./.github/workflows/docs-preview-template.yml
-    secrets: inherit
+    secrets:
+      AWS_DOCS_PR_PREVIEW_KEY_ID: ${{ secrets.AWS_DOCS_PR_PREVIEW_KEY_ID }}
+      AWS_DOCS_PR_PREVIEW_SECRET_ACCESS_KEY: ${{ secrets.AWS_DOCS_PR_PREVIEW_SECRET_ACCESS_KEY }}
     needs:
       - update-initial-status
     with:

--- a/.github/workflows/docs-preview-fork.yml
+++ b/.github/workflows/docs-preview-fork.yml
@@ -1,0 +1,74 @@
+name: docs-preview-fork
+
+on:
+  workflow_dispatch:
+    inputs:
+      PR_NUMBER:
+        type: string
+        required: true
+        description: "PR number (fork PR to build preview for)"
+      TRIGGERING_ACTOR:
+        type: string
+        required: true
+        description: "GitHub login of the fork PR author"
+      COMMIT_SHA:
+        type: string
+        required: true
+        description: "Full commit SHA to build"
+
+jobs:
+  update-initial-status:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set pending commit status
+        uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          repository_full_name: ${{ github.repository }}
+          commit_sha: ${{ inputs.COMMIT_SHA }}
+          context: "docs-preview-fork / preview"
+          description: "Docs preview build for ${{ inputs.COMMIT_SHA }} is running"
+          status: pending
+
+  preview:
+    uses: ./.github/workflows/docs-preview-template.yml
+    secrets: inherit
+    needs:
+      - update-initial-status
+    with:
+      PR_NUMBER: ${{ inputs.PR_NUMBER }}
+      TRIGGERING_ACTOR: ${{ inputs.TRIGGERING_ACTOR }}
+      COMMIT_SHA: ${{ inputs.COMMIT_SHA }}
+
+  update-failure-status:
+    runs-on: ubuntu-latest
+    if: failure() || cancelled()
+    needs:
+      - preview
+    steps:
+      - uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          repository_full_name: ${{ github.repository }}
+          commit_sha: ${{ inputs.COMMIT_SHA }}
+          context: "docs-preview-fork / preview"
+          description: "Docs preview build for ${{ inputs.COMMIT_SHA }} failed"
+          status: failure
+
+  update-success-status:
+    runs-on: ubuntu-latest
+    if: success()
+    needs:
+      - preview
+    steps:
+      - uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          repository_full_name: ${{ github.repository }}
+          commit_sha: ${{ inputs.COMMIT_SHA }}
+          context: "docs-preview-fork / preview"
+          description: "Docs preview build for ${{ inputs.COMMIT_SHA }} succeeded"
+          status: success

--- a/.github/workflows/docs-preview-template.yml
+++ b/.github/workflows/docs-preview-template.yml
@@ -12,6 +12,17 @@ on:
       COMMIT_SHA:
         type: string
         required: true
+    secrets:
+      AWS_DOCS_PR_PREVIEW_KEY_ID:
+        required: true
+      AWS_DOCS_PR_PREVIEW_SECRET_ACCESS_KEY:
+        required: true
+
+# Serialize runs per PR so an older, slower build can't overwrite a newer
+# upload; different PRs still build concurrently.
+concurrency:
+  group: docs-preview-${{ inputs.PR_NUMBER }}
+  cancel-in-progress: true
 
 permissions:
   contents: read
@@ -68,9 +79,16 @@ jobs:
         # No explicit --cache-control, matching mattermost/docs's existing
         # preview workflow (shallwefootball/s3-upload-action doesn't set one
         # either).
+        env:
+          PR_NUMBER: ${{ inputs.PR_NUMBER }}
+          BUCKET_NAME: ${{ vars.DOCS_PREVIEW_BUCKET_NAME }}
         run: |
+          if ! [[ "$PR_NUMBER" =~ ^[0-9]+$ ]]; then
+            echo "PR_NUMBER must be a positive integer, got: $PR_NUMBER" >&2
+            exit 1
+          fi
           aws s3 sync docs/site/build/ \
-            s3://${{ vars.DOCS_PREVIEW_BUCKET_NAME }}/mattermost/pr-${{ inputs.PR_NUMBER }}/ \
+            "s3://${BUCKET_NAME}/mattermost/pr-${PR_NUMBER}/" \
             --delete \
             --no-progress
 

--- a/.github/workflows/docs-preview-template.yml
+++ b/.github/workflows/docs-preview-template.yml
@@ -47,6 +47,11 @@ jobs:
           cache: npm
           cache-dependency-path: docs/site/package-lock.json
 
+      - name: Set up Go
+        uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
+        with:
+          go-version-file: api/server/go.mod
+
       - name: Install npm dependencies
         working-directory: docs/site
         run: npm ci
@@ -54,9 +59,6 @@ jobs:
       - name: Typecheck
         working-directory: docs/site
         run: npm run typecheck
-
-      - name: Build OpenAPI spec
-        run: make -C api build
 
       - name: Build Docusaurus site (preview)
         working-directory: docs/site
@@ -93,11 +95,16 @@ jobs:
             --no-progress
 
       - name: Post preview URL comment
-        uses: peter-evans/create-or-update-comment@7dfe4b0aa0c4bbd06d172692ff8a9e18381d6979 # v3.0.1
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          issue-number: ${{ inputs.PR_NUMBER }}
-          body: |
-            Newest code from ${{ inputs.TRIGGERING_ACTOR }} and commit ${{ inputs.COMMIT_SHA }} has docs preview environment ready:
-
-            **[Open preview environment](http://${{ vars.DOCS_PREVIEW_BUCKET_NAME }}.s3-website-us-east-1.amazonaws.com/mattermost/pr-${{ inputs.PR_NUMBER }}/)**
+        # Plain gh CLI instead of a third-party action -- posts a new comment
+        # every run (same behavior peter-evans/create-or-update-comment had
+        # here, since it wasn't given a comment-id/body-includes matcher).
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ inputs.PR_NUMBER }}
+          TRIGGERING_ACTOR: ${{ inputs.TRIGGERING_ACTOR }}
+          COMMIT_SHA: ${{ inputs.COMMIT_SHA }}
+          BUCKET_NAME: ${{ vars.DOCS_PREVIEW_BUCKET_NAME }}
+        run: |
+          BODY=$(printf 'Newest code from %s and commit %s has docs preview environment ready:\n\n**[Open preview environment](http://%s.s3-website-us-east-1.amazonaws.com/mattermost/pr-%s/)**' \
+            "$TRIGGERING_ACTOR" "$COMMIT_SHA" "$BUCKET_NAME" "$PR_NUMBER")
+          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$BODY"

--- a/.github/workflows/docs-preview-template.yml
+++ b/.github/workflows/docs-preview-template.yml
@@ -80,7 +80,6 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ inputs.PR_NUMBER }}
           body: |
-            Newest code from ${{ inputs.TRIGGERING_ACTOR }} and commit ${{ inputs.COMMIT_SHA }} has docs preview
-            ready:
+            Newest code from ${{ inputs.TRIGGERING_ACTOR }} and commit ${{ inputs.COMMIT_SHA }} has docs preview environment ready:
 
-            **[Open preview](http://${{ vars.DOCS_PREVIEW_BUCKET_NAME }}.s3-website-us-east-1.amazonaws.com/mattermost/pr-${{ inputs.PR_NUMBER }}/)**
+            **[Open preview environment](http://${{ vars.DOCS_PREVIEW_BUCKET_NAME }}.s3-website-us-east-1.amazonaws.com/mattermost/pr-${{ inputs.PR_NUMBER }}/)**

--- a/.github/workflows/docs-preview-template.yml
+++ b/.github/workflows/docs-preview-template.yml
@@ -1,0 +1,86 @@
+name: docs-preview-template
+
+on:
+  workflow_call:
+    inputs:
+      PR_NUMBER:
+        type: string
+        required: true
+      TRIGGERING_ACTOR:
+        type: string
+        required: true
+      COMMIT_SHA:
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview:
+    name: Build and deploy preview
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.COMMIT_SHA }}
+          submodules: true
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: docs/site/.nvmrc
+          cache: npm
+          cache-dependency-path: docs/site/package-lock.json
+
+      - name: Install npm dependencies
+        working-directory: docs/site
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: docs/site
+        run: npm run typecheck
+
+      - name: Build OpenAPI spec
+        run: make -C api build
+
+      - name: Build Docusaurus site (preview)
+        working-directory: docs/site
+        env:
+          BASE_URL: /mattermost/pr-${{ inputs.PR_NUMBER }}/
+        run: npm run build
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
+        with:
+          aws-access-key-id: ${{ secrets.AWS_DOCS_PR_PREVIEW_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_DOCS_PR_PREVIEW_SECRET_ACCESS_KEY }}
+          aws-region: us-east-1
+
+      - name: Upload preview to S3
+        # Repo-scoped prefix (mattermost/) — this bucket is shared
+        # with mattermost/docs previews during the migration transition, and
+        # PR numbers are per-repo, not global.
+        #
+        # No explicit --cache-control, matching mattermost/docs's existing
+        # preview workflow (shallwefootball/s3-upload-action doesn't set one
+        # either).
+        run: |
+          aws s3 sync docs/site/build/ \
+            s3://${{ vars.DOCS_PREVIEW_BUCKET_NAME }}/mattermost/pr-${{ inputs.PR_NUMBER }}/ \
+            --delete \
+            --no-progress
+
+      - name: Post preview URL comment
+        uses: peter-evans/create-or-update-comment@7dfe4b0aa0c4bbd06d172692ff8a9e18381d6979 # v3.0.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ inputs.PR_NUMBER }}
+          body: |
+            Newest code from ${{ inputs.TRIGGERING_ACTOR }} and commit ${{ inputs.COMMIT_SHA }} has docs preview
+            ready:
+
+            **[Open preview](http://${{ vars.DOCS_PREVIEW_BUCKET_NAME }}.s3-website-us-east-1.amazonaws.com/mattermost/pr-${{ inputs.PR_NUMBER }}/)**

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -11,7 +11,9 @@ jobs:
   deploy:
     uses: ./.github/workflows/docs-preview-template.yml
     if: github.event.pull_request.head.repo.full_name == github.repository
-    secrets: inherit
+    secrets:
+      AWS_DOCS_PR_PREVIEW_KEY_ID: ${{ secrets.AWS_DOCS_PR_PREVIEW_KEY_ID }}
+      AWS_DOCS_PR_PREVIEW_SECRET_ACCESS_KEY: ${{ secrets.AWS_DOCS_PR_PREVIEW_SECRET_ACCESS_KEY }}
     with:
       PR_NUMBER: ${{ github.event.number }}
       TRIGGERING_ACTOR: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -1,0 +1,18 @@
+name: docs-preview
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize, ready_for_review]
+    paths:
+      - 'docs/**'
+      - 'api/**'
+
+jobs:
+  deploy:
+    uses: ./.github/workflows/docs-preview-template.yml
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    secrets: inherit
+    with:
+      PR_NUMBER: ${{ github.event.number }}
+      TRIGGERING_ACTOR: ${{ github.event.pull_request.head.user.login }}
+      COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -7,6 +7,10 @@ on:
       - 'docs/**'
       - 'api/**'
 
+permissions:
+  contents: read
+  pull-requests: write
+
 jobs:
   deploy:
     uses: ./.github/workflows/docs-preview-template.yml

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -14,5 +14,5 @@ jobs:
     secrets: inherit
     with:
       PR_NUMBER: ${{ github.event.number }}
-      TRIGGERING_ACTOR: ${{ github.event.pull_request.head.user.login }}
+      TRIGGERING_ACTOR: ${{ github.event.pull_request.user.login }}
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}

--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -41,7 +41,7 @@ const config: Config = {
   },
 
   url: 'https://docs.mattermost.com',
-  baseUrl: '/',
+  baseUrl: process.env.BASE_URL ?? '/',
   trailingSlash: false,
 
   organizationName: 'mattermost',


### PR DESCRIPTION
#### Summary

Adds a PR preview workflow for docs: every PR touching `docs/**` or `api/**` gets a Docusaurus build deployed to the existing `mattermost-docs-preview-pulls` S3 bucket, with the preview URL posted as a PR comment.

- `docs-preview-template.yml`: shared `workflow_call` build/typecheck/deploy/comment logic.
- `docs-preview.yml`: triggers on same-repo PRs (guarded so fork PRs don't run this, since they can't access secrets).
- `docs-preview-fork.yml`: `workflow_dispatch` for maintainers to manually build a preview for a fork PR after reviewing its code, with commit-status updates.
- `docs-preview-cleanup.yml`: deletes the S3 prefix and comments when a PR closes, via `pull_request_target` so it works automatically for fork PRs too (safe here since it never checks out or executes PR code).
- `docusaurus.config.ts`: `baseUrl` now reads `process.env.BASE_URL`, defaulting to `/` for production builds, so the preview build can pass a PR-scoped base path.

Previews use a repo-scoped `mattermost/pr-<N>/` S3 prefix so they don't collide with `mattermost/docs`'s own previews of the same PR number in the same bucket during the migration transition.


#### Release Note

```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Changes are isolated to documentation preview CI/CD plus a Docusaurus `baseUrl` override for preview builds; default `baseUrl` remains `/`. Main risks are operational: incorrect S3 prefix sync/delete for PR previews and PR comment/URL correctness (cleanup uses `pull_request_target` and S3 deletion, but no code execution).  
**QA Recommendation:** Limited manual spot checks: verify same-repo PR preview builds and renders assets under `/mattermost/pr-<N>/`; verify fork preview manual trigger updates the expected commit status; close PR and confirm the S3 prefix is removed and the closed-PR comment is posted/updated as intended.  
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->