### PR TITLE
cloud: sync Dockerfile Go version and add cloud setup notes

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:24.04
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG GO_VERSION=1.25.9
+ARG GO_VERSION=1.26.4
 ARG NODE_VERSION=24.11.1
 ARG NVM_VERSION=0.40.3
 ARG DOCKER_VERSION=5:28.5.2-1~ubuntu.24.04~noble

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,3 +16,11 @@ When creating a pull request, follow `.github/PULL_REQUEST_TEMPLATE.md` exactly:
 This repository has a checked-in Cloud Agent environment under `.cursor/`. Docker is started by `.cursor/scripts/cloud-agent-start.sh`; if Docker is unavailable in Cloud, treat that as an environment failure rather than falling back to snapshot assumptions.
 
 The environment declares `mattermost/enterprise` as a Cursor multi-repo dependency. Cursor clones the repositories as siblings, so `server/Makefile` can use its default `../../enterprise` path; the install hook does not clone or symlink enterprise.
+
+## Cursor Cloud specific instructions
+
+Run/setup details live in `.cursor/cursor.md` (materialized as `.cursor/AGENTS.md` at start) and `.cursor/README.md`; prefer those over duplicating commands. Non-obvious caveats:
+
+- `.cursor/Dockerfile` pins toolchain versions independently of the repo. Keep its `GO_VERSION` in sync with `server/.go-version` and `NODE_VERSION` with `.nvmrc`; a stale `GO_VERSION` will fail to build the server (`go.mod` enforces the version).
+- The dev UI is served by the Go server at `http://localhost:8065`. `cd webapp && make run` compiles/watches the client into `server/client` (served by the server); it is not a standalone dev server, so the app is exercised at `:8065`.
+- Webapp Jest uses a newer flag: filter tests with `--testPathPatterns=<pattern>` (the old `--testPathPattern` is removed).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Set up and verified the Cursor Cloud Agent development environment for Mattermost.

- Bumped `.cursor/Dockerfile` `GO_VERSION` from `1.25.9` to `1.26.4` to match `server/.go-version` and the `go 1.26.4` directive in `server/go.mod` (the pinned image was stale and would fail to build the server).
- Added a `## Cursor Cloud specific instructions` section to `AGENTS.md` documenting durable, non-obvious caveats (keeping `Dockerfile` toolchain versions in sync with `server/.go-version`/`.nvmrc`, the UI being served by the Go server at `:8065`, and the updated Jest `--testPathPatterns` flag).

Verified end-to-end in a bootstrapped VM: Postgres/Redis via `make start-docker`, `make run-server` (healthy at `:8065`, Advanced license applied), webapp compiled and served, plus a login + "post a message" smoke test through the browser.

#### Release Note
```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-470a33e3-70b3-47a8-8c36-6141f550df90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-470a33e3-70b3-47a8-8c36-6141f550df90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

