### PR TITLE
docs(P13h): reconcile docs drift — End User Guide

### DIFF
--- a/docs/main/end-user-guide/access/client-availability.mdx
+++ b/docs/main/end-user-guide/access/client-availability.mdx
@@ -193,7 +193,7 @@ The following tables highlight the end user features of Mattermost and their sup
 <tr>
 <td colspan="2"><a href="mm-ref:end-user-guide%2Fcollaborate%2Forganize-using-teams%3Aleave%20a%20team">Leave team</a></td>
 <td colspan="3"><blockquote>
-<div class="line-block"><a href="mm-subst:checkmark">checkmark</a> | <a href="mm-subst:checkmark">checkmark</a> | |</div>
+<div class="line-block"><a href="mm-subst:checkmark">checkmark</a> | <a href="mm-subst:checkmark">checkmark</a> | <a href="mm-subst:checkmark">checkmark</a> |</div>
 </blockquote></td>
 </tr>
 </tbody>

--- a/docs/main/end-user-guide/collaborate/autotranslate-messages.mdx
+++ b/docs/main/end-user-guide/collaborate/autotranslate-messages.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Auto-translate messages (Beta)"
+title: "Auto-translate messages"
 ---
 <PlanAvailability slug="ent-adv" />
 

--- a/docs/main/end-user-guide/collaborate/browse-channels.mdx
+++ b/docs/main/end-user-guide/collaborate/browse-channels.mdx
@@ -20,6 +20,12 @@ From Mattermost v9.1, you can filter the list of channels by public, private, or
 
 </Tip>
 
+<Note>
+
+From Mattermost v11.8.0, if your organization uses membership policies, **Browse Channels** may include a **Recommended** filter. Recommended channels are public channels your attributes match. You can still browse and join public channels according to your organization's normal channel permissions.
+
+</Note>
+
 </TabItem>
 <TabItem value="mobile" label="Mobile">
 

--- a/docs/main/end-user-guide/collaborate/create-channels.mdx
+++ b/docs/main/end-user-guide/collaborate/create-channels.mdx
@@ -20,7 +20,7 @@ Anyone can create public channels, private channels, direct messages, and group 
 2.  Enter a channel name.
 3.  Choose whether this is a public or private channel. See the [channel types](/end-user-guide/collaborate/channel-types) documentation to learn more about public and private channels.
 4.  (Optional) Describe the channel's focus or purpose. This text is visible to all channel members in the channel header.
-5.  (Optional) Assign the channel to a category. If your system admin has enabled [channel category sorting](/administration-guide/configure/experimental-configuration-settings#enable-channel-category-sorting), you can assign the new channel to a new or existing channel category. If this option isn't available, you can <code>customize your channel sidebar \</end-user-guide/preferences/customize-your-channel-sidebar\></code>.
+5.  (Optional) Assign the channel to a category. When [channel category sorting](/administration-guide/configure/experimental-configuration-settings#enable-channel-category-sorting) is enabled (the default from Mattermost v11.8), channel admins see a **Default category (optional)** field when creating or editing a channel. You can select an existing category, type a new category name, or clear the default category from channel settings. Members who join the channel see it under that category in their sidebar. If this option isn't available, you can [customize your channel sidebar](/end-user-guide/preferences/customize-your-channel-sidebar).
 
 ## Start a direct or group message
 

--- a/docs/main/end-user-guide/collaborate/display-channel-banners.mdx
+++ b/docs/main/end-user-guide/collaborate/display-channel-banners.mdx
@@ -35,3 +35,11 @@ Disable the **Channel Banner** option in the channel settings to remove the bann
 System admins can grant any user the ability to create and manage channel banners by assigning the **Manage Channel Banners** permission in the System Console. See the [advanced permissions](/administration-guide/onboard/advanced-permissions) documentation for details.
 
 </Tip>
+
+## Classification markings
+
+From Mattermost v11.8, system admins can configure classification markings that display as global or channel-level banners in the web and desktop apps. See the [Classification Markings](/administration-guide/configure/site-configuration-settings#classification-markings) configuration documentation for setup details.
+
+Classification markings use predefined or custom classification levels, including the classification name and banner color. These markings are informational only and don't control access to channels, messages, files, or other Mattermost resources.
+
+When a channel classification is applied, Mattermost displays the selected classification as the channel banner. Classification markings take priority over a custom channel banner when both are configured for the same channel.

--- a/docs/main/end-user-guide/collaborate/join-leave-channels.mdx
+++ b/docs/main/end-user-guide/collaborate/join-leave-channels.mdx
@@ -106,3 +106,12 @@ Select the channel name at the top of the center pane to access the drop-down me
 </TabItem>
 </Tabs>
 
+### Leave a public channel added by a membership policy
+
+From Mattermost v11.8.0, when you leave a public channel you were added to by a membership policy, Mattermost asks you to confirm:
+
+- Choosing **Leave channel** removes you from the channel.
+- Choosing **Mute instead** keeps you in the channel and mutes its notifications.
+
+If the channel is already muted, Mattermost shows **Cancel** and **Leave channel** instead of **Mute instead**.
+

--- a/docs/main/end-user-guide/collaborate/learn-about-roles.mdx
+++ b/docs/main/end-user-guide/collaborate/learn-about-roles.mdx
@@ -43,6 +43,7 @@ When a team is first created, the person who set it up is made a team admin. It 
 - Ability to change the team name and import data from Slack export files.
 - Access to the **Manage Members** menu, where they can control whether team members are a **Member** or a **Team Admin**.
 - Ability to manage all aspects of a team, such as joining and managing private channels they're not a member of.
+- Ability to create and manage [attribute-based channel membership policies](/administration-guide/manage/admin/abac-team-channel-policies) for private channels within the team, when ABAC is enabled by a System Admin (Enterprise Advanced).
 
 ## Channel admin
 

--- a/docs/main/end-user-guide/collaborate/manage-channel-members.mdx
+++ b/docs/main/end-user-guide/collaborate/manage-channel-members.mdx
@@ -10,7 +10,10 @@ import TabItem from '@theme/TabItem';
 
 Any member of a channel can add other members to public or private channels, unless your system admin has restricted access to do so.
 
-When a channel has [attribute-based access controls](/administration-guide/manage/admin/attribute-based-access-control) enabled, you'll see details about which user attributes are permitted access to the channel. Only users who meet the requirements appear in search results when adding members to that channel.
+When a channel has [attribute-based access controls](/administration-guide/manage/admin/attribute-based-access-control) enabled, you'll see details about which user attributes are permitted access to the channel. Behavior differs by channel type:
+
+- **Private channels**: Only users who meet the requirements appear in search results when adding members, and only those users can be added.
+- **Public channels**: All eligible team members appear in search results, and users who meet the recommended attributes are labeled **Recommended**. Anyone can still be added because public-channel access controls are advisory and never remove existing members.
 
 <Tabs>
 <TabItem value="web-desktop" label="Web/Desktop">

--- a/docs/main/end-user-guide/collaborate/organize-using-teams.mdx
+++ b/docs/main/end-user-guide/collaborate/organize-using-teams.mdx
@@ -12,7 +12,6 @@ Users with the **Create Teams** permission can [create new teams](#create-a-team
 Mattermost can be deployed both to a single team and to multiple teams. Currently, we recommend deploying to a single team for the following reasons:
 
 - Single team deployments promote communication across the organization. When you add multiple teams, groups can become isolated.
-- We don't yet support search or channels across teams, which can impact the cross-team user experience. This includes general searches, saved posts, and recent mentions.
 - Integrations (e.g., webhooks and slash commands) are only persistent across single team deployments.
 
 However, some Mattermost customers prefer multiple team deployments for the following reasons:
@@ -20,6 +19,7 @@ However, some Mattermost customers prefer multiple team deployments for the foll
 - Teams are useful when there is a purpose for each of them. For example, one team is used for staff members and another team for external users.
 - Performance is better when users are scattered across multiple teams instead of all in the same one. With multiple teams, there is less content to load per team or channel switch and database queries are faster.
 - Creating a shared team for all users, and using advanced permissions to control who can create channels and add members to the shared team, improves cross-team collaboration when using multiple teams. Additionally, an annoucement banner can be used to provide system-wide announcements.
+- The platform supports multiple team functionalities including general search, saved posts, and recent mentions across teams.
 
 ## Team sidebar
 
@@ -70,9 +70,13 @@ You can be a member of multiple teams at the same time. To join additional teams
 
 ![Select a team name to join another team.](/images/join-team.png)
 
+From Mattermost Mobile v2.40.0, you can join another team from the mobile app by tapping the team name in the channel list header, then tapping **Join Another Team**.
+
 ## Leave a team
 
 Users can also choose to remove themselves from a team, from **Team menu \> Leave Team**. This will remove the user from the team, and from all public channels and private channels on the team.
+
+From Mattermost Mobile v2.40.0, you can leave a team from the mobile app when you belong to more than one team. In the channel list, tap the team name, tap **Leave team**, then confirm.
 
 They will only be able to rejoin the team if it's open, or if they receive a new invitation. If they do rejoin, they will no longer be a part of their old channels.
 

--- a/docs/main/end-user-guide/collaborate/react-with-emojis-gifs.mdx
+++ b/docs/main/end-user-guide/collaborate/react-with-emojis-gifs.mdx
@@ -79,7 +79,7 @@ Using Mattermost in a web browser or the desktop app, you can upload new emojis 
 ![Select Custom Emoji to upload custom emojis to Mattermost.](/images/add-custom-emoji1.png)
 
 2.  Enter a name for your custom emoji. This is the name that shows up in the emoji autocomplete.
-3.  Choose **Select**, then select the image to use for the emoji. Small, square pictures work best when selecting an image to upload. The file can be any JPG, GIF, or PNG that's up to 512 KiB in size.
+3.  Choose **Select**, then select the image to use for the emoji. Small, square pictures work best when selecting an image to upload. The file can be any JPG, GIF, or PNG that's up to 512 KiB in size. Mattermost limits the number of frames allowed in animated GIF emojis.
 4.  Select **Save**. Once saved, your emoji is added to the list of custom emoji.
 
 ![Name and upload custom emojis to Mattermost.](/images/add_custom_emoji.png)

--- a/docs/main/end-user-guide/collaborate/rename-channels.mdx
+++ b/docs/main/end-user-guide/collaborate/rename-channels.mdx
@@ -14,9 +14,9 @@ Anyone can rename the channels they belong to, unless the system admin has [rest
 Select the channel name at the top of the center pane to access the drop-down menu, then select **Channel Settings**. You'll be prompted to provide two pieces of information:
 
 - **Channel name:** The channel name that displays in the Mattermost user interface for all users. Enter a different channel name if needed or preferred.
-- **Channel URL:** The web URL used to access the channel in a web browser. Select **Edit** to change the URL, and select **Done** to save your changes. If your system admin has enabled anonymous team and channel URLs (available in Mattermost Enterprise Advanced from v11.6.0), channel URLs are assigned automatically and do not reflect the channel name.
+- **Channel URL:** The web URL used to access the channel in a web browser. Select **Edit** to change the URL, and select **Done** to save your changes. If your system admin has enabled anonymous URLs (available in Mattermost from v11.6.0), channel and team URLs are assigned automatically and do not reflect the channel or team name.
 
-If your system admin has enabled [channel category sorting](/administration-guide/configure/experimental-configuration-settings#enable-channel-category-sorting), you can assign the renamed channel to a new or existing channel category.
+When [channel category sorting](/administration-guide/configure/experimental-configuration-settings#enable-channel-category-sorting) is enabled (the default from Mattermost v11.8), channel admins can set a **Default category (optional)** for the channel. You can select an existing category, type a new category name, or clear the default category. Members who join the channel see it under that category in their sidebar.
 
 For example, a channel could be named `UX Design` and have a URL of `https://community.mattermost.com/core/channels/ux-design` (or an anonymous URL if enabled by your system admin).
 

--- a/docs/main/end-user-guide/collaborate/send-messages.mdx
+++ b/docs/main/end-user-guide/collaborate/send-messages.mdx
@@ -51,10 +51,12 @@ You can use AI to enhance your messages before sending them. This feature helps 
 
 From Mattermost v11.5, when you use AI Rewrite while composing a reply in a thread, the AI incorporates context from the thread to generate suggestions that better fit the ongoing conversation.
 
+From Mattermost v11.7, Rewrite is accessed through the **AI Actions** <img src="/img/ui/creation-outline_F1C2B.svg" alt="AI Actions icon." className="theme-icon" /> menu, alongside any custom prompts your system admin has made available.
+
 On Web/Desktop or Mobile:
 
 > 1.  Type your message in the message compose field.
-> 2.  Select the **Rewrite** <img src="/img/ui/creation-outline_F1C2B.svg" alt="AI Rewrite icon." className="theme-icon" /> option from the message actions.
+> 2.  Open the **AI Actions** <img src="/img/ui/creation-outline_F1C2B.svg" alt="AI Actions icon." className="theme-icon" /> menu from the message actions, then select **Rewrite**.
 > 3.  Select a bot from the list of available AI agents.
 > 4.  Choose from available rewrite options:
 >     - **Improve writing**: Enhance clarity and professionalism
@@ -66,6 +68,12 @@ On Web/Desktop or Mobile:
 >     - **Custom prompt**: Specify your own transformation instructions
 > 5.  Review the AI-generated suggestion. Select **Regenerate** to try again or **Discard** to return to your original message.
 > 6.  Select **Send** <img src="/img/ui/send_F048A.svg" alt="Select the Send icon to post your message." className="theme-icon" />
+
+<Tip>
+
+From Mattermost v11.7, system admins can publish custom prompts that appear alongside Rewrite in the **AI Actions** <img src="/img/ui/creation-outline_F1C2B.svg" alt="AI Actions icon." className="theme-icon" /> menu. If you don't see a custom prompt you expect, check with your system admin.
+
+</Tip>
 
 <Note>
 

--- a/docs/main/end-user-guide/collaborate/share-files-in-messages.mdx
+++ b/docs/main/end-user-guide/collaborate/share-files-in-messages.mdx
@@ -98,3 +98,9 @@ The following media formats are supported on most browsers:
 - Files: PDF, TXT
 
 Other document previews (such as Word, Excel, or PPT) are not yet supported.
+
+## Restricted file attachments
+
+If your administrator has configured attribute-based permission policies on your Mattermost instance, file uploads or downloads may be restricted based on your user attributes. Restricted attachments appear in messages with the placeholder **Files not available** and the subtitle **Access to files is restricted based on attributes**.
+
+If you expect to have access to a restricted file and don't, contact your Mattermost administrator. For administrator-facing details, see [Permission policies](/administration-guide/manage/admin/abac-system-wide-policies#permission-policies).

--- a/docs/main/end-user-guide/collaborate/team-settings.mdx
+++ b/docs/main/end-user-guide/collaborate/team-settings.mdx
@@ -84,3 +84,11 @@ When you enable this option, users looking for more teams to join will also see 
 ### Invite code
 
 The **Invite Code** is used as part of the URL in team invitation links. Select **Regenerate** to create a new invitation link and invalidate any previous link.
+
+## Membership Policies
+
+<PlanAvailability slug="entry-adv" />
+
+The **Membership Policies** tab is available to Team Admins when [Attribute-Based Access Control (ABAC)](/administration-guide/manage/admin/attribute-based-access-control) is enabled by a System Admin. It allows Team Admins to create and manage attribute-based membership policies that control access to private channels within the team.
+
+See [Team-level channel membership policies](/administration-guide/manage/admin/abac-team-channel-policies) for full details.

--- a/docs/main/end-user-guide/preferences/customize-desktop-app-experience.mdx
+++ b/docs/main/end-user-guide/preferences/customize-desktop-app-experience.mdx
@@ -65,6 +65,7 @@ With the Mattermost desktop app in focus, select the **More** <img src="/img/ui/
 - **Open app in full screen**: Configure the desktop app to open in fullscreen. Disable this setting to open the app in a windowed view.
 - **Synchronize Desktop App theme with server**: The desktop app theme automatically matches the theme set on your primary Mattermost server. Disable this setting to manage desktop app themes independently.
 - **Maximum number of open views**: From Desktop v6.0, set the maximum number of open tabs and windows per workspace. When a limit is set, Mattermost prompts you to close tabs or windows when the limit is exceeded. Leave this field blank for no maximum limit.
+- **Use native title bar** (Linux only): From Mattermost Desktop v6.2.0, render the desktop app with your Linux desktop environment's native title bar and window controls instead of the custom Mattermost title bar. Restart the desktop app to apply changes to this setting.
 
 ## Notifications
 

--- a/docs/main/end-user-guide/preferences/customize-your-channel-sidebar.mdx
+++ b/docs/main/end-user-guide/preferences/customize-your-channel-sidebar.mdx
@@ -33,7 +33,7 @@ To create categories, select the **+** symbol at the top of the sidebar. Or, sel
 
 <Note>
 
-If your system admin has enabled [channel category sorting](/administration-guide/configure/experimental-configuration-settings#enable-channel-category-sorting), you can assign channels to new or existing channel categories when [creating channels](/end-user-guide/collaborate/create-channels) and [renaming channels](/end-user-guide/collaborate/rename-channels).
+When [channel category sorting](/administration-guide/configure/experimental-configuration-settings#enable-channel-category-sorting) is enabled (the default from Mattermost v11.8), you can assign channels to new or existing channel categories when [creating channels](/end-user-guide/collaborate/create-channels) and [renaming channels](/end-user-guide/collaborate/rename-channels).
 
 </Note>
 


### PR DESCRIPTION
#### Summary
Reconciles content drift between the Sphinx-based `mattermost/docs` repo and the Docusaurus `docs/main/end-user-guide` MDX pages for the End User Guide section (16 files), as part of the P13 documentation migration/reconciliation effort. Applies only the targeted deltas that landed in `mattermost/docs` after the P2 migration fork point — no wholesale re-migration.

Key changes ported:
- Renamed "Auto-translate messages (Beta)" to "Auto-translate messages"
- Added Classification markings section to channel banners docs (v11.8)
- Documented public vs. private channel membership-policy behavior for adding members, the Recommended channels filter, and the leave-confirmation modal for policy-added public channels (v11.8.0)
- Noted the animated GIF custom emoji frame limit
- Documented the AI Actions menu replacing the standalone Rewrite action, and custom prompt publishing (v11.7)
- Documented restricted file attachments under attribute-based permission policies
- Added the team-level Membership Policies tab and the team-admin ABAC channel policy permission
- Clarified multi-team search/saved posts/mentions support and mobile join/leave team flows (Mobile v2.40.0)
- Updated channel/team anonymous URL and default category wording
- Documented the Linux-only "Use native title bar" desktop setting (v6.2.0)
- Updated the "Leave team" mobile support checkmark in the client availability table

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)