### PR TITLE
Drop UNIQUE(sharename, teamid) constraint on SharedChannels

### DIFF
--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -401,3 +401,5 @@ channels/db/migrations/postgres/000202_create_property_values_groupid_updateat_i
 channels/db/migrations/postgres/000202_create_property_values_groupid_updateat_id_index.up.sql
 channels/db/migrations/postgres/000203_add_lastnotifiedat_to_user_access_tokens.down.sql
 channels/db/migrations/postgres/000203_add_lastnotifiedat_to_user_access_tokens.up.sql
+channels/db/migrations/postgres/000204_sharedchannels_drop_sharename_teamid_unique.down.sql
+channels/db/migrations/postgres/000204_sharedchannels_drop_sharename_teamid_unique.up.sql

--- a/server/channels/db/migrations/postgres/000204_sharedchannels_drop_sharename_teamid_unique.down.sql
+++ b/server/channels/db/migrations/postgres/000204_sharedchannels_drop_sharename_teamid_unique.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sharedchannels ADD CONSTRAINT sharedchannels_sharename_teamid_key UNIQUE (sharename, teamid);

--- a/server/channels/db/migrations/postgres/000204_sharedchannels_drop_sharename_teamid_unique.up.sql
+++ b/server/channels/db/migrations/postgres/000204_sharedchannels_drop_sharename_teamid_unique.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sharedchannels DROP CONSTRAINT IF EXISTS sharedchannels_sharename_teamid_key;

--- a/server/channels/store/storetest/shared_channel_store.go
+++ b/server/channels/store/storetest/shared_channel_store.go
@@ -99,6 +99,41 @@ func testSaveSharedChannel(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.True(t, channelMod.IsShared())
 	})
 
+	t.Run("Save allows duplicate ShareName within a team", func(t *testing.T) {
+		// Regression: the SharedChannels table used to carry a UNIQUE(sharename, teamid)
+		// constraint. Because the table has no soft-delete and archiving a channel does
+		// not remove its SharedChannels row, that constraint permanently reserved a
+		// (name, team) pair and blocked re-sharing a new channel with the same name in
+		// the same team. The constraint has been dropped; two shared channels in the same
+		// team with the same ShareName must now both save.
+		teamID := model.NewId()
+
+		channel1, err := createTestChannel(ss, rctx, "test_dup_name_1")
+		require.NoError(t, err)
+		channel2, err := createTestChannel(ss, rctx, "test_dup_name_2")
+		require.NoError(t, err)
+
+		sc1 := &model.SharedChannel{
+			ChannelId: channel1.Id,
+			TeamId:    teamID,
+			CreatorId: model.NewId(),
+			ShareName: "duplicate-share-name",
+			Home:      true,
+		}
+		_, err = ss.SharedChannel().Save(sc1)
+		require.NoError(t, err, "couldn't save first shared channel")
+
+		sc2 := &model.SharedChannel{
+			ChannelId: channel2.Id,
+			TeamId:    teamID,
+			CreatorId: model.NewId(),
+			ShareName: "duplicate-share-name",
+			Home:      true,
+		}
+		_, err = ss.SharedChannel().Save(sc2)
+		require.NoError(t, err, "should allow a second shared channel with the same ShareName in the same team")
+	})
+
 	t.Run("Save invalid shared channel", func(t *testing.T) {
 		sc := &model.SharedChannel{
 			ChannelId: "",


### PR DESCRIPTION
#### Summary
Archiving a shared channel never removes its `SharedChannels` row, and the table has no soft-delete. The `UNIQUE (sharename, teamid)` constraint then permanently reserves that (name, team) pair, blocking re-sharing a new channel with the same name in the same team (`duplicate key value violates unique constraint "sharedchannels_sharename_teamid_key"`). The constraint is redundant with `Channels (name, teamid)` uniqueness and nothing reads `sharename` as a key, so this drops it (migration 000204) and adds a store regression test.

#### Release Note
```release-note
Dropped the redundant UNIQUE (ShareName, TeamId) constraint on the SharedChannels table.
```
