### PR TITLE
Add Algolia site verification to docs robots.txt

### DIFF
--- a/docs/site/static/robots.txt
+++ b/docs/site/static/robots.txt
@@ -1,0 +1,4 @@
+# algolia-site-verification: 24A3DAA227BD6D4B
+
+User-agent: *
+Allow: /

--- a/docs/site/static/robots.txt
+++ b/docs/site/static/robots.txt
@@ -1,4 +1,4 @@
-# algolia-site-verification: 24A3DAA227BD6D4B
+# Algolia-Crawler-Verif: 24A3DAA227BD6D4B
 
 User-agent: *
 Allow: /


### PR DESCRIPTION
#### Summary
Adds an `algolia-site-verification` comment to `docs/site/static/robots.txt` (served at `docs.mattermost.com/robots.txt`) to prove DNS ownership of the CloudFront distribution for the Algolia Crawler.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Isolated static documentation change with no impact on application logic, shared dependencies, or critical flows.  
**QA Recommendation:** Manual QA can be skipped; automated checks are sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->