### PR TITLE
Bumping prepackaged version of boards to 9.2.6

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -164,7 +164,7 @@ PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.9.1
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.5
-PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4
+PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.6
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.6.1
 PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.4.1
@@ -178,7 +178,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.9.1%2B885dcf9-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.5%2B4ad0d7d-fips
-	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.4%2B5855fe1-fips
+	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.6%2B99b712c-fips
 endif
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
<!-- What does this PR do? Include QA steps if not covered in the ticket. -->
This PR bumps the prepackaged version of the v9.2.6 release of boards onto the 11.8 version of Mattermost

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note
Prepackage Boards plugin version [v9.2.6](https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.2.6).
```
