### PR TITLE
E2E/Playwright Migrate T1434, T4023 and T1987

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/messaging/emoji_recently_used_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/emoji_recently_used_spec.js
@@ -205,6 +205,11 @@ describe('Messaging', () => {
             cy.uiSaveAndClose();
         });
 
+        // # Ensure the Settings modal is fully closed before navigating to Global Threads.
+        // Otherwise the closing modal races with the Threads navigation and the sidebar helper
+        // mistakes it for a tutorial modal.
+        cy.get('#accountSettingsModal').should('not.exist');
+
         // # Post a root message and a reply so a followed thread exists
         cy.apiGetChannelByName(testTeam.name, 'off-topic').then(({channel}) => {
             cy.apiCreatePost(channel.id, 'Root post for Global Threads emoji test', '', {}).then((rootResp) => {

--- a/e2e-tests/playwright/lib/src/ui/components/channels/marketplace_modal.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/marketplace_modal.ts
@@ -4,6 +4,8 @@
 import type {Locator} from '@playwright/test';
 import {expect} from '@playwright/test';
 
+import {duration} from '@/util';
+
 export default class MarketplaceModal {
     readonly container: Locator;
 
@@ -25,5 +27,46 @@ export default class MarketplaceModal {
 
     async close() {
         await this.closeButton.click();
+    }
+
+    /**
+     * Locates a plugin's row by its manifest id (e.g. "com.mattermost.plugin-channel-export").
+     * Uses an attribute-equals selector rather than a `#id` locator since manifest ids contain
+     * dots, which have special meaning in compound CSS id selectors.
+     */
+    pluginRow(pluginId: string): Locator {
+        return this.container.locator(`[id="marketplace-plugin-${pluginId}"]`);
+    }
+
+    /**
+     * Installs the first plugin in the list that isn't already installed (i.e. still shows an
+     * "Install" button, as opposed to "Configure"), and waits for its button to flip to
+     * "Configure". Returns the installed plugin's manifest id.
+     */
+    async installFirstAvailablePlugin(): Promise<string> {
+        const installButton = this.container.getByRole('button', {name: 'Install', exact: true}).first();
+        await expect(installButton).toBeVisible();
+
+        const pluginId = await installButton.evaluate((el) => {
+            const row = el.closest('[id^="marketplace-plugin-"]');
+            return row ? row.id.replace('marketplace-plugin-', '') : null;
+        });
+        if (!pluginId) {
+            throw new Error('Could not determine the plugin id for the first available "Install" button');
+        }
+
+        await installButton.click();
+        await expect(this.pluginRow(pluginId).getByRole('button', {name: 'Configure'})).toBeVisible({
+            timeout: duration.one_min,
+        });
+
+        return pluginId;
+    }
+
+    /**
+     * Clicks "Configure" for the given plugin, which navigates to its System Console settings page.
+     */
+    async clickConfigure(pluginId: string) {
+        await this.pluginRow(pluginId).getByRole('button', {name: 'Configure'}).click();
     }
 }

--- a/e2e-tests/playwright/lib/src/ui/components/channels/post_create.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/post_create.ts
@@ -221,4 +221,47 @@ export default class ChannelsPostCreate {
     async isBurnOnReadEnabled(): Promise<boolean> {
         return this.burnOnReadLabel.isVisible();
     }
+
+    /**
+     * Simulates pasting HTML (with a plain-text fallback) into the input, exercising Mattermost's
+     * own paste-formatting logic (e.g. an HTML table auto-converting to a markdown table) rather
+     * than just typing raw text.
+     *
+     * Dispatches a synthetic ClipboardEvent directly on the input: Playwright/CDP can't write
+     * arbitrary HTML to the real OS clipboard and have a genuinely OS-triggered paste read it back
+     * deterministically in CI, so this mirrors the technique this codebase's own unit tests use
+     * (`utils/paste.test.tsx`), just exercised through the real running app instead of a mock.
+     *
+     * When `withoutFormatting` is true, a Ctrl+Shift+V keydown is dispatched first to set the
+     * app's internal `isNonFormattedPaste` flag (see `advanced_text_editor/use_key_handler.tsx`),
+     * which makes the app's paste handler step aside instead of auto-converting the HTML.
+     */
+    async pasteHtml(html: string, plainText: string, {withoutFormatting = false}: {withoutFormatting?: boolean} = {}) {
+        await expect(this.input).toBeVisible();
+        await this.input.focus();
+
+        await this.input.evaluate(
+            (el, {html, plainText, withoutFormatting}) => {
+                if (withoutFormatting) {
+                    el.dispatchEvent(
+                        new KeyboardEvent('keydown', {
+                            key: 'v',
+                            ctrlKey: true,
+                            shiftKey: true,
+                            bubbles: true,
+                            cancelable: true,
+                        }),
+                    );
+                }
+
+                const dataTransfer = new DataTransfer();
+                dataTransfer.setData('text/html', html);
+                dataTransfer.setData('text/plain', plainText);
+                el.dispatchEvent(
+                    new ClipboardEvent('paste', {clipboardData: dataTransfer, bubbles: true, cancelable: true}),
+                );
+            },
+            {html, plainText, withoutFormatting},
+        );
+    }
 }

--- a/e2e-tests/playwright/lib/src/ui/components/channels/post_create.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/post_create.ts
@@ -235,6 +235,10 @@ export default class ChannelsPostCreate {
      * When `withoutFormatting` is true, a Ctrl+Shift+V keydown is dispatched first to set the
      * app's internal `isNonFormattedPaste` flag (see `advanced_text_editor/use_key_handler.tsx`),
      * which makes the app's paste handler step aside instead of auto-converting the HTML.
+     *
+     * A synthetic (untrusted) paste event never triggers the browser's own default paste, so when
+     * the app steps aside (doesn't call `preventDefault`) the plain-text fallback is inserted here
+     * to mirror what a real, OS-triggered paste would do.
      */
     async pasteHtml(html: string, plainText: string, {withoutFormatting = false}: {withoutFormatting?: boolean} = {}) {
         await expect(this.input).toBeVisible();
@@ -257,9 +261,13 @@ export default class ChannelsPostCreate {
                 const dataTransfer = new DataTransfer();
                 dataTransfer.setData('text/html', html);
                 dataTransfer.setData('text/plain', plainText);
-                el.dispatchEvent(
+                const notCancelled = el.dispatchEvent(
                     new ClipboardEvent('paste', {clipboardData: dataTransfer, bubbles: true, cancelable: true}),
                 );
+
+                if (notCancelled) {
+                    document.execCommand('insertText', false, plainText);
+                }
             },
             {html, plainText, withoutFormatting},
         );

--- a/e2e-tests/playwright/lib/src/ui/components/system_console/sections/plugins/plugin_management.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/system_console/sections/plugins/plugin_management.ts
@@ -1,0 +1,47 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {Locator} from '@playwright/test';
+import {expect} from '@playwright/test';
+
+import {ConfirmModal} from '@/ui/components/system_console/base_modal';
+
+/**
+ * System Console -> Plugins -> Plugin Management
+ */
+export default class PluginManagement {
+    readonly container: Locator;
+
+    constructor(container: Locator) {
+        this.container = container;
+    }
+
+    async toBeVisible() {
+        await expect(this.container.getByText('Plugin Management', {exact: true})).toBeVisible();
+    }
+
+    /**
+     * Locates an installed plugin's row by its manifest id.
+     */
+    pluginRow(pluginId: string): Locator {
+        return this.container.getByTestId(pluginId);
+    }
+
+    async notToHavePlugin(pluginId: string) {
+        await expect(this.pluginRow(pluginId)).not.toBeVisible();
+    }
+
+    /**
+     * Removes the given plugin via its "Remove" control and confirms the "Remove plugin?" dialog.
+     * The Enable/Remove controls in this list aren't real buttons or links (no ARIA role, no href),
+     * so this uses a scoped text locator rather than getByRole.
+     */
+    async removePlugin(pluginId: string) {
+        const row = this.pluginRow(pluginId);
+        await row.getByText('Remove', {exact: true}).click();
+
+        const confirmModal = new ConfirmModal(this.container.page().getByRole('dialog', {name: 'Remove plugin?'}));
+        await confirmModal.toBeVisible();
+        await confirmModal.confirm();
+    }
+}

--- a/e2e-tests/playwright/lib/src/ui/pages/system_console.ts
+++ b/e2e-tests/playwright/lib/src/ui/pages/system_console.ts
@@ -18,6 +18,7 @@ import UsersAndTeams from '@/ui/components/system_console/sections/site_configur
 import BoardAttributes from '@/ui/components/system_console/sections/system_attributes/board_attributes';
 import SystemProperties from '@/ui/components/system_console/sections/system_attributes/system_properties';
 import FeatureDiscovery from '@/ui/components/system_console/sections/system_users/feature_discovery';
+import PluginManagement from '@/ui/components/system_console/sections/plugins/plugin_management';
 
 export default class SystemConsolePage {
     readonly page: Page;
@@ -52,6 +53,9 @@ export default class SystemConsolePage {
 
     // Feature Discovery (license-gated features)
     readonly featureDiscovery: FeatureDiscovery;
+
+    // Plugins
+    readonly pluginManagement: PluginManagement;
 
     constructor(page: Page) {
         this.page = page;
@@ -88,6 +92,9 @@ export default class SystemConsolePage {
 
         // Feature Discovery
         this.featureDiscovery = new FeatureDiscovery(adminConsoleWrapper);
+
+        // Plugins
+        this.pluginManagement = new PluginManagement(adminConsoleWrapper);
     }
 
     async toBeVisible() {
@@ -103,6 +110,11 @@ export default class SystemConsolePage {
     /** Notifications settings URL is environment/notifications (sidebar groups under Site Configuration). */
     async gotoNotificationsSettings() {
         await this.page.goto('/admin_console/environment/notifications');
+        await this.page.waitForLoadState('networkidle');
+    }
+
+    async gotoPluginManagement() {
+        await this.page.goto('/admin_console/plugins/plugin_management');
         await this.page.waitForLoadState('networkidle');
     }
 }

--- a/e2e-tests/playwright/specs/functional/channels/messaging/paste_without_formatting.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/messaging/paste_without_formatting.spec.ts
@@ -29,6 +29,7 @@ test('MM-T1434 pasting with Ctrl/Cmd+Shift+V skips Mattermost paste formatting',
     await input.fill('');
     await postCreate.pasteHtml(html, plainText, {withoutFormatting: true});
 
-    // * Verify Mattermost's paste formatting was skipped this time (no markdown table inserted)
+    // * Verify the plain-text fallback was inserted without markdown table formatting
+    await expect(input).toHaveValue(plainText);
     await expect(input).not.toHaveValue(/\|/);
 });

--- a/e2e-tests/playwright/specs/functional/channels/messaging/paste_without_formatting.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/messaging/paste_without_formatting.spec.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+/**
+ * @objective Verify that pasting with Ctrl/Cmd+Shift+V skips Mattermost's own paste-formatting
+ * logic (e.g. auto-converting a pasted HTML table into markdown table syntax), unlike a normal
+ * paste which applies it.
+ */
+test('MM-T1434 pasting with Ctrl/Cmd+Shift+V skips Mattermost paste formatting', {tag: '@messaging'}, async ({pw}) => {
+    const {user, team} = await pw.initSetup();
+    const {channelsPage} = await pw.testBrowser.login(user);
+    await channelsPage.goto(team.name, 'town-square');
+    await channelsPage.toBeVisible();
+
+    const html = '<table><tr><td>foo</td><td>bar</td></tr></table>';
+    const plainText = 'foo\tbar';
+    const {postCreate} = channelsPage.centerView;
+    const {input} = postCreate;
+
+    // # Paste the HTML table normally
+    await postCreate.pasteHtml(html, plainText);
+
+    // * Verify Mattermost formatted it into markdown table syntax
+    await expect(input).toHaveValue('| foo | bar |\n| --- | --- |\n');
+
+    // # Clear the input, then paste the same HTML table with the "without formatting" flag
+    await input.fill('');
+    await postCreate.pasteHtml(html, plainText, {withoutFormatting: true});
+
+    // * Verify Mattermost's paste formatting was skipped this time (no markdown table inserted)
+    await expect(input).not.toHaveValue(/\|/);
+});

--- a/e2e-tests/playwright/specs/functional/channels/plugin_marketplace/install_configure_remove_plugin.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/plugin_marketplace/install_configure_remove_plugin.spec.ts
@@ -1,0 +1,40 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+/**
+ * @objective Verify a system admin can install a plugin from the Marketplace, configure it
+ * (landing in System Console), then remove it via Plugin Management.
+ */
+test(
+    'MM-T4023 MM-T1987 system admin can install, configure, and remove a plugin from the Marketplace',
+    {tag: '@marketplace'},
+    async ({pw}) => {
+        const {adminUser, team} = await pw.initSetup();
+        const {channelsPage, systemConsolePage} = await pw.testBrowser.login(adminUser);
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        // # Open the App Marketplace and install the first available plugin
+        await channelsPage.globalHeader.openAppMarketplace();
+        const marketplace = channelsPage.marketplaceModal;
+        await marketplace.toBeVisible();
+        const pluginId = await marketplace.installFirstAvailablePlugin();
+
+        // # Click "Configure", which navigates to the plugin's System Console settings page
+        await marketplace.clickConfigure(pluginId);
+        await systemConsolePage.toBeVisible();
+
+        // * Verify System Console opened directly to the installed plugin's settings page
+        expect(systemConsolePage.page.url()).toContain(`/admin_console/plugins/plugin_${pluginId}`);
+
+        // # Navigate to Plugin Management and remove the plugin
+        await systemConsolePage.gotoPluginManagement();
+        await systemConsolePage.pluginManagement.toBeVisible();
+        await systemConsolePage.pluginManagement.removePlugin(pluginId);
+
+        // * Verify the plugin no longer appears in the installed plugins list
+        await systemConsolePage.pluginManagement.notToHavePlugin(pluginId);
+    },
+);


### PR DESCRIPTION
#### Summary
Migrate T1434, T4023 and T1987

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** These updates are limited to end-to-end test code (Playwright page objects/specs and a Cypress test flake fix) and should not affect production runtime behavior. Risk is mainly confined to test stability/maintenance rather than core functionality.  
**QA Recommendation:** Automated E2E coverage should be sufficient; manual QA can be skipped.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->