### PR TITLE
Fix: Add missing index on threads.threadteamid (issue #35991) + CPA text field byte/char fix (issue #36849)

### DIFF
--- a/server/channels/app/properties/access_control_attribute_validation.go
+++ b/server/channels/app/properties/access_control_attribute_validation.go
@@ -589,7 +589,7 @@ func (h *AccessControlAttributeValidationHook) validateValueAgainstField(field *
 		if err := json.Unmarshal(value.Value, &str); err != nil {
 			return fmt.Errorf("expected string value: %w", err)
 		}
-		if len(strings.TrimSpace(str)) > model.PropertyFieldValueTypeTextMaxLength {
+		if utf8.RuneCountInString(strings.TrimSpace(str)) > model.PropertyFieldValueTypeTextMaxLength {
 			return fmt.Errorf("text value exceeds maximum length of %d characters", model.PropertyFieldValueTypeTextMaxLength)
 		}
 

--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -403,3 +403,5 @@ channels/db/migrations/postgres/000203_add_lastnotifiedat_to_user_access_tokens.
 channels/db/migrations/postgres/000203_add_lastnotifiedat_to_user_access_tokens.up.sql
 channels/db/migrations/postgres/000204_add_channel_type_space_enum.down.sql
 channels/db/migrations/postgres/000204_add_channel_type_space_enum.up.sql
+channels/db/migrations/postgres/000205_add_threadteamid_index.down.sql
+channels/db/migrations/postgres/000205_add_threadteamid_index.up.sql

--- a/server/channels/db/migrations/postgres/000205_add_threadteamid_index.down.sql
+++ b/server/channels/db/migrations/postgres/000205_add_threadteamid_index.down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_threads_threadteamid;

--- a/server/channels/db/migrations/postgres/000205_add_threadteamid_index.up.sql
+++ b/server/channels/db/migrations/postgres/000205_add_threadteamid_index.up.sql
@@ -1,0 +1,1 @@
+CREATE INDEX IF NOT EXISTS idx_threads_threadteamid ON threads(threadteamid);


### PR DESCRIPTION
## Summary

This PR fixes two issues:

### Issue #35991: Missing index on threads.threadteamid
- **Root cause**: Migration 000096 added the `threadteamid` column but never created an index
- **Impact**: Full table scans on `threads` table (millions of rows) when querying threads by team, causing severe performance degradation and outages at scale
- **Fix**: Added migration 000205 to create `CREATE INDEX IF NOT EXISTS idx_threads_threadteamid ON threads(threadteamid)`

### Issue #36849: CPA text field length enforced in bytes not characters
- **Root cause**: `validateValueAgainstField` used `len()` (byte count) instead of `utf8.RuneCountInString()` (character count)
- **Impact**: AD sync fails for non-Latin locales (CJK, Arabic, etc.) - multi-byte characters incorrectly counted
- **Fix**: Changed line 592 in `access_control_attribute_validation.go` to use `utf8.RuneCountInString()`

## Testing
- Migration up/down tested locally
- CPA validation fix follows existing pattern used in 30+ other validations in codebase (e.g., `user.go:410`, `channel.go:324`, `post.go:525`)

## Release Note
```release-note
Fixed missing database index on threads.threadteamid column that caused
severe query performance degradation and outages at scale.
Fixed CPA text field length validation to count Unicode characters instead
of bytes, resolving AD sync failures for non-Latin languages.
```

cc @mattermost/core-backend @mattermost/database

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes affect database migrations and user-facing Unicode validation, but are isolated and rollback is straightforward.  
**QA Recommendation:** Manual QA can be skipped with full automated test coverage; verify migration up/down tests in CI.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->