### PR TITLE
MM-69802: Fix empty participant ID producing malformed avatar URL

### DIFF
--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -1294,6 +1294,9 @@ func (s *SqlPostStore) prepareThreadedResponse(rctx request.CTX, posts []*postWi
 			p.Post.IsFollowing = new(*p.IsFollowing)
 		}
 		for _, userID := range p.ThreadParticipants {
+			if userID == "" {
+				continue
+			}
 			participant, ok := usersMap[userID]
 			if !ok {
 				return errors.New("cannot find thread participant with id=" + userID)

--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -1281,6 +1281,9 @@ func (s *SqlPostStore) prepareThreadedResponse(rctx request.CTX, posts []*postWi
 		}
 	} else {
 		for _, userId := range userIds {
+			if userId == "" {
+				continue
+			}
 			usersMap[userId] = &model.User{Id: userId}
 		}
 	}

--- a/server/channels/store/sqlstore/thread_store.go
+++ b/server/channels/store/sqlstore/thread_store.go
@@ -396,6 +396,9 @@ func (s *SqlThreadStore) GetThreadsForUser(rctx request.CTX, userId, teamId stri
 		}
 	} else {
 		for _, participantUserId := range participantUserIds {
+			if participantUserId == "" {
+				continue
+			}
 			allParticipants[participantUserId] = &model.User{Id: participantUserId}
 		}
 	}

--- a/webapp/channels/src/components/threading/channel_threads/thread_footer/thread_footer.test.tsx
+++ b/webapp/channels/src/components/threading/channel_threads/thread_footer/thread_footer.test.tsx
@@ -211,6 +211,20 @@ describe('components/threading/channel_threads/thread_footer', () => {
         expect(capturedAvatarsProps).toHaveProperty('userIds', ['5', '4', '3', '2', '1']);
     });
 
+    test('should filter out empty participant ids', () => {
+        thread.participants = [{id: '1'}, {id: ''}, {id: '2'}] as UserThread['participants'];
+
+        renderWithContext(
+            <ThreadFooter
+                {...props}
+            />,
+            state,
+            {useMockedStore: true},
+        );
+        expect(capturedAvatarsProps.userIds).not.toContain('');
+        expect(capturedAvatarsProps).toHaveProperty('userIds', ['2', '1']);
+    });
+
     test('should have a timestamp', () => {
         renderWithContext(
             <ThreadFooter

--- a/webapp/channels/src/components/threading/channel_threads/thread_footer/thread_footer.tsx
+++ b/webapp/channels/src/components/threading/channel_threads/thread_footer/thread_footer.tsx
@@ -61,7 +61,7 @@ function ThreadFooter({
         },
     } = thread;
 
-    const participantIds = useMemo(() => (participants || []).map(({id}) => id).reverse(), [participants]);
+    const participantIds = useMemo(() => (participants || []).map(({id}) => id).filter(Boolean).reverse(), [participants]);
 
     const handleReply = useCallback((e: React.MouseEvent) => {
         if (replyClick) {

--- a/webapp/channels/src/components/widgets/users/avatars/avatars.test.tsx
+++ b/webapp/channels/src/components/widgets/users/avatars/avatars.test.tsx
@@ -150,6 +150,21 @@ describe('components/widgets/users/Avatars', () => {
         expect(container.querySelector('[data-content="+2"]')).toBeInTheDocument();
     });
 
+    test('should not render an img with an empty or double-slash src for empty user ids', () => {
+        const {container} = renderWithContext(
+            <Avatars
+                size='xl'
+                userIds={['', '1']}
+            />,
+            state,
+        );
+
+        expect(container.querySelector('img[src=""]')).not.toBeInTheDocument();
+        expect(container.querySelector('img[src*="//image"]')).not.toBeInTheDocument();
+        expect(container.querySelector('img[src="/api/v4/users/1/image?_=1620680333191"]')).toBeInTheDocument();
+        expect(container.querySelectorAll('img.Avatar')).toHaveLength(1);
+    });
+
     test('should fetch missing users', () => {
         const {container} = renderWithContext(
             <Avatars

--- a/webapp/channels/src/components/widgets/users/avatars/avatars.tsx
+++ b/webapp/channels/src/components/widgets/users/avatars/avatars.tsx
@@ -60,6 +60,10 @@ function UserAvatar({
 
     const profilePictureURL = userId ? imageURLForUser(userId) : '';
 
+    if (!userId) {
+        return null;
+    }
+
     return (
         <ProfilePopover<HTMLButtonElement>
             triggerComponentAs='button'


### PR DESCRIPTION
#### Summary
Thread footer avatars occasionally load with the URL `/api/v4/users//image/default` (double slash, empty user ID), returning a 404. Traced through the full stack:

**Frontend (primary):**
- `thread_footer.tsx` maps `participants` to IDs with no filter — an entry with `id: ""` produces an empty string in `participantIds`.
- `avatars.tsx` (`UserAvatar`) passes the falsy `userId` directly to `imageURLForUser`, which returns `<usersRoute>//image?_=…`. The existing guard on the `profilePictureURL` variable (line 61) was not applied to the render path.

**Backend (defensive):**
- `post_store.go` and `thread_store.go` build stub `User` objects from stored participant IDs without skipping empty strings, so `{"id":""}` is serialized and reaches the client on the non-extended response path.

**Changes:**
1. `thread_footer.tsx` — add `.filter(Boolean)` to `participantIds` memo.
2. `avatars.tsx` — return `null` from `UserAvatar` when `userId` is falsy (mirrors the existing guard).
3. `post_store.go` + `thread_store.go` — skip empty participant IDs when building user stubs.

The deeper question of _how_ an empty string enters `Threads.Participants` is tracked separately.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-69802

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes are limited to filtering out empty participant/user IDs during participant resolution and avatar rendering, with frontend unit tests covering the empty-ID cases. No authentication/authorization/session or persistence/migrations logic is modified, so risk of breaking unrelated behavior is minimal.  
**QA Recommendation:** Manual QA can be skipped; automated unit tests should be sufficient.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->