### PR TITLE
Fix MM-T338 image URL race

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/files_and_attachments/upload_files_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/files_and_attachments/upload_files_spec.js
@@ -274,10 +274,9 @@ describe('Upload Files', () => {
         // # Now post with the message attachment
         cy.uiGetPostTextBox().clear().type('{enter}');
 
-        cy.findByTestId('fileAttachmentList').
-            find('img[src*="/api/v4/files/"]').
-            should('be.visible').
-            invoke('attr', 'src').
+        cy.uiGetFileThumbnail(imageFilename).
+            should('have.attr', 'src').
+            and('include', '/api/v4/files/').
             then((src) => {
                 downloadAttachmentAndVerifyItsProperties(src, imageFilename, 'inline');
             });

--- a/e2e-tests/cypress/tests/integration/channels/files_and_attachments/upload_files_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/files_and_attachments/upload_files_spec.js
@@ -261,23 +261,26 @@ describe('Upload Files', () => {
             // * Verify that image type is present
             cy.findByText(imageType).should('be.visible');
 
-            // # Get the image preview div
-            cy.get('.post-image.normal').then((imageDiv) => {
-                // # Filter out the url from the css background property
-                // url("https://imageurl") => https://imageurl
-                const imageURL = imageDiv.css('background-image').split('"')[1];
+            cy.get('.post-image.normal').
+                invoke('css', 'background-image').
+                should('include', '/api/v4/files/').
+                then((backgroundImage) => {
+                    const imageURL = backgroundImage.match(/^url\(["']?(.*?)["']?\)$/)[1];
 
-                downloadAttachmentAndVerifyItsProperties(imageURL, imageFilename, 'inline');
-            });
+                    downloadAttachmentAndVerifyItsProperties(imageURL, imageFilename, 'inline');
+                });
         });
 
         // # Now post with the message attachment
         cy.uiGetPostTextBox().clear().type('{enter}');
 
-        // * Check that the image in the post is with valid source link
-        cy.uiGetFileThumbnail(imageFilename).should('have.attr', 'src').then((src) => {
-            downloadAttachmentAndVerifyItsProperties(src, imageFilename, 'inline');
-        });
+        cy.findByTestId('fileAttachmentList').
+            find('img[src*="/api/v4/files/"]').
+            should('be.visible').
+            invoke('attr', 'src').
+            then((src) => {
+                downloadAttachmentAndVerifyItsProperties(src, imageFilename, 'inline');
+            });
     });
 
     it('MM-T2265 Multiple File Upload - 5 is successful (image, video, code, pdf, audio, other)', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Wait for API-backed image URLs before MM-T338 verifies response headers, avoiding requests to transient preview placeholders.

QA:
- MM-T338 focused stress run: 3/3 passed with Cypress retries disabled
- Full `upload_files_spec.js`: 8/8 passed
- ESLint passed

#### Release Note
```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ecd73598-d4f3-44b8-874e-75db856c27bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ecd73598-d4f3-44b8-874e-75db856c27bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

