### PR TITLE
Fix broken master: NewJobServer / extract_content worker_test

### DIFF
--- a/server/channels/jobs/extract_content/worker_test.go
+++ b/server/channels/jobs/extract_content/worker_test.go
@@ -44,13 +44,14 @@ func makeTestJobServer(t *testing.T) (*jobs.JobServer, *storetest.Store) {
 		mockStore,
 		nil,
 		mlog.CreateConsoleTestLogger(t),
+		nil,
 	)
 
 	return jobServer, mockStore
 }
 
 func expectJobDataUpdate(mockStore *storetest.Store) {
-	mockStore.JobStore.On("UpdateOptimistically", mock.AnythingOfType("*model.Job"), model.JobStatusInProgress).Return(true, nil)
+	mockStore.JobStore.On("UpdateOptimistically", mock.AnythingOfType("*model.Job"), model.JobStatusInProgress).Return(nil, nil)
 }
 
 func expectWorkerJobCompletion(mockStore *storetest.Store, job *model.Job) {


### PR DESCRIPTION
#### Summary

A bad upstream merge left `channels/jobs/extract_content/worker_test.go` out of sync with two signature changes, breaking the build and the test suite. This PR fixes both.

#### Release Note
```release-note
NONE
```
