### PR TITLE
docs(P13g): reconcile docs drift — Deployment Guide

### DIFF
--- a/docs/main/deployment-guide/desktop/desktop-msi-installer-and-group-policy-install.mdx
+++ b/docs/main/deployment-guide/desktop/desktop-msi-installer-and-group-policy-install.mdx
@@ -43,9 +43,9 @@ If a user reports a broken shortcut after upgrading to v6.1.0, the user should:
 
     ![Go to the mattermost/desktop repository on GitHub.](/images/desktop/msi_gpo/msi_gpo_installation_test_00002.png)
 
-3.  Navigate to the release page for [version v6.1.2](https://github.com/mattermost/desktop/releases/latest) and download the appropriate installer for your version of Windows (32-bit vs. 64-bit).
+3.  Navigate to the release page for [version v6.2.2](https://github.com/mattermost/desktop/releases/latest) and download the appropriate installer for your version of Windows (32-bit vs. 64-bit).
 
-4.  Download the [source.zip](https://github.com/mattermost/desktop/archive/v6.1.2.zip) file as well to extract group policy files.
+4.  Download the [source.zip](https://github.com/mattermost/desktop/archive/v6.2.2.zip) file as well to extract group policy files.
 
     ![In the mattermost/desktop repository on GitHub, go to the release page for the latest desktop release, then download the installer for your version of Windows. Download the source.zip file as well to extract group policy files.](/images/desktop/msi_gpo/msi_gpo_installation_test_00003.png)
 
@@ -90,11 +90,11 @@ The following group policies are available supporting a state option of Not Conf
 > </tbody>
 > </table>
 
-1.  Browse to the folder the above files were downloaded to and unzip the `desktop-6.1.2.zip` file in place.
+1.  Browse to the folder the above files were downloaded to and unzip the `desktop-6.2.2.zip` file in place.
 
     ![Go to the install download directory on your machine and unzip the ZIP file.](/images/desktop/msi_gpo/msi_gpo_installation_test_00004.png)
 
-2.  Navigate to the unzipped `desktop-6.1.2\resources\windows\gpo` folder and copy the contents.
+2.  Navigate to the unzipped `desktop-6.2.2\resources\windows\gpo` folder and copy the contents.
 
     ![Go to the \resources\windows\gpo directory and copy its contents.](/images/desktop/msi_gpo/msi_gpo_installation_test_00005.png)
 
@@ -215,13 +215,13 @@ Ensure the desktop app is closed before proceeding with a silent installation. B
 
 </Important>
 
-**Command Prompt:** `msiexec /i mattermost-desktop-v6.1.2-x64.msi /qn`
+**Command Prompt:** `msiexec /i mattermost-desktop-v6.2.2-x64.msi /qn`
 
-**PowerShell:** `Start-Process -FilePath "$env:systemroot\system32\msiexec.exe" -ArgumentList '/i mattermost-desktop-v6.1.2-x64.msi /qn'`
+**PowerShell:** `Start-Process -FilePath "$env:systemroot\system32\msiexec.exe" -ArgumentList '/i mattermost-desktop-v6.2.2-x64.msi /qn'`
 
 <Note>
 
-\- Replace `&lt;version&gt;` with the actual version number (e.g., `v6.1.2`). - From v6.1.0, the MSI installs per-machine by default, requiring administrator privileges.
+\- Replace `&lt;version&gt;` with the actual version number (e.g., `v6.2.2`). - From v6.1.0, the MSI installs per-machine by default, requiring administrator privileges.
 
 </Note>
 
@@ -231,7 +231,13 @@ From version v5.9.0 of the Mattermost desktop app, the following silent MSI inst
 
 Use the `APPLICATIONFOLDER` parameter to specify an installation directory for the MSI installation:
 
-- **Command Prompt:** `msiexec /i mattermost-desktop-v6.1.2-x64.msi APPLICATIONFOLDER="&lt;install directory&gt;"`
-- **PowerShell:** `Start-Process -FilePath "$env:systemroot\system32\msiexec.exe" -ArgumentList '/i mattermost-desktop-v6.1.2-x64.msi APPLICATIONFOLDER="&lt;install directory&gt;"'`
+- **Command Prompt:** `msiexec /i mattermost-desktop-v6.2.2-x64.msi APPLICATIONFOLDER="&lt;install directory&gt;"`
+- **PowerShell:** `Start-Process -FilePath "$env:systemroot\system32\msiexec.exe" -ArgumentList '/i mattermost-desktop-v6.2.2-x64.msi APPLICATIONFOLDER="&lt;install directory&gt;"'`
 
 Change this command as new versions of the Mattermost Desktop App are released.
+
+## macOS managed configuration (MDM)
+
+From Mattermost Desktop v6.2.0, admins can manage supported Desktop App configuration on macOS using managed preferences delivered through an MDM solution, in addition to the Windows group policy support described above. macOS managed preferences support the same configuration items as the Windows group policies listed in the [Install group policy files locally](#install-group-policy-files-locally) section, including predefined server lists, server management controls, and update notification controls.
+
+To apply managed configuration on macOS, deploy a configuration profile that sets the supported keys to client Macs through your MDM solution. The Mattermost Desktop App reads managed preference values on launch; restart the app after changing managed configuration for new values to take effect.

--- a/docs/main/deployment-guide/desktop/linux-desktop-install.mdx
+++ b/docs/main/deployment-guide/desktop/linux-desktop-install.mdx
@@ -62,11 +62,11 @@ Beta `.rpm` packages are available for CentOS and RHEL 7 and 8. Automatic app up
 
 ## Install the Mattermost desktop app
 
-1.  Download the latest version of the Mattermost desktop app for 64-bit systems: [mattermost-desktop-6.1.2-linux-x86_64.rpm](https://releases.mattermost.com/desktop/6.1.2/mattermost-desktop-6.1.2-linux-x86_64.rpm)
+1.  Download the latest version of the Mattermost desktop app for 64-bit systems: [mattermost-desktop-6.2.2-linux-x86_64.rpm](https://releases.mattermost.com/desktop/6.2.2/mattermost-desktop-6.2.2-linux-x86_64.rpm)
 2.  At the command line, execute the following command:
 
 > ``` sh
-> sudo rpm -i mattermost-desktop-6.1.2-linux-x86_64.rpm
+> sudo rpm -i mattermost-desktop-6.2.2-linux-x86_64.rpm
 > ```
 
 3.  Run Mattermost as a desktop app.
@@ -74,7 +74,7 @@ Beta `.rpm` packages are available for CentOS and RHEL 7 and 8. Automatic app up
 To manually update the desktop app, run the following command:
 
 > ``` sh
-> sudo rpm -u mattermost-desktop-6.1.2-linux-x86_64.rpm
+> sudo rpm -u mattermost-desktop-6.2.2-linux-x86_64.rpm
 > ```
 
 <Tip>
@@ -112,7 +112,7 @@ Flatpak packages are available for:
 > ``` sh
 > flatpak install mattermost-desktop-&#123;VERSION&#125;-linux-&#123;ARCH&#125;.flatpak
 >
-> Replace ``&#123;VERSION&#125;`` with the version number (e.g., ``6.1.2``) and ``&#123;ARCH&#125;`` with your architecture (``x86_64`` or ``aarch64``).
+> Replace ``&#123;VERSION&#125;`` with the version number (e.g., ``6.2.2``) and ``&#123;ARCH&#125;`` with your architecture (``x86_64`` or ``aarch64``).
 > ```
 
 4.  Run Mattermost as a desktop app:
@@ -142,7 +142,7 @@ For instructions on how to use the AppImage binary, please refer to the [AppImag
 
 ## Install the Desktop App's compressed tarball
 
-1.  Download the latest version of the Mattermost desktop app for 64-bit systems: [mattermost-desktop-6.1.2-linux-x64.tar.gz](https://releases.mattermost.com/desktop/6.1.2/mattermost-desktop-6.1.2-linux-x64.tar.gz)
+1.  Download the latest version of the Mattermost desktop app for 64-bit systems: [mattermost-desktop-6.2.2-linux-x64.tar.gz](https://releases.mattermost.com/desktop/6.2.2/mattermost-desktop-6.2.2-linux-x64.tar.gz)
 2.  Extract the archive to a convenient location, then give `chrome-sandbox` in the extracted directory the required ownership and permissions: `sudo chown root:root chrome-sandbox && sudo chmod 4755 chrome-sandbox`
 3.  Execute `mattermost-desktop` located inside the extracted directory.
 4.  To create a Desktop launcher, open the file `README.md`, and follow the instructions in the **Desktop launcher** section.

--- a/docs/main/deployment-guide/mobile/configure-microsoft-intune-mam.mdx
+++ b/docs/main/deployment-guide/mobile/configure-microsoft-intune-mam.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Configure Microsoft Intune Mobile Application Management (MAM)"
 ---
-<PlanAvailability slug="entry-ent" />
+<PlanAvailability slug="entry-adv" />
 
 You can configure the Mattermost Mobile App on iOS to enforce Microsoft Intune App Protection Policies (MAM) so organizational data remains protected on Bring Your Own Device (BYOD) and mixed-use devices without requiring device enrollment (MDM).
 

--- a/docs/main/deployment-guide/mobile/mobile-security-features.mdx
+++ b/docs/main/deployment-guide/mobile/mobile-security-features.mdx
@@ -53,6 +53,27 @@ Preventing file downloads protects sensitive information from being inadvertentl
 
 See the [secure file preview](/administration-guide/configure/environment-configuration-settings#enable-secure-file-preview-on-mobile) and [managing PDF link navigation](/administration-guide/configure/environment-configuration-settings#allow-pdf-link-navigation-on-mobile) configuration settings documentation for details on enabling these features.
 
+## Mobile watermarking
+
+Mobile watermarking is an experimental Enterprise Advanced capability from Mattermost v11.7 onward, that helps organizations attribute mobile screenshots and shared screen captures to a specific user, server, and point in time. When this setting is enabled by a system admin, authenticated Mattermost mobile sessions display a visible watermark overlay on top of the app interface that includes:
+
+- The user's username.
+- The server domain.
+- The current date in `YYYY-MM-DD` format.
+- The current time in `HH:mm` format.
+
+The watermark is intended to support data loss prevention (DLP) workflows by making it easier to identify the source and timing of any image taken of the Mattermost mobile app. Mobile watermarking is disabled by default.
+
+See the [Enable Mobile Watermark](/administration-guide/configure/experimental-configuration-settings#enable-mobile-watermark) configuration setting documentation for details on enabling this experimental feature.
+
+<Note>
+
+- The mobile watermark is a visual overlay only. It does not prevent users from taking screenshots, recording the screen, exporting files, or sharing content through other means. For controls that block screen capture on the device itself, see [screenshot and screen recording prevention](#screenshot-and-screen-recording-prevention).
+- This feature applies only to the Mattermost mobile app. It does not add a watermark to the Mattermost web app or desktop apps.
+- This is an experimental capability. Its behavior, defaults, and visual presentation may change in future releases based on customer feedback.
+
+</Note>
+
 ## Microsoft Intune Mobile Application Management (MAM)
 
 Mattermost supports Microsoft Intune MAM to enforce identity-based, app-level data protection on iOS devices without requiring full device enrollment in a mobile device management (MDM) solution.
@@ -80,6 +101,19 @@ Intune MAM enforcement is applied **per Mattermost workspace** and evaluated con
 This approach allows organizations to extend zero-trust and data loss prevention (DLP) controls to mobile users without assuming ownership or management of the underlying device.
 
 See the [Microsoft Intune MAM configuration guide](/deployment-guide/mobile/configure-microsoft-intune-mam) for deployment and configuration details.
+
+## Mobile Ephemeral Mode
+
+Mobile applications typically cache messages, files, and attachments on-device indefinitely. Two security concerns drive the need for administrator-controlled data lifecycle management on mobile devices:
+
+- **Unbounded sensitive data accumulation.** Without data-age controls, weeks or months of sensitive content can accumulate on any device a user has logged into — well beyond what operational need justifies.
+- **Offline exposure after device loss.** Remotely wiping a device requires it to be reachable — the condition least likely to hold when a device is lost, stolen, or in an adversarial environment. Unmanaged or personally-owned devices may not be enrolled in MDM at all, leaving cached content with no remote deletion path.
+
+Mobile Ephemeral Mode addresses both concerns by giving administrators direct, server-side control over how long data persists on mobile devices. The app enforces this policy locally — including while offline and across app and device restarts — so data is removed based on elapsed time, not device reachability.
+
+Mobile Ephemeral Mode generates an [audit log](/administration-guide/manage/logging#audit-logging) event for each delete, purge, and wipe operation. Because these operations can execute on a device that is unreachable — where no administrator has direct visibility — audit logging provides verifiable proof that ephemeral policies were enforced. This supports compliance requirements for data lifecycle management and destruction accountability. Events that occur while the device is offline are reported to the server on reconnection.
+
+See the [Mobile Ephemeral Mode configuration settings](/administration-guide/configure/environment-configuration-settings#mobile-ephemeral-mode) to configure these controls.
 
 ## Mobile data isolation
 

--- a/docs/main/deployment-guide/mobile/mobile-troubleshooting.mdx
+++ b/docs/main/deployment-guide/mobile/mobile-troubleshooting.mdx
@@ -17,6 +17,27 @@ Please note that the apps cannot connect to servers with self-signed certificate
 
 In line with Microsoft guidance we recommend [configuring intranet forms-based authentication for devices that do not support WIA](https://learn.microsoft.com/en-us/windows-server/identity/ad-fs/operations/configure-intranet-forms-based-authentication-for-devices-that-do-not-support-wia).
 
+## How do I attach mobile app logs to a message?
+
+Use `/mobile-logs` during mobile troubleshooting to let users attach Mattermost mobile app logs to messages. Running `/mobile-logs on` shows the **Attach app logs** option in the attachment menu of the message composer, so users can include device-side logs when messaging an administrator or support engineer. Users can also turn this option on or off from the **Report a problem** screen in the mobile app. The command responds with an ephemeral message visible only to the user who ran it.
+
+<Important>
+
+This command requires Mattermost mobile app v2.38 or later.
+
+</Important>
+
+- Enable **Attach app logs** for yourself using `/mobile-logs on`.
+- Disable **Attach app logs** for yourself using `/mobile-logs off`.
+- Check whether **Attach app logs** is enabled using `/mobile-logs status`.
+- System admins can manage the setting for another user by appending a username, such as `/mobile-logs on @username`, `/mobile-logs off @username`, or `/mobile-logs status @username`.
+
+<Important>
+
+Non-admin users can only manage their own preference. Attempts to target another account return a neutral **Unable to change mobile log settings for that user** message to avoid username enumeration. Preference changes made through this command are recorded in the audit log.
+
+</Important>
+
 ## I see a “Connecting…” bar that does not go away
 
 If your app is working properly, you should see a grey “Connecting…” bar that clears or says “Connected” after the app reconnects.

--- a/docs/main/deployment-guide/reference-architecture/application-architecture.mdx
+++ b/docs/main/deployment-guide/reference-architecture/application-architecture.mdx
@@ -63,7 +63,7 @@ To ensure high availability, database systems can leverage clustering, replicati
 
 **File Storage**: Manages all multimedia assets (e.g., file uploads, images, videos) shared across channels. Storage solutions include the following options:
 
-- **Local Storage**: Files stored directly on the server’s filesystem. For high availability, redundancy can be achieved using RAID configurations or backups to recover from disk failures.
+- **Local Storage**: Files stored directly on the server's filesystem. For high availability, redundancy can be achieved using RAID configurations or backups to recover from disk failures.
 - **Network Attached Storage (NAS)**: Common for enterprises centralizing file storage within their network. NAS setups can include fault-tolerant configurations like distributed systems or replication for uninterrupted access.
 - **S3**: Offers cloud-based scalable storage for larger environments or organizations with distributed deployments. The database and file storage handle scalability, ensuring efficient support for millions of messages and files while guaranteeing data consistency. S3 inherently supports high availability by distributing data across multiple availability zones, ensuring no single point of failure.
 
@@ -128,128 +128,35 @@ If Mattermost is accessible from the open internet with no VPN or MFA set up, we
 
 #### Mattermost services ports
 
-The following table lists the Mattermost services ports for Mattermost Server, push proxy, and mobile app clients. System admins with clients that need to speak to the Mattermost server without a proxy can open specific firewall ports as needed.
+The following tables list the Mattermost services ports for Mattermost Server, push proxy, and mobile app clients. System admins with clients that need to speak to the Mattermost server without a proxy can open specific firewall ports as needed.
 
 **Mattermost Server**
 
-<table style={{width: '98%'}}>
-<colgroup>
-<col style={{width: '26%'}} />
-<col style={{width: '17%'}} />
-<col style={{width: '15%'}} />
-<col style={{width: '5%'}} />
-<col style={{width: '5%'}} />
-<col style={{width: '27%'}} />
-</colgroup>
-<thead>
-<tr>
-<th>Service Name</th>
-<th>Config Setting</th>
-<th>Port (default)</th>
-<th>Protocol</th>
-<th>Direction</th>
-<th>Info</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>HTTP/Websocket</td>
-<td>ServiceSettings.ListenAddress</td>
-<td>8065/80/443 (TLS)</td>
-<td>TCP</td>
-<td>Inbound</td>
-<td rowspan="2">External (no proxy) / Internal (with proxy) Usually this requires port 80 and 443 when running HTTPS. Internal</td>
-</tr>
-<tr>
-<td>Cluster</td>
-<td>ClusterSettings.GossipPort</td>
-<td>8074</td>
-<td>TCP/UDP</td>
-<td>Inbound</td>
-</tr>
-<tr>
-<td>Metrics</td>
-<td>MetricsSettings.ListenAddress</td>
-<td>8067</td>
-<td>TCP</td>
-<td>Inbound</td>
-<td>External (no proxy) / Internal (with proxy)</td>
-</tr>
-<tr>
-<td>Database</td>
-<td>SqlSettings.DataSource</td>
-<td>5432 (PostgreSQL) / 3306 (MySQL)</td>
-<td>TCP</td>
-<td>Outbound</td>
-<td>Usually internal (recommended)</td>
-</tr>
-<tr>
-<td>LDAP</td>
-<td>LdapSettings.LdapPort</td>
-<td>389</td>
-<td>TCP/UDP</td>
-<td>Outbound</td>
-<td></td>
-</tr>
-<tr>
-<td>S3 Storage</td>
-<td>FileSettings.AmazonS3Endpoint</td>
-<td>443 (TLS)</td>
-<td>TCP</td>
-<td>Outbound</td>
-<td></td>
-</tr>
-<tr>
-<td>SMTP</td>
-<td>EmailSettings.SMTPPort</td>
-<td>10025</td>
-<td>TCP/UDP</td>
-<td>Outbound</td>
-<td></td>
-</tr>
-<tr>
-<td>Push Notifications</td>
-<td>EmailSettings.PushNotificationServer</td>
-<td>443 (TLS)</td>
-<td>TCP</td>
-<td>Outbound</td>
-<td></td>
-</tr>
-</tbody>
-</table>
+*Inbound ports*
+
+| Service | Config Setting | Port (default) | Protocol | Notes |
+|---|---|---|---|---|
+| HTTP/WebSocket | `ServiceSettings.ListenAddress` | 8065 / 80 / 443 (TLS) | TCP | External (no proxy) / Internal (with proxy). Ports 80 and 443 are typically used when running HTTPS. |
+| Cluster (HA) | `ClusterSettings.GossipPort` | 8074 | TCP/UDP | Internal only. Must be reachable between all Mattermost Server nodes. Both TCP and UDP must be open. HA only. |
+| Metrics | `MetricsSettings.ListenAddress` | 8067 | TCP | Internal only. Restrict access to trusted monitoring hosts (e.g., Prometheus). Must not be exposed to the public internet. Only required when metrics collection is enabled. |
+
+*Outbound ports*
+
+| Service | Config Setting | Port (default) | Protocol | Notes |
+|---|---|---|---|---|
+| Database | `SqlSettings.DataSource` | 5432 (PostgreSQL) | TCP | Usually internal (recommended). |
+| LDAP | `LdapSettings.LdapPort` | 389 | TCP/UDP | |
+| S3 Storage | `FileSettings.AmazonS3Endpoint` | 443 (TLS) | TCP | |
+| SMTP | `EmailSettings.SMTPPort` | 10025 | TCP/UDP | |
+| Push Notifications | `EmailSettings.PushNotificationServer` | 443 (TLS) | TCP | |
 
 **Push Proxy**
 
-<table style={{width: '97%'}}>
-<colgroup>
-<col style={{width: '12%'}} />
-<col style={{width: '14%'}} />
-<col style={{width: '14%'}} />
-<col style={{width: '9%'}} />
-<col style={{width: '10%'}} />
-<col style={{width: '36%'}} />
-</colgroup>
-<thead>
-<tr>
-<th>Service Name</th>
-<th>Config Setting</th>
-<th>Port (default)</th>
-<th>Protocol</th>
-<th>Direction</th>
-<th>Info</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td>Push Proxy</td>
-<td>ListenAddress</td>
-<td>8066</td>
-<td>TCP</td>
-<td>Inbound</td>
-<td>External (no proxy) / Internal (with proxy)</td>
-</tr>
-</tbody>
-</table>
+*Inbound ports*
+
+| Service | Config Setting | Port (default) | Protocol | Notes |
+|---|---|---|---|---|
+| Push Proxy | `ListenAddress` | 8066 | TCP | Internal only. Must be reachable only from Mattermost Server nodes. Required when running a self-hosted push proxy. |
 
 **Mobile Clients**
 

--- a/docs/main/deployment-guide/reference-architecture/deployment-scenarios/air-gapped-deployment.mdx
+++ b/docs/main/deployment-guide/reference-architecture/deployment-scenarios/air-gapped-deployment.mdx
@@ -80,6 +80,30 @@ Kubernetes is recommended for a highly scalable and robust deployment if your or
 > - Load balancer: If you already have a load balancer running in your air-gapped environment you can skip this resource, otherwise we recommend deploying [NGINX](/deployment-guide/server/setup-nginx-proxy), using the [NGINX Ingress Controller operator](https://docs.nginx.com/nginx-ingress-controller/installation/installing-nic/installation-with-operator/).
 > - Desktop app: Download the [required package](https://github.com/mattermost/desktop/releases) based on your deployment method.
 >
+> <Note>
+>
+> **Database readiness check (air-gapped recommendation)**
+>
+> If your installed Mattermost Operator supports `spec.database.readinessCheck.mode`, it can run the database-readiness init container from the same Mattermost image as the main container by setting `spec.database.readinessCheck.mode: builtin` on the `Mattermost` custom resource. The init container then invokes the in-image `mattermost db ping` command instead of pulling `postgres:13` and running `pg_isready`.
+>
+> We recommend this mode for air-gapped clusters because it removes the requirement to mirror `postgres:13` into your private registry; the only image needed for the readiness check is the Mattermost image you're already mirroring. Before using `builtin` mode, confirm that your installed operator version includes the `readinessCheck.mode` field in the Mattermost CRD or in the operator release notes. `builtin` mode also requires a Mattermost release that ships the `mattermost db ping` command (see the [Mattermost server release notes](https://github.com/mattermost/mattermost/pull/36406) for availability).
+>
+> Example:
+>
+> ``` yaml
+> spec:
+>   database:
+>     external:
+>       secret: <my-db-secret>
+>     readinessCheck:
+>       mode: builtin
+>       timeout: 5m   # optional; default is 5m
+> ```
+>
+> The legacy `external` mode (which uses `postgres:13` + `pg_isready`) remains the default for backward compatibility and is still selectable for users on older Mattermost versions, but it is slated for deprecation in a future operator release. See the [Mattermost CRD reference](https://github.com/mattermost/mattermost-operator/blob/master/docs/mattermost_v1beta1_crd.md) for the full `readinessCheck` field schema.
+>
+> </Note>
+>
 > **(Optional) Supporting Services** Consider downloading these additional resources if you plan to enable these optional components:
 >
 > - [Mattermost Calls](/administration-guide/configure/calls-deployment-guide) helm charts: [mattermost-calls-offloader](https://github.com/mattermost/mattermost-helm/tree/master/charts/mattermost-calls-offloader) and [values](https://github.com/mattermost/mattermost-helm/blob/master/charts/mattermost-calls-offloader/values.yaml) (required for recording, transcription and live captions), [mattermost-rtcd](https://github.com/mattermost/mattermost-helm/tree/master/charts/mattermost-rtcd) and [values](https://github.com/mattermost/mattermost-helm/blob/master/charts/mattermost-rtcd/values.yaml) (required for performance and scalability).

--- a/docs/main/deployment-guide/server/kubernetes/deploy-k8s.mdx
+++ b/docs/main/deployment-guide/server/kubernetes/deploy-k8s.mdx
@@ -138,6 +138,12 @@ The Mattermost Kubernetes Operator can be installed using Helm.
 > type: Opaque
 > ```
 
+<Note>
+
+The `DB_CONNECTION_CHECK_URL` value is consumed by the operator's legacy `postgres:13` + `pg_isready` readiness init container (the default `external` mode of `spec.database.readinessCheck`). New deployments are encouraged to set `spec.database.readinessCheck.mode: builtin` (see Step 5 below), in which case the readiness init container runs the in-image `mattermost db ping` command and the `DB_CONNECTION_CHECK_URL` field is no longer required. The legacy `external` mode remains the default for backward compatibility but is slated for deprecation in a future operator release.
+
+</Note>
+
 ### Step 4: Create the Filestore Secret
 
 Create a file named `mattermost-filestore-secret.yaml` to store the credentials for your object storage service (e.g., AWS S3 or any S3-compatible service). This secret must be created in the same namespace where you intend to install Mattermost. The file should contain the following YAML structure:
@@ -212,6 +218,22 @@ data:
 > >     external:
 > >       secret: &lt;database-secret-name&gt;  # The name of the database secret (e.g., my-postgres-connection)
 > > ```
+>
+> 2.  **(Recommended)** Configure the database-readiness init container to use the in-image `mattermost db ping` command instead of the legacy `postgres:13` + `pg_isready` flow. This avoids the need to pull a separate `postgres:13` image (the primary motivation for air-gapped clusters that can't mirror it) and keeps your readiness check in sync with the Mattermost release you're running.
+>
+> > ``` yaml
+> > spec:
+> >   database:
+> >     external:
+> >       secret: <database-secret-name>
+> >     readinessCheck:
+> >       mode: builtin
+> >       timeout: 5m   # optional; default is 5m
+> > ```
+>
+> Using `builtin` mode requires a Mattermost release that ships the `mattermost db ping` command (see the [Mattermost server pull request](https://github.com/mattermost/mattermost/pull/36406) for availability).
+>
+> Omitting `readinessCheck` (or setting `mode: external`) preserves the legacy `postgres:13` + `pg_isready` behavior. The legacy mode is the current default for backward compatibility and will be deprecated in a future operator release. See the [Mattermost CRD reference](https://github.com/mattermost/mattermost-operator/blob/master/docs/mattermost_v1beta1_crd.md) for the full `readinessCheck` field schema.
 
 3.  Connect to Object Storage:
 

--- a/docs/main/deployment-guide/server/linux/deploy-rhel.mdx
+++ b/docs/main/deployment-guide/server/linux/deploy-rhel.mdx
@@ -35,14 +35,14 @@ SSH onto the target host and download the release. Replace `amd64` with `arm64` 
 <TabItem value="latest" label="Latest release" default>
 
 ```sh
-wget https://releases.mattermost.com/11.6.1/mattermost-11.6.1-linux-amd64.tar.gz
+wget https://releases.mattermost.com/11.8.3/mattermost-11.8.3-linux-amd64.tar.gz
 ```
 
 </TabItem>
 <TabItem value="esr" label="Current ESR">
 
 ```sh
-wget https://releases.mattermost.com/10.11.15/mattermost-10.11.15-linux-amd64.tar.gz
+wget https://releases.mattermost.com/11.7.6/mattermost-11.7.6-linux-amd64.tar.gz
 ```
 
 </TabItem>

--- a/docs/main/deployment-guide/server/linux/deploy-tar.mdx
+++ b/docs/main/deployment-guide/server/linux/deploy-tar.mdx
@@ -44,14 +44,14 @@ SSH onto the target host and download the release. Replace `amd64` with `arm64` 
 <TabItem value="latest" label="Latest release" default>
 
 ```sh
-wget https://releases.mattermost.com/11.6.1/mattermost-11.6.1-linux-amd64.tar.gz
+wget https://releases.mattermost.com/11.8.3/mattermost-11.8.3-linux-amd64.tar.gz
 ```
 
 </TabItem>
 <TabItem value="esr" label="Current ESR">
 
 ```sh
-wget https://releases.mattermost.com/10.11.15/mattermost-10.11.15-linux-amd64.tar.gz
+wget https://releases.mattermost.com/11.7.6/mattermost-11.7.6-linux-amd64.tar.gz
 ```
 
 </TabItem>

--- a/docs/main/deployment-guide/software-hardware-requirements.mdx
+++ b/docs/main/deployment-guide/software-hardware-requirements.mdx
@@ -158,8 +158,14 @@ Flatpak packages are available for x86_64 (Intel/AMD) and aarch64 (ARM) architec
 
 #### Mattermost server operating system
 
-- Ubuntu, Debian Buster, CentOS 6+, CentOS 7+, RedHat Enterprise Linux 7+, Oracle Linux 6+, Oracle Linux 7+.
+- Ubuntu, Debian Buster, CentOS 6+, CentOS 7+, Red Hat Enterprise Linux 7+, Oracle Linux 6+, Oracle Linux 7+.
 - Using the Mattermost [Docker deployment](https://github.com/mattermost/docker) on a Docker-compatible operating system (Linux-based OS) is still recommended.
+
+<Important>
+
+Starting with Mattermost Server v12.0 (October 2026), Red Hat Enterprise Linux (RHEL) 7 and RHEL 8 will no longer be supported deployment targets. Mattermost v11.11 (September 2026) will be the last release to support RHEL 7 and RHEL 8. RHEL 9, Ubuntu 22.04/24.04 LTS, Debian Bookworm, and container-based deployments will remain fully supported. If you're running RHEL 7 or RHEL 8, plan to upgrade to RHEL 9 or migrate to another supported platform before the v12.0 release. See the [forum post](https://forum.mattermost.com/t/starting-with-mattermost-v12-0-october-2026-rhel-7-and-rhel-8-are-no-longer-supported-deployment-targets/25974) for full details and migration options.
+
+</Important>
 
 While community support exists for Fedora, FreeBSD, and Arch Linux, Mattermost does not currently include production support for these platforms.
 
@@ -219,15 +225,13 @@ When a PostgreSQL version reaches its end of life (EOL), Mattermost will require
 <td colspan="4"><a href="mm-ref:release-v10.11-extended-support-release">v10.11 ESR</a>| 2025-8-15 | 13.x</td>
 </tr>
 <tr>
-<td>v11.7 ESR <code>*</code></td>
+<td><a href="mm-ref:release-v11.7-extended-support-release">v11.7 ESR</a></td>
 <td>2026-5-15</td>
 <td>14.x (EOL 2026-11-12)</td>
 <td></td>
 </tr>
 </tbody>
 </table>
-
-`*` Forcasted release version and date.
 
 Customers will have 9 months to plan, test, and upgrade their PostgreSQL version before the new requirement takes effect. This policy aims to provide clarity and transparency so you can align database upgrades with the Mattermost release schedule. Contact a [Mattermost Expert](https://mattermost.com/contact-sales/). to discuss your options.
 
@@ -313,5 +317,5 @@ For Enterprise Edition deployments with a multi-server setup, we highly recommen
 
 - Prometheus to track system health of your Mattermost deployment, through [performance monitoring feature](/administration-guide/scale/deploy-prometheus-grafana-for-performance-monitoring) available in Mattermost Enterprise.
 - Grafana to visualize the system health metrics collected by Prometheus with the [performance monitoring feature](/administration-guide/scale/deploy-prometheus-grafana-for-performance-monitoring). Grafana 5.0.0 and later is recommended.
-- Elasticsearch to support highly efficient database searches in a cluster environment. Elasticsearch v7.17+ is supported, and Elasticsearch v8.x or AWS OpenSearch is recommended from Mattermost v9.11. [Learn more](/administration-guide/scale/enterprise-search).
+- Elasticsearch to support highly efficient database searches in a cluster environment. Elasticsearch v8.x and v9.x are supported, and Elasticsearch v9.x or AWS OpenSearch is recommended. [Learn more](/administration-guide/scale/enterprise-search).
 - AWS S3 or any S3-compatible service. Mattermost is compatible with object storage systems which implement the S3 API. You can also use local storage or a network drive using NFS. Learn more about file storage configuration options [in our documentation](/administration-guide/configure/environment-configuration-settings#file-storage).


### PR DESCRIPTION
#### Summary
Reconciles drift between `mattermost/docs` (Sphinx source, RST) and the migrated Deployment Guide pages in `docs/main/` (Docusaurus MDX) for content that changed in `mattermost/docs` after the P2 migration fork point (2026-05-14).

Files changed (11 of 12 candidate files in this sub-phase; see notes below):

- `deployment-guide/server/kubernetes/deploy-k8s.mdx` — documents the operator's `spec.database.readinessCheck.mode: builtin` option (in-image `mattermost db ping`) as the recommended alternative to the legacy `postgres:13` + `pg_isready` readiness check.
- `deployment-guide/server/linux/deploy-rhel.mdx`, `deployment-guide/server/linux/deploy-tar.mdx` — bump the "Latest release" / "Current ESR" tarball download versions to v11.8.3 / v11.7.6.
- `deployment-guide/software-hardware-requirements.mdx` — RHEL 7/8 deprecation notice (unsupported starting v12.0), Elasticsearch v8.x/v9.x support update, PostgreSQL ESR table link fix, minor wording fixes.
- `deployment-guide/mobile/configure-microsoft-intune-mam.mdx` — corrects plan availability badge from Entry/Enterprise to Entry/Enterprise Advanced.
- `deployment-guide/mobile/mobile-troubleshooting.mdx` — documents the `/mobile-logs` slash command for attaching mobile app logs to messages.
- `deployment-guide/mobile/mobile-security-features.mdx` — adds "Mobile watermarking" (experimental, v11.7) and "Mobile Ephemeral Mode" sections.
- `deployment-guide/desktop/desktop-msi-installer-and-group-policy-install.mdx` — bumps referenced desktop app version to v6.2.2 and documents macOS managed configuration (MDM) support.
- `deployment-guide/desktop/linux-desktop-install.mdx` — bumps referenced desktop app version to v6.2.2.
- `deployment-guide/reference-architecture/application-architecture.mdx` — restructures the services ports tables into separate inbound/outbound tables with clearer notes, matching the source restructuring.
- `deployment-guide/reference-architecture/deployment-scenarios/air-gapped-deployment.mdx` — adds guidance recommending the builtin DB readiness check mode for air-gapped Kubernetes clusters (avoids mirroring `postgres:13`).

**Skipped:** `deployment-guide/server/deploy-linux.mdx` — the only drift in the source RST for this page is a new "Azure" tab that includes `deploy-azure-native-vm.rst`, a new standalone page tracked separately (plan §3.2 / sub-phase P13a) and not yet present in this branch. Adding a card/tab pointing to a nonexistent page would break navigation, so this file is left untouched until that new page lands.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)