### PR TITLE
Fix flaky TestExtractConcurrency/a_timed-out_extraction_keeps_its_slot_until_the_detached_goroutine_finishes

### DIFF
--- a/server/platform/services/docextractor/docextractor_test.go
+++ b/server/platform/services/docextractor/docextractor_test.go
@@ -317,6 +317,23 @@ func (be *blockingExtractor) Extract(filename string, r io.ReadSeeker, _ int64) 
 	return "done", nil
 }
 
+// waitForExtractionSlotRelease polls until a detached extraction has released
+// its concurrency slot. be.done fires when the extractor unblocks, but the slot
+// is released in a deferred call that runs only after Extract returns.
+func waitForExtractionSlotRelease(t *testing.T, logger mlog.LoggerIFace, data []byte) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		text, err := ExtractWithExtraExtractors(
+			logger,
+			"slot-release-check.txt",
+			bytes.NewReader(data),
+			ExtractSettings{Timeout: 0},
+			[]Extractor{&slowExtractor{delay: 0}},
+		)
+		return err == nil && text == "done"
+	}, 2*time.Second, 5*time.Millisecond, "detached extraction did not release its concurrency slot")
+}
+
 func TestExtractReaderCloserOwnership(t *testing.T) {
 	logger := mlog.CreateConsoleTestLogger(t)
 
@@ -472,11 +489,10 @@ func TestExtractConcurrency(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			require.FailNow(t, "detached extraction did not finish within the deadline")
 		}
+		waitForExtractionSlotRelease(t, logger, data)
 	})
 
 	t.Run("a timed-out extraction keeps its slot until the detached goroutine finishes", func(t *testing.T) {
-		resetExtractionConcurrencyForTest(1)
-
 		be := &blockingExtractor{started: make(chan struct{}), release: make(chan struct{}), done: make(chan struct{})}
 		settings := ExtractSettings{Timeout: 50 * time.Millisecond, ReaderCloser: &recordingCloser{}}
 
@@ -500,5 +516,6 @@ func TestExtractConcurrency(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			require.FailNow(t, "detached extraction did not finish within the deadline")
 		}
+		waitForExtractionSlotRelease(t, logger, data)
 	})
 }


### PR DESCRIPTION
#### Summary
Fix flake in `TestExtractConcurrency/a_timed-out_extraction_keeps_its_slot_until_the_detached_goroutine_finishes` (`github.com/mattermost/mattermost/server/v8/platform/services/docextractor`). Tests-only change — no production behavior changes.

**Root cause:** The subtest waited for `blockingExtractor.done`, which fires when `Extract` unblocks, but the concurrency slot is released in a `defer releaseExtractionSlot()` that runs only after `Extract` returns in the detached `extractWithTimeout` goroutine. The next subtest's `resetExtractionConcurrencyForTest(1)` call and the parent test's cleanup could therefore replace `extractionSlots` while the timed-out goroutine was still releasing on the old channel, producing a data race and intermittent failures under `-race` / CI load.

**Fix:** Added `waitForExtractionSlotRelease`, which polls with a synchronous (`Timeout: 0`) extraction until the slot is free, and call it at the end of both `TestExtractConcurrency` subtests. Removed the redundant per-subtest `resetExtractionConcurrencyForTest(1)` that amplified the race between subtests.

**Verification:**
- `go test -run '^TestExtractConcurrency$' -race -count=100 -timeout=20m ./platform/services/docextractor/...` — 100/100 green locally.
- `go test -race -count=5 -timeout=20m ./platform/services/docextractor/...` — 5/5 green locally.
- Reverted the fix and re-ran `go test -run '^TestExtractConcurrency$' -race -count=20`; reproduced the data race immediately, confirming the test still guards the original behavior.

**Originally introduced in:** 303b0c7 by larkox ([MM-69221] (#37301)).

cc @marianunez

#### Ticket Link
Flaky test reported here: https://github.com/mattermost/mattermost/pull/37253

#### Release Note
```release-note
NONE
```

[MM-69221]: https://mattermost.atlassian.net/browse/MM-69221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to test synchronization and does not affect production behavior, public APIs, or shared components.  
**QA Recommendation:** Manual QA can be skipped; repeated local `-race` verification is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->