### PR TITLE
Updated minimum supported Edge and Chrome versions

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -13696,11 +13696,11 @@
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.chrome",
-    "translation": "Version 146+"
+    "translation": "Version 150+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.edge",
-    "translation": "Version 146+"
+    "translation": "Version 150+"
   },
   {
     "id": "web.error.unsupported_browser.min_browser_version.firefox",


### PR DESCRIPTION
Desktop app v6.3 will include Electron 43.0.0+ which supports Chrome 150+.

```release-note
Updated minimum Edge and Chrome versions to 150+.
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01DfEWUrN4ixMD9oQGDc4DK8)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Isolated English localization changes update browser-version messaging only, with no shared code or critical flows affected.  
**QA Recommendation:** Manual QA can be skipped; automated coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->