### PR TITLE
Enforce team-scope channel check on access policy unassign for parity…

### DIFF
--- a/server/channels/api4/access_control.go
+++ b/server/channels/api4/access_control.go
@@ -949,6 +949,11 @@ func unassignAccessPolicy(c *Context, w http.ResponseWriter, r *http.Request) {
 			c.SetPermissionError(model.PermissionManageTeamAccessRules)
 			return
 		}
+		// Mirror the assign path: every target channel must currently belong to the requesting team.
+		if appErr := c.App.ValidateTeamScopePolicyChannelAssignment(c.AppContext, assignments.TeamID, assignments.ChannelIds); appErr != nil {
+			c.Err = appErr
+			return
+		}
 	}
 
 	auditRec := c.MakeAuditRecord(model.AuditEventUnassignAccessPolicy, model.AuditStatusFail)

--- a/server/channels/api4/access_control_test.go
+++ b/server/channels/api4/access_control_test.go
@@ -2419,6 +2419,41 @@ func TestUnassignAccessPolicyTeamAdmin(t *testing.T) {
 		defer r.Body.Close()
 		require.Equal(t, 403, r.StatusCode)
 	})
+
+	t.Run("team admin cannot unassign a channel outside their team", func(t *testing.T) {
+		mockACS := setupTeamAdminABAC(t, th)
+
+		// Admin owns a policy scoped to BasicTeam but passes a channel that
+		// belongs to another team. The channel-scope guard must reject it.
+		otherTeam := th.CreateTeam(t)
+		foreignCh := th.CreateChannelWithClientAndTeam(t, th.SystemAdminClient, model.ChannelTypePrivate, otherTeam.Id)
+
+		policy := newParentPolicy(th.BasicTeam.Id)
+		savedPolicy, err := th.App.Srv().Store().AccessControlPolicy().Save(th.Context, policy)
+		require.NoError(t, err)
+		defer func() {
+			_ = th.App.Srv().Store().AccessControlPolicy().Delete(th.Context, savedPolicy.ID)
+		}()
+
+		mockACS.On("GetPolicy", mock.AnythingOfType("*request.Context"), savedPolicy.ID).
+			Return(savedPolicy, nil).Maybe()
+
+		makeTeamAdminAndLogin(t, th, th.TeamAdminUser, th.BasicTeam)
+		defer th.LoginBasic(t)
+
+		body := map[string]any{
+			"channel_ids": []string{foreignCh.Id},
+			"team_id":     th.BasicTeam.Id,
+		}
+		r, err := th.Client.DoAPIDeleteJSON(
+			context.Background(),
+			"/access_control_policies/"+savedPolicy.ID+"/unassign",
+			body,
+		)
+		require.Error(t, err)
+		defer r.Body.Close()
+		require.Equal(t, 400, r.StatusCode)
+	})
 }
 
 func TestScopeReconciliationCrossTeam(t *testing.T) {


### PR DESCRIPTION
#### Summary
Adds a per-channel team-scope check to the access control policy unassigns handler so it matches the assign path, ensuring a team admin can only unassign policies from channels that currently belong to their team, with a test covering the cross-team case

#### Ticket Link
n/a

#### Screenshots
n/a

#### Release Note
```release-note
NONE
```
