### PR TITLE
Remove stray root package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,0 @@
-{
-  "name": "mattermost",
-  "lockfileVersion": 3,
-  "requires": true,
-  "packages": {}
-}


### PR DESCRIPTION
#### Summary
Removes an orphaned, empty `package-lock.json` at the repo root that has no matching `package.json`. It was accidentally introduced in #36143.

This stray lockfile breaks the `delivery-platform` release pipeline's SBOM generation step: `snyk sbom --all-projects` cannot resolve a lockfile without a corresponding `package.json` and aborts the entire scan with `ERROR Unspecified Error (SNYK-CLI-0000)`, failing the `generate-mattermost-team-sbom` job on every release build since this file landed on `master`.

Failing run: https://github.com/mattermost/delivery-platform/actions/runs/29571678630/job/87856983402

QA steps: N/A, this only removes a leftover build artifact that was accidentally committed.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)