### PR TITLE
E2E/Playwright Migrate MM-T5801 to 06

### DIFF
--- a/e2e-tests/playwright/lib/src/ui/components/channels/search_box.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/search_box.ts
@@ -4,6 +4,8 @@
 import type {Locator} from '@playwright/test';
 import {expect} from '@playwright/test';
 
+import SearchTeamSelector from './search_team_selector';
+
 export default class SearchBox {
     readonly container: Locator;
 
@@ -14,6 +16,7 @@ export default class SearchBox {
     readonly selectedSuggestion;
     readonly searchHints;
     readonly clearButton;
+    readonly teamSelector: SearchTeamSelector;
 
     constructor(container: Locator) {
         this.container = container;
@@ -25,6 +28,7 @@ export default class SearchBox {
         this.selectedSuggestion = container.getByTestId('suggestion-selected').getByTestId('suggestion-list__main');
         this.searchHints = container.locator('#searchHints');
         this.clearButton = container.getByTestId('input-clear');
+        this.teamSelector = new SearchTeamSelector(container.getByTestId('searchTeamSelector'));
     }
 
     // clearIfPossible clears the search input if the clear button is visible. Returns true if the clear button was clicked.

--- a/e2e-tests/playwright/lib/src/ui/components/channels/search_results_panel.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/search_results_panel.ts
@@ -4,6 +4,8 @@
 import type {Locator} from '@playwright/test';
 import {expect} from '@playwright/test';
 
+import SearchTeamSelector from './search_team_selector';
+
 /**
  * The right-hand-side panel that renders search results, saved messages, and
  * recent mentions. All three share the `#searchContainer` region.
@@ -11,10 +13,12 @@ import {expect} from '@playwright/test';
 export default class SearchResultsPanel {
     readonly container: Locator;
     readonly filesTab: Locator;
+    readonly teamSelector: SearchTeamSelector;
 
     constructor(container: Locator) {
         this.container = container;
         this.filesTab = container.getByRole('tab', {name: /^Files/});
+        this.teamSelector = new SearchTeamSelector(container.getByTestId('searchResultsTeamSelector'));
     }
 
     async toBeVisible() {

--- a/e2e-tests/playwright/lib/src/ui/components/channels/search_team_selector.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/search_team_selector.ts
@@ -1,0 +1,99 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {Locator} from '@playwright/test';
+import {expect} from '@playwright/test';
+
+/**
+ * The "Select team" dropdown used to scope search to a specific team or "All Teams".
+ * The same underlying menu is rendered both in the search composer and in the search
+ * results panel header — construct with the container scoped to whichever one you need
+ * (they share the `searchTeamsSelectorMenuButton` test id, so an unscoped page-level
+ * locator is ambiguous once both are present in the DOM).
+ */
+export default class SearchTeamSelector {
+    readonly container: Locator;
+    readonly menuButton: Locator;
+
+    constructor(container: Locator) {
+        this.container = container;
+        this.menuButton = container.getByTestId('searchTeamsSelectorMenuButton');
+    }
+
+    async toBeVisible() {
+        await expect(this.container).toBeVisible();
+    }
+
+    async notToBeVisible() {
+        await expect(this.container).not.toBeVisible();
+    }
+
+    /**
+     * The dropdown menu. Only present in the DOM while open.
+     */
+    get menu(): Locator {
+        return this.container.page().getByRole('menu', {name: 'Select team'});
+    }
+
+    /**
+     * Opens the dropdown and returns the menu locator.
+     */
+    async open() {
+        await this.menuButton.click();
+        await expect(this.menu).toBeVisible();
+        return this.menu;
+    }
+
+    /**
+     * A specific team's option in the dropdown, by display name. Pass "All Teams" for the all-teams option.
+     */
+    teamOption(displayName: string): Locator {
+        return this.menu.getByRole('menuitemradio', {name: displayName});
+    }
+
+    /**
+     * Opens the dropdown and selects the given team by display name.
+     */
+    async selectTeam(displayName: string) {
+        await this.open();
+        await this.teamOption(displayName).click();
+    }
+
+    /**
+     * Opens the dropdown and selects "All Teams".
+     */
+    async selectAllTeams() {
+        await this.selectTeam('All Teams');
+    }
+
+    /**
+     * The "Search teams" filter input. Only rendered once the user belongs to more than 4 teams.
+     */
+    get filterInput(): Locator {
+        return this.menu.getByLabel('Search teams');
+    }
+
+    async filterBy(text: string) {
+        await this.filterInput.fill(text);
+    }
+
+    /**
+     * The "Your teams" section header. Only rendered when a specific team (not "All Teams")
+     * is selected, and only when the user belongs to more than 4 teams.
+     *
+     * Uses a text locator rather than `getByRole('separator', {name: ...})`: per the ARIA spec,
+     * the `separator` role doesn't support "name from content" (only `aria-label`), so the role
+     * has no accessible name here and a role+name locator would never match despite the text
+     * being visibly present.
+     */
+    get yourTeamsHeader(): Locator {
+        return this.menu.getByText('Your teams');
+    }
+
+    /**
+     * Closes the dropdown by clicking outside of it, without changing the current selection.
+     */
+    async close() {
+        await this.container.page().click('body', {position: {x: 0, y: 0}});
+    }
+}

--- a/e2e-tests/playwright/lib/src/ui/components/channels/search_team_selector.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/search_team_selector.ts
@@ -91,9 +91,9 @@ export default class SearchTeamSelector {
     }
 
     /**
-     * Closes the dropdown by clicking outside of it, without changing the current selection.
+     * Closes the dropdown by pressing Escape, without changing the current selection.
      */
     async close() {
-        await this.container.page().click('body', {position: {x: 0, y: 0}});
+        await this.container.page().keyboard.press('Escape');
     }
 }

--- a/e2e-tests/playwright/lib/src/ui/pages/channels.ts
+++ b/e2e-tests/playwright/lib/src/ui/pages/channels.ts
@@ -397,6 +397,16 @@ export default class ChannelsPage {
     }
 
     /**
+     * Switches to the given team and leaves it via the team menu, confirming the modal.
+     */
+    async leaveTeam(teamName: string) {
+        await this.switchToTeam(teamName);
+        await this.sidebarLeft.teamMenuButton.click();
+        await this.teamMenu.clickLeaveTeam();
+        await this.leaveTeamModal.confirm();
+    }
+
+    /**
      * Logs the current user out via the user account menu.
      */
     async logout() {

--- a/e2e-tests/playwright/specs/functional/channels/search/cross_team_search.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/search/cross_team_search.spec.ts
@@ -1,0 +1,174 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {Team} from '@mattermost/types/teams';
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+/**
+ * @objective Verify cross-team search still renders the team selector and returns results correctly
+ * when the Onyx (dark) theme is active.
+ */
+test('MM-T5806 cross-team search works under the Onyx (dark) theme', {tag: '@search'}, async ({pw}) => {
+    // # Create a user with two teams and post a message to search for
+    const {adminClient, team, user} = await pw.initSetup();
+    const secondTeam = await adminClient.createTeam(await pw.random.team('team', 'Team', 'O', true));
+    await adminClient.addUsersToTeam(secondTeam.id, [user.id]);
+
+    const message = 'this is a test post containing the word pineapple';
+    const channel = await adminClient.getChannelByName(team.id, 'town-square');
+    await adminClient.createPost({channel_id: channel.id, message});
+
+    // # Log in and switch to the Onyx (dark) theme
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto(team.name);
+    await channelsPage.toBeVisible();
+
+    const settingsModal = await channelsPage.openSettings();
+    const displaySettings = await settingsModal.openDisplayTab();
+    await displaySettings.selectPremadeTheme('Onyx');
+    await settingsModal.close();
+
+    // # Search for the message across teams
+    await channelsPage.searchFor('pineapple');
+
+    // * Verify the team selector and search results render correctly under the dark theme
+    await channelsPage.searchResultsPanel.teamSelector.toBeVisible();
+    await channelsPage.searchResultsPanel.toContainText(message);
+});
+
+/**
+ * @objective Verify the team filter in the search team-selector menu shows no results for a
+ * non-matching query, and correctly narrows to a single team for a partial matching query.
+ */
+test('MM-T5805 team filter shows no results for a non-matching query', {tag: '@search'}, async ({pw}) => {
+    // # Create a user and enough teams (5 total) for the team-filter input to render
+    // (see team_selector.spec.ts: the filter only shows with more than 4 teams)
+    const {adminClient, team, user} = await pw.initSetup();
+
+    const extraTeams: Record<string, Team> = {};
+    for (const fruit of ['Apple', 'Banana', 'Peach', 'Grape']) {
+        const newTeam = await adminClient.createTeam(await pw.random.team(fruit.toLowerCase(), fruit, 'O', true));
+        await adminClient.addUsersToTeam(newTeam.id, [user.id]);
+        extraTeams[fruit] = newTeam;
+    }
+
+    // # Log in, open search, and open the team selector
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto(team.name);
+    await channelsPage.toBeVisible();
+    await channelsPage.globalHeader.openSearch();
+
+    const teamSelector = channelsPage.searchBox.teamSelector;
+    await teamSelector.open();
+    await expect(teamSelector.filterInput).toBeVisible();
+
+    // # Filter by a string that matches no team
+    await teamSelector.filterBy('Rhino');
+
+    // * Verify none of the fruit teams match, but the current team is still shown (current team is always visible)
+    for (const fruit of Object.keys(extraTeams)) {
+        await expect(teamSelector.teamOption(extraTeams[fruit].display_name)).not.toBeVisible();
+    }
+    await expect(teamSelector.teamOption(team.display_name)).toBeVisible();
+
+    // # Filter by a partial string that matches exactly one team
+    await teamSelector.filterBy('Banana');
+
+    // * Verify only the matching team (plus the always-visible current team) is shown
+    await expect(teamSelector.teamOption(extraTeams.Banana.display_name)).toBeVisible();
+    await expect(teamSelector.teamOption(team.display_name)).toBeVisible();
+    for (const fruit of ['Apple', 'Peach', 'Grape']) {
+        await expect(teamSelector.teamOption(extraTeams[fruit].display_name)).not.toBeVisible();
+    }
+});
+
+/**
+ * @objective Verify the search team-selector defaults to the active team (not "All Teams"), that a
+ * typed query persists across team-selector changes, and that the "Your teams" section header in
+ * the dropdown only appears while a specific team (not "All Teams") is selected.
+ */
+test(
+    'MM-T5801 team selector defaults to the active team, preserves the query, and hides "Your teams" for All Teams',
+    {tag: '@search'},
+    async ({pw}) => {
+        // # Create a user and 4 more teams (5 total) so the "Your teams" section renders
+        // (see team_selector.spec.ts: the filter/section only shows with more than 4 teams)
+        const {adminClient, team, user} = await pw.initSetup();
+
+        const teams = [team];
+        for (let i = 0; i < 4; i++) {
+            const newTeam = await adminClient.createTeam(await pw.random.team('team', 'Team', 'O', true));
+            await adminClient.addUsersToTeam(newTeam.id, [user.id]);
+            teams.push(newTeam);
+        }
+        const secondTeam = teams[1];
+
+        const {channelsPage} = await pw.testBrowser.login(user);
+        await channelsPage.goto(team.name);
+        await channelsPage.toBeVisible();
+        await channelsPage.globalHeader.openSearch();
+
+        const teamSelector = channelsPage.searchBox.teamSelector;
+
+        // * Verify the selector defaults to the currently active team, not "All Teams"
+        await expect(teamSelector.menuButton).toContainText(team.display_name);
+
+        // # Type a query without submitting, then switch the team selector to a different team
+        await channelsPage.searchBox.searchInput.fill('pineapple');
+        await teamSelector.selectTeam(secondTeam.display_name);
+
+        // * Verify the button label updated and the query text was preserved
+        await expect(teamSelector.menuButton).toContainText(secondTeam.display_name);
+        await expect(channelsPage.searchBox.searchInput).toHaveValue('pineapple');
+
+        // * Verify the "Your teams" section header is shown while a specific team is selected
+        await teamSelector.open();
+        await expect(teamSelector.yourTeamsHeader).toBeVisible();
+
+        // # Switch to "All Teams" (the menu is already open from the check above)
+        await teamSelector.teamOption('All Teams').click();
+
+        // * Verify the "Your teams" section header is hidden once "All Teams" is selected
+        await teamSelector.open();
+        await expect(teamSelector.yourTeamsHeader).not.toBeVisible();
+    },
+);
+
+/**
+ * @objective Verify the "in:" channel filter is cleared from the search query when the team
+ * selector is switched to "All Teams", since the filter only makes sense within a single team.
+ *
+ * @knownIssue Switching the team selector to "All Teams" does NOT clear the "in:<channel>" clause
+ * from the query text — it's left in place, and submitting silently re-scopes the search back to
+ * the channel's own team rather than actually searching "All Teams".
+ */
+test.fixme(
+    'MM-T5804 "in:" channel filter is cleared when switching search to All Teams',
+    {tag: '@search'},
+    async ({pw}) => {
+        // # Create a user with a second team so "All Teams" is a real, distinct selector choice
+        const {adminClient, team, user} = await pw.initSetup();
+        const secondTeam = await adminClient.createTeam(await pw.random.team('team', 'Team', 'O', true));
+        await adminClient.addUsersToTeam(secondTeam.id, [user.id]);
+        const channel = await adminClient.getChannelByName(team.id, 'town-square');
+
+        const {channelsPage} = await pw.testBrowser.login(user);
+        await channelsPage.goto(team.name, channel.name);
+        await channelsPage.toBeVisible();
+        await channelsPage.globalHeader.openSearch();
+
+        // # Type "in:" and pick the channel from the autocomplete suggestion
+        const {searchInput} = channelsPage.searchBox;
+        await searchInput.fill('in:');
+        await searchInput.pressSequentially(channel.name);
+        await channelsPage.searchBox.container.getByText(channel.display_name, {exact: false}).first().click();
+        await expect(searchInput).toHaveValue(`in:${channel.name} `);
+
+        // # Switch the team selector to "All Teams"
+        await channelsPage.searchBox.teamSelector.selectAllTeams();
+
+        // * Verify the "in:" clause was cleared, since it's meaningless once scoped to All Teams
+        await expect(searchInput).not.toHaveValue(new RegExp(`in:${channel.name}`));
+    },
+);

--- a/e2e-tests/playwright/specs/functional/channels/search/team_selector.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/search/team_selector.spec.ts
@@ -197,10 +197,7 @@ test('MM-T5802 team filter list updates when a team is left', async ({pw}) => {
     // # Close the menu, then switch to and leave one of the extra teams
     await teamSelector.close();
     const teamToLeave = teams[teams.length - 1];
-    await channelsPage.switchToTeam(teamToLeave.name);
-    await channelsPage.sidebarLeft.teamMenuButton.click();
-    await channelsPage.teamMenu.clickLeaveTeam();
-    await channelsPage.leaveTeamModal.confirm();
+    await channelsPage.leaveTeam(teamToLeave.name);
 
     // # Reopen search and the team selector
     await channelsPage.toBeVisible();
@@ -259,10 +256,7 @@ test('MM-T5803 search results narrow to the selected team and update after leavi
     await expect(channelsPage.searchResultsPanel.container).not.toContainText(messageInFirstTeam);
 
     // # Leave the second team and re-run the same search
-    await channelsPage.switchToTeam(secondTeam.name);
-    await channelsPage.sidebarLeft.teamMenuButton.click();
-    await channelsPage.teamMenu.clickLeaveTeam();
-    await channelsPage.leaveTeamModal.confirm();
+    await channelsPage.leaveTeam(secondTeam.name);
     await channelsPage.toBeVisible();
     await channelsPage.searchFor('pineapple');
 

--- a/e2e-tests/playwright/specs/functional/channels/search/team_selector.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/search/team_selector.spec.ts
@@ -34,21 +34,15 @@ test('team selector should not be visible if user belongs to only one team', asy
     await channelsPage.globalHeader.openSearch();
 
     // * Verify that the team selector is not visible in the search box
-    const page = channelsPage.page;
-
-    // Make sure the search box is open but doesn't have a team selector
-    await expect(page.locator('#searchBox')).toBeVisible();
-    await expect(page.getByTestId('searchTeamSelector')).not.toBeVisible();
+    await channelsPage.searchBox.toBeVisible();
+    await channelsPage.searchBox.teamSelector.notToBeVisible();
 
     // # Now search for the message to see search results
-    await page.locator('#searchBox input').fill(message);
-    await page.keyboard.press('Enter');
-
-    // # Wait for search results to load
-    await expect(page.locator('#searchContainer')).toBeVisible();
+    await channelsPage.searchBox.search(message);
+    await channelsPage.searchResultsPanel.toBeVisible();
 
     // * Verify the team selector is not visible in search results panel
-    await expect(page.locator('.team-selector-container')).not.toBeVisible();
+    await channelsPage.searchResultsPanel.teamSelector.notToBeVisible();
 });
 
 test('team selector should be visible if user belongs to multiple teams', async ({pw}) => {
@@ -86,42 +80,34 @@ test('team selector should be visible if user belongs to multiple teams', async 
     await channelsPage.globalHeader.openSearch();
 
     // * Verify that the team selector is visible in the search box
-    const page = channelsPage.page;
-
-    // Make sure the search box is open and has a team selector
-    await expect(page.locator('#searchBox')).toBeVisible();
-    await expect(page.getByTestId('searchTeamSelector')).toBeVisible();
+    await channelsPage.searchBox.toBeVisible();
+    const composerTeamSelector = channelsPage.searchBox.teamSelector;
+    await composerTeamSelector.toBeVisible();
 
     // # Click on the team selector button
-    await page.getByTestId('searchTeamsSelectorMenuButton').click();
+    await composerTeamSelector.open();
 
     // * Verify that both teams are visible in the menu
-    const teamSelector = page.getByRole('menu', {name: 'Select team'});
-    await expect(teamSelector).toBeVisible();
-    await expect(teamSelector.getByText(team.display_name)).toBeVisible();
-    await expect(teamSelector.getByText(secondTeam.display_name)).toBeVisible();
-    await expect(teamSelector.getByText('All teams')).toBeVisible();
+    await expect(composerTeamSelector.teamOption(team.display_name)).toBeVisible();
+    await expect(composerTeamSelector.teamOption(secondTeam.display_name)).toBeVisible();
+    await expect(composerTeamSelector.teamOption('All Teams')).toBeVisible();
 
     // # Now search for the message to see search results
-    await page.click('body', {position: {x: 0, y: 0}}); // Click away to close team selector
-    await page.locator('#searchBox input').fill(message);
-    await page.keyboard.press('Enter');
-
-    // # Wait for search results to load
-    await expect(page.locator('#searchContainer')).toBeVisible();
+    await composerTeamSelector.close();
+    await channelsPage.searchBox.search(message);
+    await channelsPage.searchResultsPanel.toBeVisible();
 
     // * Verify the team selector is visible in search results panel
-    await expect(page.locator('.team-selector-container')).toBeVisible();
+    const resultsTeamSelector = channelsPage.searchResultsPanel.teamSelector;
+    await resultsTeamSelector.toBeVisible();
 
     // # Click on the team selector in results panel
-    await page.locator('.team-selector-container .search-teams-selector-menu-button').click();
+    await resultsTeamSelector.open();
 
     // * Verify that both teams are visible in the results panel team selector
-    const resultsTeamSelector = page.getByRole('menu', {name: 'Select team'});
-    await expect(resultsTeamSelector).toBeVisible();
-    await expect(resultsTeamSelector.getByText(team.display_name)).toBeVisible();
-    await expect(resultsTeamSelector.getByText(secondTeam.display_name)).toBeVisible();
-    await expect(resultsTeamSelector.getByText('All teams')).toBeVisible();
+    await expect(resultsTeamSelector.teamOption(team.display_name)).toBeVisible();
+    await expect(resultsTeamSelector.teamOption(secondTeam.display_name)).toBeVisible();
+    await expect(resultsTeamSelector.teamOption('All Teams')).toBeVisible();
 });
 
 test('team selector should show filter input with more than 4 teams', async ({pw}) => {
@@ -147,40 +133,140 @@ test('team selector should show filter input with more than 4 teams', async ({pw
     await channelsPage.globalHeader.openSearch();
 
     // # Verify team selector is visible and click on it
-    const page = channelsPage.page;
-    await expect(page.getByTestId('searchTeamSelector')).toBeVisible();
-    await page.getByTestId('searchTeamsSelectorMenuButton').click();
+    const teamSelector = channelsPage.searchBox.teamSelector;
+    await teamSelector.toBeVisible();
+    await teamSelector.open();
 
     // # Verify the team filter input is visible with 5 teams
-    const teamSelector = page.getByRole('menu', {name: 'Select team'});
-    await expect(teamSelector).toBeVisible();
-    await expect(teamSelector.getByLabel('Search teams')).toBeVisible();
+    await expect(teamSelector.filterInput).toBeVisible();
 
     // # Verify all teams are visible initially
     for (const t of teams) {
-        await expect(teamSelector.getByText(t.display_name)).toBeVisible();
+        await expect(teamSelector.teamOption(t.display_name)).toBeVisible();
     }
 
     // # Type filter text to match only one team
-    await teamSelector.getByLabel('Search teams').fill(teams[2].display_name);
+    await teamSelector.filterBy(teams[2].display_name);
 
     // # Verify only the matching team is visible (and the currently selected team)
-    await expect(teamSelector.getByText(teams[0].display_name)).toBeVisible(); // Current team always visible
-    await expect(teamSelector.getByText(teams[2].display_name)).toBeVisible(); // Filtered team
+    await expect(teamSelector.teamOption(teams[0].display_name)).toBeVisible(); // Current team always visible
+    await expect(teamSelector.teamOption(teams[2].display_name)).toBeVisible(); // Filtered team
 
     // # Verify other teams are hidden
     for (let i = 1; i < teams.length; i++) {
         if (i !== 2) {
             // Skip the filtered team we're expecting to see
-            await expect(teamSelector.getByText(teams[i].display_name)).not.toBeVisible();
+            await expect(teamSelector.teamOption(teams[i].display_name)).not.toBeVisible();
         }
     }
 
     // # Clear the filter
-    await teamSelector.getByLabel('Search teams').fill('');
+    await teamSelector.filterBy('');
 
     // # Verify all teams are visible again
     for (const t of teams) {
-        await expect(teamSelector.getByText(t.display_name)).toBeVisible();
+        await expect(teamSelector.teamOption(t.display_name)).toBeVisible();
     }
+});
+
+test('MM-T5802 team filter list updates when a team is left', async ({pw}) => {
+    // # Create a user and 4 more teams (5 total) so the team-filter input renders
+    const {adminClient, team, user} = await pw.initSetup();
+
+    const teams = [team];
+    for (let i = 0; i < 4; i++) {
+        const newTeam = await adminClient.createTeam(await pw.random.team('team', 'Team', 'O', true));
+        await adminClient.addUsersToTeam(newTeam.id, [user.id]);
+        teams.push(newTeam);
+    }
+
+    // # Log in as the user and open the team selector
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto(team.name);
+    await channelsPage.toBeVisible();
+    await channelsPage.globalHeader.openSearch();
+
+    const teamSelector = channelsPage.searchBox.teamSelector;
+    await teamSelector.open();
+
+    // * Verify all 5 teams are listed initially
+    for (const t of teams) {
+        await expect(teamSelector.teamOption(t.display_name)).toBeVisible();
+    }
+
+    // # Close the menu, then switch to and leave one of the extra teams
+    await teamSelector.close();
+    const teamToLeave = teams[teams.length - 1];
+    await channelsPage.switchToTeam(teamToLeave.name);
+    await channelsPage.sidebarLeft.teamMenuButton.click();
+    await channelsPage.teamMenu.clickLeaveTeam();
+    await channelsPage.leaveTeamModal.confirm();
+
+    // # Reopen search and the team selector
+    await channelsPage.toBeVisible();
+    await channelsPage.globalHeader.openSearch();
+    await teamSelector.open();
+
+    // * Verify the left team no longer appears in the filter list
+    await expect(teamSelector.teamOption(teamToLeave.display_name)).not.toBeVisible();
+
+    // * Verify the remaining teams are still listed
+    for (const t of teams.slice(0, -1)) {
+        await expect(teamSelector.teamOption(t.display_name)).toBeVisible();
+    }
+});
+
+test('MM-T5803 search results narrow to the selected team and update after leaving that team', async ({pw}) => {
+    // # Create a user with two teams, each containing a distinct message
+    const {adminClient, team, user} = await pw.initSetup();
+    const secondTeam = await adminClient.createTeam(await pw.random.team('team', 'Team', 'O', true));
+    await adminClient.addUsersToTeam(secondTeam.id, [user.id]);
+
+    const messageInFirstTeam = 'pineapple message in the first team';
+    const messageInSecondTeam = 'pineapple message in the second team';
+    const firstChannel = await adminClient.getChannelByName(team.id, 'town-square');
+    const secondChannel = await adminClient.getChannelByName(secondTeam.id, 'town-square');
+    await adminClient.createPost({channel_id: firstChannel.id, message: messageInFirstTeam});
+    await adminClient.createPost({channel_id: secondChannel.id, message: messageInSecondTeam});
+
+    // # Log in, open search, and explicitly select "All Teams"
+    // (the selector defaults to the currently active team, not "All Teams", on a fresh open)
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto(team.name);
+    await channelsPage.toBeVisible();
+    await channelsPage.globalHeader.openSearch();
+
+    const composerTeamSelector = channelsPage.searchBox.teamSelector;
+    await composerTeamSelector.selectAllTeams();
+    await channelsPage.searchBox.search('pineapple');
+
+    // * Verify both teams' messages show up
+    await channelsPage.searchResultsPanel.toContainText(messageInFirstTeam);
+    await channelsPage.searchResultsPanel.toContainText(messageInSecondTeam);
+
+    // # Reopen the search composer and narrow its team selector to the second team specifically
+    // (changing the team via the results panel's own selector updates state but does not refresh
+    // the displayed results — the search must be resubmitted via the composer, as below)
+    await channelsPage.globalHeader.openSearch();
+    await composerTeamSelector.selectTeam(secondTeam.display_name);
+
+    // # Re-submit the search now that the composer is scoped to the second team
+    await channelsPage.searchBox.searchInput.click();
+    await channelsPage.searchBox.searchInput.press('Enter');
+
+    // * Verify only the second team's message shows
+    await expect(channelsPage.searchResultsPanel.container).toContainText(messageInSecondTeam);
+    await expect(channelsPage.searchResultsPanel.container).not.toContainText(messageInFirstTeam);
+
+    // # Leave the second team and re-run the same search
+    await channelsPage.switchToTeam(secondTeam.name);
+    await channelsPage.sidebarLeft.teamMenuButton.click();
+    await channelsPage.teamMenu.clickLeaveTeam();
+    await channelsPage.leaveTeamModal.confirm();
+    await channelsPage.toBeVisible();
+    await channelsPage.searchFor('pineapple');
+
+    // * Verify only the first team's message shows now that the second team was left
+    await expect(channelsPage.searchResultsPanel.container).toContainText(messageInFirstTeam);
+    await expect(channelsPage.searchResultsPanel.container).not.toContainText(messageInSecondTeam);
 });

--- a/webapp/channels/src/components/search_results/messages_or_files_selector.tsx
+++ b/webapp/channels/src/components/search_results/messages_or_files_selector.tsx
@@ -135,7 +135,10 @@ export default function MessagesOrFilesSelector(props: Props): JSX.Element {
                 )}
             </div>
             {props.crossTeamSearchEnabled && hasMoreThanOneTeam && (
-                <div className='team-selector-container'>
+                <div
+                    className='team-selector-container'
+                    data-testid='searchResultsTeamSelector'
+                >
                     <SelectTeam
                         selectedTeamId={searchTeam}
                         onTeamSelected={props.onTeamChange}


### PR DESCRIPTION
#### Summary
Migrate tests MM-T5801 to 06

Note: MM-T5804 has a known issue. Added `fixme` 

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Production UI behavior is not modified—changes are limited to Playwright test/helpers and a `data-testid` addition. The main risk is Playwright selector/test stability, with one known behavior left unresolved via the existing `test.fixme`.  
**QA Recommendation:** Manual QA can be skipped; rely on the expanded automated Playwright coverage and validate CI stability around the marked fixme.
  
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->