### PR TITLE
[release-11.7] Backport CI buildenv + cache-warming changes

### DIFF
--- a/.github/actions/load-buildenv/action.yml
+++ b/.github/actions/load-buildenv/action.yml
@@ -1,0 +1,66 @@
+name: Load build environment
+description: >
+  Loads build-server images uploaded by setup-buildenv into the local Docker
+  daemon, and resolves the image name from the Go version. Use in jobs that
+  run the container directly (test jobs). For jobs that only need a shell
+  inside the container, use run-in-buildenv instead.
+
+inputs:
+  go-version:
+    description: "Go version used to construct the image tag (e.g. 1.26.3)."
+    required: true
+  fips-enabled:
+    description: "Set to 'true' to resolve the FIPS build image"
+    required: false
+    default: "false"
+
+outputs:
+  image:
+    description: "Fully-qualified build image name (e.g. mattermost/mattermost-build-server:1.26.3)."
+    value: ${{ steps.resolve.outputs.image }}
+
+runs:
+  using: composite
+  steps:
+    - name: Set constants
+      shell: bash
+      run: |
+        echo "BUILDENV_ARTIFACT=buildenv-image" >> "${GITHUB_ENV}"
+        echo "BUILDENV_FIPS_ARTIFACT=buildenv-fips-image" >> "${GITHUB_ENV}"
+        echo "BUILDENV_TMPDIR=/tmp/buildenv-save" >> "${GITHUB_ENV}"
+    - name: Download buildenv artifact
+      id: download
+      if: ${{ inputs.fips-enabled != 'true' }}
+      continue-on-error: true
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      with:
+        name: ${{ env.BUILDENV_ARTIFACT }}
+        path: ${{ env.BUILDENV_TMPDIR }}/
+    - name: Load buildenv from artifact
+      if: ${{ inputs.fips-enabled != 'true' && steps.download.outcome == 'success' }}
+      shell: bash
+      run: docker load -i "${BUILDENV_TMPDIR}/image.tar.gz"
+    - name: Download buildenv-fips artifact
+      id: download-fips
+      if: ${{ inputs.fips-enabled == 'true' }}
+      continue-on-error: true
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      with:
+        name: ${{ env.BUILDENV_FIPS_ARTIFACT }}
+        path: ${{ env.BUILDENV_TMPDIR }}/
+    - name: Load buildenv-fips from artifact
+      if: ${{ inputs.fips-enabled == 'true' && steps.download-fips.outcome == 'success' }}
+      shell: bash
+      run: docker load -i "${BUILDENV_TMPDIR}/image-fips.tar.gz"
+    - name: Resolve image name
+      id: resolve
+      shell: bash
+      env:
+        FIPS: ${{ inputs.fips-enabled }}
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        if [[ "${FIPS}" == 'true' ]]; then
+          echo "image=mattermost/mattermost-build-server-fips:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
+        else
+          echo "image=mattermost/mattermost-build-server:${GO_VERSION}" >> "${GITHUB_OUTPUT}"
+        fi

--- a/.github/actions/restore-e2e-npm-cache/action.yml
+++ b/.github/actions/restore-e2e-npm-cache/action.yml
@@ -8,6 +8,6 @@ runs:
       uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
       with:
         path: ~/.npm
-        key: node-cache-${{ runner.os }}-${{ runner.arch }}-npm-e2e-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}
+        key: e2e-npm-registry-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}
         restore-keys: |
-          node-cache-${{ runner.os }}-${{ runner.arch }}-npm-e2e-
+          e2e-npm-registry-${{ runner.os }}-${{ runner.arch }}-

--- a/.github/actions/restore-e2e-npm-cache/action.yml
+++ b/.github/actions/restore-e2e-npm-cache/action.yml
@@ -1,0 +1,13 @@
+name: "Restore E2E npm registry cache"
+description: "Restore ~/.npm for cypress/playwright/api jobs (keyed on all E2E lockfiles)"
+
+runs:
+  using: "composite"
+  steps:
+    - name: ci/restore-npm-cache
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      with:
+        path: ~/.npm
+        key: node-cache-${{ runner.os }}-${{ runner.arch }}-npm-e2e-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}
+        restore-keys: |
+          node-cache-${{ runner.os }}-${{ runner.arch }}-npm-e2e-

--- a/.github/actions/run-in-buildenv/action.yml
+++ b/.github/actions/run-in-buildenv/action.yml
@@ -1,0 +1,69 @@
+name: Run in build environment
+description: >
+  Runs a script inside the build-server container. Use for build and check
+  jobs that don't need direct control over the docker run invocation.
+
+  Note the special handling of HEAD_REF, REF_NAME, and RUN_ID. Since the
+  container is not otherwise given access to the runner's environment, we
+  re-export github.head_ref, github.ref_name, and github.run_id as a
+  special case for use in safely building up BUILD_NUMBER. In general,
+  don't extend this: if your use case requires more customization, use
+  load-buildenv and invoke docker run yourself.
+
+inputs:
+  run:
+    description: "Bash script to execute inside the container"
+    required: true
+  go-version:
+    description: "Go version to use (e.g. 1.24.3). Defaults to the version in server/.go-version."
+    required: false
+    default: ""
+  fips-enabled:
+    description: "Set to 'true' to use the FIPS build image"
+    required: false
+    default: "false"
+  working-directory:
+    description: "Working directory inside the container (absolute path under /mattermost/)"
+    required: false
+    default: "/mattermost/server"
+
+runs:
+  using: composite
+  steps:
+    - name: Read Go version
+      shell: bash
+      env:
+        GO_VERSION_INPUT: ${{ inputs.go-version }}
+      run: |
+        if [[ -n "${GO_VERSION_INPUT}" ]]; then
+          echo "GO_VERSION=${GO_VERSION_INPUT}" >> "${GITHUB_ENV}"
+        else
+          echo "GO_VERSION=$(cat server/.go-version)" >> "${GITHUB_ENV}"
+        fi
+    - uses: ./.github/actions/load-buildenv
+      id: buildenv
+      with:
+        go-version: ${{ env.GO_VERSION }}
+        fips-enabled: ${{ inputs.fips-enabled }}
+    - name: Run in buildenv
+      shell: bash
+      env:
+        CMD: ${{ inputs.run }}
+        IMAGE: ${{ steps.buildenv.outputs.image }}
+        WORKING_DIR: ${{ inputs.working-directory }}
+        HEAD_REF: ${{ github.head_ref }}
+        REF_NAME: ${{ github.ref_name }}
+        RUN_ID: ${{ github.run_id }}
+      run: |
+        SCRIPT=$(mktemp)
+        printf 'git config --global --add safe.directory /mattermost\n' > "${SCRIPT}"
+        printf '%s\n' "${CMD}" >> "${SCRIPT}"
+        docker run --rm \
+          --network host \
+          -e HEAD_REF -e REF_NAME -e RUN_ID \
+          -v "$PWD:/mattermost" \
+          -v "${SCRIPT}:/run-script.sh" \
+          -w "${WORKING_DIR}" \
+          "${IMAGE}" \
+          bash -eo pipefail /run-script.sh
+        rm -f "${SCRIPT}"

--- a/.github/actions/setup-buildenv/action.yml
+++ b/.github/actions/setup-buildenv/action.yml
@@ -1,0 +1,104 @@
+name: Setup build environment
+description: >
+  Builds the mattermost-build-server images if they don't yet exist on Docker
+  Hub (e.g. during a Go version bump), and uploads them as artifacts for
+  downstream jobs. Run once per workflow before any build or test jobs.
+
+inputs:
+  go-version:
+    description: "Go version (e.g. 1.26.3)"
+    required: true
+  dockerfile:
+    description: "Path to Dockerfile.buildenv (relative to workspace root)"
+    required: false
+    default: "server/build/Dockerfile.buildenv"
+  dockerfile-fips:
+    description: "Path to Dockerfile.buildenv-fips (relative to workspace root)"
+    required: false
+    default: "server/build/Dockerfile.buildenv-fips"
+
+runs:
+  using: composite
+  steps:
+    - name: Set constants
+      shell: bash
+      run: |
+        echo "BUILDENV_IMAGE=mattermost/mattermost-build-server" >> "${GITHUB_ENV}"
+        echo "BUILDENV_ARTIFACT=buildenv-image" >> "${GITHUB_ENV}"
+        echo "BUILDENV_DOCKERFILE=${{ inputs.dockerfile }}" >> "${GITHUB_ENV}"
+        echo "BUILDENV_FIPS_IMAGE=mattermost/mattermost-build-server-fips" >> "${GITHUB_ENV}"
+        echo "BUILDENV_FIPS_ARTIFACT=buildenv-fips-image" >> "${GITHUB_ENV}"
+        echo "BUILDENV_FIPS_DOCKERFILE=${{ inputs.dockerfile-fips }}" >> "${GITHUB_ENV}"
+        echo "BUILDENV_TMPDIR=/tmp/buildenv-save" >> "${GITHUB_ENV}"
+    # ── Regular ────────────────────────────────────────────────────────
+    - name: Resolve regular image
+      id: resolve
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        docker manifest inspect "${BUILDENV_IMAGE}:${GO_VERSION}" > /dev/null 2>&1 || \
+          echo "needs-build=true" >> "${GITHUB_OUTPUT}"
+    - name: Build regular image
+      if: ${{ steps.resolve.outputs.needs-build == 'true' }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: docker build -t "${BUILDENV_IMAGE}:${GO_VERSION}" - < "${BUILDENV_DOCKERFILE}"
+    - name: Save and upload regular image
+      if: ${{ steps.resolve.outputs.needs-build == 'true' }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        mkdir -p "${BUILDENV_TMPDIR}"
+        docker save "${BUILDENV_IMAGE}:${GO_VERSION}" | gzip > "${BUILDENV_TMPDIR}/image.tar.gz"
+    - name: Upload regular image artifact
+      if: ${{ steps.resolve.outputs.needs-build == 'true' }}
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ env.BUILDENV_ARTIFACT }}
+        path: ${{ env.BUILDENV_TMPDIR }}/image.tar.gz
+        retention-days: 1
+    # ── FIPS (skipped on fork PRs) ─────────────────────────────────────
+    - name: Docker Hub login
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
+      with:
+        username: ${{ env.DOCKERHUB_USERNAME }}
+        password: ${{ env.DOCKERHUB_TOKEN }}
+    - name: Setup Chainctl
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      uses: chainguard-dev/setup-chainctl@c125f765e82b09a42af3185f3214465314d75c5d # v0.5.0
+      with:
+        identity: ${{ env.CHAINCTL_IDENTITY }}
+    - name: Resolve FIPS image
+      id: resolve-fips
+      if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        docker manifest inspect "${BUILDENV_FIPS_IMAGE}:${GO_VERSION}" > /dev/null 2>&1 || \
+          echo "needs-build=true" >> "${GITHUB_OUTPUT}"
+    - name: Build FIPS image
+      if: ${{ steps.resolve-fips.outputs.needs-build == 'true' }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: docker build -t "${BUILDENV_FIPS_IMAGE}:${GO_VERSION}" - < "${BUILDENV_FIPS_DOCKERFILE}"
+    - name: Save and upload FIPS image
+      if: ${{ steps.resolve-fips.outputs.needs-build == 'true' }}
+      shell: bash
+      env:
+        GO_VERSION: ${{ inputs.go-version }}
+      run: |
+        mkdir -p "${BUILDENV_TMPDIR}"
+        docker save "${BUILDENV_FIPS_IMAGE}:${GO_VERSION}" | gzip > "${BUILDENV_TMPDIR}/image-fips.tar.gz"
+    - name: Upload FIPS image artifact
+      if: ${{ steps.resolve-fips.outputs.needs-build == 'true' }}
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: ${{ env.BUILDENV_FIPS_ARTIFACT }}
+        path: ${{ env.BUILDENV_TMPDIR }}/image-fips.tar.gz
+        retention-days: 1

--- a/.github/actions/webapp-setup/action.yml
+++ b/.github/actions/webapp-setup/action.yml
@@ -27,6 +27,9 @@ runs:
           webapp/platform/shared/node_modules
           webapp/platform/types/node_modules
         key: node-modules-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json') }}
+        # fall back to most recent cache for this OS if package-lock.json changed
+        restore-keys: |
+          node-modules-${{ runner.os }}-
     - name: ci/restore-node-modules
       if: inputs.read-only == 'true'
       uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
@@ -40,6 +43,9 @@ runs:
           webapp/platform/shared/node_modules
           webapp/platform/types/node_modules
         key: node-modules-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json') }}
+        # fall back to most recent cache for this OS if package-lock.json changed
+        restore-keys: |
+          node-modules-${{ runner.os }}-
     - name: ci/resolve-cache-hit
       id: cache-hit
       shell: bash

--- a/.github/actions/webapp-setup/action.yml
+++ b/.github/actions/webapp-setup/action.yml
@@ -1,6 +1,12 @@
 name: "Web app setup"
 description: "Set up NPM and dependencies"
 
+inputs:
+  read-only:
+    description: "Restore from cache without saving"
+    required: false
+    default: "false"
+
 runs:
   using: "composite"
   steps:
@@ -9,8 +15,9 @@ runs:
       with:
         node-version-file: ".nvmrc"
     - name: ci/cache-node-modules
+      if: inputs.read-only != 'true'
       uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-      id: cache-node-modules
+      id: cache-node-modules-rw
       with:
         path: |
           webapp/node_modules
@@ -20,16 +27,34 @@ runs:
           webapp/platform/shared/node_modules
           webapp/platform/types/node_modules
         key: node-modules-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json') }}
+    - name: ci/restore-node-modules
+      if: inputs.read-only == 'true'
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      id: cache-node-modules-ro
+      with:
+        path: |
+          webapp/node_modules
+          webapp/channels/node_modules
+          webapp/platform/client/node_modules
+          webapp/platform/components/node_modules
+          webapp/platform/shared/node_modules
+          webapp/platform/types/node_modules
+        key: node-modules-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json') }}
+    - name: ci/resolve-cache-hit
+      id: cache-hit
+      shell: bash
+      run: |
+        echo "cache-hit=${{ steps.cache-node-modules-rw.outputs.cache-hit || steps.cache-node-modules-ro.outputs.cache-hit }}" >> $GITHUB_OUTPUT
     - name: ci/get-node-modules
-      if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      if: steps.cache-hit.outputs.cache-hit != 'true'
       shell: bash
       working-directory: webapp
       run: |
         make node_modules
     - name: ci/build-platform-packages
-      # These are built automatically when depenedencies are installed, but they aren't cached properly, so we need to
+      # These are built automatically when dependencies are installed, but they aren't cached properly, so we need to
       # manually build them when the cache is hit. They aren't worth caching because they have too many dependencies.
-      if: steps.cache-node-modules.outputs.cache-hit == 'true'
+      if: steps.cache-hit.outputs.cache-hit == 'true'
       shell: bash
       working-directory: webapp
       run: |

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/api.yml
+++ b/.github/workflows/api.yml
@@ -22,11 +22,12 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: ci/restore-npm-cache
+        uses: ./.github/actions/restore-e2e-npm-cache
+
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: .nvmrc
-          cache: "npm"
-          cache-dependency-path: api/package-lock.json
 
       - name: Run build
         run: make build

--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -30,6 +30,8 @@ jobs:
     steps:
       - name: buildenv/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: buildenv/docker-login
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
@@ -76,6 +78,8 @@ jobs:
           identity: ${{ env.CHAINCTL_IDENTITY }}
       - name: buildenv/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: buildenv/docker-login
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -24,6 +24,7 @@ jobs:
       issues: read
       id-token: write
     steps:
+      # Keep persist-credentials default while anthropics/claude-code-action#1236 is open
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -26,6 +26,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/docker-push-mirrored.yml
+++ b/.github/workflows/docker-push-mirrored.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: cd/Login to Docker Hub
         uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2 # v4.0.0
         with:

--- a/.github/workflows/e2e-ci-cache-warm.yml
+++ b/.github/workflows/e2e-ci-cache-warm.yml
@@ -44,7 +44,7 @@ jobs:
         uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.npm
-          key: node-cache-${{ runner.os }}-${{ runner.arch }}-npm-e2e-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}
+          key: e2e-npm-registry-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}
           lookup-only: true
 
       - name: ci/setup-node
@@ -75,4 +75,4 @@ jobs:
         uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
           path: ~/.npm
-          key: node-cache-${{ runner.os }}-${{ runner.arch }}-npm-e2e-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}
+          key: e2e-npm-registry-${{ runner.os }}-${{ runner.arch }}-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}

--- a/.github/workflows/e2e-ci-cache-warm.yml
+++ b/.github/workflows/e2e-ci-cache-warm.yml
@@ -1,0 +1,78 @@
+# Warms the ~/.npm registry cache used by the e2e suites (cypress, playwright,
+# api). Runs once per day on master; all e2e/api CI jobs restore this cache
+# read-only via .github/actions/restore-e2e-npm-cache and never write back, so
+# this job is its sole writer.
+#
+# The cache is keyed on the OS/arch and a hash of all e2e lockfiles. Keep the key
+# below in sync with .github/actions/restore-e2e-npm-cache, which is the canonical
+# definition of the bucket's lockfile set. PRs that change a lockfile miss the
+# exact key and fall back to the most recent warm entry via restore-keys.
+#
+# The webapp node_modules cache is warmed separately by webapp-ci-cache-warm.yml.
+name: E2E CI Cache Warm
+
+on:
+  schedule:
+    - cron: "0 1 * * *" # Daily 1am UTC — 1 h before e2e CI typically runs
+  workflow_dispatch:
+
+# Prevent an overlapping manual dispatch and scheduled run from both missing the
+# lookup and then racing to reserve the same cache key.
+concurrency:
+  group: e2e-ci-cache-warm
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write # required to save the Actions cache
+
+jobs:
+  warm:
+    name: Warm E2E npm Registry Cache
+    runs-on: ubuntu-24.04
+    # Bound a hung run so it can't hold the concurrency group for the default
+    # 6-hour timeout and block subsequent warm runs.
+    timeout-minutes: 60
+    steps:
+      - name: Checkout mattermost project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Check if npm registry cache already warm
+        id: e2e-npm-check
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.npm
+          key: node-cache-${{ runner.os }}-${{ runner.arch }}-npm-e2e-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}
+          lookup-only: true
+
+      - name: ci/setup-node
+        if: steps.e2e-npm-check.outputs.cache-hit != 'true'
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: ".nvmrc"
+
+      # ~/.npm is content-addressable and grows additively across installs, so we
+      # populate it by running each suite's install, then save the single bucket.
+      - name: Install playwright npm packages
+        if: steps.e2e-npm-check.outputs.cache-hit != 'true'
+        working-directory: e2e-tests/playwright
+        run: npm ci
+
+      - name: Install cypress npm packages
+        if: steps.e2e-npm-check.outputs.cache-hit != 'true'
+        working-directory: e2e-tests/cypress
+        run: npm ci
+
+      - name: Install api npm packages
+        if: steps.e2e-npm-check.outputs.cache-hit != 'true'
+        working-directory: api
+        run: npm ci
+
+      - name: Save npm registry cache
+        if: steps.e2e-npm-check.outputs.cache-hit != 'true'
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: ~/.npm
+          key: node-cache-${{ runner.os }}-${{ runner.arch }}-npm-e2e-${{ hashFiles('e2e-tests/cypress/package-lock.json', 'e2e-tests/playwright/package-lock.json', 'api/package-lock.json') }}

--- a/.github/workflows/e2e-fulltests-ci.yml
+++ b/.github/workflows/e2e-fulltests-ci.yml
@@ -115,6 +115,7 @@ jobs:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: "${{ inputs.ref || github.sha }}"
           fetch-depth: 0
       - name: ci/generate-test-variables

--- a/.github/workflows/e2e-tests-check.yml
+++ b/.github/workflows/e2e-tests-check.yml
@@ -15,6 +15,7 @@ jobs:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: ci/setup-node

--- a/.github/workflows/e2e-tests-check.yml
+++ b/.github/workflows/e2e-tests-check.yml
@@ -18,14 +18,25 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
+      - name: ci/restore-npm-cache
+        uses: ./.github/actions/restore-e2e-npm-cache
       - name: ci/setup-node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: |
-            e2e-tests/cypress/package-lock.json
-            e2e-tests/playwright/package-lock.json
+      - name: ci/npm-cache-verify
+        # Heal any partial/dangling entries left in the restored ~/.npm cache
+        # before running `npm ci`. Avoids the intermittent EEXIST/ENOENT
+        # failures in npm's cacache writer.
+        run: npm cache verify
+
+      # Set up web app subpackages and eslint plugin, restoring the warmed
+      # node_modules cache read-only and falling back to `make node_modules` on a
+      # miss.
+      - name: ci/webapp-setup
+        uses: ./.github/actions/webapp-setup
+        with:
+          read-only: "true"
 
       # Cypress check
       - name: ci/cypress/npm-install

--- a/.github/workflows/e2e-tests-ci-template.yml
+++ b/.github/workflows/e2e-tests-ci-template.yml
@@ -120,7 +120,6 @@ jobs:
         shell: bash
     outputs:
       workers: "${{ steps.generate.outputs.workers }}"
-      node-cache-dependency-path: "${{ steps.generate.outputs.node-cache-dependency-path }}"
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -131,11 +130,9 @@ jobs:
         id: generate
         env:
           WORKERS: ${{ inputs.workers_number }}
-          TEST: ${{ inputs.TEST }}
         run: |
           [ "$WORKERS" -gt "0" ] # Assert that the workers number is an integer greater than 0
           echo "workers="$(jq --slurp --compact-output '[range('"$WORKERS"')] | map(tostring)' /dev/null) >> $GITHUB_OUTPUT
-          echo "node-cache-dependency-path=e2e-tests/${TEST}/package-lock.json" >> $GITHUB_OUTPUT
 
   generate-test-cycle:
     runs-on: ubuntu-24.04
@@ -153,13 +150,13 @@ jobs:
         with:
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
+      - name: ci/restore-npm-cache
+        uses: ./.github/actions/restore-e2e-npm-cache
       - name: ci/setup-node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         id: setup_node
         with:
           node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: "e2e-tests/cypress/package-lock.json" # NB: the generate-cycle script is cypress-specific operation for now
       - name: ci/e2e-test-gencycle
         id: e2e-test-gencycle
         env:
@@ -237,13 +234,13 @@ jobs:
           mkdir -p ~/.docker/cli-plugins
           ln -sfn /usr/local/opt/docker-compose/bin/docker-compose ~/.docker/cli-plugins/docker-compose
           sudo ln -sf $HOME/.colima/default/docker.sock /var/run/docker.sock
+      - name: ci/restore-npm-cache
+        uses: ./.github/actions/restore-e2e-npm-cache
       - name: ci/setup-node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         id: setup_node
         with:
           node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: ${{ needs.generate-build-variables.outputs.node-cache-dependency-path }}
       - name: ci/e2e-test
         run: |
           make cloud-init
@@ -317,14 +314,15 @@ jobs:
           path: |
             e2e-tests/${{ inputs.TEST }}/logs/
             e2e-tests/${{ inputs.TEST }}/results/
+      - name: ci/restore-npm-cache
+        if: "${{ inputs.enable_reporting }}"
+        uses: ./.github/actions/restore-e2e-npm-cache
       - name: ci/setup-node
         if: "${{ inputs.enable_reporting }}"
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         id: setup_node
         with:
           node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: ${{ needs.generate-build-variables.outputs.node-cache-dependency-path }}
       - name: ci/publish-report
         if: "${{ inputs.enable_reporting }}"
         env:

--- a/.github/workflows/e2e-tests-ci.yml
+++ b/.github/workflows/e2e-tests-ci.yml
@@ -35,6 +35,7 @@ jobs:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: ci/resolve-pr-and-commit
@@ -127,6 +128,7 @@ jobs:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ needs.resolve-pr.outputs.COMMIT_SHA }}
           fetch-depth: 0
       - name: ci/check-relevant-changes

--- a/.github/workflows/e2e-tests-cypress-template.yml
+++ b/.github/workflows/e2e-tests-cypress-template.yml
@@ -141,12 +141,12 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
+      - name: ci/restore-npm-cache
+        uses: ./.github/actions/restore-e2e-npm-cache
       - name: ci/setup-node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: "e2e-tests/cypress/package-lock.json"
 
       - name: ci/generate-test-cycle
         id: generate-cycle
@@ -203,12 +203,20 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
+      - name: ci/restore-npm-cache
+        uses: ./.github/actions/restore-e2e-npm-cache
       - name: ci/setup-node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: "e2e-tests/cypress/package-lock.json"
+      - name: ci/npm-cache-verify
+        # Heal any partial/dangling entries left in the restored ~/.npm cache
+        # before running `npm ci`. Avoids the intermittent EEXIST/ENOENT
+        # failures in npm's cacache writer.
+        run: npm cache verify
+      - name: ci/get-webapp-node-modules
+        working-directory: webapp
+        run: make node_modules
       - name: ci/run-tests
         run: |
           make cloud-init
@@ -300,12 +308,12 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
+      - name: ci/restore-npm-cache
+        uses: ./.github/actions/restore-e2e-npm-cache
       - name: ci/setup-node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: "e2e-tests/cypress/package-lock.json"
       - name: ci/run-failed-specs
         env:
           SPEC_FILES: ${{ needs.calculate-results.outputs.failed_specs }}
@@ -349,12 +357,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: ci/restore-npm-cache
+        uses: ./.github/actions/restore-e2e-npm-cache
       - name: ci/setup-node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: "e2e-tests/cypress/package-lock.json"
 
       # PATH A: run-failed-tests was skipped (no failures to retest)
       - name: ci/download-results-path-a

--- a/.github/workflows/e2e-tests-cypress-template.yml
+++ b/.github/workflows/e2e-tests-cypress-template.yml
@@ -138,6 +138,7 @@ jobs:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
       - name: ci/setup-node
@@ -199,6 +200,7 @@ jobs:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
       - name: ci/setup-node
@@ -247,6 +249,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: ci/download-results
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
@@ -293,6 +297,7 @@ jobs:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
       - name: ci/setup-node
@@ -342,6 +347,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: ci/setup-node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/e2e-tests-on-merge.yml
+++ b/.github/workflows/e2e-tests-on-merge.yml
@@ -26,6 +26,7 @@ jobs:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ inputs.branch }}
           fetch-depth: 50
       - name: ci/generate-variables

--- a/.github/workflows/e2e-tests-on-release.yml
+++ b/.github/workflows/e2e-tests-on-release.yml
@@ -29,6 +29,7 @@ jobs:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ inputs.branch }}
           fetch-depth: 50
       - name: ci/validate-inputs

--- a/.github/workflows/e2e-tests-playwright-template.yml
+++ b/.github/workflows/e2e-tests-playwright-template.yml
@@ -159,12 +159,17 @@ jobs:
         with:
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
+      - name: ci/restore-npm-cache
+        uses: ./.github/actions/restore-e2e-npm-cache
       - name: ci/setup-node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: "e2e-tests/playwright/package-lock.json"
+      - name: ci/npm-cache-verify
+        # Heal any partial/dangling entries left in the restored ~/.npm cache
+        # before running `npm ci`. Avoids the intermittent EEXIST/ENOENT
+        # failures in npm's cacache writer.
+        run: npm cache verify
       - name: ci/get-webapp-node-modules
         working-directory: webapp
         run: make node_modules
@@ -210,12 +215,12 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: ci/restore-npm-cache
+        uses: ./.github/actions/restore-e2e-npm-cache
       - name: ci/setup-node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: "e2e-tests/playwright/package-lock.json"
       - name: ci/download-shard-results
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
@@ -323,12 +328,12 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: ci/restore-npm-cache
+        uses: ./.github/actions/restore-e2e-npm-cache
       - name: ci/setup-node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".nvmrc"
-          cache: npm
-          cache-dependency-path: "e2e-tests/playwright/package-lock.json"
 
       # Download merged results (uploaded by calculate-results)
       - name: ci/download-results

--- a/.github/workflows/i18n-ci-template.yml
+++ b/.github/workflows/i18n-ci-template.yml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get changed files
         id: changed-files

--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -39,6 +39,8 @@ jobs:
 
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup BUILD_IMAGE
         id: build
         run: |

--- a/.github/workflows/mmctl-test-template.yml
+++ b/.github/workflows/mmctl-test-template.yml
@@ -36,19 +36,22 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Setup BUILD_IMAGE
-        id: build
+      - name: buildenv/load
+        id: buildenv
+        uses: ./.github/actions/load-buildenv
+        with:
+          go-version: ${{ inputs.go-version }}
+          fips-enabled: ${{ inputs.fips-enabled }}
+      - name: Setup log artifact name
+        id: log-artifact
         run: |
           if [[ ${{ inputs.fips-enabled }} == 'true' ]]; then
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}-fips" >> "${GITHUB_OUTPUT}"
           else
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}" >> "${GITHUB_OUTPUT}"
           fi
 
@@ -70,7 +73,7 @@ jobs:
 
       - name: Run mmctl Tests
         env:
-          BUILD_IMAGE: ${{ steps.build.outputs.BUILD_IMAGE }}
+          BUILD_IMAGE: ${{ steps.buildenv.outputs.image }}
         run: |
           if [[ ${{ github.ref_name }} == 'master' ]]; then
             export TESTFLAGS="-timeout 90m -race"
@@ -100,13 +103,13 @@ jobs:
         with:
           report-path: server/report.xml
           zephyr-api-key: ${{ secrets.MM_E2E_ZEPHYR_API_KEY }}
-          build-image: ${{ steps.build.outputs.BUILD_IMAGE }}
+          build-image: ${{ steps.buildenv.outputs.image }}
 
       - name: Archive logs
         if: ${{ always() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: ${{ steps.build.outputs.LOG_ARTIFACT_NAME }}
+          name: ${{ steps.log-artifact.outputs.LOG_ARTIFACT_NAME }}
           path: |
             server/gotestsum.json
             server/report.xml

--- a/.github/workflows/sentry.yaml
+++ b/.github/workflows/sentry.yaml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: cd/Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: cd/Create Sentry release
         uses: getsentry/action-release@dab6548b3c03c4717878099e43782cf5be654289 # v3.5.0
 

--- a/.github/workflows/server-ci-artifacts.yml
+++ b/.github/workflows/server-ci-artifacts.yml
@@ -86,6 +86,7 @@ jobs:
         if: github.event.workflow_run.head_repository.full_name != github.repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           sparse-checkout: server/build/
           sparse-checkout-cone-mode: true
 

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -37,6 +37,8 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Calculate version
         id: calculate
         working-directory: server/
@@ -58,6 +60,8 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Generate mocks
@@ -75,6 +79,8 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Run go mod tidy
@@ -92,6 +98,8 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Run golangci
@@ -107,6 +115,8 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Run make-gen-serialized
@@ -124,6 +134,8 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Run mattermost-vet-api
@@ -139,6 +151,8 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Extract migrations files
         run: make migrations-extract
       - name: Check migration files
@@ -154,6 +168,8 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Generate email templates
         run: |
           npm install -g mjml@4.9.0
@@ -171,6 +187,8 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Generate store layers
@@ -188,6 +206,8 @@ jobs:
     steps:
       - name: Checkout mattermost-server
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Run setup-go-work
         run: make setup-go-work
       - name: Check docs
@@ -348,6 +368,8 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: ci/setup-node
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -62,8 +62,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Generate mocks
         run: make mocks
       - name: Check mocks
@@ -81,8 +79,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Run go mod tidy
         run: make modules-tidy
       - name: Check modules
@@ -100,8 +96,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Run golangci
         run: make check-style
   check-gen-serialized:
@@ -117,8 +111,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Run make-gen-serialized
         run: make gen-serialized
       - name: Check serialized
@@ -136,8 +128,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Run mattermost-vet-api
         run: make vet-api
   check-migrations:
@@ -189,8 +179,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Generate store layers
         run: make store-layers
       - name: Check generated code
@@ -208,8 +196,6 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Check docs
         run: |
           echo "Making sure docs are updated"
@@ -376,8 +362,6 @@ jobs:
           node-version-file: ".nvmrc"
           cache: "npm"
           cache-dependency-path: "webapp/package-lock.json"
-      - name: Run setup-go-work
-        run: make setup-go-work
       - name: Build
         run: |
           make config-reset

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -60,10 +60,12 @@ jobs:
         uses: ./.github/actions/setup-buildenv
         with:
           go-version: ${{ steps.calculate.outputs.GO_VERSION }}
-  check-mocks:
-    name: Check mocks
+  check-generated:
+    name: Check generated files
     needs: go
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -71,23 +73,14 @@ jobs:
           persist-credentials: false
       - uses: ./.github/actions/run-in-buildenv
         with:
-          run: make mocks
-      - name: Check mocks
-        run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the mocks using `make mocks`"; exit 1; fi
-  check-go-mod-tidy:
-    name: Check go mod tidy
-    needs: go
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/run-in-buildenv
-        with:
-          run: make modules-tidy
-      - name: Check modules
-        run: if [[ -n $(git status --porcelain) ]]; then echo "Please tidy up the Go modules using make modules-tidy"; git diff; exit 1; fi
+          run: make generated
+      - name: Check generated files
+        run: |
+          if [ -n "$(git status --porcelain)" ]; then
+            echo "Generated files are out of date. Please run 'make generated' and commit the result."
+            git diff
+            exit 1
+          fi
   check-style:
     name: check-style
     needs: go
@@ -100,20 +93,6 @@ jobs:
       - uses: ./.github/actions/run-in-buildenv
         with:
           run: make check-style
-  check-gen-serialized:
-    name: Check serialization methods for hot structs
-    needs: go
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/run-in-buildenv
-        with:
-          run: make gen-serialized
-      - name: Check serialized
-        run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the serialized files using 'make gen-serialized'"; exit 1; fi
   check-mattermost-vet-api:
     name: Vet API
     needs: go
@@ -126,64 +105,6 @@ jobs:
       - uses: ./.github/actions/run-in-buildenv
         with:
           run: make vet-api
-  check-migrations:
-    name: Check migration files
-    needs: go
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/run-in-buildenv
-        with:
-          run: make migrations-extract
-      - name: Check migration files
-        run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the migrations using make migrations-extract"; exit 1; fi
-  check-email-templates:
-    name: Generate email templates
-    needs: go
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/run-in-buildenv
-        with:
-          run: |
-            npm install -g mjml@4.9.0
-            make build-templates
-      - name: Check generated email templates
-        run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the email templates using `make build-templates`"; exit 1; fi
-  check-store-layers:
-    name: Check store layers
-    needs: go
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/run-in-buildenv
-        with:
-          run: make store-layers
-      - name: Check generated code
-        run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the store layers using make store-layers"; exit 1; fi
-  check-mmctl-docs:
-    name: Check mmctl docs
-    needs: go
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Checkout mattermost-server
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/run-in-buildenv
-        with:
-          run: make mmctl-docs
-      - name: Check docs
-        run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the mmctl docs using make mmctl-docs"; exit 1; fi
   test-postgres-binary:
     if: github.event_name == 'push' # Only run postgres binary tests on master/release pushes: odds are low this regresses, so save the cycles for pull requests.
     name: Postgres with binary parameters

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -64,8 +64,6 @@ jobs:
     name: Check generated files
     needs: go
     runs-on: ubuntu-22.04
-    permissions:
-      contents: read
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -16,8 +16,6 @@ on:
       - ".github/workflows/server-test-template.yml"
       - ".github/workflows/server-test-merge-template.yml"
       - ".github/workflows/mmctl-test-template.yml"
-      - "!server/build/Dockerfile.buildenv"
-      - "!server/build/Dockerfile.buildenv-fips"
       - "tools/mattermost-govet/**"
       - "!server/**/*.md"
       - "!server/NOTICE.txt"
@@ -31,12 +29,17 @@ jobs:
   go:
     name: Compute Go Version
     runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      pull-requests: read
+      actions: write
+      id-token: write  # for chainguard (FIPS base image pull)
     outputs:
       version: ${{ steps.calculate.outputs.GO_VERSION }}
       gomod-changed: ${{ steps.changed-files.outputs.any_changed }}
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
       - name: Calculate version
@@ -45,162 +48,142 @@ jobs:
         run: echo GO_VERSION=$(cat .go-version) >> "${GITHUB_OUTPUT}"
       - name: Check for go.mod changes
         id: changed-files
-        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323 # v47.0.5
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323  # v47.0.5
         with:
           files: |
             **/go.mod
+      - name: Setup build environment
+        env:
+          CHAINCTL_IDENTITY: ee399b4c72dd4e58e3d617f78fc47b74733c9557/922f2d48307d6f5f
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        uses: ./.github/actions/setup-buildenv
+        with:
+          go-version: ${{ steps.calculate.outputs.GO_VERSION }}
   check-mocks:
     name: Check mocks
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Generate mocks
-        run: make mocks
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make mocks
       - name: Check mocks
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the mocks using `make mocks`"; exit 1; fi
   check-go-mod-tidy:
     name: Check go mod tidy
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Run go mod tidy
-        run: make modules-tidy
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make modules-tidy
       - name: Check modules
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please tidy up the Go modules using make modules-tidy"; git diff; exit 1; fi
   check-style:
     name: check-style
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Run golangci
-        run: make check-style
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make check-style
   check-gen-serialized:
     name: Check serialization methods for hot structs
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Run make-gen-serialized
-        run: make gen-serialized
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make gen-serialized
       - name: Check serialized
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the serialized files using 'make gen-serialized'"; exit 1; fi
   check-mattermost-vet-api:
     name: Vet API
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Run mattermost-vet-api
-        run: make vet-api
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make vet-api
   check-migrations:
     name: Check migration files
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Extract migrations files
-        run: make migrations-extract
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make migrations-extract
       - name: Check migration files
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the migrations using make migrations-extract"; exit 1; fi
   check-email-templates:
     name: Generate email templates
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Generate email templates
-        run: |
-          npm install -g mjml@4.9.0
-          make build-templates
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: |
+            npm install -g mjml@4.9.0
+            make build-templates
       - name: Check generated email templates
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the email templates using `make build-templates`"; exit 1; fi
   check-store-layers:
     name: Check store layers
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: Generate store layers
-        run: make store-layers
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make store-layers
       - name: Check generated code
         run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the store layers using make store-layers"; exit 1; fi
   check-mmctl-docs:
     name: Check mmctl docs
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
     steps:
       - name: Checkout mattermost-server
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
+      - uses: ./.github/actions/run-in-buildenv
+        with:
+          run: make mmctl-docs
       - name: Check docs
-        run: |
-          echo "Making sure docs are updated"
-          make mmctl-docs
-          if [[ -n $(git status --porcelain) ]]; then echo "Please update the mmctl docs using make mmctl-docs"; exit 1; fi
+        run: if [[ -n $(git status --porcelain) ]]; then echo "Please update the mmctl docs using make mmctl-docs"; exit 1; fi
   test-postgres-binary:
     if: github.event_name == 'push' # Only run postgres binary tests on master/release pushes: odds are low this regresses, so save the cycles for pull requests.
     name: Postgres with binary parameters
@@ -220,7 +203,7 @@ jobs:
     name: Postgres (shard ${{ matrix.shard }})
     needs: go
     strategy:
-      fail-fast: false # Let all shards complete so we get full test results
+      fail-fast: false  # Let all shards complete so we get full test results
       matrix:
         shard: [0, 1, 2, 3]
     uses: ./.github/workflows/server-test-template.yml
@@ -344,29 +327,20 @@ jobs:
     name: Build mattermost server app
     needs: go
     runs-on: ubuntu-22.04
-    container: mattermost/mattermost-build-server:${{ needs.go.outputs.version }}
-    defaults:
-      run:
-        working-directory: server
-    env:
-      BUILD_NUMBER: "${GITHUB_HEAD_REF}-${GITHUB_RUN_ID}"
-      FIPS_ENABLED: false
     steps:
       - name: Checkout mattermost project
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
           persist-credentials: false
-      - name: ci/setup-node
-        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
-        with:
-          node-version-file: ".nvmrc"
-          cache: "npm"
-          cache-dependency-path: "webapp/package-lock.json"
       - name: Build
-        run: |
-          make config-reset
-          make build-cmd
-          make package
+        uses: ./.github/actions/run-in-buildenv
+        with:
+          run: |
+            export BUILD_NUMBER="$(printf '%s' "${HEAD_REF:-${REF_NAME}}" | tr -c 'A-Za-z0-9._-' '-')-${RUN_ID}"
+            export FIPS_ENABLED=false
+            make config-reset
+            make build-cmd
+            make package
       - name: Persist dist artifacts
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
@@ -377,7 +351,7 @@ jobs:
           retention-days: 2
       - name: Persist build artifacts
         if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
-        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+        uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f  # v7.0.0
         with:
           name: server-build-artifact
           path: server/build/

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -78,6 +78,7 @@ jobs:
         run: |
           if [ -n "$(git status --porcelain)" ]; then
             echo "Generated files are out of date. Please run 'make generated' and commit the result."
+            git status --porcelain
             git diff
             exit 1
           fi

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -73,6 +73,8 @@ jobs:
 
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Restore test timing data
         if: inputs.shard-total > 1

--- a/.github/workflows/server-test-template.yml
+++ b/.github/workflows/server-test-template.yml
@@ -54,6 +54,7 @@ on:
 permissions:
   id-token: write
   contents: read
+  actions: read    # for load-buildenv artifact listing
 
 jobs:
   test:
@@ -75,6 +76,12 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
+      - name: buildenv/load
+        id: buildenv
+        uses: ./.github/actions/load-buildenv
+        with:
+          go-version: ${{ inputs.go-version }}
+          fips-enabled: ${{ inputs.fips-enabled }}
 
       - name: Restore test timing data
         if: inputs.shard-total > 1
@@ -96,14 +103,12 @@ jobs:
           restore-keys: |
             server-test-timing-v2-
 
-      - name: Setup BUILD_IMAGE
-        id: build
+      - name: Setup log artifact name
+        id: log-artifact
         run: |
           if [[ ${{ inputs.fips-enabled }} == 'true' ]]; then
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server-fips:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}-fips" >> "${GITHUB_OUTPUT}"
           else
-            echo "BUILD_IMAGE=mattermost/mattermost-build-server:${{ inputs.go-version }}" >> "${GITHUB_OUTPUT}"
             echo "LOG_ARTIFACT_NAME=${{ inputs.logsartifact }}" >> "${GITHUB_OUTPUT}"
           fi
 
@@ -189,7 +194,7 @@ jobs:
 
       - name: Run Tests
         env:
-          BUILD_IMAGE: ${{ steps.build.outputs.BUILD_IMAGE }}
+          BUILD_IMAGE: ${{ steps.buildenv.outputs.image }}
         run: |
           if [[ ${{ github.ref_name }} == 'master' && ${{ inputs.fullyparallel }} != true && "${{ inputs.test-target }}" == "test-server" ]]; then
             export RACE_MODE="-race"
@@ -242,7 +247,7 @@ jobs:
         if: ${{ always() }}
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
         with:
-          name: ${{ steps.build.outputs.LOG_ARTIFACT_NAME }}
+          name: ${{ steps.log-artifact.outputs.LOG_ARTIFACT_NAME }}
           path: |
             server/gotestsum.json
             server/report.xml

--- a/.github/workflows/tag-public-module.yaml
+++ b/.github/workflows/tag-public-module.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: release/checkout-mattermost
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - name: release/find-latest-public-module-tags

--- a/.github/workflows/tools-ci.yml
+++ b/.github/workflows/tools-ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:
@@ -39,6 +41,8 @@ jobs:
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Setup Go
         uses: actions/setup-go@4b73464bb391d4059bd26b0524d20df3927bd417 # v6.3.0
         with:

--- a/.github/workflows/webapp-ci-cache-warm.yml
+++ b/.github/workflows/webapp-ci-cache-warm.yml
@@ -1,0 +1,77 @@
+# Warms the webapp node_modules cache used by webapp CI and the E2E v2 templates
+# (via .github/actions/webapp-setup). Runs once per day on master so the cache is
+# fresh before CI runs; webapp CI restores it read-only, though the E2E v2
+# templates also populate it within their own runs.
+#
+# The cache is keyed on the OS and a hash of webapp/package-lock.json. PRs that
+# change the lockfile miss the exact key and fall back to the most recent warm
+# entry via restore-keys, then reconcile the delta with `make node_modules`.
+#
+# The E2E ~/.npm registry cache is warmed separately by e2e-ci-cache-warm.yml.
+name: Webapp CI Cache Warm
+
+on:
+  schedule:
+    - cron: "0 1 * * *" # Daily 1am UTC — 1 h before webapp CI typically runs
+  workflow_dispatch:
+
+# Prevent an overlapping manual dispatch and scheduled run from both missing the
+# lookup and then racing to reserve the same cache key.
+concurrency:
+  group: webapp-ci-cache-warm
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write # required to save the Actions cache
+
+jobs:
+  warm:
+    name: Warm Webapp node_modules Cache
+    runs-on: ubuntu-24.04
+    # Bound a hung run so it can't hold the concurrency group for the default
+    # 6-hour timeout and block subsequent warm runs.
+    timeout-minutes: 60
+    steps:
+      - name: Checkout mattermost project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Check if node_modules cache already warm
+        id: node-modules-check
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            webapp/node_modules
+            webapp/channels/node_modules
+            webapp/platform/client/node_modules
+            webapp/platform/components/node_modules
+            webapp/platform/shared/node_modules
+            webapp/platform/types/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json') }}
+          lookup-only: true
+
+      - name: ci/setup-node
+        if: steps.node-modules-check.outputs.cache-hit != 'true'
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: ".nvmrc"
+
+      - name: Install node modules
+        if: steps.node-modules-check.outputs.cache-hit != 'true'
+        working-directory: webapp
+        run: make node_modules
+
+      - name: Save node_modules cache
+        if: steps.node-modules-check.outputs.cache-hit != 'true'
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            webapp/node_modules
+            webapp/channels/node_modules
+            webapp/platform/client/node_modules
+            webapp/platform/components/node_modules
+            webapp/platform/shared/node_modules
+            webapp/platform/types/node_modules
+          key: node-modules-${{ runner.os }}-${{ hashFiles('webapp/package-lock.json') }}

--- a/.github/workflows/webapp-ci.yml
+++ b/.github/workflows/webapp-ci.yml
@@ -23,6 +23,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
       - name: ci/lint
@@ -38,6 +40,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
       - name: ci/i18n-extract
@@ -55,6 +59,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
       - name: ci/check-external-links
@@ -71,6 +77,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
       - name: ci/lint
@@ -91,6 +99,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
       - name: ci/test
@@ -122,6 +132,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
       - name: ci/test
@@ -154,6 +166,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
       - name: ci/test
@@ -178,6 +192,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
       - name: ci/download-coverage-artifacts
@@ -234,6 +250,8 @@ jobs:
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
       - name: ci/build

--- a/.github/workflows/webapp-ci.yml
+++ b/.github/workflows/webapp-ci.yml
@@ -27,6 +27,8 @@ jobs:
           persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
+        with:
+          read-only: "true"
       - name: ci/lint
         run: |
           npm run check
@@ -44,6 +46,8 @@ jobs:
           persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
+        with:
+          read-only: "true"
       - name: ci/i18n-extract
         working-directory: webapp/channels
         run: |
@@ -63,6 +67,8 @@ jobs:
           persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
+        with:
+          read-only: "true"
       - name: ci/check-external-links
         run: |
           set -o pipefail
@@ -81,6 +87,8 @@ jobs:
           persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
+        with:
+          read-only: "true"
       - name: ci/lint
         run: |
           npm run check-types
@@ -103,6 +111,8 @@ jobs:
           persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
+        with:
+          read-only: "true"
       - name: ci/test
         env:
           NODE_OPTIONS: --max_old_space_size=5120
@@ -136,6 +146,8 @@ jobs:
           persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
+        with:
+          read-only: "true"
       - name: ci/test
         env:
           NODE_OPTIONS: --max_old_space_size=5120
@@ -170,6 +182,8 @@ jobs:
           persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
+        with:
+          read-only: "true"
       - name: ci/test
         env:
           NODE_OPTIONS: --max_old_space_size=5120
@@ -196,6 +210,8 @@ jobs:
           persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
+        with:
+          read-only: "true"
       - name: ci/download-coverage-artifacts
         uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
         with:
@@ -254,6 +270,8 @@ jobs:
           persist-credentials: false
       - name: ci/setup
         uses: ./.github/actions/webapp-setup
+        with:
+          read-only: "true"
       - name: ci/build
         run: |
           npm run build

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build package run stop run-client run-server run-node run-haserver stop-haserver stop-client stop-server restart restart-server restart-client restart-haserver start-docker update-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-freebsd build-windows package-prep package-linux package-osx package-windows internal-test-web-client vet run-server-for-web-client-tests diff-config prepackaged-plugins prepackaged-binaries test-server test-server-ee test-server-elasticsearch test-server-quick test-server-race test-mmctl-unit test-mmctl-e2e test-mmctl test-mmctl-coverage mmctl-build mmctl-docs new-migration migrations-extract test-public mocks-public run-server-faketime
+.PHONY: build package run stop run-client run-server run-node run-haserver stop-haserver stop-client stop-server restart restart-server restart-client restart-haserver start-docker update-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-freebsd build-windows package-prep package-linux package-osx package-windows internal-test-web-client vet run-server-for-web-client-tests diff-config prepackaged-plugins prepackaged-binaries test-server test-server-ee test-server-elasticsearch test-server-quick test-server-race test-mmctl-unit test-mmctl-e2e test-mmctl test-mmctl-coverage mmctl-build mmctl-docs new-migration migrations-extract test-public mocks-public run-server-faketime check-go-fix
 
 ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
@@ -431,7 +431,10 @@ ifneq ($(SKIP_SETUP_GO_WORK),true)
 	fi
 endif
 
-check-style: plugin-checker vet golangci-lint ## Runs style/lint checks
+check-go-fix: setup-go-work ## Check if go fix would modify any files.
+	$(GO) fix -diff ./...
+
+check-style: plugin-checker vet golangci-lint check-go-fix ## Runs style/lint checks
 
 gotestsum:
 	$(GO) install gotest.tools/gotestsum@v1.13.0
@@ -443,7 +446,7 @@ test-compile: setup-go-work gotestsum ## Compile tests.
 		$(GO) test $(GOFLAGS) -c $$package; \
 	done
 
-modules-tidy: ## Tidy Go modules
+modules-tidy: setup-go-work ## Tidy Go modules
 	mv enterprise/external_imports.go enterprise/external_imports.go.orig
 	-$(GO) mod tidy
 	-cd public && $(GO) mod tidy
@@ -852,6 +855,7 @@ ifeq ($(BUILD_ENTERPRISE_READY),true)
   endif
 endif
 
+vet-api: setup-go-work
 vet-api: export GO := $(GO)
 vet-api: export GOBIN := $(GOBIN)
 vet-api: export ROOT := $(ROOT)

--- a/server/Makefile
+++ b/server/Makefile
@@ -434,7 +434,7 @@ mocks: store-mocks filestore-mocks ldap-mocks plugin-mocks einterfaces-mocks sea
 layers: store-layers pluginapi
 
 .PHONY: generated
-generated: mocks layers
+generated: mocks layers gen-serialized migrations-extract build-templates mmctl-docs modules-tidy ## Regenerate every committed generated asset checked by the check-generated CI job.
 
 .PHONY: check-prereqs-enterprise
 check-prereqs-enterprise: setup-go-work ## Checks prerequisite software status for enterprise.

--- a/server/Makefile
+++ b/server/Makefile
@@ -431,10 +431,7 @@ ifneq ($(SKIP_SETUP_GO_WORK),true)
 	fi
 endif
 
-check-go-fix: setup-go-work ## Check if go fix would modify any files.
-	$(GO) fix -diff ./...
-
-check-style: plugin-checker vet golangci-lint check-go-fix ## Runs style/lint checks
+check-style: plugin-checker vet golangci-lint
 
 gotestsum:
 	$(GO) install gotest.tools/gotestsum@v1.13.0

--- a/server/Makefile
+++ b/server/Makefile
@@ -1,5 +1,3 @@
-.PHONY: build package run stop run-client run-server run-node run-haserver stop-haserver stop-client stop-server restart restart-server restart-client restart-haserver start-docker update-docker clean-dist clean nuke check-style check-client-style check-server-style check-unit-tests test dist run-client-tests setup-run-client-tests cleanup-run-client-tests test-client build-linux build-osx build-freebsd build-windows package-prep package-linux package-osx package-windows internal-test-web-client vet run-server-for-web-client-tests diff-config prepackaged-plugins prepackaged-binaries test-server test-server-ee test-server-elasticsearch test-server-quick test-server-race test-mmctl-unit test-mmctl-e2e test-mmctl test-mmctl-coverage mmctl-build mmctl-docs new-migration migrations-extract test-public mocks-public run-server-faketime check-go-fix
-
 ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 ifeq ($(OS),Windows_NT)
@@ -192,6 +190,7 @@ endif
 
 CONFIG_FILE_PATH ?= ./config/config.json
 
+.PHONY: all
 all: run ## Alias for 'run'.
 
 -include config.override.mk
@@ -240,6 +239,7 @@ ifneq ($(DOCKER_SERVICES_OVERRIDE),true)
   ENABLED_DOCKER_SERVICES:=$(ENABLED_DOCKER_SERVICES) $(TEMP_DOCKER_SERVICES)
 endif
 
+.PHONY: start-docker
 start-docker: setup-go-work ## Starts the docker containers for local development.
 ifneq ($(IS_CI),false)
 	@echo CI Build: skipping docker start
@@ -261,11 +261,13 @@ endif
   endif
 endif
 
+.PHONY: update-docker
 update-docker: setup-go-work stop-docker ## Updates the docker containers for local development.
 	@echo Updating docker containers
 
 	$(GO) run ./build/docker-compose-generator/main.go $(ENABLED_DOCKER_SERVICES) | docker compose -f docker-compose.makefile.yml -f /dev/stdin $(DOCKER_COMPOSE_OVERRIDE) up --no-start
 
+.PHONY: run-haserver
 run-haserver:
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	@echo Starting mattermost in an HA topology '(3 node cluster)'
@@ -273,10 +275,12 @@ ifeq ($(BUILD_ENTERPRISE_READY),true)
 	docker compose -f docker-compose.yaml $(DOCKER_COMPOSE_OVERRIDE) up --remove-orphans haproxy
 endif
 
+.PHONY: stop-haserver
 stop-haserver:
 	@echo Stopping docker containers for HA topology
 	docker compose stop
 
+.PHONY: stop-docker
 stop-docker: ## Stops the docker containers for local development.
 ifeq ($(MM_NO_DOCKER),true)
 	@echo No Docker Enabled: skipping docker stop
@@ -286,6 +290,7 @@ else
 	docker compose stop
 endif
 
+.PHONY: clean-docker
 clean-docker: ## Deletes the docker containers for local development.
 ifeq ($(MM_NO_DOCKER),true)
 	@echo No Docker Enabled: skipping docker clean
@@ -298,9 +303,11 @@ else
 	docker volume rm mattermost-server_postgres-14-data || true
 endif
 
+.PHONY: plugin-checker
 plugin-checker: setup-go-work
 	$(GO) run $(GOFLAGS) ./public/plugin/checker
 
+.PHONY: prepackaged-plugins
 prepackaged-plugins: ## Populate the prepackaged-plugins directory.
 	@echo Downloading prepackaged plugins: $(PLUGIN_PACKAGES)
 	mkdir -p prepackaged_plugins
@@ -309,6 +316,7 @@ prepackaged-plugins: ## Populate the prepackaged-plugins directory.
 		curl -f -O -L https://plugins.releases.mattermost.com/release/$$plugin_package.tar.gz.sig; \
 	done
 
+.PHONY: prepackaged-binaries
 prepackaged-binaries: ## Populate the prepackaged-binaries to the bin directory
 ifeq ($(shell test -f bin/mmctl && printf "yes"),yes)
 	@echo "MMCTL already exists in bin/mmctl, not compiling."
@@ -316,6 +324,7 @@ else
 	$(MAKE) mmctl-build
 endif
 
+.PHONY: golang-versions
 golang-versions: ## Install Golang versions used for compatibility testing (e.g. plugins)
 	@for version in $(GO_COMPATIBILITY_TEST_VERSIONS); do \
 		$(GO) install golang.org/dl/go$$version@latest && \
@@ -323,6 +332,7 @@ golang-versions: ## Install Golang versions used for compatibility testing (e.g.
 	done
 	export GO_COMPATIBILITY_TEST_VERSIONS="${GO_COMPATIBILITY_TEST_VERSIONS}"
 
+.PHONY: golangci-lint
 golangci-lint: setup-go-work ## Run golangci-lint on codebase
 	$(GO) install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4
 ifeq ($(BUILD_ENTERPRISE_READY),true)
@@ -331,86 +341,108 @@ else
 	$(GOBIN)/golangci-lint run ./... ./public/...
 endif
 
+.PHONY: i18n-extract
 i18n-extract: ## Extract strings for translation from the source code
 	cd ../tools/mmgotool && $(GO) install .
 	$(GOBIN)/mmgotool i18n extract --portal-dir=""
 
+.PHONY: i18n-check
 i18n-check: ## Exit on empty translation strings and translation source strings
 	cd ../tools/mmgotool && $(GO) install .
 	$(GOBIN)/mmgotool i18n clean-empty --portal-dir="" --check
 	$(GOBIN)/mmgotool i18n check-empty-src --portal-dir=""
 
+.PHONY: store-mocks
 store-mocks: setup-go-work ## Creates mock files.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config channels/store/.mockery.yaml
 
+.PHONY: cache-mocks
 cache-mocks: setup-go-work
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config platform/services/cache/.mockery.yaml
 
 
+.PHONY: store-layers
 store-layers: setup-go-work ## Generate layers for the store
 	$(GO) generate $(GOFLAGS) ./channels/store
 
+.PHONY: new-migration
 new-migration: ## Creates a new migration. Run with make new-migration name=<>
 	$(GO) install github.com/mattermost/morph/cmd/morph@1e0640c
 	@echo "Generating new migration for postgres"
 	$(GOBIN)/morph new script $(name) --driver postgres --dir channels/db/migrations --sequence
 
+.PHONY: filestore-mocks
 filestore-mocks: setup-go-work ## Creates mock files.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config platform/shared/filestore/.mockery.yaml
 
+.PHONY: ldap-mocks
 ldap-mocks: setup-go-work ## Creates mock files for ldap.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --dir $(BUILD_ENTERPRISE_DIR)/ldap --all --inpackage --note 'Regenerate this file using `make ldap-mocks`.'
 
+.PHONY: plugin-mocks
 plugin-mocks: setup-go-work ## Creates mock files for plugins.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config public/plugin/.mockery.yaml
 
+.PHONY: einterfaces-mocks
 einterfaces-mocks: setup-go-work ## Creates mock files for einterfaces.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config einterfaces/.mockery.yaml
 
+.PHONY: searchengine-mocks
 searchengine-mocks: setup-go-work ## Creates mock files for searchengines.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config platform/services/searchengine/.mockery.yaml
 
+.PHONY: sharedchannel-mocks
 sharedchannel-mocks: setup-go-work ## Creates mock files for shared channels.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config platform/services/sharedchannel/.mockery.yaml
 
+.PHONY: misc-mocks
 misc-mocks: setup-go-work ## Creates mocks for misc interfaces.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config channels/utils/.mockery.yaml
 
+.PHONY: email-mocks
 email-mocks: setup-go-work ## Creates mocks for misc interfaces.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config channels/app/email/.mockery.yaml
 
+.PHONY: platform-mocks
 platform-mocks: setup-go-work ## Creates mocks for platform interfaces.
 	$(GO) install github.com/vektra/mockery/v2/...@v2.53.4
 	$(GOBIN)/mockery --config channels/app/platform/.mockery.yaml
 
+.PHONY: mmctl-mocks
 mmctl-mocks: setup-go-work ## Creates mocks for mmctl
 	$(GO) install github.com/golang/mock/mockgen@v1.6.0
 	$(GOBIN)/mockgen -destination=cmd/mmctl/mocks/client_mock.go -copyright_file=cmd/mmctl/mocks/copyright.txt -package=mocks github.com/mattermost/mattermost/server/v8/cmd/mmctl/client Client
 
+.PHONY: pluginapi
 pluginapi: setup-go-work ## Generates api and hooks glue code for plugins
 	cd ./public && $(GO) generate $(GOFLAGS) ./plugin
 
+.PHONY: mocks
 mocks: store-mocks filestore-mocks ldap-mocks plugin-mocks einterfaces-mocks searchengine-mocks sharedchannel-mocks misc-mocks email-mocks platform-mocks mmctl-mocks mocks-public cache-mocks
 
+.PHONY: layers
 layers: store-layers pluginapi
 
+.PHONY: generated
 generated: mocks layers
 
+.PHONY: check-prereqs-enterprise
 check-prereqs-enterprise: setup-go-work ## Checks prerequisite software status for enterprise.
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	./scripts/prereq-check-enterprise.sh
 endif
 
+.PHONY: setup-go-work
 setup-go-work: export BUILD_ENTERPRISE_READY := $(BUILD_ENTERPRISE_READY)
 setup-go-work: ## Sets up your go.work file
 ifneq ($(SKIP_SETUP_GO_WORK),true)
@@ -431,11 +463,14 @@ ifneq ($(SKIP_SETUP_GO_WORK),true)
 	fi
 endif
 
+.PHONY: check-style
 check-style: plugin-checker vet golangci-lint
 
+.PHONY: gotestsum
 gotestsum:
 	$(GO) install gotest.tools/gotestsum@v1.13.0
 
+.PHONY: test-compile
 test-compile: setup-go-work gotestsum ## Compile tests.
 	@echo COMPILE TESTS
 
@@ -443,12 +478,14 @@ test-compile: setup-go-work gotestsum ## Compile tests.
 		$(GO) test $(GOFLAGS) -c $$package; \
 	done
 
+.PHONY: modules-tidy
 modules-tidy: setup-go-work ## Tidy Go modules
 	mv enterprise/external_imports.go enterprise/external_imports.go.orig
 	-$(GO) mod tidy
 	-cd public && $(GO) mod tidy
 	mv enterprise/external_imports.go.orig enterprise/external_imports.go
 
+.PHONY: test-server-pre
 test-server-pre: check-prereqs-enterprise start-docker gotestsum golang-versions ## Runs tests.
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	@echo Running all tests
@@ -456,6 +493,7 @@ else
 	@echo Running only TE tests
 endif
 
+.PHONY: test-server-race
 test-server-race: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-server-race: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-server-race: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
@@ -474,6 +512,7 @@ ifneq ($(IS_CI),true)
   endif
 endif
 
+.PHONY: test-server
 test-server: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-server: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-server: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
@@ -488,6 +527,7 @@ ifneq ($(IS_CI),true)
   endif
 endif
 
+.PHONY: test-server-ee
 test-server-ee: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-server-ee: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-server-ee: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
@@ -497,6 +537,7 @@ test-server-ee: check-prereqs-enterprise start-docker gotestsum ## Runs EE tests
 
 ES_PACKAGES=$(shell $(GO) list ./enterprise/elasticsearch/...)
 
+.PHONY: test-server-elasticsearch
 test-server-elasticsearch: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-server-elasticsearch: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-server-elasticsearch: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
@@ -504,6 +545,7 @@ test-server-elasticsearch: check-prereqs-enterprise start-docker gotestsum ## Ru
 	@echo Running only Elasticsearch tests
 	$(GOBIN)/gotestsum --rerun-fails=3 --packages="$(ES_PACKAGES)" -- $(GOFLAGS) -timeout=20m
 
+.PHONY: test-server-quick
 test-server-quick: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-server-quick: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-server-quick: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
@@ -516,28 +558,35 @@ else
 	$(GOBIN)/gotestsum --packages="$(TE_PACKAGES)" -- $(GOFLAGS) -short
 endif
 
+.PHONY: internal-test-web-client
 internal-test-web-client: setup-go-work ## Runs web client tests.
 	$(GO) run $(GOFLAGS) $(PLATFORM_FILES) test web_client_tests
 
+.PHONY: run-server-for-web-client-tests
 run-server-for-web-client-tests: setup-go-work ## Tests the server for web client.
 	$(GO) run $(GOFLAGS) $(PLATFORM_FILES) test web_client_tests_server
 
+.PHONY: test-client
 test-client: ## Test client app.
 	@echo Running client tests
 
 	cd $(BUILD_WEBAPP_DIR) && $(MAKE) test
 
+.PHONY: test
 test: test-server test-client ## Runs all checks and tests below (except race detection and postgres).
 
+.PHONY: cover
 cover: ## Runs the golang coverage tool. You must run the unit tests first.
 	@echo Opening coverage info in browser. If this failed run make test first
 
 	$(GO) tool cover -html=cover.out
 	$(GO) tool cover -html=ecover.out
 
+.PHONY: test-data
 test-data: export MM_SERVICESETTINGS_ENABLELOCALMODE := true
 test-data: run-server inject-test-data stop-server ## start a local instance and add test data to it.
 
+.PHONY: inject-test-data
 inject-test-data: # add test data to the local instance.
 	@if ! ./scripts/wait-for-system-start.sh; then \
 		make stop-server; \
@@ -552,6 +601,7 @@ inject-test-data: # add test data to the local instance.
 	@echo Login with a regular account username=user-1 password=SampleUs@r-1
 	@echo ========================================================================
 
+.PHONY: test-mmctl-unit
 test-mmctl-unit: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-mmctl-unit: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-mmctl-unit: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
@@ -559,6 +609,7 @@ test-mmctl-unit: check-prereqs-enterprise gotestsum
 	@echo Running mmctl unit tests
 	$(GOBIN)/gotestsum --packages="$(MMCTL_PACKAGES)" -- -tags 'unit $(MMCTL_BUILD_TAGS)' $(MMCTL_TESTFLAGS)
 
+.PHONY: test-mmctl-e2e
 test-mmctl-e2e: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-mmctl-e2e: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-mmctl-e2e: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
@@ -566,6 +617,7 @@ test-mmctl-e2e: check-prereqs-enterprise gotestsum start-docker
 	@echo Running mmctl e2e tests
 	$(GOBIN)/gotestsum --packages="$(MMCTL_PACKAGES)" -- -tags 'e2e $(MMCTL_BUILD_TAGS)' $(MMCTL_TESTFLAGS)
 
+.PHONY: test-mmctl
 test-mmctl: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-mmctl: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-mmctl: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
@@ -573,6 +625,7 @@ test-mmctl: check-prereqs-enterprise gotestsum start-docker
 	@echo Running all mmctl tests
 	$(GOBIN)/gotestsum --packages="$(MMCTL_PACKAGES)" -- -tags 'unit e2e $(MMCTL_BUILD_TAGS)' $(MMCTL_TESTFLAGS)
 
+.PHONY: test-mmctl-coverage
 test-mmctl-coverage: export GOTESTSUM_FORMAT := $(GOTESTSUM_FORMAT)
 test-mmctl-coverage: export GOTESTSUM_JUNITFILE := $(GOTESTSUM_JUNITFILE)
 test-mmctl-coverage: export GOTESTSUM_JSONFILE := $(GOTESTSUM_JSONFILE)
@@ -581,6 +634,7 @@ test-mmctl-coverage: check-prereqs-enterprise gotestsum start-docker
 	$(GOBIN)/gotestsum --packages="$(MMCTL_PACKAGES)" -- -tags 'unit e2e $(MMCTL_BUILD_TAGS)' -coverprofile=mmctlcover.out $(MMCTL_TESTFLAGS)
 	$(GO) tool cover -html=mmctlcover.out
 
+.PHONY: validate-go-version
 validate-go-version: ## Validates the installed version of go against Mattermost's minimum requirement.
 	@if [ $(GO_MAJOR_VERSION) -gt $(MINIMUM_SUPPORTED_GO_MAJOR_VERSION) ]; then \
 		exit 0 ;\
@@ -592,9 +646,11 @@ validate-go-version: ## Validates the installed version of go against Mattermost
 		exit 1; \
 	fi
 
+.PHONY: build-templates
 build-templates: ## Compile all mjml email templates
 	cd $(TEMPLATES_DIR) && $(MAKE) build
 
+.PHONY: run-server
 run-server: setup-go-work prepackaged-binaries validate-go-version start-docker client ## Starts the server.
 	@echo Running mattermost for development
 ifeq ($(MM_USE_PGVECTOR),true)
@@ -604,6 +660,7 @@ endif
 	mkdir -p $(BUILD_WEBAPP_DIR)/channels/dist/files
 	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' -tags '$(BUILD_TAGS)' $(PLATFORM_FILES) $(RUN_IN_BACKGROUND)
 
+.PHONY: run-server-faketime
 run-server-faketime: setup-go-work prepackaged-binaries validate-go-version start-docker client ## Starts the server with FAKETIME.
 ifndef FAKETIME
 	$(error FAKETIME is not set. Usage: make run-server-faketime FAKETIME="+30d")
@@ -628,9 +685,11 @@ endif
 			$(GOBIN)/mattermost-faketime $(RUN_IN_BACKGROUND) \
 	fi
 
+.PHONY: run-server-pgvector
 run-server-pgvector: ## Starts the server with pgvector PostgreSQL image.
 	@MM_USE_PGVECTOR=true $(MAKE) run-server
 
+.PHONY: debug-server
 debug-server: setup-go-work start-docker ## Compile and start server using delve.
 	mkdir -p $(BUILD_WEBAPP_DIR)/channels/dist/files
 	$(DELVE) debug $(PLATFORM_FILES) --build-flags="-ldflags '\
@@ -641,6 +700,7 @@ debug-server: setup-go-work start-docker ## Compile and start server using delve
 		-X github.com/mattermost/mattermost/server/public/model.BuildEnterpriseReady=$(BUILD_ENTERPRISE_READY)'\
 		-tags '$(BUILD_TAGS)'"
 
+.PHONY: debug-server-headless
 debug-server-headless: setup-go-work start-docker ## Debug server from within an IDE like VSCode or IntelliJ.
 	mkdir -p $(BUILD_WEBAPP_DIR)/channels/dist/files
 	$(DELVE) debug --headless --listen=:2345 --api-version=2 --accept-multiclient $(PLATFORM_FILES) --build-flags="-ldflags '\
@@ -651,6 +711,7 @@ debug-server-headless: setup-go-work start-docker ## Debug server from within an
 		-X github.com/mattermost/mattermost/server/public/model.BuildEnterpriseReady=$(BUILD_ENTERPRISE_READY)'\
 		-tags '$(BUILD_TAGS)'"
 
+.PHONY: run-node
 run-node: export MM_SERVICESETTINGS_SITEURL=http://localhost:8066
 run-node: export MM_SERVICESETTINGS_LISTENADDRESS=:8066
 run-node: export MM_SERVICESETTINGS_ENABLELOCALMODE=true
@@ -663,12 +724,14 @@ run-node: setup-go-work start-docker ## Runs a shared channel node.
 
 	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' -tags '$(BUILD_TAGS)' $(PLATFORM_FILES) $(RUN_IN_BACKGROUND)
 
+.PHONY: run-cli
 run-cli: setup-go-work start-docker ## Runs CLI.
 	@echo Running mattermost for development
 	@echo Example should be like 'make ARGS="-version" run-cli'
 
 	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' -tags '$(BUILD_TAGS)' $(PLATFORM_FILES) ${ARGS}
 
+.PHONY: run-client
 run-client: client ## Runs the webapp.
 	@echo Running mattermost client for development
 
@@ -678,18 +741,23 @@ client: ## Sets up a symlink to the compiled files generated by the web app
 	@echo Setting up symlink to client directory
 	ln -nfs $(BUILD_WEBAPP_DIR)/channels/dist client
 
+.PHONY: run-client-fullmap
 run-client-fullmap: client ## Legacy alias to run-client
 	@echo Running mattermost client for development
 
 	cd $(BUILD_WEBAPP_DIR) && $(MAKE) run
 
+.PHONY: run
 run: run-server run-client ## Runs the server and webapp.
 
+.PHONY: run-pgvector
 run-pgvector: ## Runs the server and webapp with pgvector PostgreSQL image.
 	@MM_USE_PGVECTOR=true $(MAKE) run
 
+.PHONY: run-fullmap
 run-fullmap: run-server run-client ## Legacy alias to run
 
+.PHONY: stop-server
 stop-server: ## Stops the server.
 	@echo Stopping mattermost
 
@@ -707,20 +775,26 @@ else
 	done
 endif
 
+.PHONY: stop-client
 stop-client: ## Stops the webapp.
 	@echo Stopping mattermost client
 
 	cd $(BUILD_WEBAPP_DIR) && $(MAKE) stop
 
+.PHONY: stop
 stop: stop-server stop-client stop-docker ## Stops server, client and the docker compose.
 
+.PHONY: restart
 restart: restart-server restart-client ## Restarts the server and webapp.
 
+.PHONY: restart-server
 restart-server: | stop-server run-server ## Restarts the mattermost server to pick up development change.
 
+.PHONY: restart-server-pgvector
 restart-server-pgvector: ## Restarts the server with pgvector PostgreSQL image.
 	@MM_USE_PGVECTOR=true $(MAKE) restart-server
 
+.PHONY: restart-haserver
 restart-haserver:
 	@echo Restarting mattermost in an HA topology
 
@@ -729,12 +803,15 @@ restart-haserver:
 	docker compose restart leader
 	docker compose restart haproxy
 
+.PHONY: restart-client
 restart-client: | stop-client run-client ## Restarts the webapp.
 
+.PHONY: run-job-server
 run-job-server: setup-go-work ## Runs the background job server.
 	@echo Running job server for development
 	$(GO) run $(GOFLAGS) -ldflags '$(LDFLAGS)' -tags '$(BUILD_TAGS)' $(PLATFORM_FILES) jobserver &
 
+.PHONY: config-ldap
 config-ldap: ## Configures LDAP.
 	@echo Setting up configuration for local LDAP
 
@@ -746,6 +823,7 @@ config-ldap: ## Configures LDAP.
 	cp ${TMPDIR}/config.json ${CONFIG_FILE_PATH}
 	rm ${TMPDIR}/config.json
 
+.PHONY: config-saml
 config-saml: ## Configures SAML.
 	@echo Setting up configuration for local SAML with keycloak, please ensure your keycloak is running on http://localhost:8484
 
@@ -759,6 +837,7 @@ config-saml: ## Configures SAML.
 	cp ${TMPDIR}/config.json ${CONFIG_FILE_PATH}
 	rm ${TMPDIR}/config.json
 
+.PHONY: config-openid
 config-openid: ## Configures OpenID.
 	@echo Setting up configuration for local OpenID with keycloak, please ensure your keycloak is running on http://localhost:8484
 
@@ -772,14 +851,17 @@ config-openid: ## Configures OpenID.
 
 	@echo Finished setting up configuration for local OpenID with keycloak
 
+.PHONY: config-reset
 config-reset: setup-go-work ## Resets the config/config.json file to the default production values.
 	@echo Resetting configuration to production default
 	rm -f config/config.json
 	OUTPUT_CONFIG=$(PWD)/config/config.json $(GO) run $(GOFLAGS) -tags production ./scripts/config_generator
 
+.PHONY: diff-config
 diff-config: ## Compares default configuration between two mattermost versions
 	@./scripts/diff-config.sh
 
+.PHONY: clean
 clean: setup-go-work stop-docker ## Clean up everything except persistent server data.
 	@echo Cleaning
 
@@ -802,15 +884,18 @@ clean: setup-go-work stop-docker ## Clean up everything except persistent server
 	rm -f channels/imports/imports.go
 	rm -f cmd/mattermost/cprofile*.out
 
+.PHONY: nuke
 nuke: clean clean-docker ## Clean plus removes persistent server data.
 	@echo BOOM
 
 	rm -rf data
 	rm -f go.work go.work.sum
 
+.PHONY: setup-mac
 setup-mac: ## Adds macOS hosts entries for Docker.
 	echo $$(boot2docker ip 2> /dev/null) dockerhost | sudo tee -a /etc/hosts
 
+.PHONY: update-dependencies
 update-dependencies: ## Uses go get -u to update all the dependencies while holding back any that require it.
 	@echo Updating Dependencies
 
@@ -829,6 +914,7 @@ ifeq ($(BUILD_ENTERPRISE_READY),true)
 	mv enterprise/external_imports.go.orig enterprise/external_imports.go
 endif
 
+.PHONY: vet
 vet: setup-go-work ## Run mattermost go vet specific checks
 	cd ../tools/mattermost-govet && $(GO) install .
 	$(GO) vet -vettool=$(GOBIN)/mattermost-govet \
@@ -852,6 +938,7 @@ ifeq ($(BUILD_ENTERPRISE_READY),true)
   endif
 endif
 
+.PHONY: vet-api
 vet-api: setup-go-work
 vet-api: export GO := $(GO)
 vet-api: export GOBIN := $(GOBIN)
@@ -861,6 +948,7 @@ vet-api: ## Run mattermost go vet to verify api4 documentation, currently not pa
 	make -C ../api build
 	./scripts/vet-api-check.sh
 
+.PHONY: gen-serialized
 gen-serialized:	export LICENSE_HEADER:=$(LICENSE_HEADER)
 gen-serialized: setup-go-work ## Generates serialization methods for hot structs
 	# This tool only works at a file level, not at a package level.
@@ -888,30 +976,36 @@ gen-serialized: setup-go-work ## Generates serialization methods for hot structs
 	@cat ./public/model/team_member_serial_gen.go >> tmp.go
 	@mv tmp.go ./public/model/team_member_serial_gen.go
 
+.PHONY: todo
 todo: ## Display TODO and FIXME items in the source code.
 	@! ag --ignore Makefile --ignore-dir runtime '(TODO|XXX|FIXME|"FIX ME")[: ]+'
 ifeq ($(BUILD_ENTERPRISE_READY),true)
 	@! ag --ignore Makefile --ignore-dir runtime '(TODO|XXX|FIXME|"FIX ME")[: ]+' $(BUILD_ENTERPRISE_DIR)/
 endif
 
+.PHONY: mmctl-build
 mmctl-build: setup-go-work ## Compiles and generates the mmctl binary
 	$(GO) build $(GOFLAGS) -trimpath -ldflags '$(MMCTL_LDFLAGS)' -o bin/mmctl ./cmd/mmctl
 
+.PHONY: mmctl-docs
 mmctl-docs: setup-go-work ## Generate the mmctl docs
 	rm -rf ./cmd/mmctl/docs
 	cd ./cmd/mmctl && $(GO) run mmctl.go docs
 
 ## Help documentation à la https://marmelab.com/blog/2016/02/29/auto-documented-makefile.html
+.PHONY: help
 help:
 	@grep -E '^[0-9a-zA-Z_-]+:.*?## .*$$' ./Makefile | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 	@echo
 	@echo You can modify the default settings for this Makefile creating a file config.mk based on the default-config.mk
 	@echo
 
+.PHONY: migrations-extract
 migrations-extract:
 	@echo Listing migration files
 	@echo "# Autogenerated file to synchronize migrations sequence in the PR workflow, please do not edit." > channels/db/migrations/migrations.list
 	find channels/db/migrations -maxdepth 2 -mindepth 2 | sort >> channels/db/migrations/migrations.list
 
+.PHONY: test-local-filestore
 test-local-filestore: setup-go-work # Run tests for local filestore
 	$(GO) test ./platform/shared/filestore -run '^TestLocalFileBackend' -v

--- a/server/build/release.mk
+++ b/server/build/release.mk
@@ -1,7 +1,10 @@
+.PHONY: dist
 dist: | check-style test package
 
+.PHONY: build-linux
 build-linux: build-linux-amd64 build-linux-arm64
 
+.PHONY: build-linux-amd64
 build-linux-amd64: setup-go-work
 	@echo Build Linux amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"linux_amd64")
@@ -20,6 +23,7 @@ ifeq ($(FIPS_ENABLED),true)
 	$(GO) tool nm $(GOBIN)/$(MMCTL_BIN_NAME) | grep -qE "func_go_openssl_OpenSSL_version|_mkcgo_OpenSSL_version" || (echo "ERROR: FIPS mmctl binary missing OpenSSL integration" && exit 1)
 endif
 
+.PHONY: build-linux-arm64
 build-linux-arm64: setup-go-work
 ifeq ($(FIPS_ENABLED),true)
 	@echo Skipping Build Linux arm64 for FIPS
@@ -33,6 +37,7 @@ else
 endif
 endif
 
+.PHONY: build-osx
 build-osx: setup-go-work
 	@echo Build OSX amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"darwin_amd64")
@@ -49,8 +54,10 @@ else
 	env GOOS=darwin GOARCH=arm64 $(GO) build -o $(GOBIN)/darwin_arm64 $(GOFLAGS) -trimpath -tags '$(BUILD_TAGS) production' -ldflags '$(LDFLAGS)' ./...
 endif
 
+.PHONY: build-freebsd
 build-freebsd: build-freebsd-amd64 build-freebsd-arm64
 
+.PHONY: build-freebsd-amd64
 build-freebsd-amd64: setup-go-work
 	@echo Build FreeBSD amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"freebsd_amd64")
@@ -60,6 +67,7 @@ else
 	env GOOS=freebsd GOARCH=amd64 $(GO) build -o $(GOBIN)/freebsd_amd64 $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./...
 endif
 
+.PHONY: build-freebsd-arm64
 build-freebsd-arm64: setup-go-work
 	@echo Build FreeBSD arm64
 ifeq ($(BUILDER_GOOS_GOARCH),"freebsd_arm64")
@@ -69,6 +77,7 @@ else
 	env GOOS=freebsd GOARCH=arm64 $(GO) build -o $(GOBIN)/freebsd_arm64 $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./...
 endif
 
+.PHONY: build-windows
 build-windows: setup-go-work
 	@echo Build Windows amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
@@ -78,6 +87,7 @@ else
 	env GOOS=windows GOARCH=amd64 $(GO) build -o $(GOBIN)/windows_amd64 $(GOFLAGS) -trimpath -tags '$(BUILD_TAGS) production' -ldflags '$(LDFLAGS)' ./...
 endif
 
+.PHONY: build-cmd-linux
 build-cmd-linux: setup-go-work
 	@echo Build CMD Linux amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"linux_amd64")
@@ -107,6 +117,7 @@ else
 endif
 endif
 
+.PHONY: build-cmd-osx
 build-cmd-osx: setup-go-work
 	@echo Build CMD OSX amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"darwin_amd64")
@@ -123,6 +134,7 @@ else
 	env GOOS=darwin GOARCH=arm64 $(GO) build -o $(GOBIN)/darwin_arm64 $(GOFLAGS) -trimpath -tags '$(BUILD_TAGS) production' -ldflags '$(LDFLAGS)' ./cmd/...
 endif
 
+.PHONY: build-cmd-freebsd
 build-cmd-freebsd: setup-go-work
 	@echo Build CMD FreeBSD amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"freebsd_amd64")
@@ -139,6 +151,7 @@ else
 	env GOOS=freebsd GOARCH=arm64 $(GO) build -o $(GOBIN)/freebsd_arm64 $(GOFLAGS) -trimpath -tags production -ldflags '$(LDFLAGS)' ./cmd/...
 endif
 
+.PHONY: build-cmd-windows
 build-cmd-windows: setup-go-work
 	@echo Build CMD Windows amd64
 ifeq ($(BUILDER_GOOS_GOARCH),"windows_amd64")
@@ -149,16 +162,20 @@ else
 endif
 
 # Only build linux by default. Other platforms can be built by specifying the platform.
+.PHONY: build
 build: setup-go-work build-client build-linux
 
 # Only build linux by default. Other platforms can be built by specifying the platform.
+.PHONY: build-cmd
 build-cmd: setup-go-work build-client build-cmd-linux
 
+.PHONY: build-client
 build-client:
 	@echo Building mattermost web app
 
 	cd $(BUILD_WEBAPP_DIR) && $(MAKE) dist
 
+.PHONY: package-prep
 package-prep: setup-go-work
 	@ echo Packaging mattermost
 	@# Remove any old files
@@ -202,6 +219,7 @@ endif
 		cp bin/manifest.txt $(DIST_PATH); \
 	fi
 
+.PHONY: fetch-prepackaged-plugins
 fetch-prepackaged-plugins:
 	@# Import Mattermost plugin public key, ignoring errors. In FIPS mode, GPG fails to start
 	@# the gpg-agent, but still imports the key. If it really fails, it will fail validation later.
@@ -215,6 +233,7 @@ fetch-prepackaged-plugins:
 	done
 	@echo "Done"
 
+.PHONY: package-general
 package-general:
 	@# Create needed directories
 	mkdir -p $(DIST_PATH_GENERIC)/bin
@@ -227,6 +246,7 @@ else
 	cp $(GOBIN)/$(CURRENT_PACKAGE_ARCH)/$(MM_BIN_NAME) $(GOBIN)/$(CURRENT_PACKAGE_ARCH)/$(MMCTL_BIN_NAME) $(DIST_PATH_GENERIC)/bin # from cross-compiled bin dir
 endif
 
+.PHONY: package-plugins
 package-plugins: fetch-prepackaged-plugins
 	@# Create needed directories
 	mkdir -p $(DIST_PATH_GENERIC)/prepackaged_plugins
@@ -243,6 +263,7 @@ package-plugins: fetch-prepackaged-plugins
 		fi; \
 	done
 
+.PHONY: package-osx-amd64
 package-osx-amd64: package-prep
 	DIST_PATH_GENERIC=$(DIST_PATH_OSX_AMD64) CURRENT_PACKAGE_ARCH=darwin_amd64 MM_BIN_NAME=mattermost MMCTL_BIN_NAME=mmctl $(MAKE) package-general
 	@# Package
@@ -250,6 +271,7 @@ package-osx-amd64: package-prep
 	@# Cleanup
 	rm -rf $(DIST_ROOT)/darwin_amd64
 
+.PHONY: package-osx-arm64
 package-osx-arm64: package-prep
 	DIST_PATH_GENERIC=$(DIST_PATH_OSX_ARM64) CURRENT_PACKAGE_ARCH=darwin_arm64 MM_BIN_NAME=mattermost MMCTL_BIN_NAME=mmctl $(MAKE) package-general
 	@# Package
@@ -257,8 +279,10 @@ package-osx-arm64: package-prep
 	@# Cleanup
 	rm -rf $(DIST_ROOT)/darwin_arm64
 
+.PHONY: package-osx
 package-osx: package-osx-amd64 package-osx-arm64
 
+.PHONY: package-freebsd-amd64
 package-freebsd-amd64: package-prep
 	DIST_PATH_GENERIC=$(DIST_PATH_FREEBSD_AMD64) CURRENT_PACKAGE_ARCH=freebsd_amd64 MM_BIN_NAME=mattermost MMCTL_BIN_NAME=mmctl $(MAKE) package-general
 	@# Package
@@ -266,6 +290,7 @@ package-freebsd-amd64: package-prep
 	@# Cleanup
 	rm -rf $(DIST_ROOT)/freebsd_amd64
 
+.PHONY: package-freebsd-arm64
 package-freebsd-arm64: package-prep
 	DIST_PATH_GENERIC=$(DIST_PATH_FREEBSD_ARM64) CURRENT_PACKAGE_ARCH=freebsd_arm64 MM_BIN_NAME=mattermost MMCTL_BIN_NAME=mmctl $(MAKE) package-general
 	@# Package
@@ -273,8 +298,10 @@ package-freebsd-arm64: package-prep
 	@# Cleanup
 	rm -rf $(DIST_ROOT)/freebsd_arm64
 
+.PHONY: package-freebsd
 package-freebsd: package-freebsd-amd64 package-freebsd-arm64
 
+.PHONY: package-linux-amd64
 package-linux-amd64: package-prep
 	DIST_PATH_GENERIC=$(DIST_PATH_LIN_AMD64) PLUGIN_ARCH=linux-amd64 $(MAKE) package-plugins
 	DIST_PATH_GENERIC=$(DIST_PATH_LIN_AMD64) CURRENT_PACKAGE_ARCH=linux_amd64 MM_BIN_NAME=mattermost MMCTL_BIN_NAME=mmctl $(MAKE) package-general
@@ -283,6 +310,7 @@ package-linux-amd64: package-prep
 	@# Cleanup
 	rm -rf $(DIST_ROOT)/linux_amd64
 
+.PHONY: package-linux-arm64
 package-linux-arm64: package-prep
 ifeq ($(FIPS_ENABLED),true)
 	@echo Skipping package linux arm64 for FIPS
@@ -294,8 +322,10 @@ else
 	rm -rf $(DIST_ROOT)/linux_arm64
 endif
 
+.PHONY: package-linux
 package-linux: package-linux-amd64 package-linux-arm64
 
+.PHONY: package-windows
 package-windows: package-prep
 	DIST_PATH_GENERIC=$(DIST_PATH_WIN) CURRENT_PACKAGE_ARCH=windows_amd64 MM_BIN_NAME=mattermost.exe MMCTL_BIN_NAME=mmctl.exe $(MAKE) package-general
 	@# Package
@@ -304,6 +334,7 @@ package-windows: package-prep
 	rm -rf $(DIST_ROOT)/windows
 
 # Only package linux by default. Other platforms can be packaged by specifying the platform.
+.PHONY: package
 package: package-linux
 	rm -rf tmpprepackaged
 	rm -rf $(DIST_PATH)

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -1383,6 +1383,27 @@ func (s *RetryLayerChannelStore) AutocompleteInTeam(rctx request.CTX, teamID str
 
 }
 
+func (s *RetryLayerChannelStore) AutocompleteInTeamFiltered(rctx request.CTX, teamID string, userID string, term string, includeDeleted bool, isGuest bool, privateOnly bool, excludeGroupConstrained bool) (model.ChannelList, error) {
+
+	tries := 0
+	for {
+		result, err := s.ChannelStore.AutocompleteInTeamFiltered(rctx, teamID, userID, term, includeDeleted, isGuest, privateOnly, excludeGroupConstrained)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerChannelStore) AutocompleteInTeamForSearch(teamID string, userID string, term string, includeDeleted bool) (model.ChannelList, error) {
 
 	tries := 0

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -1227,6 +1227,22 @@ func (s *TimerLayerChannelStore) AutocompleteInTeam(rctx request.CTX, teamID str
 	return result, err
 }
 
+func (s *TimerLayerChannelStore) AutocompleteInTeamFiltered(rctx request.CTX, teamID string, userID string, term string, includeDeleted bool, isGuest bool, privateOnly bool, excludeGroupConstrained bool) (model.ChannelList, error) {
+	start := time.Now()
+
+	result, err := s.ChannelStore.AutocompleteInTeamFiltered(rctx, teamID, userID, term, includeDeleted, isGuest, privateOnly, excludeGroupConstrained)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("ChannelStore.AutocompleteInTeamFiltered", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerChannelStore) AutocompleteInTeamForSearch(teamID string, userID string, term string, includeDeleted bool) (model.ChannelList, error) {
 	start := time.Now()
 

--- a/server/cmd/mmctl/docs/mmctl.rst
+++ b/server/cmd/mmctl/docs/mmctl.rst
@@ -51,6 +51,7 @@ SEE ALSO
 * `mmctl permissions <mmctl_permissions.rst>`_ 	 - Management of permissions
 * `mmctl plugin <mmctl_plugin.rst>`_ 	 - Management of plugins
 * `mmctl post <mmctl_post.rst>`_ 	 - Management of posts
+* `mmctl report <mmctl_report.rst>`_ 	 - Reporting commands
 * `mmctl roles <mmctl_roles.rst>`_ 	 - Manage user roles
 * `mmctl saml <mmctl_saml.rst>`_ 	 - SAML related utilities
 * `mmctl sampledata <mmctl_sampledata.rst>`_ 	 - Generate sample data

--- a/server/cmd/mmctl/docs/mmctl_import_process.rst
+++ b/server/cmd/mmctl/docs/mmctl_import_process.rst
@@ -30,6 +30,7 @@ Options
       --bypass-upload     If this is set, the file is not processed from the server, but rather directly read from the filesystem. Works only in --local mode.
       --extract-content   If this is set, document attachments will be extracted and indexed during the import process. It is advised to disable it to improve performance. (default true)
   -h, --help              help for process
+      --workers int       The number of concurrent import worker goroutines. Controls database load during import. When set to 0 (default), uses the number of CPUs available. Maximum allowed is 4x the CPU count.
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/server/cmd/mmctl/docs/mmctl_license.rst
+++ b/server/cmd/mmctl/docs/mmctl_license.rst
@@ -37,6 +37,7 @@ SEE ALSO
 ~~~~~~~~
 
 * `mmctl <mmctl.rst>`_ 	 - Remote client for the Open Source, self-hosted Slack-alternative
+* `mmctl license get <mmctl_license_get.rst>`_ 	 - Get the current license.
 * `mmctl license remove <mmctl_license_remove.rst>`_ 	 - Remove the current license.
 * `mmctl license upload <mmctl_license_upload.rst>`_ 	 - Upload a license.
 * `mmctl license upload-string <mmctl_license_upload-string.rst>`_ 	 - Upload a license from a string.

--- a/server/cmd/mmctl/docs/mmctl_license_get.rst
+++ b/server/cmd/mmctl/docs/mmctl_license_get.rst
@@ -1,36 +1,33 @@
-.. _mmctl_post_create:
+.. _mmctl_license_get:
 
-mmctl post create
+mmctl license get
 -----------------
 
-Create a post
+Get the current license.
 
 Synopsis
 ~~~~~~~~
 
 
-Create a post
+Get the current server license and print it.
 
 ::
 
-  mmctl post create [flags]
+  mmctl license get [flags]
 
 Examples
 ~~~~~~~~
 
 ::
 
-    post create myteam:mychannel --message "some text for the post"
+    license get
 
 Options
 ~~~~~~~
 
 ::
 
-  -b, --burn-on-read      Message will be deleted after a certain time after being read
-  -h, --help              help for create
-  -m, --message string    Message for the post
-  -r, --reply-to string   Post id to reply to
+  -h, --help   help for get
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -50,5 +47,5 @@ Options inherited from parent commands
 SEE ALSO
 ~~~~~~~~
 
-* `mmctl post <mmctl_post.rst>`_ 	 - Management of posts
+* `mmctl license <mmctl_license.rst>`_ 	 - Licensing commands
 

--- a/server/cmd/mmctl/docs/mmctl_post.rst
+++ b/server/cmd/mmctl/docs/mmctl_post.rst
@@ -40,4 +40,5 @@ SEE ALSO
 * `mmctl post create <mmctl_post_create.rst>`_ 	 - Create a post
 * `mmctl post delete <mmctl_post_delete.rst>`_ 	 - Mark posts as deleted or permanently delete posts with the --permanent flag
 * `mmctl post list <mmctl_post_list.rst>`_ 	 - List posts for a channel
+* `mmctl post reveal <mmctl_post_reveal.rst>`_ 	 - Reveal a post
 

--- a/server/cmd/mmctl/docs/mmctl_post_reveal.rst
+++ b/server/cmd/mmctl/docs/mmctl_post_reveal.rst
@@ -1,36 +1,33 @@
-.. _mmctl_post_create:
+.. _mmctl_post_reveal:
 
-mmctl post create
+mmctl post reveal
 -----------------
 
-Create a post
+Reveal a post
 
 Synopsis
 ~~~~~~~~
 
 
-Create a post
+Reveal a post
 
 ::
 
-  mmctl post create [flags]
+  mmctl post reveal [post] [flags]
 
 Examples
 ~~~~~~~~
 
 ::
 
-    post create myteam:mychannel --message "some text for the post"
+    post reveal udjmt396tjghi8wnsk3a1qs1sw
 
 Options
 ~~~~~~~
 
 ::
 
-  -b, --burn-on-read      Message will be deleted after a certain time after being read
-  -h, --help              help for create
-  -m, --message string    Message for the post
-  -r, --reply-to string   Post id to reply to
+  -h, --help   help for reveal
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/server/cmd/mmctl/docs/mmctl_report.rst
+++ b/server/cmd/mmctl/docs/mmctl_report.rst
@@ -1,36 +1,22 @@
-.. _mmctl_post_create:
+.. _mmctl_report:
 
-mmctl post create
------------------
+mmctl report
+------------
 
-Create a post
+Reporting commands
 
 Synopsis
 ~~~~~~~~
 
 
-Create a post
-
-::
-
-  mmctl post create [flags]
-
-Examples
-~~~~~~~~
-
-::
-
-    post create myteam:mychannel --message "some text for the post"
+Reporting commands
 
 Options
 ~~~~~~~
 
 ::
 
-  -b, --burn-on-read      Message will be deleted after a certain time after being read
-  -h, --help              help for create
-  -m, --message string    Message for the post
-  -r, --reply-to string   Post id to reply to
+  -h, --help   help for report
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -50,5 +36,6 @@ Options inherited from parent commands
 SEE ALSO
 ~~~~~~~~
 
-* `mmctl post <mmctl_post.rst>`_ 	 - Management of posts
+* `mmctl <mmctl.rst>`_ 	 - Remote client for the Open Source, self-hosted Slack-alternative
+* `mmctl report posts <mmctl_report_posts.rst>`_ 	 - Retrieve posts for reporting purposes
 

--- a/server/cmd/mmctl/docs/mmctl_report_posts.rst
+++ b/server/cmd/mmctl/docs/mmctl_report_posts.rst
@@ -1,0 +1,79 @@
+.. _mmctl_report_posts:
+
+mmctl report posts
+------------------
+
+Retrieve posts for reporting purposes
+
+Synopsis
+~~~~~~~~
+
+
+Retrieve posts from a channel for reporting purposes. This command supports
+pagination and can filter posts by time range. Results can be output in JSON format
+for further processing.
+
+::
+
+  mmctl report posts [channel] [flags]
+
+Examples
+~~~~~~~~
+
+::
+
+    # Get posts from a channel with default settings
+    mmctl report posts myteam:mychannel
+
+    # Get posts with JSON output
+    mmctl report posts myteam:mychannel --json
+
+    # Get posts sorted by update_at in descending order
+    mmctl report posts myteam:mychannel --time-field update_at --sort-direction desc
+
+    # Get posts including deleted posts and metadata
+    mmctl report posts myteam:mychannel --include-deleted --include-metadata
+
+    # Get posts excluding ALL system posts
+    mmctl report posts myteam:mychannel --exclude-system-posts
+
+    # Get more posts per page (max 1000)
+    mmctl report posts myteam:mychannel --per-page 500
+
+    # Resume pagination from a specific cursor (use next_cursor from previous response)
+    mmctl report posts myteam:mychannel --cursor "MTphYmMxMjM6Y3JlYXRlX2F0OmZhbHNlOmZhbHNlOmFzYzoxNjQwMDAwMzAwMDAwOnBvc3Qz"
+
+Options
+~~~~~~~
+
+::
+
+      --cursor string           Opaque cursor for pagination (use next_cursor from previous response)
+      --exclude-system-posts    Exclude ALL system posts (any type starting with 'system_')
+  -h, --help                    help for posts
+      --include-deleted         Include deleted posts
+      --include-metadata        Include file info, reactions, etc.
+      --per-page int            Number of posts per page (max 1000) (default 100)
+      --sort-direction string   Sort direction (asc or desc) (default "asc")
+      --time-field string       Time field to use for sorting (create_at or update_at) (default "create_at")
+
+Options inherited from parent commands
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+::
+
+      --config string                path to the configuration file (default "$XDG_CONFIG_HOME/mmctl/config")
+      --disable-pager                disables paged output
+      --insecure-sha1-intermediate   allows to use insecure TLS protocols, such as SHA-1
+      --insecure-tls-version         allows to use TLS versions 1.0 and 1.1
+      --json                         the output format will be in json format
+      --local                        allows communicating with the server through a unix socket
+      --quiet                        prevent mmctl to generate output for the commands
+      --strict                       will only run commands if the mmctl version matches the server one
+      --suppress-warnings            disables printing warning messages
+
+SEE ALSO
+~~~~~~~~
+
+* `mmctl report <mmctl_report.rst>`_ 	 - Reporting commands
+

--- a/server/cmd/mmctl/docs/mmctl_roles.rst
+++ b/server/cmd/mmctl/docs/mmctl_roles.rst
@@ -37,6 +37,7 @@ SEE ALSO
 ~~~~~~~~
 
 * `mmctl <mmctl.rst>`_ 	 - Remote client for the Open Source, self-hosted Slack-alternative
+* `mmctl roles list <mmctl_roles_list.rst>`_ 	 - List available roles
 * `mmctl roles member <mmctl_roles_member.rst>`_ 	 - Remove system admin privileges
 * `mmctl roles system-admin <mmctl_roles_system-admin.rst>`_ 	 - Set a user as system admin
 

--- a/server/cmd/mmctl/docs/mmctl_roles_list.rst
+++ b/server/cmd/mmctl/docs/mmctl_roles_list.rst
@@ -1,36 +1,34 @@
-.. _mmctl_post_create:
+.. _mmctl_roles_list:
 
-mmctl post create
------------------
+mmctl roles list
+----------------
 
-Create a post
+List available roles
 
 Synopsis
 ~~~~~~~~
 
 
-Create a post
+List available roles
 
 ::
 
-  mmctl post create [flags]
+  mmctl roles list [flags]
 
 Examples
 ~~~~~~~~
 
 ::
 
-    post create myteam:mychannel --message "some text for the post"
+    $ mmctl roles list
+    $ mmctl roles list --json
 
 Options
 ~~~~~~~
 
 ::
 
-  -b, --burn-on-read      Message will be deleted after a certain time after being read
-  -h, --help              help for create
-  -m, --message string    Message for the post
-  -r, --reply-to string   Post id to reply to
+  -h, --help   help for list
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -50,5 +48,5 @@ Options inherited from parent commands
 SEE ALSO
 ~~~~~~~~
 
-* `mmctl post <mmctl_post.rst>`_ 	 - Management of posts
+* `mmctl roles <mmctl_roles.rst>`_ 	 - Manage user roles
 

--- a/server/cmd/mmctl/docs/mmctl_user_list.rst
+++ b/server/cmd/mmctl/docs/mmctl_user_list.rst
@@ -27,11 +27,12 @@ Options
 
 ::
 
-      --all            Fetch all users. --page flag will be ignore if provided
+      --all            Fetch all users. --page flag will be ignored if provided
   -h, --help           help for list
-      --inactive       If supplied, only users which are inactive will be fetch
+      --inactive       If supplied, only users which are inactive will be fetched
       --page int       Page number to fetch for the list of users
       --per-page int   Number of users to be fetched (default 200)
+      --role string    If supplied, only users with the given role will be fetched
       --team string    If supplied, only users belonging to this team will be listed
 
 Options inherited from parent commands

--- a/server/platform/shared/filestore/mocks/s3CopyClient.go
+++ b/server/platform/shared/filestore/mocks/s3CopyClient.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 
 	minio "github.com/minio/minio-go/v7"
+
 	mock "github.com/stretchr/testify/mock"
 )
 

--- a/server/public/Makefile
+++ b/server/public/Makefile
@@ -1,7 +1,9 @@
+.PHONY: test-public
 test-public: gotestsum
 	$(GOBIN)/gotestsum ./public/... -- $(GOFLAGS)
 
 ## Generates mock golang interfaces for testing
+.PHONY: mocks-public
 mocks-public:
 	$(GO) install github.com/golang/mock/mockgen@v1.6.0
 	$(GOBIN)/mockgen -destination public/pluginapi/experimental/panel/mocks/mock_panel.go -package mock_panel github.com/mattermost/mattermost/server/public/pluginapi/experimental/panel Panel

--- a/server/public/model/user_serial_gen.go
+++ b/server/public/model/user_serial_gen.go
@@ -10,6 +10,134 @@ import (
 )
 
 // DecodeMsg implements msgp.Decodable
+func (z *LoginTypeResponse) DecodeMsg(dc *msgp.Reader) (err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, err = dc.ReadMapHeader()
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, err = dc.ReadMapKeyPtr()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "AuthService":
+			z.AuthService, err = dc.ReadString()
+			if err != nil {
+				err = msgp.WrapError(err, "AuthService")
+				return
+			}
+		case "IsDeactivated":
+			z.IsDeactivated, err = dc.ReadBool()
+			if err != nil {
+				err = msgp.WrapError(err, "IsDeactivated")
+				return
+			}
+		default:
+			err = dc.Skip()
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z LoginTypeResponse) EncodeMsg(en *msgp.Writer) (err error) {
+	// map header, size 2
+	// write "AuthService"
+	err = en.Append(0x82, 0xab, 0x41, 0x75, 0x74, 0x68, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65)
+	if err != nil {
+		return
+	}
+	err = en.WriteString(z.AuthService)
+	if err != nil {
+		err = msgp.WrapError(err, "AuthService")
+		return
+	}
+	// write "IsDeactivated"
+	err = en.Append(0xad, 0x49, 0x73, 0x44, 0x65, 0x61, 0x63, 0x74, 0x69, 0x76, 0x61, 0x74, 0x65, 0x64)
+	if err != nil {
+		return
+	}
+	err = en.WriteBool(z.IsDeactivated)
+	if err != nil {
+		err = msgp.WrapError(err, "IsDeactivated")
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z LoginTypeResponse) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	// map header, size 2
+	// string "AuthService"
+	o = append(o, 0x82, 0xab, 0x41, 0x75, 0x74, 0x68, 0x53, 0x65, 0x72, 0x76, 0x69, 0x63, 0x65)
+	o = msgp.AppendString(o, z.AuthService)
+	// string "IsDeactivated"
+	o = append(o, 0xad, 0x49, 0x73, 0x44, 0x65, 0x61, 0x63, 0x74, 0x69, 0x76, 0x61, 0x74, 0x65, 0x64)
+	o = msgp.AppendBool(o, z.IsDeactivated)
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *LoginTypeResponse) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	var field []byte
+	_ = field
+	var zb0001 uint32
+	zb0001, bts, err = msgp.ReadMapHeaderBytes(bts)
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	for zb0001 > 0 {
+		zb0001--
+		field, bts, err = msgp.ReadMapKeyZC(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		switch msgp.UnsafeString(field) {
+		case "AuthService":
+			z.AuthService, bts, err = msgp.ReadStringBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "AuthService")
+				return
+			}
+		case "IsDeactivated":
+			z.IsDeactivated, bts, err = msgp.ReadBoolBytes(bts)
+			if err != nil {
+				err = msgp.WrapError(err, "IsDeactivated")
+				return
+			}
+		default:
+			bts, err = msgp.Skip(bts)
+			if err != nil {
+				err = msgp.WrapError(err)
+				return
+			}
+		}
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z LoginTypeResponse) Msgsize() (s int) {
+	s = 1 + 12 + msgp.StringPrefixSize + len(z.AuthService) + 14 + msgp.BoolSize
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *User) DecodeMsg(dc *msgp.Reader) (err error) {
 	var zb0001 uint32
 	zb0001, err = dc.ReadArrayHeader()


### PR DESCRIPTION
#### Summary

To help continue to address GitHub actions cache pressure, to support the ability to bump Go patch versions on demand in release branches, and to avoid needless merge conflicts as we inevitably need to keep v11.7+ up-to-date, cherry-pick some of the biggest CI changes from the past few weeks:

- #36876
- #37268
- #37286
- #37182
- #37393
- #37427
- #37447
- #37451

#### Generated Files

Note that https://github.com/mattermost/mattermost/pull/37451 was inspired precisely because these branches /didn't/ have up-to-date generated files. Those changes are included with this PR.

#### Ticket Link
N/A

#### Release Note
```release-note
NONE
```
