### PR TITLE
Stop posting docs preview PR comments; link preview from status check

### DIFF
--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -9,15 +9,11 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   cleanup:
     name: Delete preview from S3
     runs-on: ubuntu-latest
-    # Fork PRs don't get secrets on plain pull_request events, so this would
-    # just fail for them -- a separate scheduled sweep handles fork preview
-    # cleanup instead of switching this to pull_request_target.
     if: github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Configure AWS credentials
@@ -33,11 +29,3 @@ jobs:
           BUCKET_NAME: ${{ vars.DOCS_PREVIEW_BUCKET_NAME }}
         run: |
           aws s3 rm "s3://${BUCKET_NAME}/mattermost/pr-${PR_NUMBER}/" --recursive
-
-      - name: Comment on closed PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" \
-            --body "Docs preview for PR #${PR_NUMBER} has been removed from S3."

--- a/.github/workflows/docs-preview-fork.yml
+++ b/.github/workflows/docs-preview-fork.yml
@@ -19,7 +19,6 @@ on:
 permissions:
   contents: read
   statuses: write
-  pull-requests: write
 
 jobs:
   update-initial-status:
@@ -45,7 +44,6 @@ jobs:
       - update-initial-status
     with:
       PR_NUMBER: ${{ inputs.PR_NUMBER }}
-      TRIGGERING_ACTOR: ${{ inputs.TRIGGERING_ACTOR }}
       COMMIT_SHA: ${{ inputs.COMMIT_SHA }}
 
   update-failure-status:
@@ -79,3 +77,4 @@ jobs:
           context: "docs-preview-fork / preview"
           description: "Docs preview build for ${{ inputs.COMMIT_SHA }} succeeded"
           status: success
+          target_url: "http://${{ vars.DOCS_PREVIEW_BUCKET_NAME }}.s3-website-us-east-1.amazonaws.com/mattermost/pr-${{ inputs.PR_NUMBER }}/"

--- a/.github/workflows/docs-preview-template.yml
+++ b/.github/workflows/docs-preview-template.yml
@@ -6,9 +6,6 @@ on:
       PR_NUMBER:
         type: string
         required: true
-      TRIGGERING_ACTOR:
-        type: string
-        required: true
       COMMIT_SHA:
         type: string
         required: true
@@ -26,7 +23,6 @@ concurrency:
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   preview:
@@ -93,18 +89,3 @@ jobs:
             "s3://${BUCKET_NAME}/mattermost/pr-${PR_NUMBER}/" \
             --delete \
             --no-progress
-
-      - name: Post preview URL comment
-        # Plain gh CLI instead of a third-party action -- posts a new comment
-        # every run (same behavior peter-evans/create-or-update-comment had
-        # here, since it wasn't given a comment-id/body-includes matcher).
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_NUMBER: ${{ inputs.PR_NUMBER }}
-          TRIGGERING_ACTOR: ${{ inputs.TRIGGERING_ACTOR }}
-          COMMIT_SHA: ${{ inputs.COMMIT_SHA }}
-          BUCKET_NAME: ${{ vars.DOCS_PREVIEW_BUCKET_NAME }}
-        run: |
-          BODY=$(printf 'Newest code from %s and commit %s has docs preview environment ready:\n\n**[Open preview environment](http://%s.s3-website-us-east-1.amazonaws.com/mattermost/pr-%s/)**' \
-            "$TRIGGERING_ACTOR" "$COMMIT_SHA" "$BUCKET_NAME" "$PR_NUMBER")
-          gh pr comment "$PR_NUMBER" --repo "${{ github.repository }}" --body "$BODY"

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -9,16 +9,65 @@ on:
 
 permissions:
   contents: read
-  pull-requests: write
+  statuses: write
 
 jobs:
+  update-initial-status:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    steps:
+      - name: Set pending commit status
+        uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          repository_full_name: ${{ github.repository }}
+          commit_sha: ${{ github.event.pull_request.head.sha }}
+          context: "docs-preview / preview"
+          description: "Docs preview build for ${{ github.event.pull_request.head.sha }} is running"
+          status: pending
+
   deploy:
     uses: ./.github/workflows/docs-preview-template.yml
     if: github.event.pull_request.head.repo.full_name == github.repository
+    needs:
+      - update-initial-status
     secrets:
       AWS_DOCS_PR_PREVIEW_KEY_ID: ${{ secrets.AWS_DOCS_PR_PREVIEW_KEY_ID }}
       AWS_DOCS_PR_PREVIEW_SECRET_ACCESS_KEY: ${{ secrets.AWS_DOCS_PR_PREVIEW_SECRET_ACCESS_KEY }}
     with:
       PR_NUMBER: ${{ github.event.number }}
-      TRIGGERING_ACTOR: ${{ github.event.pull_request.user.login }}
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
+
+  update-failure-status:
+    runs-on: ubuntu-latest
+    if: failure() || cancelled()
+    needs:
+      - deploy
+    steps:
+      - uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          repository_full_name: ${{ github.repository }}
+          commit_sha: ${{ github.event.pull_request.head.sha }}
+          context: "docs-preview / preview"
+          description: "Docs preview build for ${{ github.event.pull_request.head.sha }} failed"
+          status: failure
+
+  update-success-status:
+    runs-on: ubuntu-latest
+    if: success()
+    needs:
+      - deploy
+    steps:
+      - uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          repository_full_name: ${{ github.repository }}
+          commit_sha: ${{ github.event.pull_request.head.sha }}
+          context: "docs-preview / preview"
+          description: "Docs preview build for ${{ github.event.pull_request.head.sha }} succeeded"
+          status: success
+          target_url: "http://${{ vars.DOCS_PREVIEW_BUCKET_NAME }}.s3-website-us-east-1.amazonaws.com/mattermost/pr-${{ github.event.number }}/"


### PR DESCRIPTION
#### Summary
Docs preview workflows (`docs-preview`, `docs-preview-fork`, `docs-preview-template`, `docs-preview-cleanup`) no longer post messages in the PR conversation:

- `docs-preview-cleanup`: removed the "preview removed from S3" comment on PR close.
- `docs-preview-template`: removed the "preview environment ready" comment posted after a successful build.
- `docs-preview` and `docs-preview-fork`: instead of a comment, the preview link is now attached as the `target_url` on the `docs-preview / preview` / `docs-preview-fork / preview` commit status, so the status check's "Details" link goes straight to the live preview instead of the Actions run.

Also dropped the now-unused `pull-requests: write` permission and `TRIGGERING_ACTOR` input/passthrough (only needed for the comment body).

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes span multiple docs preview workflows and alter reusable workflow inputs and status reporting, creating some risk of deployment or status-update regressions. The impact is isolated to preview automation and is straightforward to roll back.
**QA Recommendation:** Skip manual QA; automated coverage should be sufficient, with a quick workflow run verification recommended if available.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->