### PR TITLE
fix(ui): fix layout conflicts in Thread previews with robust CSS

### DIFF
--- a/webapp/channels/src/components/threading/global_threads/thread_item/thread_item.scss
+++ b/webapp/channels/src/components/threading/global_threads/thread_item/thread_item.scss
@@ -135,7 +135,7 @@
         color: rgba(var(--center-channel-color-rgb), 1);
 
         > * {
-            @include mixins.text-clamp(2, false);
+            @include mixins.text-clamp(2);
         }
     }
 

--- a/webapp/channels/src/components/threading/global_threads/thread_item/thread_item.scss
+++ b/webapp/channels/src/components/threading/global_threads/thread_item/thread_item.scss
@@ -129,9 +129,8 @@
     }
 
     div.preview {
-        height: 40px;
-        max-height: 40px;
         overflow: hidden;
+        height: 40px;
         margin: 0 0 10px;
         color: rgba(var(--center-channel-color-rgb), 1);
 

--- a/webapp/channels/src/components/threading/global_threads/thread_item/thread_item.scss
+++ b/webapp/channels/src/components/threading/global_threads/thread_item/thread_item.scss
@@ -130,10 +130,14 @@
 
     div.preview {
         height: 40px;
+        max-height: 40px;
+        overflow: hidden;
         margin: 0 0 10px;
         color: rgba(var(--center-channel-color-rgb), 1);
 
-        @include mixins.text-clamp(2, 20);
+        > * {
+            @include mixins.text-clamp(2, false);
+        }
     }
 
     .menu-anchor {


### PR DESCRIPTION
#### Summary

This pull request makes a small adjustment to the styling of thread previews in the global threads component for some browsers, for example, Chrome 150. The change ensures that the preview content is consistently clamped and visually contained within its designated area.

- Styling improvements for thread previews:
  * Updated the `div.preview` selector in `thread_item.scss` to use `overflow: hidden`, and applied the `text-clamp` mixin to all direct children with a fixed line count but no explicit character limit. This helps prevent overflow and maintains a clean appearance for thread previews.

This pull request makes a small update to the styling of thread previews in the `thread_item.scss` file. The main change is to improve how text is clamped and overflow is handled in the thread preview area.

#### Ticket Link

- Fixes: https://github.com/mattermost/mattermost/issues/37501

#### Screenshots

before (left-bottom)

<img width="898" height="329" alt="beforepr" src="https://github.com/user-attachments/assets/9f314cee-5cef-4bcf-96bc-f0ce5a2ba055" />

after (left-bottom)

<img width="858" height="336" alt="SCR-20260715-bnpy" src="https://github.com/user-attachments/assets/21b24f79-a7d7-4b8c-89fa-0e4549d49165" />

#### Release Note

```release-note
Fixed broken UI in Thread previews in some latest browsers.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Limited to SCSS styling for the global thread preview’s overflow/clamping behavior, not logic or data flow. Risk is primarily visual truncation/overlap differences in long multi-element previews across browsers.  
**QA Recommendation:** Skip broad manual QA; do a quick visual check of long multi-element thread previews (including Chrome 150) and one other browser.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->