### PR TITLE
MM-69802: Fix avatar alt text rendering visibly on broken image load

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/threads/thread_footer_avatar.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/threads/thread_footer_avatar.spec.ts
@@ -55,7 +55,7 @@ test('MM-69802 Thread footer avatar with broken image URL renders with equal wid
     await expect(avatarImages.first()).toBeVisible();
 
     const count = await avatarImages.count();
-    expect(count).toBe(2)
+    expect(count).toBe(2);
 
     // * Verify each avatar has equal width and height
     for (let i = 0; i < count; i++) {

--- a/e2e-tests/playwright/specs/functional/channels/threads/thread_footer_avatar.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/threads/thread_footer_avatar.spec.ts
@@ -1,0 +1,67 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test, PlaywrightClient4, testConfig} from '@mattermost/playwright-lib';
+
+/**
+ * @objective Verify that thread footer avatars with a broken image URL still render at correct
+ * square dimensions — i.e. width equals height — confirming that alt text does not distort
+ * the element when the image fails to load.
+ */
+test('MM-69802 Thread footer avatar with broken image URL renders with equal width and height', async ({pw}) => {
+    // adminClient.createPost always posts as sysadmin regardless of user_id,
+    // so we need a dedicated client per user to get distinct thread participants.
+    const {adminClient, team, user, userClient} = await pw.initSetup();
+
+    const [otherUser1, otherUser2] = await adminClient.createUsers(team.id, 2, 'thread-avatar');
+
+    const makeUserClient = async (u: typeof otherUser1) => {
+        const c = new PlaywrightClient4();
+        c.setUrl(testConfig.baseURL);
+        await c.login(u.username, (u as any).password);
+        return c;
+    };
+    const [otherUserClient1, otherUserClient2] = await Promise.all([
+        makeUserClient(otherUser1),
+        makeUserClient(otherUser2),
+    ]);
+
+    // Set up a channel with all users and a threaded exchange
+    const channel = await adminClient.createPublicChannel(team.id, 'thread-avatar-test');
+    await adminClient.addToChannel(user.id, channel.id);
+    await adminClient.addToChannel(otherUser1.id, channel.id);
+    await adminClient.addToChannel(otherUser2.id, channel.id);
+
+    const root = await userClient.createPost({channel_id: channel.id, message: 'Root post'});
+    await otherUserClient1.createPost({channel_id: channel.id, message: 'Reply', root_id: root.id});
+    await otherUserClient2.createPost({channel_id: channel.id, message: 'Reply', root_id: root.id});
+
+    const {channelsPage, page} = await pw.testBrowser.login(user);
+
+    // # Intercept all user profile picture requests (both the versioned URL and the /default
+    // fallback) so the browser is forced to render alt text — the state the CSS fix addresses.
+    await page.route(/\/api\/v4\/users\/[^/]*\/image/, (route) => route.fulfill({status: 404}));
+
+    await channelsPage.goto(team.name, channel.name);
+    await channelsPage.toBeVisible();
+
+    const rootPost = await channelsPage.centerView.getPostById(root.id);
+    await rootPost.toBeVisible();
+
+    const {threadFooter} = rootPost;
+    await threadFooter.toBeVisible();
+
+    const avatarImages = threadFooter.container.locator('img.Avatar');
+    await expect(avatarImages.first()).toBeVisible();
+
+    const count = await avatarImages.count();
+    expect(count).toBe(2)
+
+    // * Verify each avatar has equal width and height
+    for (let i = 0; i < count; i++) {
+        const box = await avatarImages.nth(i).boundingBox();
+        expect(box).not.toBeNull();
+        expect(box!.width).toBe(box!.height);
+        expect(box!.width).toBeGreaterThan(0);
+    }
+});

--- a/webapp/channels/src/components/widgets/users/avatar/avatar.scss
+++ b/webapp/channels/src/components/widgets/users/avatar/avatar.scss
@@ -12,8 +12,8 @@ img.Avatar {
     &.Avatar-lg,
     &.Avatar-xl,
     &.Avatar-xxl {
-        font-size: 0;
         min-width: 0;
+        font-size: 0;
     }
 }
 

--- a/webapp/channels/src/components/widgets/users/avatar/avatar.scss
+++ b/webapp/channels/src/components/widgets/users/avatar/avatar.scss
@@ -1,5 +1,22 @@
 @use "sass:color";
 
+img.Avatar {
+    // Hide alt text that deforms the circled shape of the avatars in the thread footer.
+    // font-size: 0 prevents alt text from expanding the box on broken images.
+    // min-width: 0 lets width follow the browser's natural broken-image icon size
+    //              so it matches height and border-radius: 50% stays circular.
+    &.Avatar-xxs,
+    &.Avatar-xs,
+    &.Avatar-sm,
+    &.Avatar-md,
+    &.Avatar-lg,
+    &.Avatar-xl,
+    &.Avatar-xxl {
+        font-size: 0;
+        min-width: 0;
+    }
+}
+
 .Avatar {
     &,
     &:focus,

--- a/webapp/channels/src/components/widgets/users/avatar/avatar.test.tsx
+++ b/webapp/channels/src/components/widgets/users/avatar/avatar.test.tsx
@@ -129,6 +129,18 @@ describe('components/widgets/users/Avatar', () => {
         expect(avatar.src).toBe(initialSrc);
     });
 
+    test('should still render an img element after image load error', () => {
+        render(withIntl(
+            <Avatar url='test-url'/>,
+        ));
+
+        const avatar = screen.getByRole('img') as HTMLImageElement;
+
+        fireEvent.error(avatar);
+
+        expect(screen.getByRole('img')).toBeInTheDocument();
+    });
+
     describe('getAvatarWidth', () => {
         test('should return correct width for xxs size', () => {
             expect(getAvatarWidth('xxs')).toBe('16px');

--- a/webapp/channels/src/components/widgets/users/avatars/avatars.tsx
+++ b/webapp/channels/src/components/widgets/users/avatars/avatars.tsx
@@ -59,6 +59,7 @@ function UserAvatar({
     const name = useSelector((state: GlobalState) => displayNameGetter(state, true)(user));
 
     const profilePictureURL = userId ? imageURLForUser(userId) : '';
+    const avatarPictureURL = userId ? imageURLForUser(userId, user?.last_picture_update) : '';
 
     return (
         <ProfilePopover<HTMLButtonElement>
@@ -71,7 +72,7 @@ function UserAvatar({
                 title={name}
             >
                 <Avatar
-                    url={imageURLForUser(userId, user?.last_picture_update)}
+                    url={avatarPictureURL}
                     username={user?.username}
                     tabIndex={-1}
                     {...props}


### PR DESCRIPTION
#### Summary
When a thread footer participant's profile image fails to load (404), the browser renders the `<img>` element's `alt` text (`user profile image`) visibly into the thread footer. It overflows the avatar circle and overlaps adjacent UI elements.

Two rules on `img.Avatar` fix this:
- `min-width: 0` — keeps the border-radius: 50% working
- `font-size: 0` — suppresses the alt text

This is covered by both a unit and an E2E test.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-69802

#### Screenshots
N/A (CSS-only change; the broken state shows visible overflowing text, the fix shows a plain grey circle)

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes are limited to avatar image rendering (CSS adjustments to suppress broken-image alt text/layout distortion) and avatar URL construction using `last_picture_update`, without impacting auth/session or backend contracts. Automated unit + Playwright coverage exercise the broken-image/error and layout behavior.  
**QA Recommendation:** Manual QA can be skipped; automated coverage is sufficient.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->