### PR TITLE
ci: consolidate docs-preview checks into one status with preview URL

### DIFF
--- a/.github/workflows/docs-preview-fork.yml
+++ b/.github/workflows/docs-preview-fork.yml
@@ -7,10 +7,6 @@ on:
         type: string
         required: true
         description: "PR number (fork PR to build preview for)"
-      TRIGGERING_ACTOR:
-        type: string
-        required: true
-        description: "GitHub login of the fork PR author"
       COMMIT_SHA:
         type: string
         required: true
@@ -21,6 +17,9 @@ permissions:
   statuses: write
 
 jobs:
+  # workflow_dispatch jobs are not attached to the PR check suite. The commit
+  # status below is what appears on the PR — same pattern as
+  # mattermost/docs preview-env-fork.yml (CLD-5815).
   update-initial-status:
     runs-on: ubuntu-latest
     steps:
@@ -31,11 +30,11 @@ jobs:
         with:
           repository_full_name: ${{ github.repository }}
           commit_sha: ${{ inputs.COMMIT_SHA }}
-          context: "docs-preview-fork / preview"
+          context: docs-preview
           description: "Docs preview build for ${{ inputs.COMMIT_SHA }} is running"
           status: pending
 
-  preview:
+  deploy:
     uses: ./.github/workflows/docs-preview-template.yml
     secrets:
       AWS_DOCS_PR_PREVIEW_KEY_ID: ${{ secrets.AWS_DOCS_PR_PREVIEW_KEY_ID }}
@@ -45,12 +44,13 @@ jobs:
     with:
       PR_NUMBER: ${{ inputs.PR_NUMBER }}
       COMMIT_SHA: ${{ inputs.COMMIT_SHA }}
+      STATUS_CONTEXT: docs-preview
 
   update-failure-status:
     runs-on: ubuntu-latest
     if: failure() || cancelled()
     needs:
-      - preview
+      - deploy
     steps:
       - uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
         env:
@@ -58,23 +58,6 @@ jobs:
         with:
           repository_full_name: ${{ github.repository }}
           commit_sha: ${{ inputs.COMMIT_SHA }}
-          context: "docs-preview-fork / preview"
+          context: docs-preview
           description: "Docs preview build for ${{ inputs.COMMIT_SHA }} failed"
           status: failure
-
-  update-success-status:
-    runs-on: ubuntu-latest
-    if: success()
-    needs:
-      - preview
-    steps:
-      - uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          repository_full_name: ${{ github.repository }}
-          commit_sha: ${{ inputs.COMMIT_SHA }}
-          context: "docs-preview-fork / preview"
-          description: "Docs preview build for ${{ inputs.COMMIT_SHA }} succeeded"
-          status: success
-          target_url: "http://${{ vars.DOCS_PREVIEW_BUCKET_NAME }}.s3-website-us-east-1.amazonaws.com/mattermost/pr-${{ inputs.PR_NUMBER }}/"

--- a/.github/workflows/docs-preview-fork.yml
+++ b/.github/workflows/docs-preview-fork.yml
@@ -17,9 +17,6 @@ permissions:
   statuses: write
 
 jobs:
-  # workflow_dispatch jobs are not attached to the PR check suite. The commit
-  # status below is what appears on the PR — same pattern as
-  # mattermost/docs preview-env-fork.yml (CLD-5815).
   update-initial-status:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docs-preview-fork.yml
+++ b/.github/workflows/docs-preview-fork.yml
@@ -42,19 +42,3 @@ jobs:
       PR_NUMBER: ${{ inputs.PR_NUMBER }}
       COMMIT_SHA: ${{ inputs.COMMIT_SHA }}
       STATUS_CONTEXT: docs-preview
-
-  update-failure-status:
-    runs-on: ubuntu-latest
-    if: failure() || cancelled()
-    needs:
-      - deploy
-    steps:
-      - uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          repository_full_name: ${{ github.repository }}
-          commit_sha: ${{ inputs.COMMIT_SHA }}
-          context: docs-preview
-          description: "Docs preview build for ${{ inputs.COMMIT_SHA }} failed"
-          status: failure

--- a/.github/workflows/docs-preview-template.yml
+++ b/.github/workflows/docs-preview-template.yml
@@ -9,6 +9,12 @@ on:
       COMMIT_SHA:
         type: string
         required: true
+      # Commit status context shown on the PR. Details (⋯) links to the preview
+      # when status is success. Empty skips status updates.
+      STATUS_CONTEXT:
+        type: string
+        required: false
+        default: docs-preview
     secrets:
       AWS_DOCS_PR_PREVIEW_KEY_ID:
         required: true
@@ -23,10 +29,10 @@ concurrency:
 
 permissions:
   contents: read
+  statuses: write
 
 jobs:
-  preview:
-    name: Build and deploy preview
+  deploy:
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout
@@ -89,3 +95,37 @@ jobs:
             "s3://${BUCKET_NAME}/mattermost/pr-${PR_NUMBER}/" \
             --delete \
             --no-progress
+
+      - name: Set preview URL
+        id: preview
+        env:
+          BUCKET_NAME: ${{ vars.DOCS_PREVIEW_BUCKET_NAME }}
+          PR_NUMBER: ${{ inputs.PR_NUMBER }}
+        run: |
+          echo "url=http://${BUCKET_NAME}.s3-website-us-east-1.amazonaws.com/mattermost/pr-${PR_NUMBER}/" >> "$GITHUB_OUTPUT"
+
+      # Details (⋯) on this check links to the preview URL via target_url.
+      - name: Set success commit status
+        if: ${{ inputs.STATUS_CONTEXT != '' }}
+        uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          repository_full_name: ${{ github.repository }}
+          commit_sha: ${{ inputs.COMMIT_SHA }}
+          context: ${{ inputs.STATUS_CONTEXT }}
+          description: "Docs preview build for ${{ inputs.COMMIT_SHA }} succeeded"
+          status: success
+          target_url: ${{ steps.preview.outputs.url }}
+
+      - name: Set failure commit status
+        if: ${{ always() && inputs.STATUS_CONTEXT != '' && (failure() || cancelled()) }}
+        uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          repository_full_name: ${{ github.repository }}
+          commit_sha: ${{ inputs.COMMIT_SHA }}
+          context: ${{ inputs.STATUS_CONTEXT }}
+          description: "Docs preview build for ${{ inputs.COMMIT_SHA }} failed"
+          status: failure

--- a/.github/workflows/docs-preview.yml
+++ b/.github/workflows/docs-preview.yml
@@ -12,62 +12,13 @@ permissions:
   statuses: write
 
 jobs:
-  update-initial-status:
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.head.repo.full_name == github.repository
-    steps:
-      - name: Set pending commit status
-        uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          repository_full_name: ${{ github.repository }}
-          commit_sha: ${{ github.event.pull_request.head.sha }}
-          context: "docs-preview / preview"
-          description: "Docs preview build for ${{ github.event.pull_request.head.sha }} is running"
-          status: pending
-
   deploy:
     uses: ./.github/workflows/docs-preview-template.yml
     if: github.event.pull_request.head.repo.full_name == github.repository
-    needs:
-      - update-initial-status
     secrets:
       AWS_DOCS_PR_PREVIEW_KEY_ID: ${{ secrets.AWS_DOCS_PR_PREVIEW_KEY_ID }}
       AWS_DOCS_PR_PREVIEW_SECRET_ACCESS_KEY: ${{ secrets.AWS_DOCS_PR_PREVIEW_SECRET_ACCESS_KEY }}
     with:
       PR_NUMBER: ${{ github.event.number }}
       COMMIT_SHA: ${{ github.event.pull_request.head.sha }}
-
-  update-failure-status:
-    runs-on: ubuntu-latest
-    if: failure() || cancelled()
-    needs:
-      - deploy
-    steps:
-      - uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          repository_full_name: ${{ github.repository }}
-          commit_sha: ${{ github.event.pull_request.head.sha }}
-          context: "docs-preview / preview"
-          description: "Docs preview build for ${{ github.event.pull_request.head.sha }} failed"
-          status: failure
-
-  update-success-status:
-    runs-on: ubuntu-latest
-    if: success()
-    needs:
-      - deploy
-    steps:
-      - uses: mattermost/actions/delivery/update-commit-status@fec7b836001c9380d4bfaf28d443945c103a098c
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
-        with:
-          repository_full_name: ${{ github.repository }}
-          commit_sha: ${{ github.event.pull_request.head.sha }}
-          context: "docs-preview / preview"
-          description: "Docs preview build for ${{ github.event.pull_request.head.sha }} succeeded"
-          status: success
-          target_url: "http://${{ vars.DOCS_PREVIEW_BUCKET_NAME }}.s3-website-us-east-1.amazonaws.com/mattermost/pr-${{ github.event.number }}/"
+      STATUS_CONTEXT: docs-preview


### PR DESCRIPTION
#### Summary
Fixes docs PR previews so a `docs-preview` check’s Details (⋯) link opens the preview environment.

Previously, same-repo previews used several status-update jobs plus a deploy job. That cluttered the checks list, and there was no clear single check whose Details link was the preview URL.
<img width="1296" height="254" alt="Screenshot 2026-07-15 at 22 28 17" src="https://github.com/user-attachments/assets/372c94ce-df17-4b16-8fa1-b5e3ffe6ef1e" />


Fork previews keep pending/failure status updates for `workflow_dispatch`, all under the same `docs-preview` context.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Changes rewire commit-status posting and the shared docs-preview template’s job structure/inputs across both same-repo and fork preview workflows, so incorrect status contexts or missing `Details` (target URL) are possible. Blast radius is limited to CI status reporting and preview URLs, with no runtime/application logic touched.  
**QA Recommendation:** Manually verify the docs-preview status check for both same-repository PRs and fork `workflow_dispatch` PRs: pending → success (Details links to preview URL) and pending → failure/cancelled (failure status is posted under the correct `docs-preview` context).

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->