### PR TITLE
Make server-ci.yml always trigger so required checks never get stuck pending

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -370,6 +370,7 @@ jobs:
     permissions: {}
     runs-on: ubuntu-22.04
     needs:
+      - go
       - merge-postgres-test-results
       - test-elasticsearch-v8
       - test-opensearch-v2
@@ -379,7 +380,14 @@ jobs:
       - merge-postgres-fips-test-results
     steps:
       - name: Server CI Complete
-        run: echo "Server CI Complete"
+        run: |
+          # Explicitly fail here rather than relying on `if:`, since a job
+          # skipped via `if:` is reported as "Success" by GitHub.
+          if [ "${{ needs.go.result }}" != "success" ]; then
+            echo "::error::'go' job did not succeed (result: ${{ needs.go.result }}); relevant-changed could not be computed reliably. Failing Server CI Complete."
+            exit 1
+          fi
+          echo "Server CI Complete"
 
   ci-report:
     name: Server CI Report

--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -11,16 +11,6 @@ on:
       - master
       - release-*
   pull_request:
-    paths:
-      - "server/**"
-      - ".github/workflows/server-ci.yml"
-      - ".github/workflows/server-test-template.yml"
-      - ".github/workflows/server-test-merge-template.yml"
-      - ".github/workflows/mmctl-test-template.yml"
-      - "tools/mattermost-govet/**"
-      - "!server/**/*.md"
-      - "!server/NOTICE.txt"
-      - "!server/CHANGELOG.md"
 
 concurrency:
   group: ${{ github.event_name == 'pull_request' && format('{0}-{1}', github.workflow, github.ref) || github.run_id }}
@@ -41,6 +31,10 @@ jobs:
     outputs:
       version: ${{ steps.calculate.outputs.GO_VERSION }}
       gomod-changed: ${{ steps.changed-files.outputs.any_changed }}
+      # Individual jobs below use this to skip via `if:` rather
+      # than the workflow being skipped entirely,
+      # so required status checks always get reported.
+      relevant-changed: ${{ github.event_name != 'pull_request' || steps.changed-relevant.outputs.any_changed == 'true' }}
     steps:
       - name: Checkout mattermost project
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
@@ -56,6 +50,22 @@ jobs:
         with:
           files: |
             **/go.mod
+      - name: Check for relevant Server CI path changes
+        id: changed-relevant
+        if: github.event_name == 'pull_request'
+        uses: tj-actions/changed-files@22103cc46bda19c2b464ffe86db46df6922fd323  # v47.0.5
+        with:
+          files: |
+            server/**
+            .github/workflows/server-ci.yml
+            .github/workflows/server-test-template.yml
+            .github/workflows/server-test-merge-template.yml
+            .github/workflows/mmctl-test-template.yml
+            tools/mattermost-govet/**
+          files_ignore: |
+            server/**/*.md
+            server/NOTICE.txt
+            server/CHANGELOG.md
       - name: Setup build environment
         env:
           CHAINCTL_IDENTITY: ee399b4c72dd4e58e3d617f78fc47b74733c9557/922f2d48307d6f5f
@@ -67,6 +77,7 @@ jobs:
   check-generated:
     name: Check generated files
     needs: go
+    if: needs.go.outputs.relevant-changed == 'true'
     runs-on: ubuntu-22.04
     services:
       # make default-roles-permissions snapshots a live database.
@@ -106,7 +117,7 @@ jobs:
     name: Check backport migrations
     needs: go
     # Only backports (release-* base) must keep a migration's version+name; new master migrations are expected.
-    if: startsWith(github.base_ref, 'release-')
+    if: needs.go.outputs.relevant-changed == 'true' && startsWith(github.base_ref, 'release-')
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout mattermost project
@@ -124,6 +135,7 @@ jobs:
   check-style:
     name: check-style
     needs: go
+    if: needs.go.outputs.relevant-changed == 'true'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout mattermost project
@@ -136,6 +148,7 @@ jobs:
   check-mattermost-vet-api:
     name: Vet API
     needs: go
+    if: needs.go.outputs.relevant-changed == 'true'
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout mattermost project
@@ -153,6 +166,7 @@ jobs:
   test-postgres-normal:
     name: Postgres (shard ${{ matrix.shard }})
     needs: go
+    if: needs.go.outputs.relevant-changed == 'true'
     strategy:
       fail-fast: false  # Let all shards complete so we get full test results
       matrix:
@@ -178,7 +192,7 @@ jobs:
   merge-postgres-test-results:
     name: Merge Postgres Test Results
     needs: test-postgres-normal
-    if: always()
+    if: always() && needs.test-postgres-normal.result != 'skipped'
     permissions:
       contents: read
       actions: write
@@ -192,6 +206,7 @@ jobs:
   test-elasticsearch-v8:
     name: Elasticsearch v8 Compatibility
     needs: go
+    if: needs.go.outputs.relevant-changed == 'true'
     permissions:
       contents: read
       actions: write
@@ -209,6 +224,7 @@ jobs:
   test-opensearch-v2:
     name: OpenSearch v2 Compatibility
     needs: go
+    if: needs.go.outputs.relevant-changed == 'true'
     permissions:
       contents: read
       actions: write
@@ -226,7 +242,9 @@ jobs:
   # FIPS tests: run on PRs when go.mod changed or branch name contains "fips".
   # Sharded for fast iteration. Weekly workflow provides regular full coverage.
   test-postgres-normal-fips:
-    if: contains(github.head_ref, 'fips') || needs.go.outputs.gomod-changed == 'true'
+    if: >-
+      needs.go.outputs.relevant-changed == 'true' &&
+      (contains(github.head_ref, 'fips') || needs.go.outputs.gomod-changed == 'true')
     name: "Postgres FIPS (shard ${{ matrix.shard }})"
     needs: go
     strategy:
@@ -264,6 +282,7 @@ jobs:
   test-mmctl:
     name: Run mmctl tests
     needs: go
+    if: needs.go.outputs.relevant-changed == 'true'
     permissions:
       contents: read
       actions: write
@@ -278,7 +297,9 @@ jobs:
       go-version: ${{ needs.go.outputs.version }}
       fips-enabled: false
   test-mmctl-fips:
-    if: contains(github.head_ref, 'fips') || needs.go.outputs.gomod-changed == 'true'
+    if: >-
+      needs.go.outputs.relevant-changed == 'true' &&
+      (contains(github.head_ref, 'fips') || needs.go.outputs.gomod-changed == 'true')
     name: Run mmctl tests (FIPS)
     needs: go
     permissions:
@@ -300,6 +321,7 @@ jobs:
   build-mattermost-server:
     name: Build mattermost server app
     needs: go
+    if: needs.go.outputs.relevant-changed == 'true'
     permissions:
       contents: read
       actions: write


### PR DESCRIPTION
#### Summary
`server-ci.yml` used a top-level `pull_request.paths` filter, so on PRs that don't touch server code the workflow never triggers at all. Since GitHub only marks a required status check as satisfied once a matching check run is reported, a required check like "Server CI Complete" gets stuck "Pending"/"Expected" forever on those PRs and blocks merging, even though nothing relevant needed to run.

This moves the path filtering out of the trigger and into a job-level `if:`, driven by a new `relevant-changed` output computed in the `go` job (`true` for push/workflow_dispatch, or for pull_request only when a relevant path changed). All the substantive jobs are now gated on `relevant-changed` instead of the workflow simply not running. `merge-postgres-test-results` also now skips cleanly if `test-postgres-normal` was skipped (matching the existing pattern for the FIPS merge job), instead of trying to merge nonexistent artifacts.

The workflow now always runs and always reports a status, so any of its job checks (including the `ci-complete` aggregator, "Server CI Complete") can safely be added as a required branch protection check without getting stuck pending.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to CI workflow orchestration; the main risk is incorrectly skipping relevant jobs or reporting an inaccurate completion status.  
**QA Recommendation:** Manual QA can be skipped; rely on automated CI validation.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->