### PR TITLE
Fix flaky TestExtractConcurrency

### DIFF
--- a/server/platform/services/docextractor/docextractor_test.go
+++ b/server/platform/services/docextractor/docextractor_test.go
@@ -317,6 +317,30 @@ func (be *blockingExtractor) Extract(filename string, r io.ReadSeeker, _ int64) 
 	return "done", nil
 }
 
+// waitForExtractionSlotsIdle polls until every extraction slot has been
+// released. be.done only signals that the extractor finished; the detached
+// goroutine may still be running defers that release its slot.
+func waitForExtractionSlotsIdle(t *testing.T, limit int) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		acquired := 0
+		for i := 0; i < limit; i++ {
+			if tryAcquireExtractionSlot() {
+				acquired++
+				continue
+			}
+			for j := 0; j < acquired; j++ {
+				releaseExtractionSlot()
+			}
+			return false
+		}
+		for i := 0; i < acquired; i++ {
+			releaseExtractionSlot()
+		}
+		return true
+	}, 2*time.Second, 10*time.Millisecond, "extraction slots did not become idle")
+}
+
 func TestExtractReaderCloserOwnership(t *testing.T) {
 	logger := mlog.CreateConsoleTestLogger(t)
 
@@ -443,7 +467,10 @@ func TestArchiveMaxFileSize(t *testing.T) {
 func TestExtractConcurrency(t *testing.T) {
 	logger := mlog.CreateConsoleTestLogger(t)
 	resetExtractionConcurrencyForTest(1)
-	t.Cleanup(func() { resetExtractionConcurrencyForTest(runtime.NumCPU()) })
+	t.Cleanup(func() {
+		waitForExtractionSlotsIdle(t, 1)
+		resetExtractionConcurrencyForTest(runtime.NumCPU())
+	})
 
 	data := []byte("hello world")
 
@@ -472,11 +499,10 @@ func TestExtractConcurrency(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			require.FailNow(t, "detached extraction did not finish within the deadline")
 		}
+		waitForExtractionSlotsIdle(t, 1)
 	})
 
 	t.Run("a timed-out extraction keeps its slot until the detached goroutine finishes", func(t *testing.T) {
-		resetExtractionConcurrencyForTest(1)
-
 		be := &blockingExtractor{started: make(chan struct{}), release: make(chan struct{}), done: make(chan struct{})}
 		settings := ExtractSettings{Timeout: 50 * time.Millisecond, ReaderCloser: &recordingCloser{}}
 
@@ -500,5 +526,6 @@ func TestExtractConcurrency(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			require.FailNow(t, "detached extraction did not finish within the deadline")
 		}
+		waitForExtractionSlotsIdle(t, 1)
 	})
 }

--- a/server/platform/services/docextractor/docextractor_test.go
+++ b/server/platform/services/docextractor/docextractor_test.go
@@ -324,20 +324,18 @@ func waitForExtractionSlotsIdle(t *testing.T, limit int) {
 	t.Helper()
 	require.Eventually(t, func() bool {
 		acquired := 0
+		ok := true
 		for range limit {
-			if tryAcquireExtractionSlot() {
-				acquired++
-				continue
+			if !tryAcquireExtractionSlot() {
+				ok = false
+				break
 			}
-			for range acquired {
-				releaseExtractionSlot()
-			}
-			return false
+			acquired++
 		}
 		for range acquired {
 			releaseExtractionSlot()
 		}
-		return true
+		return ok
 	}, 2*time.Second, 10*time.Millisecond, "extraction slots did not become idle")
 }
 

--- a/server/platform/services/docextractor/docextractor_test.go
+++ b/server/platform/services/docextractor/docextractor_test.go
@@ -324,17 +324,17 @@ func waitForExtractionSlotsIdle(t *testing.T, limit int) {
 	t.Helper()
 	require.Eventually(t, func() bool {
 		acquired := 0
-		for i := 0; i < limit; i++ {
+		for range limit {
 			if tryAcquireExtractionSlot() {
 				acquired++
 				continue
 			}
-			for j := 0; j < acquired; j++ {
+			for range acquired {
 				releaseExtractionSlot()
 			}
 			return false
 		}
-		for i := 0; i < acquired; i++ {
+		for range acquired {
 			releaseExtractionSlot()
 		}
 		return true


### PR DESCRIPTION
#### Summary
Fix flake in `TestExtractConcurrency` (`platform/services/docextractor`). Tests-only change — no production behavior changes.

**Root cause:** The second subtest called `resetExtractionConcurrencyForTest` while detached extraction goroutines from the first subtest were still running `releaseExtractionSlot` defers, racing on the package-level `extractionSlots` channel. `be.done` only signals that the extractor finished; slot release happens afterward in the detached goroutine.

**Fix:** Added `waitForExtractionSlotsIdle` to poll until all slots are acquirable before advancing between subtests or restoring the default concurrency limit in cleanup. Removed the redundant `resetExtractionConcurrencyForTest(1)` call in the second subtest (the parent already sets limit=1).

**Verification:**
- `go test -run '^TestExtractConcurrency$' -race -count=100 -timeout=20m ./platform/services/docextractor/...` — 100/100 green locally.
- Reverted the fix and re-ran `-race -count=20`; reproduced the data race in the original test.

**Originally introduced in:** 303b0c7 by larkox ([MM-69221] (#37301)).

cc @marianunez

#### Ticket Link
Flaky test reported here: https://github.com/mattermost/mattermost/pull/37526

#### Release Note
```release-note
NONE
```

[MM-69221]: https://mattermost.atlassian.net/browse/MM-69221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The changes are confined to `docextractor_test.go` and only add/adjust test synchronization around a package-level extraction semaphore, without touching production extractor logic. The main risk is timing sensitivity in the test itself, mitigated by polling until slots are confirmed idle before concurrency reset.  
**QA Recommendation:** Manual QA is not required; rely on automated race-enabled test coverage.
  
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->