### PR TITLE
[2/5] Recover wedged recap jobs and orphaned processing recaps

### DIFF
--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -1796,7 +1796,7 @@ func (s *Server) initJobs() {
 	s.Jobs.RegisterJobType(
 		model.JobTypeRecap,
 		recap.MakeWorker(s.Jobs, s.Store(), New(ServerConnector(s.Channels()))),
-		nil,
+		recap.MakeScheduler(s.Jobs, s.Store(), New(ServerConnector(s.Channels()))),
 	)
 
 	s.Jobs.RegisterJobType(

--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -417,3 +417,5 @@ channels/db/migrations/postgres/000210_add_recap_skip_fields.down.sql
 channels/db/migrations/postgres/000210_add_recap_skip_fields.up.sql
 channels/db/migrations/postgres/000211_add_recaps_scheduled_recap_id_index.down.sql
 channels/db/migrations/postgres/000211_add_recaps_scheduled_recap_id_index.up.sql
+channels/db/migrations/postgres/000212_add_recaps_status_update_at_index.down.sql
+channels/db/migrations/postgres/000212_add_recaps_status_update_at_index.up.sql

--- a/server/channels/db/migrations/postgres/000212_add_recaps_status_update_at_index.down.sql
+++ b/server/channels/db/migrations/postgres/000212_add_recaps_status_update_at_index.down.sql
@@ -1,0 +1,2 @@
+-- morph:nontransactional
+DROP INDEX CONCURRENTLY IF EXISTS idx_recaps_status_update_at;

--- a/server/channels/db/migrations/postgres/000212_add_recaps_status_update_at_index.up.sql
+++ b/server/channels/db/migrations/postgres/000212_add_recaps_status_update_at_index.up.sql
@@ -1,0 +1,2 @@
+-- morph:nontransactional
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_recaps_status_update_at ON Recaps(Status, UpdateAt);

--- a/server/channels/jobs/recap/scheduler.go
+++ b/server/channels/jobs/recap/scheduler.go
@@ -68,21 +68,22 @@ func (s *Scheduler) resetWedgedJobs(rctx request.CTX) {
 	}
 }
 
-func (s *Scheduler) markRecapFailed(rctx request.CTX, recapID, userID string) {
+func (s *Scheduler) markRecapFailed(rctx request.CTX, recapID, userID string) bool {
 	transitioned, err := s.store.Recap().MarkRecapFailedIfIncomplete(recapID)
 	if err != nil {
 		rctx.Logger().Error("Failed to mark recap as failed",
 			mlog.String("recap_id", recapID),
 			mlog.Err(err))
-		return
+		return false
 	}
 	if !transitioned {
 		rctx.Logger().Debug("Recap is already terminal or deleted",
 			mlog.String("recap_id", recapID))
-		return
+		return false
 	}
 
 	publishRecapUpdate(s.app, recapID, userID)
+	return true
 }
 
 func (s *Scheduler) sweepOrphanedRecaps(rctx request.CTX) {
@@ -112,10 +113,14 @@ func (s *Scheduler) sweepOrphanedRecaps(rctx request.CTX) {
 			continue
 		}
 
-		rctx.Logger().Warn("Recap stuck in processing with no live job; marking failed",
+		rctx.Logger().Debug("Recap stuck in processing with no live job; attempting failure transition",
 			mlog.String("recap_id", recap.Id),
 			mlog.String("user_id", recap.UserId),
 			mlog.Millis("update_at", recap.UpdateAt))
-		s.markRecapFailed(rctx, recap.Id, recap.UserId)
+		if s.markRecapFailed(rctx, recap.Id, recap.UserId) {
+			rctx.Logger().Warn("Marked orphaned recap as failed",
+				mlog.String("recap_id", recap.Id),
+				mlog.String("user_id", recap.UserId))
+		}
 	}
 }

--- a/server/channels/jobs/recap/scheduler.go
+++ b/server/channels/jobs/recap/scheduler.go
@@ -69,26 +69,19 @@ func (s *Scheduler) resetWedgedJobs(rctx request.CTX) {
 }
 
 func (s *Scheduler) markRecapFailed(rctx request.CTX, recapID, userID string) {
-	recap, err := s.store.Recap().GetRecap(recapID)
+	transitioned, err := s.store.Recap().MarkRecapFailedIfIncomplete(recapID)
 	if err != nil {
-		rctx.Logger().Warn("Could not get recap for reset job",
-			mlog.String("recap_id", recapID),
-			mlog.Err(err))
-		return
-	}
-	if recap.Status != model.RecapStatusProcessing && recap.Status != model.RecapStatusPending {
-		rctx.Logger().Debug("Recap for reset job is already terminal",
-			mlog.String("recap_id", recapID),
-			mlog.String("recap_status", recap.Status))
-		return
-	}
-
-	if err := s.store.Recap().UpdateRecapStatus(recapID, model.RecapStatusFailed); err != nil {
 		rctx.Logger().Error("Failed to mark recap as failed",
 			mlog.String("recap_id", recapID),
 			mlog.Err(err))
 		return
 	}
+	if !transitioned {
+		rctx.Logger().Debug("Recap is already terminal or deleted",
+			mlog.String("recap_id", recapID))
+		return
+	}
+
 	publishRecapUpdate(s.app, recapID, userID)
 }
 
@@ -123,12 +116,6 @@ func (s *Scheduler) sweepOrphanedRecaps(rctx request.CTX) {
 			mlog.String("recap_id", recap.Id),
 			mlog.String("user_id", recap.UserId),
 			mlog.Millis("update_at", recap.UpdateAt))
-		if err := s.store.Recap().UpdateRecapStatus(recap.Id, model.RecapStatusFailed); err != nil {
-			rctx.Logger().Error("Failed to mark orphaned recap as failed",
-				mlog.String("recap_id", recap.Id),
-				mlog.Err(err))
-			continue
-		}
-		publishRecapUpdate(s.app, recap.Id, recap.UserId)
+		s.markRecapFailed(rctx, recap.Id, recap.UserId)
 	}
 }

--- a/server/channels/jobs/recap/scheduler.go
+++ b/server/channels/jobs/recap/scheduler.go
@@ -1,0 +1,134 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package recap
+
+import (
+	"time"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+	"github.com/mattermost/mattermost/server/v8/channels/jobs"
+	"github.com/mattermost/mattermost/server/v8/channels/store"
+)
+
+const (
+	// SchedulerPeriod controls the recovery cadence.
+	SchedulerPeriod = time.Minute
+	// RecapJobWedgedTimeout is the maximum interval without job activity.
+	RecapJobWedgedTimeout = 30 * time.Minute
+	// OrphanedRecapCutoff gives job recovery priority over the orphan sweep.
+	OrphanedRecapCutoff = 2 * RecapJobWedgedTimeout
+
+	orphanSweepLimit = 100
+)
+
+// Scheduler recovers wedged recap jobs and processing recaps without live jobs.
+type Scheduler struct {
+	*jobs.PeriodicScheduler
+	jobServer *jobs.JobServer
+	store     store.Store
+	app       AppIface
+}
+
+func MakeScheduler(jobServer *jobs.JobServer, storeInstance store.Store, appInstance AppIface) *Scheduler {
+	isEnabled := func(cfg *model.Config) bool {
+		return cfg.AIRecapsEnabled()
+	}
+	return &Scheduler{
+		PeriodicScheduler: jobs.NewPeriodicScheduler(jobServer, model.JobTypeRecap, SchedulerPeriod, isEnabled),
+		jobServer:         jobServer,
+		store:             storeInstance,
+		app:               appInstance,
+	}
+}
+
+// ScheduleJob runs the recovery passes and never creates a job.
+func (s *Scheduler) ScheduleJob(rctx request.CTX, _ *model.Config, _ bool, _ *model.Job) (*model.Job, *model.AppError) {
+	s.resetWedgedJobs(rctx)
+	s.sweepOrphanedRecaps(rctx)
+	return nil, nil
+}
+
+func (s *Scheduler) resetWedgedJobs(rctx request.CTX) {
+	resetJobs, appErr := s.jobServer.ResetWedgedJobs(rctx, model.JobTypeRecap, RecapJobWedgedTimeout)
+	if appErr != nil {
+		rctx.Logger().Error("Failed to reset wedged recap jobs", mlog.Err(appErr))
+		return
+	}
+
+	for _, job := range resetJobs {
+		recapID := job.Data["recap_id"]
+		if recapID == "" {
+			rctx.Logger().Warn("Reset recap job has no recap ID", jobs.JobLoggerFields(job)...)
+			continue
+		}
+		s.markRecapFailed(rctx, recapID, job.Data["user_id"])
+	}
+}
+
+func (s *Scheduler) markRecapFailed(rctx request.CTX, recapID, userID string) {
+	recap, err := s.store.Recap().GetRecap(recapID)
+	if err != nil {
+		rctx.Logger().Warn("Could not get recap for reset job",
+			mlog.String("recap_id", recapID),
+			mlog.Err(err))
+		return
+	}
+	if recap.Status != model.RecapStatusProcessing && recap.Status != model.RecapStatusPending {
+		rctx.Logger().Debug("Recap for reset job is already terminal",
+			mlog.String("recap_id", recapID),
+			mlog.String("recap_status", recap.Status))
+		return
+	}
+
+	if err := s.store.Recap().UpdateRecapStatus(recapID, model.RecapStatusFailed); err != nil {
+		rctx.Logger().Error("Failed to mark recap as failed",
+			mlog.String("recap_id", recapID),
+			mlog.Err(err))
+		return
+	}
+	publishRecapUpdate(s.app, recapID, userID)
+}
+
+func (s *Scheduler) sweepOrphanedRecaps(rctx request.CTX) {
+	cutoff := model.GetMillis() - OrphanedRecapCutoff.Milliseconds()
+	recaps, err := s.store.Recap().GetRecapsByStatusOlderThan(model.RecapStatusProcessing, cutoff, orphanSweepLimit)
+	if err != nil {
+		rctx.Logger().Error("Failed to get orphaned processing recaps", mlog.Err(err))
+		return
+	}
+
+	for _, recap := range recaps {
+		jobsForRecap, err := s.store.Job().GetByTypeAndData(
+			rctx,
+			model.JobTypeRecap,
+			map[string]string{"recap_id": recap.Id},
+			true,
+			model.JobStatusPending,
+			model.JobStatusInProgress,
+		)
+		if err != nil {
+			rctx.Logger().Warn("Could not verify live jobs for processing recap",
+				mlog.String("recap_id", recap.Id),
+				mlog.Err(err))
+			continue
+		}
+		if len(jobsForRecap) > 0 {
+			continue
+		}
+
+		rctx.Logger().Warn("Recap stuck in processing with no live job; marking failed",
+			mlog.String("recap_id", recap.Id),
+			mlog.String("user_id", recap.UserId),
+			mlog.Millis("update_at", recap.UpdateAt))
+		if err := s.store.Recap().UpdateRecapStatus(recap.Id, model.RecapStatusFailed); err != nil {
+			rctx.Logger().Error("Failed to mark orphaned recap as failed",
+				mlog.String("recap_id", recap.Id),
+				mlog.Err(err))
+			continue
+		}
+		publishRecapUpdate(s.app, recap.Id, recap.UserId)
+	}
+}

--- a/server/channels/jobs/recap/scheduler_test.go
+++ b/server/channels/jobs/recap/scheduler_test.go
@@ -74,8 +74,7 @@ func TestRecapSchedulerWedgedJobMarksRecapFailedAndPublishes(t *testing.T) {
 		}), model.JobStatusInProgress).
 		Return(wedged, nil).
 		Once()
-	mockStore.RecapStore.On("GetRecap", "r1").Return(&model.Recap{Id: "r1", Status: model.RecapStatusProcessing}, nil).Once()
-	mockStore.RecapStore.On("UpdateRecapStatus", "r1", model.RecapStatusFailed).Return(nil).Once()
+	mockStore.RecapStore.On("MarkRecapFailedIfIncomplete", "r1").Return(true, nil).Once()
 	mockApp.On("Publish", recapUpdateMatcher("r1", "u1")).Once()
 	mockStore.RecapStore.
 		On("GetRecapsByStatusOlderThan", model.RecapStatusProcessing, mock.AnythingOfType("int64"), orphanSweepLimit).
@@ -88,7 +87,7 @@ func TestRecapSchedulerWedgedJobMarksRecapFailedAndPublishes(t *testing.T) {
 	mockStore.JobStore.AssertNumberOfCalls(t, "UpdateOptimistically", 1)
 }
 
-func TestRecapSchedulerWedgedJobSkipsTerminalRecap(t *testing.T) {
+func TestRecapSchedulerWedgedJobDoesNotClobberCompletedRecap(t *testing.T) {
 	scheduler, cfg, mockStore, mockApp := makeRecapScheduler(t)
 	stale := model.GetMillis() - (RecapJobWedgedTimeout + time.Minute).Milliseconds()
 	wedged := &model.Job{
@@ -103,7 +102,7 @@ func TestRecapSchedulerWedgedJobSkipsTerminalRecap(t *testing.T) {
 		On("UpdateOptimistically", mock.Anything, model.JobStatusInProgress).
 		Return(wedged, nil).
 		Once()
-	mockStore.RecapStore.On("GetRecap", "r1").Return(&model.Recap{Id: "r1", Status: model.RecapStatusCompleted}, nil).Once()
+	mockStore.RecapStore.On("MarkRecapFailedIfIncomplete", "r1").Return(false, nil).Once()
 	mockStore.RecapStore.
 		On("GetRecapsByStatusOlderThan", model.RecapStatusProcessing, mock.AnythingOfType("int64"), orphanSweepLimit).
 		Return([]*model.Recap{}, nil).
@@ -112,7 +111,6 @@ func TestRecapSchedulerWedgedJobSkipsTerminalRecap(t *testing.T) {
 	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
 	require.Nil(t, appErr)
 	require.Nil(t, job)
-	mockStore.RecapStore.AssertNotCalled(t, "UpdateRecapStatus", mock.Anything, mock.Anything)
 	mockApp.AssertNotCalled(t, "Publish", mock.Anything)
 }
 
@@ -136,13 +134,36 @@ func TestRecapSchedulerOrphanSweepSkipsRecapsWithLiveJobs(t *testing.T) {
 		On("GetByTypeAndData", mock.Anything, model.JobTypeRecap, map[string]string{"recap_id": "b"}, true, model.JobStatusPending, model.JobStatusInProgress).
 		Return([]*model.Job{}, nil).
 		Once()
-	mockStore.RecapStore.On("UpdateRecapStatus", "b", model.RecapStatusFailed).Return(nil).Once()
+	mockStore.RecapStore.On("MarkRecapFailedIfIncomplete", "b").Return(true, nil).Once()
 	mockApp.On("Publish", recapUpdateMatcher("b", "ub")).Once()
 
 	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
 	require.Nil(t, appErr)
 	require.Nil(t, job)
-	mockStore.RecapStore.AssertNotCalled(t, "UpdateRecapStatus", "a", mock.Anything)
+	mockStore.RecapStore.AssertNotCalled(t, "MarkRecapFailedIfIncomplete", "a")
+}
+
+func TestRecapSchedulerOrphanSweepDoesNotClobberCompletedRecap(t *testing.T) {
+	scheduler, cfg, mockStore, mockApp := makeRecapScheduler(t)
+	recap := &model.Recap{Id: "r1", UserId: "u1", Status: model.RecapStatusProcessing}
+	mockStore.JobStore.
+		On("GetAllByTypeAndStatus", mock.Anything, model.JobTypeRecap, model.JobStatusInProgress).
+		Return([]*model.Job{}, nil).
+		Once()
+	mockStore.RecapStore.
+		On("GetRecapsByStatusOlderThan", model.RecapStatusProcessing, mock.AnythingOfType("int64"), orphanSweepLimit).
+		Return([]*model.Recap{recap}, nil).
+		Once()
+	mockStore.JobStore.
+		On("GetByTypeAndData", mock.Anything, model.JobTypeRecap, map[string]string{"recap_id": "r1"}, true, model.JobStatusPending, model.JobStatusInProgress).
+		Return([]*model.Job{}, nil).
+		Once()
+	mockStore.RecapStore.On("MarkRecapFailedIfIncomplete", "r1").Return(false, nil).Once()
+
+	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
+	require.Nil(t, appErr)
+	require.Nil(t, job)
+	mockApp.AssertNotCalled(t, "Publish", mock.Anything)
 }
 
 func TestRecapSchedulerOrphanSweepCutoffAndLimit(t *testing.T) {

--- a/server/channels/jobs/recap/scheduler_test.go
+++ b/server/channels/jobs/recap/scheduler_test.go
@@ -1,0 +1,210 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package recap
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+	"github.com/mattermost/mattermost/server/v8/channels/jobs"
+	"github.com/mattermost/mattermost/server/v8/channels/store/storetest"
+	"github.com/mattermost/mattermost/server/v8/channels/utils/testutils"
+)
+
+func makeRecapScheduler(t *testing.T) (*Scheduler, *model.Config, *storetest.Store, *MockAppIface) {
+	t.Helper()
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	cfg.FeatureFlags.EnableAIRecaps = true
+
+	mockStore := &storetest.Store{}
+	t.Cleanup(func() {
+		mockStore.AssertExpectations(t)
+	})
+	mockApp := &MockAppIface{}
+	t.Cleanup(func() {
+		mockApp.AssertExpectations(t)
+	})
+
+	jobServer := jobs.NewJobServer(&testutils.StaticConfigService{Cfg: cfg}, mockStore, nil, mlog.CreateConsoleTestLogger(t), nil)
+	jobServer.RegisterJobType(model.JobTypeRecap, jobs.NewSimpleWorker(
+		"Recap",
+		jobServer,
+		func(logger mlog.LoggerIFace, job *model.Job) error { return nil },
+		func(cfg *model.Config) bool { return true },
+	), nil)
+
+	return MakeScheduler(jobServer, mockStore, mockApp), cfg, mockStore, mockApp
+}
+
+func recapUpdateMatcher(recapID, userID string) any {
+	return mock.MatchedBy(func(message *model.WebSocketEvent) bool {
+		return message.EventType() == model.WebsocketEventRecapUpdated &&
+			message.GetBroadcast().UserId == userID &&
+			message.GetData()["recap_id"] == recapID
+	})
+}
+
+func TestRecapSchedulerWedgedJobMarksRecapFailedAndPublishes(t *testing.T) {
+	scheduler, cfg, mockStore, mockApp := makeRecapScheduler(t)
+	stale := model.GetMillis() - (RecapJobWedgedTimeout + time.Minute).Milliseconds()
+	wedged := &model.Job{
+		Id: "j1", Type: model.JobTypeRecap, StartAt: stale, LastActivityAt: stale,
+		Data: map[string]string{"recap_id": "r1", "user_id": "u1"},
+	}
+	fresh := &model.Job{
+		Id: "j2", Type: model.JobTypeRecap, StartAt: model.GetMillis(), LastActivityAt: model.GetMillis(),
+	}
+	mockStore.JobStore.
+		On("GetAllByTypeAndStatus", mock.Anything, model.JobTypeRecap, model.JobStatusInProgress).
+		Return([]*model.Job{wedged, fresh}, nil).
+		Once()
+	mockStore.JobStore.
+		On("UpdateOptimistically", mock.MatchedBy(func(job *model.Job) bool {
+			return job == wedged && job.Status == model.JobStatusError &&
+				job.Data["recap_id"] == "r1" && job.Data["user_id"] == "u1"
+		}), model.JobStatusInProgress).
+		Return(wedged, nil).
+		Once()
+	mockStore.RecapStore.On("GetRecap", "r1").Return(&model.Recap{Id: "r1", Status: model.RecapStatusProcessing}, nil).Once()
+	mockStore.RecapStore.On("UpdateRecapStatus", "r1", model.RecapStatusFailed).Return(nil).Once()
+	mockApp.On("Publish", recapUpdateMatcher("r1", "u1")).Once()
+	mockStore.RecapStore.
+		On("GetRecapsByStatusOlderThan", model.RecapStatusProcessing, mock.AnythingOfType("int64"), orphanSweepLimit).
+		Return([]*model.Recap{}, nil).
+		Once()
+
+	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
+	require.Nil(t, appErr)
+	require.Nil(t, job)
+	mockStore.JobStore.AssertNumberOfCalls(t, "UpdateOptimistically", 1)
+}
+
+func TestRecapSchedulerWedgedJobSkipsTerminalRecap(t *testing.T) {
+	scheduler, cfg, mockStore, mockApp := makeRecapScheduler(t)
+	stale := model.GetMillis() - (RecapJobWedgedTimeout + time.Minute).Milliseconds()
+	wedged := &model.Job{
+		Id: "j1", Type: model.JobTypeRecap, StartAt: stale, LastActivityAt: stale,
+		Data: map[string]string{"recap_id": "r1", "user_id": "u1"},
+	}
+	mockStore.JobStore.
+		On("GetAllByTypeAndStatus", mock.Anything, model.JobTypeRecap, model.JobStatusInProgress).
+		Return([]*model.Job{wedged}, nil).
+		Once()
+	mockStore.JobStore.
+		On("UpdateOptimistically", mock.Anything, model.JobStatusInProgress).
+		Return(wedged, nil).
+		Once()
+	mockStore.RecapStore.On("GetRecap", "r1").Return(&model.Recap{Id: "r1", Status: model.RecapStatusCompleted}, nil).Once()
+	mockStore.RecapStore.
+		On("GetRecapsByStatusOlderThan", model.RecapStatusProcessing, mock.AnythingOfType("int64"), orphanSweepLimit).
+		Return([]*model.Recap{}, nil).
+		Once()
+
+	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
+	require.Nil(t, appErr)
+	require.Nil(t, job)
+	mockStore.RecapStore.AssertNotCalled(t, "UpdateRecapStatus", mock.Anything, mock.Anything)
+	mockApp.AssertNotCalled(t, "Publish", mock.Anything)
+}
+
+func TestRecapSchedulerOrphanSweepSkipsRecapsWithLiveJobs(t *testing.T) {
+	scheduler, cfg, mockStore, mockApp := makeRecapScheduler(t)
+	recapA := &model.Recap{Id: "a", UserId: "ua", Status: model.RecapStatusProcessing}
+	recapB := &model.Recap{Id: "b", UserId: "ub", Status: model.RecapStatusProcessing}
+	mockStore.JobStore.
+		On("GetAllByTypeAndStatus", mock.Anything, model.JobTypeRecap, model.JobStatusInProgress).
+		Return([]*model.Job{}, nil).
+		Once()
+	mockStore.RecapStore.
+		On("GetRecapsByStatusOlderThan", model.RecapStatusProcessing, mock.AnythingOfType("int64"), orphanSweepLimit).
+		Return([]*model.Recap{recapA, recapB}, nil).
+		Once()
+	mockStore.JobStore.
+		On("GetByTypeAndData", mock.Anything, model.JobTypeRecap, map[string]string{"recap_id": "a"}, true, model.JobStatusPending, model.JobStatusInProgress).
+		Return([]*model.Job{{Id: "live", Status: model.JobStatusInProgress}}, nil).
+		Once()
+	mockStore.JobStore.
+		On("GetByTypeAndData", mock.Anything, model.JobTypeRecap, map[string]string{"recap_id": "b"}, true, model.JobStatusPending, model.JobStatusInProgress).
+		Return([]*model.Job{}, nil).
+		Once()
+	mockStore.RecapStore.On("UpdateRecapStatus", "b", model.RecapStatusFailed).Return(nil).Once()
+	mockApp.On("Publish", recapUpdateMatcher("b", "ub")).Once()
+
+	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
+	require.Nil(t, appErr)
+	require.Nil(t, job)
+	mockStore.RecapStore.AssertNotCalled(t, "UpdateRecapStatus", "a", mock.Anything)
+}
+
+func TestRecapSchedulerOrphanSweepCutoffAndLimit(t *testing.T) {
+	scheduler, cfg, mockStore, _ := makeRecapScheduler(t)
+	now := model.GetMillis()
+	mockStore.JobStore.
+		On("GetAllByTypeAndStatus", mock.Anything, model.JobTypeRecap, model.JobStatusInProgress).
+		Return([]*model.Job{}, nil).
+		Once()
+	mockStore.RecapStore.
+		On("GetRecapsByStatusOlderThan", model.RecapStatusProcessing, mock.MatchedBy(func(cutoff int64) bool {
+			return cutoff >= now-(61*time.Minute).Milliseconds() &&
+				cutoff <= now-(59*time.Minute).Milliseconds()
+		}), orphanSweepLimit).
+		Return([]*model.Recap{}, nil).
+		Once()
+
+	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
+	require.Nil(t, appErr)
+	require.Nil(t, job)
+}
+
+func TestRecapSchedulerEnabled(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *model.Config
+		want bool
+	}{
+		{
+			name: "feature and setting enabled",
+			cfg: &model.Config{
+				FeatureFlags: &model.FeatureFlags{EnableAIRecaps: true},
+				AIRecapSettings: model.AIRecapSettings{
+					Enable: model.NewPointer(true),
+				},
+			},
+			want: true,
+		},
+		{
+			name: "feature disabled",
+			cfg: &model.Config{
+				FeatureFlags: &model.FeatureFlags{EnableAIRecaps: false},
+				AIRecapSettings: model.AIRecapSettings{
+					Enable: model.NewPointer(true),
+				},
+			},
+		},
+		{
+			name: "setting disabled",
+			cfg: &model.Config{
+				FeatureFlags: &model.FeatureFlags{EnableAIRecaps: true},
+				AIRecapSettings: model.AIRecapSettings{
+					Enable: model.NewPointer(false),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			scheduler, _, _, _ := makeRecapScheduler(t)
+			require.Equal(t, tt.want, scheduler.Enabled(tt.cfg))
+		})
+	}
+}

--- a/server/channels/jobs/recovery.go
+++ b/server/channels/jobs/recovery.go
@@ -1,0 +1,53 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package jobs
+
+import (
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+)
+
+// ResetWedgedJobs marks in-progress jobs of the given type as errored when they have shown
+// no activity for longer than the given timeout. Both LastActivityAt and StartAt must be
+// stale, and the transition is optimistic so a concurrently completed job is not clobbered.
+// It returns only jobs whose transition committed.
+func (srv *JobServer) ResetWedgedJobs(rctx request.CTX, jobType string, timeout time.Duration) ([]*model.Job, *model.AppError) {
+	jobs, appErr := srv.GetJobsByTypeAndStatus(rctx, jobType, model.JobStatusInProgress)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	cutoff := model.GetMillis() - timeout.Milliseconds()
+	var resetJobs []*model.Job
+	for _, job := range jobs {
+		if job.LastActivityAt >= cutoff || job.StartAt >= cutoff {
+			continue
+		}
+
+		logger := rctx.Logger().With(JobLoggerFields(job)...)
+		logger.Warn("Job appears to be wedged. Marking it as errored.",
+			mlog.Millis("last_activity_at", job.LastActivityAt),
+			mlog.Millis("start_at", job.StartAt),
+			mlog.Duration("wedged_timeout", timeout),
+		)
+
+		wedgedErr := model.NewAppError("ResetWedgedJobs", "app.job.wedged.app_error", nil,
+			fmt.Sprintf("no job activity for longer than %s; last_activity_at=%d start_at=%d",
+				timeout, job.LastActivityAt, job.StartAt),
+			http.StatusInternalServerError)
+		if setErr := srv.SetJobError(job, wedgedErr); setErr != nil {
+			logger.Warn("Could not mark wedged job as errored; it is likely no longer in progress",
+				mlog.Err(setErr))
+			continue
+		}
+		resetJobs = append(resetJobs, job)
+	}
+
+	return resetJobs, nil
+}

--- a/server/channels/jobs/recovery_test.go
+++ b/server/channels/jobs/recovery_test.go
@@ -5,6 +5,7 @@ package jobs
 
 import (
 	"errors"
+	"maps"
 	"os"
 	"testing"
 	"time"
@@ -108,9 +109,7 @@ func TestResetWedgedJobs(t *testing.T) {
 				}
 
 				originalData := make(map[string]string, len(job.Data))
-				for key, value := range job.Data {
-					originalData[key] = value
-				}
+				maps.Copy(originalData, job.Data)
 				matcher := mock.MatchedBy(func(candidate *model.Job) bool {
 					if candidate != job || candidate.Status != model.JobStatusError || candidate.Progress != -1 || candidate.Data["error"] == "" {
 						return false

--- a/server/channels/jobs/recovery_test.go
+++ b/server/channels/jobs/recovery_test.go
@@ -1,0 +1,161 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package jobs
+
+import (
+	"errors"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+)
+
+func TestResetWedgedJobs(t *testing.T) {
+	if os.Getenv("ENABLE_FULLY_PARALLEL_TESTS") == "true" {
+		t.Parallel()
+	}
+
+	const jobType = "some_job_type"
+	timeout := 15 * time.Minute
+	now := model.GetMillis()
+	stale := now - (timeout + time.Minute).Milliseconds()
+	fresh := now
+
+	type outcome string
+	const (
+		reset    outcome = "reset"
+		lostRace outcome = "lost_race"
+	)
+
+	tests := []struct {
+		name        string
+		jobs        []*model.Job
+		storeErr    error
+		outcomes    map[string]outcome
+		wantErrorID string
+		wantUpdates int
+	}{
+		{
+			name: "no in-progress jobs",
+			jobs: []*model.Job{},
+		},
+		{
+			name:        "store error",
+			storeErr:    errors.New("boom"),
+			wantErrorID: "app.job.get_all_jobs_by_type_and_status.app_error",
+		},
+		{
+			name: "both timestamps fresh",
+			jobs: []*model.Job{{Id: "fresh", Type: jobType, StartAt: fresh, LastActivityAt: fresh}},
+		},
+		{
+			name: "stale LastActivityAt, fresh StartAt",
+			jobs: []*model.Job{{Id: "fresh-start", Type: jobType, StartAt: fresh, LastActivityAt: stale}},
+		},
+		{
+			name: "fresh LastActivityAt, stale StartAt",
+			jobs: []*model.Job{{Id: "fresh-activity", Type: jobType, StartAt: stale, LastActivityAt: fresh}},
+		},
+		{
+			name: "both stale resets",
+			jobs: []*model.Job{{
+				Id: "reset", Type: jobType, StartAt: stale, LastActivityAt: stale, Data: map[string]string{"k": "v"},
+			}},
+			outcomes:    map[string]outcome{"reset": reset},
+			wantUpdates: 1,
+		},
+		{
+			name: "both stale but lost race",
+			jobs: []*model.Job{{
+				Id: "lost", Type: jobType, StartAt: stale, LastActivityAt: stale,
+			}},
+			outcomes:    map[string]outcome{"lost": lostRace},
+			wantUpdates: 2,
+		},
+		{
+			name: "mixed batch",
+			jobs: []*model.Job{
+				{Id: "mixed-fresh", Type: jobType, StartAt: fresh, LastActivityAt: fresh},
+				{Id: "mixed-reset", Type: jobType, StartAt: stale, LastActivityAt: stale, Data: map[string]string{"recap_id": "r1"}},
+				{Id: "mixed-lost", Type: jobType, StartAt: stale, LastActivityAt: stale},
+			},
+			outcomes:    map[string]outcome{"mixed-reset": reset, "mixed-lost": lostRace},
+			wantUpdates: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			jobServer, mockStore, mockMetrics := makeJobServer(t)
+			rctx := request.TestContext(t)
+
+			mockStore.JobStore.
+				On("GetAllByTypeAndStatus", mock.Anything, jobType, model.JobStatusInProgress).
+				Return(tt.jobs, tt.storeErr).
+				Once()
+
+			var wantReset []*model.Job
+			for _, job := range tt.jobs {
+				jobOutcome, ok := tt.outcomes[job.Id]
+				if !ok {
+					continue
+				}
+
+				originalData := make(map[string]string, len(job.Data))
+				for key, value := range job.Data {
+					originalData[key] = value
+				}
+				matcher := mock.MatchedBy(func(candidate *model.Job) bool {
+					if candidate != job || candidate.Status != model.JobStatusError || candidate.Progress != -1 || candidate.Data["error"] == "" {
+						return false
+					}
+					for key, value := range originalData {
+						if candidate.Data[key] != value {
+							return false
+						}
+					}
+					return true
+				})
+
+				switch jobOutcome {
+				case reset:
+					mockStore.JobStore.
+						On("UpdateOptimistically", matcher, model.JobStatusInProgress).
+						Return(job, nil).
+						Once()
+					mockMetrics.On("DecrementJobActive", jobType).Once()
+					wantReset = append(wantReset, job)
+				case lostRace:
+					mockStore.JobStore.
+						On("UpdateOptimistically", matcher, model.JobStatusInProgress).
+						Return(nil, nil).
+						Once()
+					mockStore.JobStore.
+						On("UpdateOptimistically", matcher, model.JobStatusCancelRequested).
+						Return(nil, nil).
+						Once()
+				}
+			}
+
+			resetJobs, appErr := jobServer.ResetWedgedJobs(rctx, jobType, timeout)
+			if tt.wantErrorID != "" {
+				expectErrorId(t, tt.wantErrorID, appErr)
+				require.Nil(t, resetJobs)
+				return
+			}
+
+			require.Nil(t, appErr)
+			require.Equal(t, wantReset, resetJobs)
+			for i, job := range wantReset {
+				require.Same(t, job, resetJobs[i])
+			}
+			mockStore.JobStore.AssertNumberOfCalls(t, "UpdateOptimistically", tt.wantUpdates)
+		})
+	}
+}

--- a/server/channels/jobs/scheduled_recap/scheduler.go
+++ b/server/channels/jobs/scheduled_recap/scheduler.go
@@ -16,6 +16,9 @@ import (
 // SchedulerPollingInterval defines how often the scheduler polls for due scheduled recaps.
 const SchedulerPollingInterval = 1 * time.Minute
 
+// ScheduledRecapJobWedgedTimeout is the maximum time a scheduled recap job may remain in progress.
+const ScheduledRecapJobWedgedTimeout = 15 * time.Minute
+
 // Scheduler polls for due scheduled recaps and creates jobs for them.
 type Scheduler struct {
 	*jobs.PeriodicScheduler
@@ -48,6 +51,16 @@ func (s *Scheduler) NextScheduleTime(cfg *model.Config, now time.Time, pendingJo
 
 // ScheduleJob polls for due scheduled recaps and creates jobs for each.
 func (s *Scheduler) ScheduleJob(rctx request.CTX, cfg *model.Config, pendingJobs bool, lastJob *model.Job) (*model.Job, *model.AppError) {
+	if _, appErr := s.jobServer.ResetWedgedJobs(rctx, model.JobTypeScheduledRecap, ScheduledRecapJobWedgedTimeout); appErr != nil {
+		mlog.Error("Failed to reset wedged scheduled recap jobs", mlog.Err(appErr))
+		// Continue: enqueueing due schedules that are not blocked is still useful.
+	}
+	// Known accepted risk: if the dead worker crashed between committing the Recap row and
+	// MarkExecuted (a milliseconds-wide window inside CreateRecapFromSchedule), the retry
+	// creates a duplicate recap for that run. Deliberately not mitigated: it would need a
+	// recap-by-schedule store query and reconciliation semantics disproportionate to the
+	// window, and SaveRecapIfUnderDailyLimit caps the damage.
+
 	now := model.GetMillis()
 	dueRecaps, err := s.store.ScheduledRecap().GetDueBefore(now, 100)
 	if err != nil {

--- a/server/channels/jobs/scheduled_recap/scheduler_test.go
+++ b/server/channels/jobs/scheduled_recap/scheduler_test.go
@@ -4,7 +4,9 @@
 package scheduled_recap
 
 import (
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
@@ -39,6 +41,10 @@ func TestScheduleJobEnqueuesEachDueRecapAndSkipsDuplicateAtomically(t *testing.T
 	duplicateRecap := *dueRecap1
 	dueRecaps := []*model.ScheduledRecap{dueRecap1, dueRecap2, &duplicateRecap}
 
+	mockStore.JobStore.
+		On("GetAllByTypeAndStatus", mock.Anything, model.JobTypeScheduledRecap, model.JobStatusInProgress).
+		Return([]*model.Job{}, nil).
+		Once()
 	mockStore.ScheduledRecapStore.
 		On("GetDueBefore", mock.AnythingOfType("int64"), 100).
 		Return(dueRecaps, nil)
@@ -64,6 +70,106 @@ func TestScheduleJobEnqueuesEachDueRecapAndSkipsDuplicateAtomically(t *testing.T
 
 	scheduler := MakeScheduler(jobServer, mockStore)
 	job, appErr := scheduler.ScheduleJob(request.EmptyContext(mlog.CreateConsoleTestLogger(t)), cfg, false, nil)
+	require.Nil(t, appErr)
+	require.Nil(t, job)
+}
+
+func TestScheduleJobResetsWedgedJobThenEnqueuesSameTick(t *testing.T) {
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	cfg.FeatureFlags.EnableAIRecaps = true
+
+	mockStore := &storetest.Store{}
+	t.Cleanup(func() {
+		mockStore.AssertExpectations(t)
+	})
+	jobServer := jobs.NewJobServer(&testutils.StaticConfigService{Cfg: cfg}, mockStore, nil, mlog.CreateConsoleTestLogger(t), nil)
+	jobServer.RegisterJobType(model.JobTypeScheduledRecap, jobs.NewSimpleWorker(
+		model.JobTypeScheduledRecap,
+		jobServer,
+		func(logger mlog.LoggerIFace, job *model.Job) error { return nil },
+		func(cfg *model.Config) bool { return true },
+	), nil)
+
+	scheduledRecap := testScheduledRecap(true)
+	stale := model.GetMillis() - (ScheduledRecapJobWedgedTimeout + time.Minute).Milliseconds()
+	wedged := &model.Job{
+		Id:             model.NewId(),
+		Type:           model.JobTypeScheduledRecap,
+		StartAt:        stale,
+		LastActivityAt: stale,
+		Data:           map[string]string{"scheduled_recap_id": scheduledRecap.Id},
+	}
+	var order []string
+	mockStore.JobStore.
+		On("GetAllByTypeAndStatus", mock.Anything, model.JobTypeScheduledRecap, model.JobStatusInProgress).
+		Return([]*model.Job{wedged}, nil).
+		Once()
+	mockStore.JobStore.
+		On("UpdateOptimistically", mock.MatchedBy(func(job *model.Job) bool {
+			return job == wedged && job.Status == model.JobStatusError &&
+				job.Data["scheduled_recap_id"] == scheduledRecap.Id
+		}), model.JobStatusInProgress).
+		Run(func(args mock.Arguments) {
+			order = append(order, "reset")
+		}).
+		Return(wedged, nil).
+		Once()
+	mockStore.ScheduledRecapStore.
+		On("GetDueBefore", mock.AnythingOfType("int64"), 100).
+		Return([]*model.ScheduledRecap{scheduledRecap}, nil).
+		Once()
+	mockStore.JobStore.
+		On("SaveOnceByTypeAndData", mock.MatchedBy(func(job *model.Job) bool {
+			return job.Type == model.JobTypeScheduledRecap &&
+				job.Data["scheduled_recap_id"] == scheduledRecap.Id
+		}), map[string]string{"scheduled_recap_id": scheduledRecap.Id}).
+		Run(func(args mock.Arguments) {
+			order = append(order, "enqueue")
+		}).
+		Return(func(job *model.Job, data map[string]string) *model.Job { return job }, nil).
+		Once()
+
+	scheduler := MakeScheduler(jobServer, mockStore)
+	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
+	require.Nil(t, appErr)
+	require.Nil(t, job)
+	require.Equal(t, []string{"reset", "enqueue"}, order)
+}
+
+func TestScheduleJobContinuesWhenWedgedResetFails(t *testing.T) {
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	cfg.FeatureFlags.EnableAIRecaps = true
+
+	mockStore := &storetest.Store{}
+	t.Cleanup(func() {
+		mockStore.AssertExpectations(t)
+	})
+	jobServer := jobs.NewJobServer(&testutils.StaticConfigService{Cfg: cfg}, mockStore, nil, mlog.CreateConsoleTestLogger(t), nil)
+	jobServer.RegisterJobType(model.JobTypeScheduledRecap, jobs.NewSimpleWorker(
+		model.JobTypeScheduledRecap,
+		jobServer,
+		func(logger mlog.LoggerIFace, job *model.Job) error { return nil },
+		func(cfg *model.Config) bool { return true },
+	), nil)
+
+	scheduledRecap := testScheduledRecap(true)
+	mockStore.JobStore.
+		On("GetAllByTypeAndStatus", mock.Anything, model.JobTypeScheduledRecap, model.JobStatusInProgress).
+		Return(nil, errors.New("boom")).
+		Once()
+	mockStore.ScheduledRecapStore.
+		On("GetDueBefore", mock.AnythingOfType("int64"), 100).
+		Return([]*model.ScheduledRecap{scheduledRecap}, nil).
+		Once()
+	mockStore.JobStore.
+		On("SaveOnceByTypeAndData", mock.Anything, map[string]string{"scheduled_recap_id": scheduledRecap.Id}).
+		Return(func(job *model.Job, data map[string]string) *model.Job { return job }, nil).
+		Once()
+
+	scheduler := MakeScheduler(jobServer, mockStore)
+	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
 	require.Nil(t, appErr)
 	require.Nil(t, job)
 }

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -11638,6 +11638,27 @@ func (s *RetryLayerRecapStore) MarkRecapAsRead(id string) error {
 
 }
 
+func (s *RetryLayerRecapStore) MarkRecapFailedIfIncomplete(id string) (bool, error) {
+
+	tries := 0
+	for {
+		result, err := s.RecapStore.MarkRecapFailedIfIncomplete(id)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerRecapStore) MarkRecapSkipped(id string, reason string) error {
 
 	tries := 0

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -11575,6 +11575,27 @@ func (s *RetryLayerRecapStore) GetRecapChannelsByRecapId(recapId string) ([]*mod
 
 }
 
+func (s *RetryLayerRecapStore) GetRecapsByStatusOlderThan(status string, olderThan int64, limit int) ([]*model.Recap, error) {
+
+	tries := 0
+	for {
+		result, err := s.RecapStore.GetRecapsByStatusOlderThan(status, olderThan, limit)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerRecapStore) GetRecapsForUser(userId string, page int, perPage int) ([]*model.Recap, error) {
 
 	tries := 0

--- a/server/channels/store/sqlstore/recap_store.go
+++ b/server/channels/store/sqlstore/recap_store.go
@@ -245,6 +245,34 @@ func (s *SqlRecapStore) UpdateRecapStatus(id, status string) error {
 	return nil
 }
 
+// MarkRecapFailedIfIncomplete atomically fails a non-terminal recap so recovery
+// cannot overwrite a worker that completed concurrently.
+func (s *SqlRecapStore) MarkRecapFailedIfIncomplete(id string) (bool, error) {
+	query := s.getQueryBuilder().
+		Update("Recaps").
+		SetMap(map[string]any{
+			"Status":   model.RecapStatusFailed,
+			"UpdateAt": model.GetMillis(),
+		}).
+		Where(sq.Eq{
+			"Id":       id,
+			"DeleteAt": 0,
+			"Status":   []string{model.RecapStatusPending, model.RecapStatusProcessing},
+		})
+
+	result, err := s.GetMaster().ExecBuilder(query)
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to mark Recap as failed for id=%s", id)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return false, errors.Wrapf(err, "failed to get affected rows after marking Recap as failed for id=%s", id)
+	}
+
+	return rowsAffected > 0, nil
+}
+
 // MarkRecapSkipped flips a still-pending recap to skipped. Scoped to pending so a
 // recap a worker has already started processing is never clobbered.
 func (s *SqlRecapStore) MarkRecapSkipped(id, reason string) error {

--- a/server/channels/store/sqlstore/recap_store.go
+++ b/server/channels/store/sqlstore/recap_store.go
@@ -192,6 +192,21 @@ func (s *SqlRecapStore) GetRecapsForUser(userId string, page, perPage int) ([]*m
 	return recaps, nil
 }
 
+func (s *SqlRecapStore) GetRecapsByStatusOlderThan(status string, olderThan int64, limit int) ([]*model.Recap, error) {
+	query := s.recapSelectQuery.
+		Where(sq.Eq{"Status": status, "DeleteAt": 0}).
+		Where(sq.Lt{"UpdateAt": olderThan}).
+		OrderBy("UpdateAt ASC").
+		Limit(uint64(limit))
+
+	var recaps []*model.Recap
+	if err := s.GetReplica().SelectBuilder(&recaps, query); err != nil {
+		return nil, errors.Wrapf(err, "failed to get Recaps with status=%s older than %d", status, olderThan)
+	}
+
+	return recaps, nil
+}
+
 func (s *SqlRecapStore) UpdateRecap(recap *model.Recap) (*model.Recap, error) {
 	query := s.getQueryBuilder().
 		Update("Recaps").

--- a/server/channels/store/sqlstore/recap_store_test.go
+++ b/server/channels/store/sqlstore/recap_store_test.go
@@ -5,6 +5,7 @@ package sqlstore
 
 import (
 	"testing"
+	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/request"
@@ -104,6 +105,60 @@ func TestRecapStore(t *testing.T) {
 			}
 			assert.ElementsMatch(t, []string{completed, failed}, ids)
 			assert.NotContains(t, ids, skipped)
+		})
+
+		t.Run("GetRecapsByStatusOlderThan", func(t *testing.T) {
+			now := model.GetMillis()
+			save := func(status string, updateAt int64) *model.Recap {
+				recap := &model.Recap{
+					Id:                model.NewId(),
+					UserId:            model.NewId(),
+					Title:             "Test Recap",
+					CreateAt:          updateAt,
+					UpdateAt:          updateAt,
+					TotalMessageCount: 1,
+					Status:            status,
+					BotID:             "test-bot-id",
+				}
+				_, err := ss.Recap().SaveRecap(recap)
+				require.NoError(t, err)
+				return recap
+			}
+
+			oldest := save(model.RecapStatusProcessing, now-(2*time.Hour).Milliseconds())
+			newer := save(model.RecapStatusProcessing, now-(90*time.Minute).Milliseconds())
+			fresh := save(model.RecapStatusProcessing, now)
+			completed := save(model.RecapStatusCompleted, now-(2*time.Hour).Milliseconds())
+			deleted := save(model.RecapStatusProcessing, now-(2*time.Hour).Milliseconds())
+			require.NoError(t, ss.Recap().DeleteRecap(deleted.Id))
+
+			seededIDs := map[string]bool{
+				oldest.Id:    true,
+				newer.Id:     true,
+				fresh.Id:     true,
+				completed.Id: true,
+				deleted.Id:   true,
+			}
+			toIDs := func(recaps []*model.Recap) []string {
+				ids := make([]string, 0, len(recaps))
+				for _, recap := range recaps {
+					require.True(t, seededIDs[recap.Id], "unexpected recap returned: %s", recap.Id)
+					ids = append(ids, recap.Id)
+				}
+				return ids
+			}
+
+			recaps, err := ss.Recap().GetRecapsByStatusOlderThan(model.RecapStatusProcessing, now-time.Hour.Milliseconds(), 10)
+			require.NoError(t, err)
+			assert.Equal(t, []string{oldest.Id, newer.Id}, toIDs(recaps))
+
+			recaps, err = ss.Recap().GetRecapsByStatusOlderThan(model.RecapStatusProcessing, now-time.Hour.Milliseconds(), 1)
+			require.NoError(t, err)
+			assert.Equal(t, []string{oldest.Id}, toIDs(recaps))
+
+			recaps, err = ss.Recap().GetRecapsByStatusOlderThan(model.RecapStatusProcessing, now-(3*time.Hour).Milliseconds(), 10)
+			require.NoError(t, err)
+			assert.Empty(t, recaps)
 		})
 
 		t.Run("UpdateRecapStatus", func(t *testing.T) {

--- a/server/channels/store/sqlstore/recap_store_test.go
+++ b/server/channels/store/sqlstore/recap_store_test.go
@@ -186,6 +186,57 @@ func TestRecapStore(t *testing.T) {
 			assert.Equal(t, model.RecapStatusCompleted, updatedRecap.Status)
 		})
 
+		t.Run("MarkRecapFailedIfIncomplete", func(t *testing.T) {
+			tests := []struct {
+				name             string
+				status           string
+				wantTransitioned bool
+				wantStatus       string
+			}{
+				{
+					name:             "pending recap transitions",
+					status:           model.RecapStatusPending,
+					wantTransitioned: true,
+					wantStatus:       model.RecapStatusFailed,
+				},
+				{
+					name:             "processing recap transitions",
+					status:           model.RecapStatusProcessing,
+					wantTransitioned: true,
+					wantStatus:       model.RecapStatusFailed,
+				},
+				{
+					name:       "completed recap is unchanged",
+					status:     model.RecapStatusCompleted,
+					wantStatus: model.RecapStatusCompleted,
+				},
+			}
+
+			for _, tt := range tests {
+				t.Run(tt.name, func(t *testing.T) {
+					recap := &model.Recap{
+						Id:       model.NewId(),
+						UserId:   model.NewId(),
+						Title:    "Test Recap",
+						CreateAt: model.GetMillis(),
+						UpdateAt: model.GetMillis(),
+						Status:   tt.status,
+						BotID:    "test-bot-id",
+					}
+					_, err := ss.Recap().SaveRecap(recap)
+					require.NoError(t, err)
+
+					transitioned, err := ss.Recap().MarkRecapFailedIfIncomplete(recap.Id)
+					require.NoError(t, err)
+					assert.Equal(t, tt.wantTransitioned, transitioned)
+
+					updated, err := ss.Recap().GetRecap(recap.Id)
+					require.NoError(t, err)
+					assert.Equal(t, tt.wantStatus, updated.Status)
+				})
+			}
+		})
+
 		t.Run("SaveAndGetRecapChannels", func(t *testing.T) {
 			recapId := model.NewId()
 

--- a/server/channels/store/sqlstore/recap_store_test.go
+++ b/server/channels/store/sqlstore/recap_store_test.go
@@ -190,6 +190,7 @@ func TestRecapStore(t *testing.T) {
 			tests := []struct {
 				name             string
 				status           string
+				deleted          bool
 				wantTransitioned bool
 				wantStatus       string
 			}{
@@ -210,6 +211,12 @@ func TestRecapStore(t *testing.T) {
 					status:     model.RecapStatusCompleted,
 					wantStatus: model.RecapStatusCompleted,
 				},
+				{
+					name:       "soft-deleted processing recap is unchanged",
+					status:     model.RecapStatusProcessing,
+					deleted:    true,
+					wantStatus: model.RecapStatusProcessing,
+				},
 			}
 
 			for _, tt := range tests {
@@ -225,11 +232,17 @@ func TestRecapStore(t *testing.T) {
 					}
 					_, err := ss.Recap().SaveRecap(recap)
 					require.NoError(t, err)
+					if tt.deleted {
+						require.NoError(t, ss.Recap().DeleteRecap(recap.Id))
+					}
 
 					transitioned, err := ss.Recap().MarkRecapFailedIfIncomplete(recap.Id)
 					require.NoError(t, err)
 					assert.Equal(t, tt.wantTransitioned, transitioned)
 
+					if tt.deleted {
+						return
+					}
 					updated, err := ss.Recap().GetRecap(recap.Id)
 					require.NoError(t, err)
 					assert.Equal(t, tt.wantStatus, updated.Status)

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -1418,6 +1418,10 @@ type RecapStore interface {
 	UpdateRecap(recap *model.Recap) (*model.Recap, error)
 	GetRecap(id string) (*model.Recap, error)
 	GetRecapsForUser(userId string, page, perPage int) ([]*model.Recap, error)
+	// GetRecapsByStatusOlderThan returns non-deleted recaps in the given status whose
+	// UpdateAt is strictly older than the given timestamp, oldest first, at most limit rows.
+	// Used by the recap recovery scheduler to find rows stuck in 'processing'.
+	GetRecapsByStatusOlderThan(status string, olderThan int64, limit int) ([]*model.Recap, error)
 	UpdateRecapStatus(id, status string) error
 	// MarkRecapSkipped flips a recap to the skipped status with the given reason.
 	// Skipped recaps are excluded from the daily-limit count, so this frees the slot

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -1423,6 +1423,9 @@ type RecapStore interface {
 	// Used by the recap recovery scheduler to find rows stuck in 'processing'.
 	GetRecapsByStatusOlderThan(status string, olderThan int64, limit int) ([]*model.Recap, error)
 	UpdateRecapStatus(id, status string) error
+	// MarkRecapFailedIfIncomplete atomically marks a pending or processing recap
+	// as failed. It returns false when the recap is already terminal or deleted.
+	MarkRecapFailedIfIncomplete(id string) (bool, error)
 	// MarkRecapSkipped flips a recap to the skipped status with the given reason.
 	// Skipped recaps are excluded from the daily-limit count, so this frees the slot
 	// for a recap that never ran (e.g. its processing job failed to enqueue).

--- a/server/channels/store/storetest/mocks/RecapStore.go
+++ b/server/channels/store/storetest/mocks/RecapStore.go
@@ -246,6 +246,34 @@ func (_m *RecapStore) MarkRecapAsRead(id string) error {
 	return r0
 }
 
+// MarkRecapFailedIfIncomplete provides a mock function with given fields: id
+func (_m *RecapStore) MarkRecapFailedIfIncomplete(id string) (bool, error) {
+	ret := _m.Called(id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MarkRecapFailedIfIncomplete")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (bool, error)); ok {
+		return rf(id)
+	}
+	if rf, ok := ret.Get(0).(func(string) bool); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // MarkRecapSkipped provides a mock function with given fields: id, reason
 func (_m *RecapStore) MarkRecapSkipped(id string, reason string) error {
 	ret := _m.Called(id, reason)

--- a/server/channels/store/storetest/mocks/RecapStore.go
+++ b/server/channels/store/storetest/mocks/RecapStore.go
@@ -168,6 +168,36 @@ func (_m *RecapStore) GetRecapChannelsByRecapId(recapId string) ([]*model.RecapC
 	return r0, r1
 }
 
+// GetRecapsByStatusOlderThan provides a mock function with given fields: status, olderThan, limit
+func (_m *RecapStore) GetRecapsByStatusOlderThan(status string, olderThan int64, limit int) ([]*model.Recap, error) {
+	ret := _m.Called(status, olderThan, limit)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetRecapsByStatusOlderThan")
+	}
+
+	var r0 []*model.Recap
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, int64, int) ([]*model.Recap, error)); ok {
+		return rf(status, olderThan, limit)
+	}
+	if rf, ok := ret.Get(0).(func(string, int64, int) []*model.Recap); ok {
+		r0 = rf(status, olderThan, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.Recap)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, int64, int) error); ok {
+		r1 = rf(status, olderThan, limit)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetRecapsForUser provides a mock function with given fields: userId, page, perPage
 func (_m *RecapStore) GetRecapsForUser(userId string, page int, perPage int) ([]*model.Recap, error) {
 	ret := _m.Called(userId, page, perPage)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -9251,6 +9251,22 @@ func (s *TimerLayerRecapStore) MarkRecapAsRead(id string) error {
 	return err
 }
 
+func (s *TimerLayerRecapStore) MarkRecapFailedIfIncomplete(id string) (bool, error) {
+	start := time.Now()
+
+	result, err := s.RecapStore.MarkRecapFailedIfIncomplete(id)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RecapStore.MarkRecapFailedIfIncomplete", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerRecapStore) MarkRecapSkipped(id string, reason string) error {
 	start := time.Now()
 

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -9203,6 +9203,22 @@ func (s *TimerLayerRecapStore) GetRecapChannelsByRecapId(recapId string) ([]*mod
 	return result, err
 }
 
+func (s *TimerLayerRecapStore) GetRecapsByStatusOlderThan(status string, olderThan int64, limit int) ([]*model.Recap, error) {
+	start := time.Now()
+
+	result, err := s.RecapStore.GetRecapsByStatusOlderThan(status, olderThan, limit)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RecapStore.GetRecapsByStatusOlderThan", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerRecapStore) GetRecapsForUser(userId string, page int, perPage int) ([]*model.Recap, error) {
 	start := time.Now()
 

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -7581,6 +7581,10 @@
     "translation": "Unable to update job status. Invalid status set"
   },
   {
+    "id": "app.job.wedged.app_error",
+    "translation": "The job stopped reporting progress and was marked as failed."
+  },
+  {
     "id": "app.last_accessible_file.app_error",
     "translation": "Error fetching last accessible file"
   },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Part 2 of 5 in the scheduled-recap concurrency stack (stacked on #37602).

If a node dies while a recap or scheduled-recap job is `InProgress`, nothing recovers it today: the `SaveOnceByTypeAndData` dedup blocks that schedule from ever re-enqueueing (its `NextRunAt` never advances), and the `Recaps` row stays stuck in `processing` with a spinner in the UI. Concurrent processing increases exposure to this.

Changes:
- `JobServer.ResetWedgedJobs`: marks `InProgress` jobs of a type as errored when both `LastActivityAt` and `StartAt` are stale (mirrors the migrations-scheduler precedent). Uses the optimistic InProgress-only CAS so it can never clobber a live worker's success write.
- New leader-only recovery scheduler for `Recap` jobs (1-min tick): resets wedged jobs (30-min timeout; the worker refreshes `LastActivityAt` per channel), marks their `Recaps` rows failed, and publishes `recap_updated` so clients stop spinning. Also sweeps orphaned `processing` recaps with no live job (new `GetRecapsByStatusOlderThan` store query + supporting index, migration 000212), verifying against the master before failing them.
- The scheduled-recap scheduler resets wedged `ScheduledRecap` jobs (15-min timeout) at the top of each tick; since `NextRunAt` never advanced, the schedule re-enqueues in the same tick — automatic retry.

Wedged recap jobs are deliberately failed rather than retried: a retry would re-summarize channels that already completed (duplicate LLM spend). Accepted, documented risk: a crash in the seconds-wide window between recap creation and `MarkExecuted` can produce one duplicate recap on retry, capped by the daily limit.

QA steps:
1. Enable AI Recaps; create a recap; kill the server mid-processing.
2. Restart; within ~30–60 min the recap flips to failed and the client is notified (or, for a schedule, the schedule re-fires automatically).
3. Store test `TestRecapStore/GetRecapsByStatusOlderThan` covers the sweep query; jobs tests cover CAS-loss and live-worker interleavings.

#### Release Note

```release-note
AI recap jobs orphaned by a server restart or crash are now automatically recovered: stuck recaps are marked failed and users are notified, and stalled recap schedules resume firing. Added an index on Recaps(Status, UpdateAt).
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7037e36f-6e9f-4b1a-8cb6-2ce0c4fcf08b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7037e36f-6e9f-4b1a-8cb6-2ce0c4fcf08b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Medium 🟡

**Regression Risk:** Changes span shared job recovery, scheduling, persistence, and migration layers; recovery timing and duplicate-job edge cases could affect recap processing. Automated coverage is strong, but production timing scenarios remain a consideration.  
**QA Recommendation:** Manual QA can be skipped; rely on automated tests with targeted monitoring after deployment.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->