### PR TITLE
Fix assorted down migrations, add additional testing

### DIFF
--- a/server/channels/db/migrations/postgres/000010_create_group_channels.down.sql
+++ b/server/channels/db/migrations/postgres/000010_create_group_channels.down.sql
@@ -1,1 +1,1 @@
-DROP TABLE IF EXISTS groupchanels;
+DROP TABLE IF EXISTS groupchannels;

--- a/server/channels/db/migrations/postgres/000015_create_systems.down.sql
+++ b/server/channels/db/migrations/postgres/000015_create_systems.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS systems;

--- a/server/channels/db/migrations/postgres/000043_thread_memberships.down.sql
+++ b/server/channels/db/migrations/postgres/000043_thread_memberships.down.sql
@@ -4,4 +4,4 @@ DROP INDEX IF EXISTS idx_thread_memberships_last_update_at;
 
 ALTER TABLE threadmemberships DROP COLUMN IF EXISTS unreadmentions;
 
-DROP TABLE IF EXISTS theadmemberships;
+DROP TABLE IF EXISTS threadmemberships;

--- a/server/channels/db/migrations/postgres/000129_add_property_system_architecture.down.sql
+++ b/server/channels/db/migrations/postgres/000129_add_property_system_architecture.down.sql
@@ -1,3 +1,4 @@
 DROP TABLE IF EXISTS PropertyGroups;
 DROP TABLE IF EXISTS PropertyFields;
 DROP TABLE IF EXISTS PropertyValues;
+DROP TYPE IF EXISTS property_field_type;

--- a/server/channels/store/sqlstore/migrate_test.go
+++ b/server/channels/store/sqlstore/migrate_test.go
@@ -8,32 +8,93 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/v8/channels/store/storetest"
+	"github.com/mattermost/morph/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+const postgresSchemaObjectsQuery = `
+SELECT pg_catalog.pg_describe_object(d.classid, d.objid, d.objsubid)
+  FROM pg_catalog.pg_depend d
+ WHERE d.refclassid = 'pg_catalog.pg_namespace'::pg_catalog.regclass
+   AND d.refobjid = pg_catalog.current_schema()::pg_catalog.regnamespace
+   AND d.deptype = 'n'
+ ORDER BY 1`
+
+// postgresSchemaObjects returns stable descriptions of objects that belong to
+// the current PostgreSQL schema. Use it to list all tables, indexes, and other
+// schema objects in the database.
+func postgresSchemaObjects(t *testing.T, store *SqlStore) []string {
+	t.Helper()
+
+	var objects []string
+	require.NoError(t, store.GetMaster().Select(&objects, postgresSchemaObjectsQuery))
+	return objects
+}
+
 func TestUpAndDownMigrations(t *testing.T) {
 	logger := mlog.CreateTestLogger(t)
 
-	testDrivers := []string{
-		model.DatabaseDriverPostgres,
-	}
-
-	for _, driver := range testDrivers {
-		t.Run("Should be reversible for "+driver, func(t *testing.T) {
-			settings, err := makeSqlSettings(driver)
-			if err != nil {
-				t.Skip(err)
-			}
-
-			store, err := New(*settings, logger, nil)
-			require.NoError(t, err)
-			defer store.Close()
-
-			err = store.migrate(migrationsDirectionDown, false, true)
-			assert.NoError(t, err, "downing migrations should not error")
+	t.Run("store", func(t *testing.T) {
+		settings, err := makeSqlSettings(model.DatabaseDriverPostgres)
+		if err != nil {
+			t.Skip(err)
+		}
+		t.Cleanup(func() {
+			storetest.CleanupSqlSettings(settings)
 		})
-	}
+
+		store, err := New(*settings, logger, nil)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			store.Close()
+		})
+
+		err = store.migrate(migrationsDirectionDown, false, true)
+		assert.NoError(t, err, "downing migrations should not error")
+	})
+
+	t.Run("manual morph application", func(t *testing.T) {
+		settings, err := makeSqlSettings(model.DatabaseDriverPostgres)
+		if err != nil {
+			t.Skip(err)
+		}
+		t.Cleanup(func() {
+			storetest.CleanupSqlSettings(settings)
+		})
+
+		store, err := New(*settings, logger, nil, SkipMigrations())
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			store.Close()
+		})
+
+		engine, err := store.initMorph(false, true)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, engine.Close())
+		})
+
+		pending, err := engine.Diff(models.Up)
+		require.NoError(t, err)
+		require.NotEmpty(t, pending)
+		initialSchema := postgresSchemaObjects(t, store)
+
+		applied, err := engine.Apply(-1)
+		require.NoError(t, err, "applying migrations should not error")
+		require.Equal(t, len(pending), applied)
+
+		rolledBack, err := engine.ApplyDown(-1)
+		require.NoError(t, err, "downing migrations should not error")
+		require.Equal(t, applied, rolledBack)
+
+		var migrationCount int
+		require.NoError(t, store.GetMaster().Get(&migrationCount, "SELECT COUNT(*) FROM db_migrations"))
+		assert.Zero(t, migrationCount, "all migration records should be removed")
+		assert.Equal(t, initialSchema, postgresSchemaObjects(t, store),
+			"schema differs after rollback; a down migration may not fully reverse its corresponding up migration")
+	})
 }
 
 // TestMigratorPreMigrate exercises the exported entry point invoked by the


### PR DESCRIPTION
#### Summary
Fix typos detected in migrations, thanks to [mussa_wiso13 on Community](https://community.mattermost.com/core/pl/gi9ibxsif7bzxrapqszz639eda). After adding some test coverage to verify the database is empty after unwinding all migrations, fix two extra down migrations as well.

#### Ticket Link
None

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes affect database migration and rollback integrity across multiple PostgreSQL migrations, but added automated coverage validates complete migration reversal.  
**QA Recommendation:** Manual QA can be skipped; rely on the migration test suite across supported database drivers.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->