### PR TITLE
docs(P13i+P13j): reconcile docs drift — Integrations Guide, Security Guide, Use Case Guide, Get Help

### DIFF
--- a/docs/main/get-help/community-chat.mdx
+++ b/docs/main/get-help/community-chat.mdx
@@ -36,6 +36,6 @@ To familiarize yourself with our community contribution process, start by explor
 - [QA: Contributors](https://community.mattermost.com/core/channels/qa-contributors)
 - [Thank you!](https://community.mattermost.com/core/channels/thank-you)
 
-There are many channels that specialize in different areas of the Mattermost platform. To find and join them, search “**Developers:**” in the [LHS](https://handbook.mattermost.com/company/about-mattermost/list-of-terms#lhs) “🔍 Find channel” search bar on the community server.
+There are many channels that specialize in different areas of the Mattermost platform. To find and join them, search for **Developers:** using the [LHS](https://handbook.mattermost.com/company/about-mattermost/list-of-terms#lhs) "Find channel" search bar on the community server.
 
 We hold a public developer community meeting every Wednesday at 8:30 AM Palo Alto time. ☎️ The meeting is held via an audio call in [Developers: Meeting](https://community.mattermost.com/core/channels/developers-meeting) and everyone is welcome. This weekly meeting is a great opportunity to ask questions about the project and get involved.

--- a/docs/main/integrations-guide/github.mdx
+++ b/docs/main/integrations-guide/github.mdx
@@ -70,9 +70,24 @@ We recommend making a copy of your webhook secret and encryption key, as it will
 
 **Create a webhook in GitHub**
 
-Create a webhook in GitHub for each GitHub organization you want to set up.
+Create a webhook in GitHub to send events to Mattermost. You can create the webhook at either level:
 
-1.  In GitHub, go to the **Settings** page where you want to send notifications from, then select **Webhooks** in the sidebar.
+- **Organization level**: Delivers events for every repository in the organization.
+- **Repository level**: One webhook per repository you want to send events from to Mattermost.
+
+<Important>
+
+Make sure only **one** webhook delivers events for any given repository. If a repository is covered by both an organization-level webhook and a repository-level webhook (or by duplicate webhooks), GitHub delivers each event more than once, and Mattermost posts a duplicate notification for every delivery. If notifications appear two or more times, review the webhooks in your GitHub organization and repository settings, and remove the extras so that exactly one webhook delivers each repository's events.
+
+</Important>
+
+<Note>
+
+When you subscribe a channel to a specific repository using `/github subscriptions add owner/repository` while relying on an **organization-level** webhook, the plugin might report `No webhook was found for this repository or organization` even though the organization-level webhook is delivering events correctly. This check currently only looks for repository-level webhooks; the message is informational and doesn't mean events are missing, so it's safe to ignore. If you prefer to avoid it, deliver that repository's events through a repository-level webhook *instead of* the organization-level webhook.
+
+</Note>
+
+1.  In GitHub, go to the **Settings** page (for your organization or a specific repository) where you want to send notifications from, then select **Webhooks** in the sidebar.
 2.  Select **Add Webhook**.
 3.  Set the following values:
 

--- a/docs/main/integrations-guide/no-code-automation.mdx
+++ b/docs/main/integrations-guide/no-code-automation.mdx
@@ -104,7 +104,7 @@ Zapier is ideal for non-technical users who want the fastest path to connect Mat
 
 Zapier’s strength is the breadth of integrations. Without coding, you can integrate Mattermost with everything from CRMs to social media. This is perfect for non-technical users who want to automate notifications or routine tasks, such as posting daily reports or sending Mattermost channel messages when forms are submitted. Zapier provides a user-friendly wizard and template library to get started quickly.
 
-Explore building workflows with the [Mattermost Zapier integration](https://n8n.io/integrations/mattermost/).
+Explore building workflows with the [Mattermost Zapier integration](https://zapier.com/apps/mattermost/integrations).
 
 ## Supported Triggers
 

--- a/docs/main/integrations-guide/servicenow.mdx
+++ b/docs/main/integrations-guide/servicenow.mdx
@@ -45,7 +45,7 @@ Once the update set is uploaded, it creates a new role called `x_830655_mm_std.u
 ### Update the API secret on the change of ServiceNow Webhook Secret
 
 1.  In Mattermost, copy the **Webhook Secret** from your Mattermost instance by going to **System Console \> Plugins \> ServiceNow**.
-2.  In your ServiceNow instance, go to **All \> x_830655_mm_std_servicenow_for_mattermost_notifications_auth.list**. (**Note**: You must enter the complete name and search.)
+2.  In your ServiceNow instance, open the auth table's list view by navigating directly to `https://<your-instance>.service-now.com/x_830655_mm_std_servicenow_for_mattermost_notifications_auth_list.do`, replacing `<your-instance>` with your ServiceNow instance subdomain.
 3.  On the page, select the row containing your Mattermost Server URL. If that row doesn't exist, create it manually by selecting **New** located in the top-right corner, and adding your Mattermost Server URL.
 4.  Update the **API Secret** in the ServiceNow instance with the **Webhook Secret** from Mattermost, and select **Update**.
 

--- a/docs/main/security-guide/mobile-security.mdx
+++ b/docs/main/security-guide/mobile-security.mdx
@@ -75,10 +75,24 @@ Additionally, administrators can control link navigation within PDF files when s
 
 Learn more about [enabling secure file preview on mobile](/administration-guide/configure/environment-configuration-settings#enable-secure-file-preview-on-mobile) and [allow PDF link navigation on mobile](/administration-guide/configure/environment-configuration-settings#allow-pdf-link-navigation-on-mobile) in the Mattermost mobile app.
 
+## Mobile watermarking
+
+Mobile watermarking is an experimental Enterprise Advanced capability available from Mattermost v11.7 onward that helps organizations identify the source and timing of mobile screenshots or shared screen captures. When enabled by a system admin, authenticated Mattermost mobile sessions display a visible watermark overlay that includes the user's username, the server domain, and the current date and time. This supports data loss prevention (DLP) workflows by attributing any image taken of the Mattermost mobile app to a specific user, server, and point in time.
+
+The mobile watermark is a visual overlay only. It does not prevent screenshots, screen recordings, file exports, or content sharing through other means, and it is not a substitute for screen capture prevention or other mobile security controls. Mobile watermarking is disabled by default.
+
+Learn more about Mattermost [mobile watermarking](/deployment-guide/mobile/mobile-security-features#mobile-watermarking) and how to [enable the experimental Mobile Watermark setting](/administration-guide/configure/experimental-configuration-settings#enable-mobile-watermark).
+
 ## Burn-on-read messages
 
 Burn-on-read messages reduce the window of exposure for sensitive content by automatically deleting messages after they are revealed. This approach supports secure, time-bound communication by ensuring that sensitive information doesn't persist on the device longer than necessary.
 
 Administrators can enable burn-on-read messaging and set the burn-on-read duration to align with organizational policies. Learn more about [sending burn-on-read messages](/end-user-guide/collaborate/send-messages#send-burn-on-read-messages) and [enabling burn-on-read messages](/administration-guide/configure/site-configuration-settings#enable-burn-on-read-messages).
+
+## Mobile Ephemeral Mode
+
+Mobile applications typically cache messages, files, and attachments indefinitely. Without data-age controls or a device-side deletion mechanism, a lost or stolen device retains all cached content — and MDM remote wipe cannot help when the device is offline. Mobile Ephemeral Mode addresses this by giving administrators timer-based controls that run on-device, independently of server connectivity, ensuring data is removed based on elapsed time rather than device reachability.
+
+Administrators can configure the maximum age of cached content and how long data persists after a device goes offline. A server-initiated wipe triggered by access revocation removes all data, including credentials, as soon as the device receives the command. Learn more about [Mobile Ephemeral Mode](/deployment-guide/mobile/mobile-security-features#mobile-ephemeral-mode).
 
 [Book a live demo](https://mattermost.com/request-demo/) or [talk to a Mattermost expert](https://mattermost.com/contact-sales/) to explore tailored solutions for your organization's secure collaboration needs. Or try Mattermost yourself with a [1-hour preview](https://mattermost.com/sign-up/) for instant access to a live sandbox environment.

--- a/docs/main/use-case-guide/mission-ready-mobile.mdx
+++ b/docs/main/use-case-guide/mission-ready-mobile.mdx
@@ -5,7 +5,7 @@ Mission environments demand secure, reliable mobile collaboration, from intellig
 
 Mattermost provides a secure, mission-ready mobile platform built for defense, law enforcement, and public sector operations. Optimized for low-bandwidth and disconnected conditions, Mattermost ensures secure communication on government-issued devices while enabling compliant collaboration on personal phones—without reliance on consumer apps or invasive controls.
 
-With protections including ID-only push notifications, biometric authentication, jailbreak detection, and full MDM/EMM support, Mattermost delivers control, compliance, and usability across a range of challenging field conditions.
+With protections including ID-only push notifications, biometric authentication, jailbreak detection, ephemeral data lifecycle controls, and full MDM/EMM support, Mattermost delivers control, compliance, and usability across a range of challenging field conditions.
 
 ![An infographic illustrating "Security-Optimized Mobility" with two devices side-by-side: A Mattermost server (on the left) and a mobile device (on the right). The Mattermost server displays a list of security features, including "Zero Trust Security (Channel ABAC, Files ABAC)," "Secure File Viewer," "TLS Data in Transit (Post Quantum)," "Authentication and Access Control (MFA, SSO)," "Data Spillage Handling," and more, with asterisks (\*) indicating functionality scheduled for release later in 2025. On the right, the mobile device mirrors corresponding security features, such as "Secure File Viewer," "TLS," "Burn on Read," "End-to-End Encryption," "Biometric Authentication," and others, with blue arrows connecting the related features on the server and the mobile device, signifying seamless integration and support for advanced security across these endpoints.](/images/mission-ready-mobile.png)
 
@@ -29,7 +29,7 @@ When personal devices are the only available channel—whether in partner nation
 
 **Benefits**
 
-- **Enable trusted communications on BYOD** using lightweight AppConfig policies with [EMM optionality](/deployment-guide/mobile/deploy-mobile-apps-using-emm-provider) that avoids intrusive control while ensuring essential security baselines.
+- **Enable trusted communications on BYOD** using lightweight AppConfig policies with [EMM optionality](/deployment-guide/mobile/deploy-mobile-apps-using-emm-provider) that avoids intrusive control while ensuring essential security baselines. Pair with [Mobile Ephemeral Mode](/deployment-guide/mobile/mobile-security-features#mobile-ephemeral-mode) to enforce admin-controlled data lifecycle — automatically purging cached messages without requiring MDM connectivity.
 - **Prevent unauthorized data sharing**: Mitigate leakage with [screenshot and screen recording prevention](/deployment-guide/mobile/mobile-security-features#screenshot-and-screen-recording-prevention) and [jailbreak/root detection](/deployment-guide/mobile/mobile-security-features#jailbreak-and-root-detection) that block high-risk mobile behaviors.
 - **Secure access without cloud dependency** via [self-hosted deployments](/deployment-guide/server/server-deployment-planning#deployment-options) or [air-gapped infrastructures](/deployment-guide/reference-architecture/deployment-scenarios/air-gapped-deployment) that prevent sensitive data from touching public networks.
 - **Deliver rapid alerts with low bandwidth impact** using [ID-only push notifications](/administration-guide/configure/push-notification-server-configuration-settings#id-only-push-notifications), ideal for DDIL (disconnected, intermittent, low-bandwidth) conditions.
@@ -44,6 +44,7 @@ Mattermost on mobile is hardened to operate under mission-grade security expecta
 - **Zero Trust security architecture** with channel- and file-level [attribute-based access control (ABAC)](/administration-guide/manage/admin/attribute-based-access-control).
 - **TLS with post-quantum readiness** and end-to-end\* [encryption options](/security-guide/security-guide-index) for high-assurance deployments.
 - **Burn-on-read messaging**: Use [secure file viewers](/security-guide/mobile-security#secure-file-preview), [burn on read messaging](/end-user-guide/collaborate/send-messages#send-burn-on-read-messages), and advanced data spillage controls\* to protect sensitive information and minimize persistent data exposure.
+- **Ephemeral data lifecycle controls**: [Mobile Ephemeral Mode](/deployment-guide/mobile/mobile-security-features#mobile-ephemeral-mode) enforces admin-defined retention limits on approved personal devices — automatically deleting cached content by data age and time offline, with audit logging of deletion events reported to the server on reconnection.
 - **DoD STIG container support** with FIPS 140-3 validation\*, and [audit logging](/administration-guide/manage/logging#audit-logging) to ensure deployment compliance in regulated missions.
 - **Isolated mobile sessions** from host operating systems by partnering with platforms like Hypori in high-assurance BYOD scenarios.
 


### PR DESCRIPTION
#### Summary

Reconciles drift accumulated in `mattermost/docs` (Sphinx source) since the P13 fork point into the corresponding MDX pages in `docs/main/`, combining the small Integrations Guide (P13i) and Security Guide + Use Case Guide + Get Help (P13j) sub-phases into one PR per the P13 plan.

- `docs/main/integrations-guide/servicenow.mdx`: Updated the ServiceNow auth table lookup step to use the direct URL path (`.../x_830655_mm_std_servicenow_for_mattermost_notifications_auth_list.do`) instead of the in-product search, which no longer works reliably on current ServiceNow releases.
- `docs/main/integrations-guide/github.mdx`: Clarified that GitHub webhooks can be created at the organization or repository level, added an important warning about duplicate notifications when both levels are covered, and added a note explaining the "No webhook was found" message shown when subscribing a specific repo while relying on an org-level webhook.
- `docs/main/integrations-guide/no-code-automation.mdx`: Fixed the Zapier integration link, which incorrectly pointed to the n8n integrations page.
- `docs/main/integrations-guide/built-in-slash-commands.mdx`: No content drift found upstream (only a trailing-newline diff) — left unchanged.
- `docs/main/security-guide/mobile-security.mdx`: Added "Mobile watermarking" (experimental, Enterprise Advanced, v11.7+) and "Mobile Ephemeral Mode" sections.
- `docs/main/use-case-guide/mission-ready-mobile.mdx`: Added Mobile Ephemeral Mode references to the intro, BYOD benefits, and field-forward security features.
- `docs/main/get-help/community-chat.mdx`: Updated the community server search bar wording to match the source update.

#### Release Note

```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Documentation-only changes span multiple guides and include authentication and mobile security guidance, but do not modify application behavior or shared code. Risk is limited to inaccurate links or instructions.

**QA Recommendation:** Perform a brief documentation link and rendering check; no manual product QA is required.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->