### PR TITLE
Add --active flag to mmctl user list

### DIFF
--- a/docs/main/administration-guide/manage/mmctl-command-line-tool.mdx
+++ b/docs/main/administration-guide/manage/mmctl-command-line-tool.mdx
@@ -7242,10 +7242,13 @@ mmctl user list
 **Options**
 
 ``` sh
---all            Fetch all users. --page flag will be ignore if provided
+--active         If supplied, only users which are active will be fetched
+--all            Fetch all users. --page flag will be ignored if provided
 -h, --help       help for list
+--inactive       If supplied, only users which are inactive will be fetched
 --page int       Page number to fetch for the list of users
---per-page int   Number of users to be fetched (maximum 200)
+--per-page int   Number of users to be fetched (default 200)
+--role string    If supplied, only users with the given role will be fetched
 --team string    If supplied, only users belonging to this team will be listed
 ```
 

--- a/server/cmd/mmctl/commands/user.go
+++ b/server/cmd/mmctl/commands/user.go
@@ -388,6 +388,7 @@ func init() {
 	ListUsersCmd.Flags().Int("per-page", DefaultPageSize, "Number of users to be fetched")
 	ListUsersCmd.Flags().Bool("all", false, "Fetch all users. --page flag will be ignored if provided")
 	ListUsersCmd.Flags().String("team", "", "If supplied, only users belonging to this team will be listed")
+	ListUsersCmd.Flags().Bool("active", false, "If supplied, only users which are active will be fetched")
 	ListUsersCmd.Flags().Bool("inactive", false, "If supplied, only users which are inactive will be fetched")
 	ListUsersCmd.Flags().String("role", "", "If supplied, only users with the given role will be fetched")
 
@@ -806,6 +807,7 @@ func ResetListUsersCmd(t *testing.T) *cobra.Command {
 	require.NoError(t, ListUsersCmd.Flags().Set("all", "false"))
 	require.NoError(t, ListUsersCmd.Flags().Set("team", ""))
 	require.NoError(t, ListUsersCmd.Flags().Set("role", ""))
+	require.NoError(t, ListUsersCmd.Flags().Set("active", "false"))
 	require.NoError(t, ListUsersCmd.Flags().Set("inactive", "false"))
 
 	return ListUsersCmd
@@ -828,10 +830,17 @@ func listUsersCmdF(c client.Client, command *cobra.Command, args []string) error
 	if err != nil {
 		return err
 	}
-	// if inactive, DeletedAt != 0
+	// if active, DeleteAt == 0; if inactive, DeleteAt != 0
+	active, err := command.Flags().GetBool("active")
+	if err != nil {
+		return err
+	}
 	inactive, err := command.Flags().GetBool("inactive")
 	if err != nil {
 		return err
+	}
+	if active && inactive {
+		return errors.New("--active and --inactive flags cannot be used together")
 	}
 
 	roleName, err := command.Flags().GetString("role")
@@ -853,6 +862,9 @@ func listUsersCmdF(c client.Client, command *cobra.Command, args []string) error
 	}
 
 	params := url.Values{}
+	if active {
+		params.Add("active", "true")
+	}
 	if inactive {
 		params.Add("inactive", "true")
 	}

--- a/server/cmd/mmctl/commands/user_e2e_test.go
+++ b/server/cmd/mmctl/commands/user_e2e_test.go
@@ -294,6 +294,26 @@ func (s *MmctlE2ETestSuite) TestListUserCmd() {
 		}
 	})
 
+	s.RunForAllClients("Get list of active users", func(c client.Client) {
+		printer.Clean()
+
+		cmd := ResetListUsersCmd(s.T())
+		s.Require().NoError(cmd.Flags().Set("per-page", "12"))
+		s.Require().NoError(cmd.Flags().Set("all", "true"))
+		s.Require().NoError(cmd.Flags().Set("active", "true"))
+
+		err := listUsersCmdF(c, cmd, []string{})
+		s.Require().Nil(err)
+		s.Require().GreaterOrEqual(len(printer.GetLines()), 2)
+		s.Len(printer.GetErrorLines(), 0)
+		for _, each := range printer.GetLines() {
+			user := each.(*model.User)
+			s.Require().Contains(userPool, user.Username)
+			s.Require().NotContains(inactivePool, user.Username)
+			s.Require().Equal(int64(0), user.DeleteAt)
+		}
+	})
+
 	// create users with team
 	for range 10 {
 		userData := model.User{

--- a/server/cmd/mmctl/commands/user_test.go
+++ b/server/cmd/mmctl/commands/user_test.go
@@ -1798,6 +1798,57 @@ func (s *MmctlUnitTestSuite) TestListUserCmdF() {
 		s.Require().Equal(&mockUser3, printer.GetLines()[1])
 	})
 
+	s.Run("Listing all active users", func() {
+		printer.Clean()
+
+		email1 := "example1@example.com"
+		mockUser1 := model.User{Username: "ExampleUser1", Email: email1}
+		email2 := "example2@example.com"
+		mockUser2 := model.User{Username: "ExampleUser2", Email: email2}
+
+		cmd := ResetListUsersCmd(s.T())
+		s.Require().NoError(cmd.Flags().Set("per-page", "1"))
+		s.Require().NoError(cmd.Flags().Set("all", "true"))
+		s.Require().NoError(cmd.Flags().Set("active", "true"))
+
+		s.client.
+			EXPECT().
+			GetUsersWithCustomQueryParameters(context.TODO(), 0, 1, "active=true", "").
+			Return([]*model.User{&mockUser1}, &model.Response{}, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUsersWithCustomQueryParameters(context.TODO(), 1, 1, "active=true", "").
+			Return([]*model.User{&mockUser2}, &model.Response{}, nil).
+			Times(1)
+
+		s.client.
+			EXPECT().
+			GetUsersWithCustomQueryParameters(context.TODO(), 2, 1, "active=true", "").
+			Return([]*model.User{}, &model.Response{}, nil).
+			Times(1)
+
+		err := listUsersCmdF(s.client, cmd, []string{})
+		s.Require().Nil(err)
+		s.Require().Len(printer.GetLines(), 2)
+		s.Require().Equal(&mockUser1, printer.GetLines()[0])
+		s.Require().Equal(&mockUser2, printer.GetLines()[1])
+	})
+
+	s.Run("Fail to list users when both active and inactive flags are set", func() {
+		printer.Clean()
+
+		cmd := ResetListUsersCmd(s.T())
+		s.Require().NoError(cmd.Flags().Set("active", "true"))
+		s.Require().NoError(cmd.Flags().Set("inactive", "true"))
+
+		err := listUsersCmdF(s.client, cmd, []string{})
+		s.Require().Error(err)
+		s.Require().EqualError(err, "--active and --inactive flags cannot be used together")
+		s.Require().Empty(printer.GetLines())
+	})
+
 	s.Run("Listing inactive users with paging skipping 1 page", func() {
 		printer.Clean()
 

--- a/server/cmd/mmctl/docs/mmctl_user_list.rst
+++ b/server/cmd/mmctl/docs/mmctl_user_list.rst
@@ -27,6 +27,7 @@ Options
 
 ::
 
+      --active         If supplied, only users which are active will be fetched
       --all            Fetch all users. --page flag will be ignored if provided
   -h, --help           help for list
       --inactive       If supplied, only users which are inactive will be fetched


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Adds an `--active` flag to `mmctl user list`, complementary to the existing `--inactive` flag, so admins can list only active users.

- Passes `active=true` to the users API when `--active` is set
- Errors if `--active` and `--inactive` are used together
- Adds unit and e2e coverage
- Updates mmctl docs and the admin CLI reference

#### Release Note
```release-note
Added --active flag to mmctl user list to filter for active users only.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f554cd6-248e-4e43-8cd7-6a696bbd5203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f554cd6-248e-4e43-8cd7-6a696bbd5203"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to `mmctl user list` flag parsing and query construction, with unit and end-to-end coverage for active filtering and conflicting flags.  
**QA Recommendation:** Manual QA can be skipped; automated coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->