### PR TITLE
cursor: bump Cloud Agent Go to 1.26.4 to match .go-version

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:24.04
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG GO_VERSION=1.25.9
+ARG GO_VERSION=1.26.4
 ARG NODE_VERSION=24.11.1
 ARG NVM_VERSION=0.40.3
 ARG DOCKER_VERSION=5:28.5.2-1~ubuntu.24.04~noble

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -8,7 +8,7 @@ The Docker build context is `.cursor/` only. The Dockerfile intentionally does n
 
 - Ubuntu 24.04.
 - Docker CE 28.5.2 with `fuse-overlayfs` and `iptables-legacy`, matching Cursor's Docker-in-Cloud guidance for complex compose setups.
-- Go 1.25.9 from `server/.go-version`.
+- Go 1.26.4 from `server/.go-version`.
 - Node 24.11.1/npm 11 via nvm, matching `.nvmrc` and `webapp/package.json`.
 - Browser runtime libraries for the Playwright e2e suite.
 - AWS CLI v2 for S3 uploads.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

While verifying the checked-in Cursor Cloud Agent development environment end-to-end, I found the `.cursor/Dockerfile` still pinned `GO_VERSION=1.25.9`, while the repo now requires Go `1.26.4` (both `server/.go-version` and `server/go.mod`). Since `.cursor/environment.json` builds from this Dockerfile (the source of truth for the Cloud Agent environment), this bumps the pinned Go toolchain to `1.26.4` and updates the matching note in `.cursor/README.md` so the baked image matches the repo's required Go version instead of relying on `GOTOOLCHAIN` auto-download at build/run time.

I validated the full dev environment with Go `1.26.4` + Node `24.11.1`: hydrated Go/webapp deps, ran the enterprise server against PostgreSQL, built and served the webapp, created the first admin user, created a team, and posted a message — all confirmed working. Scoped lint (`golangci-lint`, `eslint`) and tests (`go test`, `jest`) also pass.

#### Release Note
```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5e223ba3-89ab-4465-a716-f008db6c1c4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5e223ba3-89ab-4465-a716-f008db6c1c4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

