### PR TITLE
Fix: import_process handles all os.Stat errors, not just file not exist (issue #37492)

### DIFF
--- a/server/channels/jobs/import_process/worker.go
+++ b/server/channels/jobs/import_process/worker.go
@@ -5,7 +5,6 @@ package import_process
 
 import (
 	"archive/zip"
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -55,8 +54,8 @@ func MakeWorker(jobServer *jobs.JobServer, app AppIface) *jobs.SimpleWorker {
 		if job.Data["local_mode"] == "true" {
 			// We simply read the file from the local filesystem.
 			info, err := os.Stat(importFileName)
-			if errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("file %s doesn't exist.", importFileName)
+			if err != nil {
+				return fmt.Errorf("failed to stat file %s: %w", importFileName, err)
 			}
 
 			importFileSize = info.Size()


### PR DESCRIPTION
## Summary
Fix error handling in  to return any error from  instead of only checking for .

## Changes
- Changed error check from  to 
- Updated error message to include the original error using  format verb for proper error wrapping
- Removed unused  import

## Release Note
```release-note
Fix import process worker to handle all os.Stat errors, not just file not exist
```

## Reviewers
@jasonblais @jfrerich

## Labels
kind/bug, release-note


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Isolated error-handling change in a single import worker; no shared utilities, APIs, or critical flows are affected.  
**QA Recommendation:** Manual QA can be skipped; automated testing is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->