### PR TITLE
MM-67336: Request structured JSON output for AI message rewrites

### DIFF
--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -3416,6 +3416,20 @@ func (a *App) SendTestMessage(rctx request.CTX, userID string) (*model.Post, *mo
 	return post, nil
 }
 
+// rewriteResponseJSONSchema is the structured output schema for the LLM rewrite response.
+// Defined at package level to avoid re-allocating on every call.
+var rewriteResponseJSONSchema = map[string]any{
+	"type": "object",
+	"properties": map[string]any{
+		"rewritten_text": map[string]any{
+			"type":        "string",
+			"description": "The rewritten version of the message",
+		},
+	},
+	"required":             []any{"rewritten_text"},
+	"additionalProperties": false,
+}
+
 // RewriteMessage rewrites a message using AI based on the specified action
 func (a *App) RewriteMessage(
 	rctx request.CTX,
@@ -3464,6 +3478,7 @@ func (a *App) RewriteMessage(
 			{Role: "system", Message: systemPrompt},
 			{Role: "user", Message: userPrompt},
 		},
+		JSONOutputFormat: rewriteResponseJSONSchema,
 		OperationSubType: normalizeRewriteAction(action),
 		UserID:           sessionUserID,
 	}

--- a/server/channels/app/post_rewrite_test.go
+++ b/server/channels/app/post_rewrite_test.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -24,5 +25,27 @@ func TestBuildRewriteSystemPrompt(t *testing.T) {
 	t.Run("returns_base_prompt_when_no_locale", func(t *testing.T) {
 		prompt := buildRewriteSystemPrompt("")
 		require.Equal(t, basePrompt, prompt)
+	})
+}
+
+func TestRewriteMessage(t *testing.T) {
+	t.Run("sets_structured_output_schema_on_bridge_request", func(t *testing.T) {
+		bridge := &testAgentsBridge{
+			completeFn: func(sessionUserID, agentID string, req BridgeCompletionRequest) (string, error) {
+				return `{"rewritten_text":"Rewritten message"}`, nil
+			},
+		}
+
+		th := Setup(t, WithAgentsBridge(bridge)).InitBasic(t)
+		ctx := th.Context.WithSession(&model.Session{UserId: th.BasicUser.Id})
+
+		response, appErr := th.App.RewriteMessage(ctx, model.NewId(), "original message", model.RewriteActionImproveWriting, "", "")
+		require.Nil(t, appErr)
+		require.NotNil(t, response)
+		assert.Equal(t, "Rewritten message", response.RewrittenText)
+		require.Len(t, bridge.completeCalls, 1)
+		assert.Equal(t, BridgeOperationRewrite, bridge.completeCalls[0].request.Operation)
+		assert.Equal(t, string(model.RewriteActionImproveWriting), bridge.completeCalls[0].request.OperationSubType)
+		assert.Equal(t, rewriteResponseJSONSchema, bridge.completeCalls[0].request.JSONOutputFormat)
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
The AI Rewrites feature relied solely on prompt instructions to get JSON back from the model, then did a raw `json.Unmarshal` on the completion. Models frequently wrap the JSON in markdown fences or add preamble, causing flaky `app.post.rewrite.parse_response_failed` errors.

This sets `JSONOutputFormat` on the rewrite `BridgeCompletionRequest`, mirroring the existing Recaps pattern (`summarizePostsJSONSchema` in `summarization.go`). With the schema present, the Agents plugin either enforces native structured output (when the agent supports it) or — with the companion plugin change (mattermost/mattermost-plugin-agents) — converts the schema into prompt instructions and strips markdown fences, so the request works with models that lack native structured output support.

The JSON-demanding system prompt is kept as belt-and-braces for older plugin versions.

QA steps: with the Agents bridge enabled, use any rewrite action (Improve writing, Shorten, etc.) in the message composer against agents both with and without Structured Output enabled; the rewritten text should be returned reliably without parse errors.

#### Ticket Link
Jira https://mattermost.atlassian.net/browse/MM-67336

#### Release Note
```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1f2b8406-fc24-41fe-9cfa-eca3ae19ff07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1f2b8406-fc24-41fe-9cfa-eca3ae19ff07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Medium 🟡

**Regression Risk:** Structured output changes affect the user-facing AI rewrite path and bridge request contract; compatibility is mitigated by retaining the existing JSON prompt and adding targeted automated coverage.  
**QA Recommendation:** Manual QA is recommended for rewrite responses with and without Structured Output enabled, including malformed-output and legacy-plugin scenarios.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->