### PR TITLE
Prepackage mattermost-plugin-agents v2.5.0-rc1

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -163,7 +163,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.1
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.11.0
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.2
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.0-rc1
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.7.0
@@ -177,7 +177,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.11.0%2B931852a-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.2%2B1305067-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.0-rc1%2B666ae7a-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.0%2Bd454327-fips
 endif
 


### PR DESCRIPTION
#### Summary

Updates the default prepackaged [mattermost-plugin-agents](https://github.com/mattermost/mattermost-plugin-agents) artifact from **2.4.2** to **2.5.0-rc1** ([release v2.5.0-rc1](https://github.com/mattermost/mattermost-plugin-agents/releases/tag/v2.5.0-rc1)) for the `master` branch.

Both prepackaged plugin lists are updated:
- non-FIPS: `mattermost-plugin-agents-v2.5.0-rc1`
- FIPS: `mattermost-plugin-agents-v2.5.0-rc1%2B666ae7a-fips` (`666ae7a` is the tagged release commit)

Bundles verified on `plugins.releases.mattermost.com`.

#### Release Note
```release-note
Prepackaged the Mattermost Agents plugin at version 2.5.0-rc1 instead of 2.4.2.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to plugin package references in the Makefile and do not affect application logic or critical user flows.  
**QA Recommendation:** Manual QA can be skipped; automated coverage and artifact verification are sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->