### PR TITLE
Bump Cloud Agent Go to 1.26.4 to match server/.go-version

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:24.04
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG GO_VERSION=1.25.9
+ARG GO_VERSION=1.26.4
 ARG NODE_VERSION=24.11.1
 ARG NVM_VERSION=0.40.3
 ARG DOCKER_VERSION=5:28.5.2-1~ubuntu.24.04~noble

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -8,7 +8,7 @@ The Docker build context is `.cursor/` only. The Dockerfile intentionally does n
 
 - Ubuntu 24.04.
 - Docker CE 28.5.2 with `fuse-overlayfs` and `iptables-legacy`, matching Cursor's Docker-in-Cloud guidance for complex compose setups.
-- Go 1.25.9 from `server/.go-version`.
+- Go 1.26.4 from `server/.go-version`.
 - Node 24.11.1/npm 11 via nvm, matching `.nvmrc` and `webapp/package.json`.
 - Browser runtime libraries for the Playwright e2e suite.
 - AWS CLI v2 for S3 uploads.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

The checked-in Cloud Agent environment (`.cursor/Dockerfile`) pinned `GO_VERSION=1.25.9`, but the repository now requires Go `1.26.4` (`server/.go-version` and the `go 1.26.4` directive in `server/go.mod`). An image built from the current Dockerfile ships a Go toolchain older than the one the module requires, so this bumps the Dockerfile ARG (and the matching note in `.cursor/README.md`) to `1.26.4`.

Verified in a Cloud Agent session running Go `1.26.4`: `make setup-go-work`, `go mod download`, `make run` (server + webapp), `go test ./public/utils/...`, `golangci-lint run`, and the webapp `check-types` all succeed, and the server serves the app at `http://localhost:8065`.

```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-91a23218-e244-4922-9a9f-97670ec8a8cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-91a23218-e244-4922-9a9f-97670ec8a8cb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

