### PR TITLE
Update Playbooks plugin to v2.11.0 (incl. FIPS)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -160,7 +160,7 @@ PLUGIN_PACKAGES += mattermost-plugin-calls-v1.12.2
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.1
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.1
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.10.0
+PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.11.0
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.2
@@ -176,7 +176,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.10.0%2B090a26d-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.11.0%2B931852a-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.2%2B1305067-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0%2Bd454327-fips
 endif


### PR DESCRIPTION
#### Summary
Update Playbooks plugin to v2.11.0 (FIPS and non-FIPS).

The non-FIPS pin is bumped from v2.10.0 to v2.11.0 in the same commit.

The FIPS build was produced automatically by the [Release Mattermost-Plugins Artifacts pipeline](https://github.com/mattermost/delivery-platform/actions/runs/29458599018) in `delivery-platform`, triggered directly by the `v2.11.0` tag push to `mattermost-plugin-playbooks` (this plugin has `build/fips.mk` on `master`, so FIPS builds run automatically on tag push — no manual CI-trigger branch was needed for this one).

Source commit on the Playbooks repo: [`931852a`](https://github.com/mattermost/mattermost-plugin-playbooks/commit/931852afcca95a44ab57178a80ba45be4bd10dfc).

The signed FIPS bundle is reachable at [https://plugins.releases.mattermost.com/release/mattermost-plugin-playbooks-v2.11.0%2B931852a-fips-linux-amd64.tar.gz](https://plugins.releases.mattermost.com/release/mattermost-plugin-playbooks-v2.11.0%2B931852a-fips-linux-amd64.tar.gz).

This needs to be cherry-picked to the active release branch once merged.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69284

#### Screenshots
--

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change only updates Playbooks package references and FIPS checksums in the Makefile, with no application logic or critical flows affected.  
**QA Recommendation:** Manual QA can be skipped; verify package builds and dependency resolution in CI.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
