### PR TITLE
[MM-69592] Remove feature flag: OnboardingTourTips

### DIFF
--- a/e2e-tests/playwright/lib/src/server/default_config.ts
+++ b/e2e-tests/playwright/lib/src/server/default_config.ts
@@ -796,7 +796,6 @@ const defaultServerConfig: AdminConfig = {
         AppsEnabled: false,
         NormalizeLdapDNs: false,
         WysiwygEditor: false,
-        OnboardingTourTips: true,
         EnableExportDirectDownload: false,
         MoveThreadsEnabled: false,
         CloudDedicatedExportUI: false,

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -30,8 +30,6 @@ type FeatureFlags struct {
 	// Enable WYSIWYG text editor
 	WysiwygEditor bool
 
-	OnboardingTourTips bool
-
 	EnableExportDirectDownload bool
 
 	MoveThreadsEnabled bool
@@ -144,7 +142,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.AppsEnabled = false
 	f.NormalizeLdapDNs = false
 	f.WysiwygEditor = false
-	f.OnboardingTourTips = true
 	f.EnableExportDirectDownload = false
 	f.MoveThreadsEnabled = false
 	f.CloudDedicatedExportUI = false

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/preferences.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/preferences.ts
@@ -322,10 +322,6 @@ export function getVisibleDmGmLimit(state: GlobalState, userPreferences?: Prefer
     return getInt(state, Preferences.CATEGORY_SIDEBAR_SETTINGS, Preferences.LIMIT_VISIBLE_DMS_GMS, defaultLimit, userPreferences);
 }
 
-export function onboardingTourTipsEnabled(state: GlobalState): boolean {
-    return getFeatureFlagValue(state, 'OnboardingTourTips') === 'true';
-}
-
 export function moveThreadsEnabled(state: GlobalState): boolean {
     return getFeatureFlagValue(state, 'MoveThreadsEnabled') === 'true' && getLicense(state).IsLicensed === 'true';
 }


### PR DESCRIPTION
#### Summary
Removes the `OnboardingTourTips` feature flag, which gated the in-product onboarding tour tips for new users in the web app. The flag defaulted to `true` and the webapp selector that read it (`onboardingTourTipsEnabled`) had no callers, so the tips were already effectively always enabled. This is a mechanical cleanup with no behavior change:

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-69592

```release-note
Remove unused feature flag OnboardingTourTips
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The cleanup removes an unused, default-enabled feature flag and selector without changing behavior. Compile-time consumers could be affected by the removed public field, but the change is isolated and straightforward to validate.

**QA Recommendation:** Manual QA can be skipped; rely on automated tests and compilation checks.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->