### PR TITLE
Address CodeRabbit review on cross-team search selector tests

### DIFF
--- a/e2e-tests/playwright/lib/src/ui/components/channels/search_team_selector.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/search_team_selector.ts
@@ -91,9 +91,9 @@ export default class SearchTeamSelector {
     }
 
     /**
-     * Closes the dropdown by clicking outside of it, without changing the current selection.
+     * Closes the dropdown by pressing Escape, without changing the current selection.
      */
     async close() {
-        await this.container.page().click('body', {position: {x: 0, y: 0}});
+        await this.container.page().keyboard.press('Escape');
     }
 }

--- a/e2e-tests/playwright/lib/src/ui/pages/channels.ts
+++ b/e2e-tests/playwright/lib/src/ui/pages/channels.ts
@@ -397,6 +397,16 @@ export default class ChannelsPage {
     }
 
     /**
+     * Switches to the given team and leaves it via the team menu, confirming the modal.
+     */
+    async leaveTeam(teamName: string) {
+        await this.switchToTeam(teamName);
+        await this.sidebarLeft.teamMenuButton.click();
+        await this.teamMenu.clickLeaveTeam();
+        await this.leaveTeamModal.confirm();
+    }
+
+    /**
      * Logs the current user out via the user account menu.
      */
     async logout() {

--- a/e2e-tests/playwright/specs/functional/channels/search/team_selector.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/search/team_selector.spec.ts
@@ -197,10 +197,7 @@ test('MM-T5802 team filter list updates when a team is left', async ({pw}) => {
     // # Close the menu, then switch to and leave one of the extra teams
     await teamSelector.close();
     const teamToLeave = teams[teams.length - 1];
-    await channelsPage.switchToTeam(teamToLeave.name);
-    await channelsPage.sidebarLeft.teamMenuButton.click();
-    await channelsPage.teamMenu.clickLeaveTeam();
-    await channelsPage.leaveTeamModal.confirm();
+    await channelsPage.leaveTeam(teamToLeave.name);
 
     // # Reopen search and the team selector
     await channelsPage.toBeVisible();
@@ -259,10 +256,7 @@ test('MM-T5803 search results narrow to the selected team and update after leavi
     await expect(channelsPage.searchResultsPanel.container).not.toContainText(messageInFirstTeam);
 
     // # Leave the second team and re-run the same search
-    await channelsPage.switchToTeam(secondTeam.name);
-    await channelsPage.sidebarLeft.teamMenuButton.click();
-    await channelsPage.teamMenu.clickLeaveTeam();
-    await channelsPage.leaveTeamModal.confirm();
+    await channelsPage.leaveTeam(secondTeam.name);
     await channelsPage.toBeVisible();
     await channelsPage.searchFor('pineapple');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Addresses the two CodeRabbit nitpicks on #37530:

- `SearchTeamSelector.close()` now dismisses the "Select team" menu by pressing `Escape` instead of clicking a fixed viewport coordinate (`body` at `0,0`), which was fragile if UI shifts into that corner. Verified against `menu.tsx` that the MUI-based menu closes on `escapeKeyDown`.
- Extracted the repeated "switch to team → open team menu → leave team → confirm" sequence (duplicated in MM-T5802 and MM-T5803) into a `ChannelsPage.leaveTeam(teamName)` helper, matching the existing composite-method pattern (`switchToTeam`, `searchFor`).

#### Release Note
```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a1a434d5-4c1f-4874-aee5-499189c42ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a1a434d5-4c1f-4874-aee5-499189c42ff2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

