### PR TITLE
Fix: CPA text field length validation uses characters not bytes (issue #36849)

### DIFF
--- a/server/channels/app/properties/access_control_attribute_validation.go
+++ b/server/channels/app/properties/access_control_attribute_validation.go
@@ -589,7 +589,7 @@ func (h *AccessControlAttributeValidationHook) validateValueAgainstField(field *
 		if err := json.Unmarshal(value.Value, &str); err != nil {
 			return fmt.Errorf("expected string value: %w", err)
 		}
-		if len(strings.TrimSpace(str)) > model.PropertyFieldValueTypeTextMaxLength {
+		if utf8.RuneCountInString(strings.TrimSpace(str)) > model.PropertyFieldValueTypeTextMaxLength {
 			return fmt.Errorf("text value exceeds maximum length of %d characters", model.PropertyFieldValueTypeTextMaxLength)
 		}
 


### PR DESCRIPTION
## Summary

Fixes issue #36849: CPA text field length limit enforced in bytes instead of characters, breaking AD sync for non-Latin locales.

### Root Cause
In `access_control_attribute_validation.go:592`, the validation used `len(strings.TrimSpace(str))` which returns **byte count**, not **character count**.

For multi-byte Unicode characters (CJK = 3 bytes, Arabic = 2 bytes):
- 64-char CJK string = 192 bytes → incorrectly rejected (exceeds 64 byte limit)
- 64-char Arabic string = 128 bytes → incorrectly rejected

### Fix
Changed to `utf8.RuneCountInString(strings.TrimSpace(str))` which correctly counts Unicode code points (characters).

This matches the pattern used in 30+ other validations across the codebase:
- `user.go:410` - Nickname validation
- `channel.go:324` - Channel display name  
- `post.go:525` - Post message
- `channel_join_request.go:118` - Join request message

### Testing
- Verified `unicode/utf8` import already present (line 14)
- Error message already correctly says "characters"
- Follows existing codebase conventions

#### Release Note
```release-note
Fixed CPA text field length validation to count Unicode characters instead
of bytes, resolving AD sync failures for non-Latin languages.
```

cc @mattermost/core-backend

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The isolated validation change only adjusts Unicode length counting in one field, with no shared dependencies or API changes.  
**QA Recommendation:** Manual QA can be skipped; automated testing should be sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->