### PR TITLE
Add UserWillBeUpdated plugin hook and CreatePasswordRecoveryToken API

### DIFF
--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -370,6 +370,10 @@ func (api *PluginAPI) UpdateUser(user *model.User) (*model.User, *model.AppError
 	return api.app.UpdateUser(api.ctx, user, true)
 }
 
+func (api *PluginAPI) CreatePasswordRecoveryToken(userID, email string) (*model.Token, *model.AppError) {
+	return api.app.CreatePasswordRecoveryToken(api.ctx, userID, email)
+}
+
 func (api *PluginAPI) UpdateUserAuth(userID string, userAuth *model.UserAuth) (*model.UserAuth, *model.AppError) {
 	return api.app.UpdateUserAuth(api.ctx, userID, userAuth)
 }

--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -730,6 +730,31 @@ func TestPluginAPIUserCustomStatus(t *testing.T) {
 	assert.Equal(t, csClear, userCs)
 }
 
+func TestPluginAPICreatePasswordRecoveryToken(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	api := th.SetupPluginAPI()
+
+	token, appErr := api.CreatePasswordRecoveryToken(th.BasicUser.Id, th.BasicUser.Email)
+	require.Nil(t, appErr)
+	require.NotNil(t, token)
+	assert.Equal(t, model.TokenTypePasswordRecovery, token.Type)
+	assert.NotEmpty(t, token.Token)
+
+	// A second create invalidates the first token.
+	token2, appErr := api.CreatePasswordRecoveryToken(th.BasicUser.Id, th.BasicUser.Email)
+	require.Nil(t, appErr)
+	require.NotNil(t, token2)
+	assert.NotEqual(t, token.Token, token2.Token)
+
+	appErr = th.App.ResetPasswordFromToken(th.Context, token.Token, model.NewTestPassword())
+	require.NotNil(t, appErr)
+
+	appErr = th.App.ResetPasswordFromToken(th.Context, token2.Token, model.NewTestPassword())
+	require.Nil(t, appErr)
+}
+
 func TestPluginAPIGetFile(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)

--- a/server/channels/app/plugin_hooks_user_test.go
+++ b/server/channels/app/plugin_hooks_user_test.go
@@ -1,0 +1,264 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+func TestHookUserWillBeUpdated(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	t.Run("rejected", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) UserWillBeUpdated(c *plugin.Context, newUser, oldUser *model.User) (*model.User, string) {
+				return nil, "update not permitted"
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		original := th.BasicUser.Username
+		updated := th.BasicUser.DeepCopy()
+		updated.Username = "shouldnotpersist"
+
+		_, appErr := th.App.UpdateUser(th.Context, updated, false)
+		require.NotNil(t, appErr)
+		assert.Contains(t, appErr.Id, "rejected_by_plugin")
+
+		fetched, err := th.App.GetUser(th.BasicUser.Id)
+		require.Nil(t, err)
+		assert.Equal(t, original, fetched.Username)
+	})
+
+	t.Run("modified", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"strings"
+
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) UserWillBeUpdated(c *plugin.Context, newUser, oldUser *model.User) (*model.User, string) {
+				newUser.Nickname = strings.ToUpper(newUser.Nickname)
+				return newUser, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		updated := th.BasicUser.DeepCopy()
+		updated.Nickname = "lowercase nick"
+
+		_, appErr := th.App.UpdateUser(th.Context, updated, false)
+		require.Nil(t, appErr)
+
+		fetched, err := th.App.GetUser(th.BasicUser.Id)
+		require.Nil(t, err)
+		assert.Equal(t, "LOWERCASE NICK", fetched.Nickname)
+	})
+
+	t.Run("old vs new diff", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) UserWillBeUpdated(c *plugin.Context, newUser, oldUser *model.User) (*model.User, string) {
+				if oldUser.Username != newUser.Username {
+					return nil, "username changed"
+				}
+				return nil, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		changed := th.BasicUser.DeepCopy()
+		changed.Username = "renameduser" + model.NewId()[:8]
+		_, appErr := th.App.UpdateUser(th.Context, changed, false)
+		require.NotNil(t, appErr)
+		assert.Contains(t, appErr.Id, "rejected_by_plugin")
+
+		same := th.BasicUser.DeepCopy()
+		same.Nickname = "allowed nickname change"
+		_, appErr = th.App.UpdateUser(th.Context, same, false)
+		require.Nil(t, appErr)
+	})
+
+	t.Run("allowed", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) UserWillBeUpdated(c *plugin.Context, newUser, oldUser *model.User) (*model.User, string) {
+				return nil, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		updated := th.BasicUser.DeepCopy()
+		updated.Nickname = "allowed"
+		_, appErr := th.App.UpdateUser(th.Context, updated, false)
+		require.Nil(t, appErr)
+
+		fetched, err := th.App.GetUser(th.BasicUser.Id)
+		require.Nil(t, err)
+		assert.Equal(t, "allowed", fetched.Nickname)
+	})
+
+	t.Run("immutable id and create_at restored", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) UserWillBeUpdated(c *plugin.Context, newUser, oldUser *model.User) (*model.User, string) {
+				newUser.Id = "forged-id"
+				newUser.CreateAt = 1
+				newUser.Nickname = "kept"
+				return newUser, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		updated := th.BasicUser.DeepCopy()
+		updated.Nickname = "ignored"
+		_, appErr := th.App.UpdateUser(th.Context, updated, false)
+		require.Nil(t, appErr)
+
+		fetched, err := th.App.GetUser(th.BasicUser.Id)
+		require.Nil(t, err)
+		assert.Equal(t, th.BasicUser.Id, fetched.Id)
+		assert.Equal(t, th.BasicUser.CreateAt, fetched.CreateAt)
+		assert.Equal(t, "kept", fetched.Nickname)
+	})
+
+	t.Run("plugin email mutation subject to domain restriction", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t).InitBasic(t)
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.TeamSettings.RestrictCreationToDomains = "allowed.example"
+		})
+
+		tearDown, _, _ := SetAppEnvironmentWithPlugins(t, []string{
+			`
+			package main
+
+			import (
+				"github.com/mattermost/mattermost/server/public/plugin"
+				"github.com/mattermost/mattermost/server/public/model"
+			)
+
+			type MyPlugin struct {
+				plugin.MattermostPlugin
+			}
+
+			func (p *MyPlugin) UserWillBeUpdated(c *plugin.Context, newUser, oldUser *model.User) (*model.User, string) {
+				newUser.Email = "evil@denied.example"
+				return newUser, ""
+			}
+
+			func main() {
+				plugin.ClientMain(&MyPlugin{})
+			}
+			`,
+		}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		updated := th.BasicUser.DeepCopy()
+		updated.Nickname = "trigger-update"
+		_, appErr := th.App.UpdateUser(th.Context, updated, false)
+		require.NotNil(t, appErr)
+		assert.Equal(t, "api.user.update_user.accepted_domain.app_error", appErr.Id)
+	})
+}

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -1492,6 +1492,12 @@ func (a *App) UpdateUser(rctx request.CTX, user *model.User, sendNotifications b
 		user.CreateAt = prev.CreateAt
 	}
 
+	// Plugins run before username/email validation so mutations cannot bypass those checks.
+	user, appErr := a.runUserWillBeUpdated(rctx, user, prev)
+	if appErr != nil {
+		return nil, appErr
+	}
+
 	if user.Username != prev.Username {
 		if err := a.isUniqueToGroupNames(user.Username); err != nil {
 			err.Where = "UpdateUser"

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -1883,10 +1883,8 @@ func (a *App) CreatePasswordRecoveryToken(rctx request.CTX, userID, email string
 		return nil, model.NewAppError("CreatePasswordRecoveryToken", "api.user.create_password_token.error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	// remove any previously created tokens for user
-	appErr := a.InvalidatePasswordRecoveryTokensForUser(userID)
-	if appErr != nil {
-		rctx.Logger().Warn("Error while deleting additional user tokens.", mlog.Err(appErr))
+	if appErr := a.InvalidatePasswordRecoveryTokensForUser(userID); appErr != nil {
+		return nil, appErr
 	}
 
 	token := model.NewToken(model.TokenTypePasswordRecovery, string(jsonData))

--- a/server/channels/app/user_plugin_hooks.go
+++ b/server/channels/app/user_plugin_hooks.go
@@ -1,0 +1,38 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"net/http"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+)
+
+// runUserWillBeUpdated dispatches UserWillBeUpdated before UpdateUser validation/persist.
+// Immutable identity fields (Id, CreateAt) are always restored from prev after plugins run.
+func (a *App) runUserWillBeUpdated(rctx request.CTX, user, prev *model.User) (*model.User, *model.AppError) {
+	var rejectionReason string
+	pCtx := pluginContext(rctx)
+	a.ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
+		replacement, reason := hooks.UserWillBeUpdated(pCtx, user, prev)
+		if reason != "" {
+			rejectionReason = reason
+			return false
+		}
+		if replacement != nil {
+			user = replacement
+		}
+		return true
+	}, plugin.UserWillBeUpdatedID)
+	if rejectionReason != "" {
+		return nil, model.NewAppError("UpdateUser", "app.user.update_user.rejected_by_plugin",
+			map[string]any{"Reason": rejectionReason}, "", http.StatusBadRequest)
+	}
+
+	user.Id = prev.Id
+	user.CreateAt = prev.CreateAt
+	return user, nil
+}

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9715,6 +9715,10 @@
     "translation": "Unable to update the date of the last update of the user."
   },
   {
+    "id": "app.user.update_user.rejected_by_plugin",
+    "translation": "User update rejected by plugin: {{.Reason}}"
+  },
+  {
     "id": "app.user.verify_email.app_error",
     "translation": "Unable to update verify email field."
   },

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -263,7 +263,8 @@ type API interface {
 	UpdateUser(user *model.User) (*model.User, *model.AppError)
 
 	// CreatePasswordRecoveryToken creates a password recovery token for the user and
-	// invalidates any existing ones. The token value is Token.Token.
+	// invalidates any existing ones. Returns an error if existing tokens cannot be
+	// invalidated. The token value is Token.Token.
 	//
 	// @tag User
 	// Minimum server version: 11.10

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -262,6 +262,13 @@ type API interface {
 	// Minimum server version: 5.2
 	UpdateUser(user *model.User) (*model.User, *model.AppError)
 
+	// CreatePasswordRecoveryToken creates a password recovery token for the user and
+	// invalidates any existing ones. The token value is Token.Token.
+	//
+	// @tag User
+	// Minimum server version: 11.10
+	CreatePasswordRecoveryToken(userID, email string) (*model.Token, *model.AppError)
+
 	// GetUserStatus will get a user's status.
 	//
 	// @tag User

--- a/server/public/plugin/api_timer_layer_generated.go
+++ b/server/public/plugin/api_timer_layer_generated.go
@@ -301,6 +301,13 @@ func (api *apiTimerLayer) UpdateUser(user *model.User) (*model.User, *model.AppE
 	return _returnsA, _returnsB
 }
 
+func (api *apiTimerLayer) CreatePasswordRecoveryToken(userID, email string) (*model.Token, *model.AppError) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := api.apiImpl.CreatePasswordRecoveryToken(userID, email)
+	api.recordTime(startTime, "CreatePasswordRecoveryToken", _returnsB == nil)
+	return _returnsA, _returnsB
+}
+
 func (api *apiTimerLayer) GetUserStatus(userID string) (*model.Status, *model.AppError) {
 	startTime := timePkg.Now()
 	_returnsA, _returnsB := api.apiImpl.GetUserStatus(userID)

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -2188,6 +2188,61 @@ func (s *hooksRPCServer) DraftWillBeUpserted(args *Z_DraftWillBeUpsertedArgs, re
 	return nil
 }
 
+func init() {
+	hookNameToId["UserWillBeUpdated"] = UserWillBeUpdatedID
+}
+
+type Z_UserWillBeUpdatedArgs struct {
+	A *Context
+	B *model.User
+	C *model.User
+}
+
+type Z_UserWillBeUpdatedReturns struct {
+	A *model.User
+	B string
+}
+
+func (g *hooksRPCClient) UserWillBeUpdated(c *Context, newUser, oldUser *model.User) (*model.User, string) {
+	_args := &Z_UserWillBeUpdatedArgs{c, newUser, oldUser}
+	_returns := &Z_UserWillBeUpdatedReturns{}
+	if g.implemented[UserWillBeUpdatedID] {
+		if err := g.client.Call("Plugin.UserWillBeUpdated", _args, _returns); err != nil {
+			g.log.Error("RPC call UserWillBeUpdated to plugin failed.", mlog.Err(err))
+		}
+	}
+	return _returns.A, _returns.B
+}
+
+// UserWillBeUpdatedWithRPCErr returns the same values as UserWillBeUpdated, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) UserWillBeUpdatedWithRPCErr(c *Context, newUser, oldUser *model.User) (*model.User, string, error) {
+	_args := &Z_UserWillBeUpdatedArgs{c, newUser, oldUser}
+	_returns := &Z_UserWillBeUpdatedReturns{}
+	var _err error
+	if g.implemented[UserWillBeUpdatedID] {
+		_err = g.client.Call("Plugin.UserWillBeUpdated", _args, _returns)
+		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksWithRPCErrGenerated contract).
+			_returns = &Z_UserWillBeUpdatedReturns{}
+			g.log.Debug("RPC call UserWillBeUpdated to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _returns.B, _err
+}
+
+func (s *hooksRPCServer) UserWillBeUpdated(args *Z_UserWillBeUpdatedArgs, returns *Z_UserWillBeUpdatedReturns) error {
+	if hook, ok := s.impl.(interface {
+		UserWillBeUpdated(c *Context, newUser, oldUser *model.User) (*model.User, string)
+	}); ok {
+		returns.A, returns.B = hook.UserWillBeUpdated(args.A, args.B, args.C)
+	} else {
+		return encodableError(fmt.Errorf("Hook UserWillBeUpdated called but not implemented."))
+	}
+	return nil
+}
+
 // HooksWithRPCErrGenerated provides a WithRPCErr variant for every generated hook. The last error return
 // is always the RPC transport error — if non-nil, the plugin's other return values are zero. For
 // hooks whose base signature already returns error, the tuple is (originalReturns..., rpcErr)
@@ -2280,6 +2335,8 @@ type HooksWithRPCErrGenerated interface {
 	ScheduledPostWillBeCreatedWithRPCErr(c *Context, scheduledPost *model.ScheduledPost) (*model.ScheduledPost, string, error)
 
 	DraftWillBeUpsertedWithRPCErr(c *Context, draft *model.Draft) (*model.Draft, string, error)
+
+	UserWillBeUpdatedWithRPCErr(c *Context, newUser, oldUser *model.User) (*model.User, string, error)
 }
 
 type Z_RegisterCommandArgs struct {
@@ -3363,6 +3420,36 @@ func (s *apiRPCServer) UpdateUser(args *Z_UpdateUserArgs, returns *Z_UpdateUserR
 		returns.A, returns.B = hook.UpdateUser(args.A)
 	} else {
 		return encodableError(fmt.Errorf("API UpdateUser called but not implemented."))
+	}
+	return nil
+}
+
+type Z_CreatePasswordRecoveryTokenArgs struct {
+	A string
+	B string
+}
+
+type Z_CreatePasswordRecoveryTokenReturns struct {
+	A *model.Token
+	B *model.AppError
+}
+
+func (g *apiRPCClient) CreatePasswordRecoveryToken(userID, email string) (*model.Token, *model.AppError) {
+	_args := &Z_CreatePasswordRecoveryTokenArgs{userID, email}
+	_returns := &Z_CreatePasswordRecoveryTokenReturns{}
+	if err := g.client.Call("Plugin.CreatePasswordRecoveryToken", _args, _returns); err != nil {
+		log.Printf("RPC call to CreatePasswordRecoveryToken API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) CreatePasswordRecoveryToken(args *Z_CreatePasswordRecoveryTokenArgs, returns *Z_CreatePasswordRecoveryTokenReturns) error {
+	if hook, ok := s.impl.(interface {
+		CreatePasswordRecoveryToken(userID, email string) (*model.Token, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.CreatePasswordRecoveryToken(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("API CreatePasswordRecoveryToken called but not implemented."))
 	}
 	return nil
 }

--- a/server/public/plugin/hooks.go
+++ b/server/public/plugin/hooks.go
@@ -74,6 +74,7 @@ const (
 	ScheduledPostWillBeCreatedID              = 54
 	DraftWillBeUpsertedID                     = 55
 	MessagesWillBeConsumedWithContextID       = 56
+	UserWillBeUpdatedID                       = 57
 	TotalHooksID                              = iota
 )
 
@@ -521,4 +522,20 @@ type Hooks interface {
 	//
 	// Minimum server version: 11.9
 	DraftWillBeUpserted(c *Context, draft *model.Draft) (*model.Draft, string)
+
+	// UserWillBeUpdated is invoked before a user update is validated and committed, allowing
+	// plugins to modify the user or reject the update.
+	//
+	// To reject the update, return a non-empty string describing why. To modify the user, return
+	// the replacement *model.User and an empty string. To allow the update without modification,
+	// return nil and an empty string.
+	//
+	// Mutations are subject to the same UpdateUser validation as the caller (username uniqueness,
+	// email domain restrictions, etc.). Id and CreateAt are always restored from the stored user.
+	//
+	// Fires from the app-layer UpdateUser path so REST, local API, plugin API, import, and bulk
+	// callers all hit it. Dedicated paths such as UpdateActive / UpdatePassword do not.
+	//
+	// Minimum server version: 11.10
+	UserWillBeUpdated(c *Context, newUser, oldUser *model.User) (*model.User, string)
 }

--- a/server/public/plugin/hooks_timer_layer_generated.go
+++ b/server/public/plugin/hooks_timer_layer_generated.go
@@ -371,6 +371,13 @@ func (hooks *hooksTimerLayer) DraftWillBeUpserted(c *Context, draft *model.Draft
 	return _returnsA, _returnsB
 }
 
+func (hooks *hooksTimerLayer) UserWillBeUpdated(c *Context, newUser, oldUser *model.User) (*model.User, string) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := hooks.hooksImpl.UserWillBeUpdated(c, newUser, oldUser)
+	hooks.recordTime(startTime, "UserWillBeUpdated", true)
+	return _returnsA, _returnsB
+}
+
 func (hooks *hooksTimerLayer) OnDeactivateWithRPCErr() (error, error) {
 	startTime := timePkg.Now()
 	_returnsA, _returnsRPCErr := hooks.hooksWithRPCErrImpl.OnDeactivateWithRPCErr()
@@ -655,5 +662,12 @@ func (hooks *hooksTimerLayer) DraftWillBeUpsertedWithRPCErr(c *Context, draft *m
 	startTime := timePkg.Now()
 	_returnsA, _returnsB, _returnsRPCErr := hooks.hooksWithRPCErrImpl.DraftWillBeUpsertedWithRPCErr(c, draft)
 	hooks.recordTime(startTime, "DraftWillBeUpsertedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsA, _returnsB, _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) UserWillBeUpdatedWithRPCErr(c *Context, newUser, oldUser *model.User) (*model.User, string, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB, _returnsRPCErr := hooks.hooksWithRPCErrImpl.UserWillBeUpdatedWithRPCErr(c, newUser, oldUser)
+	hooks.recordTime(startTime, "UserWillBeUpdatedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsA, _returnsB, _returnsRPCErr
 }

--- a/server/public/plugin/plugintest/api.go
+++ b/server/public/plugin/plugintest/api.go
@@ -412,6 +412,38 @@ func (_m *API) CreateOAuthApp(app *model.OAuthApp) (*model.OAuthApp, *model.AppE
 	return r0, r1
 }
 
+// CreatePasswordRecoveryToken provides a mock function with given fields: userID, email
+func (_m *API) CreatePasswordRecoveryToken(userID string, email string) (*model.Token, *model.AppError) {
+	ret := _m.Called(userID, email)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreatePasswordRecoveryToken")
+	}
+
+	var r0 *model.Token
+	var r1 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, string) (*model.Token, *model.AppError)); ok {
+		return rf(userID, email)
+	}
+	if rf, ok := ret.Get(0).(func(string, string) *model.Token); ok {
+		r0 = rf(userID, email)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Token)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string) *model.AppError); ok {
+		r1 = rf(userID, email)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // CreatePost provides a mock function with given fields: post
 func (_m *API) CreatePost(post *model.Post) (*model.Post, *model.AppError) {
 	ret := _m.Called(post)

--- a/server/public/plugin/plugintest/hooks.go
+++ b/server/public/plugin/plugintest/hooks.go
@@ -840,6 +840,36 @@ func (_m *Hooks) UserHasLoggedIn(c *plugin.Context, user *model.User) {
 	_m.Called(c, user)
 }
 
+// UserWillBeUpdated provides a mock function with given fields: c, newUser, oldUser
+func (_m *Hooks) UserWillBeUpdated(c *plugin.Context, newUser *model.User, oldUser *model.User) (*model.User, string) {
+	ret := _m.Called(c, newUser, oldUser)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UserWillBeUpdated")
+	}
+
+	var r0 *model.User
+	var r1 string
+	if rf, ok := ret.Get(0).(func(*plugin.Context, *model.User, *model.User) (*model.User, string)); ok {
+		return rf(c, newUser, oldUser)
+	}
+	if rf, ok := ret.Get(0).(func(*plugin.Context, *model.User, *model.User) *model.User); ok {
+		r0 = rf(c, newUser, oldUser)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.User)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*plugin.Context, *model.User, *model.User) string); ok {
+		r1 = rf(c, newUser, oldUser)
+	} else {
+		r1 = ret.Get(1).(string)
+	}
+
+	return r0, r1
+}
+
 // UserWillLogIn provides a mock function with given fields: c, user
 func (_m *Hooks) UserWillLogIn(c *plugin.Context, user *model.User) string {
 	ret := _m.Called(c, user)

--- a/server/public/pluginapi/user.go
+++ b/server/public/pluginapi/user.go
@@ -123,6 +123,15 @@ func (u *UserService) Update(user *model.User) error {
 	return nil
 }
 
+// CreatePasswordRecoveryToken creates a password recovery token for the user and
+// invalidates any existing ones. The token value is Token.Token.
+//
+// Minimum server version: 11.10
+func (u *UserService) CreatePasswordRecoveryToken(userID, email string) (*model.Token, error) {
+	token, appErr := u.api.CreatePasswordRecoveryToken(userID, email)
+	return token, normalizeAppErr(appErr)
+}
+
 // Delete deletes a user.
 //
 // Minimum server version: 5.2

--- a/server/public/pluginapi/user.go
+++ b/server/public/pluginapi/user.go
@@ -124,7 +124,8 @@ func (u *UserService) Update(user *model.User) error {
 }
 
 // CreatePasswordRecoveryToken creates a password recovery token for the user and
-// invalidates any existing ones. The token value is Token.Token.
+// invalidates any existing ones. Returns an error if existing tokens cannot be
+// invalidated. The token value is Token.Token.
 //
 // Minimum server version: 11.10
 func (u *UserService) CreatePasswordRecoveryToken(userID, email string) (*model.Token, error) {


### PR DESCRIPTION
#### Summary
Adds a `UserWillBeUpdated` plugin hook invoked from `App.UpdateUser` (via `runUserWillBeUpdated`) before username/email validation, so plugins can reject or mutate profile updates. `Id` and `CreateAt` are always restored from the stored user after plugins run. Also adds a `CreatePasswordRecoveryToken` plugin API (and pluginapi helper) for invite-style flows that need to mint recovery tokens.

#### Release Note
```release-note
Added UserWillBeUpdated plugin hook and CreatePasswordRecoveryToken plugin API.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** The `App.UpdateUser` execution order now includes a new plugin hook prior to key validations, which can alter user update behavior when plugins implement the hook. The password recovery token API/RPC surface was expanded and token invalidation error handling changed to return errors directly, affecting related flows.  
**QA Recommendation:** Run targeted manual smoke tests for user update scenarios with/without plugins and for invite-style password recovery token creation + reset flows; rely on automated tests for broader coverage.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->