### PR TITLE
fix: correct Message Actions menu positioning on narrow displays

### DIFF
--- a/webapp/channels/src/components/widgets/menu/menu.scss
+++ b/webapp/channels/src/components/widgets/menu/menu.scss
@@ -182,9 +182,7 @@
     }
 
     &.openUp {
-        @media screen and (min-width: 768px) {
-            top: auto;
-            bottom: 100%;
-        }
+        top: auto;
+        bottom: 100%;
     }
 }

--- a/webapp/channels/src/sass/responsive/_mobile.scss
+++ b/webapp/channels/src/sass/responsive/_mobile.scss
@@ -272,9 +272,7 @@
             }
         }
 
-        .post,
-        .SidebarMenu,
-        .GlobalThreads {
+        .SidebarMenu {
             .Menu {
                 position: fixed;
                 z-index: 9999;


### PR DESCRIPTION
#### Summary

Fixes an issue where the Message Actions menu could appear at the top of the message pane instead of next to the clicked message when using a narrow, single-column layout with a long, scrollable channel or thread.

This change:
- Removes the mobile `position: fixed` override for post and Global Threads menus so they continue using their existing inline positioning.
- Enables `openUp` positioning on narrow layouts by removing the desktop-only media query restriction.

#### QA Steps

1. Start a Mattermost server and open the web app.
2. Resize the browser to a narrow/mobile-width viewport (less than 768px wide).
3. Open a channel or thread with enough messages to require scrolling.
4. Scroll down in the message list.
5. Click the Message Actions button on a post.
6. Verify the menu opens adjacent to the clicked button instead of appearing at the top of the message pane.
7. Verify the menu continues to behave correctly on desktop layouts.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/37404

#### Screenshots

N/A

#### Release Note

```release-note
Fixed an issue where the Message Actions menu could appear off-screen in narrow layouts with long, scrollable channels or threads.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to responsive menu positioning and do not affect shared business logic or critical flows. Risk is limited to visual positioning across viewport sizes.

**QA Recommendation:** Targeted manual QA for narrow and desktop message layouts is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->