### PR TITLE
[5/5] Add recap processing metrics and log enrichment

### DIFF
--- a/server/channels/app/scheduled_recap.go
+++ b/server/channels/app/scheduled_recap.go
@@ -6,6 +6,7 @@ package app
 import (
 	"errors"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -261,6 +262,9 @@ func (a *App) CreateRecapFromSchedule(rctx request.CTX, sr *model.ScheduledRecap
 		"agent_id":            sr.AgentId,
 		"time_period":         sr.TimePeriod,
 		"custom_instructions": sr.CustomInstructions,
+		// NextRunAt is still the due time for this run because MarkExecuted
+		// advances the schedule only after this method returns.
+		"scheduled_for": strconv.FormatInt(sr.NextRunAt, 10),
 	}
 
 	_, jobErr := a.CreateJob(rctx, &model.Job{

--- a/server/channels/app/scheduled_recap_test.go
+++ b/server/channels/app/scheduled_recap_test.go
@@ -5,6 +5,7 @@ package app
 
 import (
 	"os"
+	"strconv"
 	"testing"
 	"time"
 
@@ -368,6 +369,7 @@ func TestCreateRecapFromScheduleAllUnreads(t *testing.T) {
 		Enabled:            true,
 		CreateAt:           model.GetMillis(),
 		UpdateAt:           model.GetMillis(),
+		NextRunAt:          model.GetMillis() - 60_000,
 	}
 
 	recap, createErr := th.App.CreateRecapFromSchedule(th.Context, scheduledRecap)
@@ -389,6 +391,7 @@ func TestCreateRecapFromScheduleAllUnreads(t *testing.T) {
 	require.NotNil(t, recapJob)
 	assert.Equal(t, model.TimePeriodLastWeek, recapJob.Data["time_period"])
 	assert.Equal(t, "Focus on launch risks", recapJob.Data["custom_instructions"])
+	assert.Equal(t, strconv.FormatInt(scheduledRecap.NextRunAt, 10), recapJob.Data["scheduled_for"])
 }
 
 func TestCreateScheduledRecapMasterToggleDisabled(t *testing.T) {

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -1795,7 +1795,7 @@ func (s *Server) initJobs() {
 
 	s.Jobs.RegisterJobType(
 		model.JobTypeRecap,
-		recap.MakeWorker(s.Jobs, s.Store(), New(ServerConnector(s.Channels()))),
+		recap.MakeWorker(s.Jobs, s.Store(), New(ServerConnector(s.Channels())), func() einterfaces.MetricsInterface { return s.GetMetrics() }),
 		recap.MakeScheduler(s.Jobs, s.Store(), New(ServerConnector(s.Channels()))),
 	)
 

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -1802,7 +1802,7 @@ func (s *Server) initJobs() {
 	s.Jobs.RegisterJobType(
 		model.JobTypeScheduledRecap,
 		scheduled_recap.MakeWorker(s.Jobs, s.Store(), New(ServerConnector(s.Channels()))),
-		scheduled_recap.MakeScheduler(s.Jobs, s.Store()),
+		scheduled_recap.MakeScheduler(s.Jobs, s.Store(), func() einterfaces.MetricsInterface { return s.GetMetrics() }),
 	)
 
 	s.Jobs.RegisterJobType(

--- a/server/channels/jobs/recap/worker.go
+++ b/server/channels/jobs/recap/worker.go
@@ -6,6 +6,7 @@ package recap
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/jobs"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
+	"github.com/mattermost/mattermost/server/v8/einterfaces"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/sync/semaphore"
 )
@@ -36,7 +38,7 @@ const (
 	progressUpdateInterval = time.Second
 )
 
-func MakeWorker(jobServer *jobs.JobServer, storeInstance store.Store, appInstance AppIface) *jobs.PoolWorker {
+func MakeWorker(jobServer *jobs.JobServer, storeInstance store.Store, appInstance AppIface, getMetrics func() einterfaces.MetricsInterface) *jobs.PoolWorker {
 	isEnabled := func(cfg *model.Config) bool {
 		return cfg.AIRecapsEnabled()
 	}
@@ -52,7 +54,7 @@ func MakeWorker(jobServer *jobs.JobServer, storeInstance store.Store, appInstanc
 
 	execute := func(logger mlog.LoggerIFace, job *model.Job) error {
 		defer jobServer.HandleJobPanic(logger, job)
-		return processRecapJob(logger, job, storeInstance, appInstance, llmSemaphore, func(progress int64) {
+		return processRecapJob(logger, job, storeInstance, appInstance, getMetrics(), llmSemaphore, func(progress int64) {
 			_ = jobServer.SetJobProgress(job, progress)
 		})
 	}
@@ -67,7 +69,21 @@ func MakeWorker(jobServer *jobs.JobServer, storeInstance store.Store, appInstanc
 	return jobs.NewPoolWorker("Recap", jobServer, execute, isEnabled, poolSize)
 }
 
-func processRecapJob(logger mlog.LoggerIFace, job *model.Job, storeInstance store.Store, appInstance AppIface, llmSemaphore *semaphore.Weighted, setProgress func(int64)) error {
+func processRecapJob(logger mlog.LoggerIFace, job *model.Job, storeInstance store.Store, appInstance AppIface, metrics einterfaces.MetricsInterface, llmSemaphore *semaphore.Weighted, setProgress func(int64)) error {
+	jobStartTime := time.Now()
+
+	var scheduledFor int64
+	if raw := job.Data["scheduled_for"]; raw != "" {
+		parsed, parseErr := strconv.ParseInt(raw, 10, 64)
+		if parseErr != nil {
+			logger.Warn("Ignoring invalid scheduled_for in recap job data",
+				mlog.String("scheduled_for", raw),
+				mlog.Err(parseErr))
+		} else {
+			scheduledFor = parsed
+		}
+	}
+
 	recapID := job.Data["recap_id"]
 	userID := job.Data["user_id"]
 	channelIDs := strings.Split(job.Data["channel_ids"], ",")
@@ -107,11 +123,17 @@ func processRecapJob(logger mlog.LoggerIFace, job *model.Job, storeInstance stor
 	// collector goroutine exclusively owns the totals and the progress writes,
 	// so no accumulator state is shared. The results channel is buffered to
 	// the full channel count so a worker's send can never block.
-	results := make(chan model.RecapChannelResult, len(channelIDs))
+	type channelOutcome struct {
+		result  model.RecapChannelResult
+		semWait time.Duration
+	}
+	results := make(chan channelOutcome, len(channelIDs))
 
 	totalMessages := 0
 	successfulChannels := make([]string, 0, len(channelIDs))
 	failedChannels := make([]string, 0, len(channelIDs))
+	var semWaitTotal time.Duration
+	var semWaitMax time.Duration
 
 	collectorDone := make(chan struct{})
 	go func() {
@@ -122,11 +144,15 @@ func processRecapJob(logger mlog.LoggerIFace, job *model.Job, storeInstance stor
 		var lastEmitAt time.Time
 		for completed := 1; completed <= len(channelIDs); completed++ {
 			outcome := <-results
-			if outcome.Success {
-				totalMessages += outcome.MessageCount
-				successfulChannels = append(successfulChannels, outcome.ChannelID)
+			semWaitTotal += outcome.semWait
+			if outcome.semWait > semWaitMax {
+				semWaitMax = outcome.semWait
+			}
+			if outcome.result.Success {
+				totalMessages += outcome.result.MessageCount
+				successfulChannels = append(successfulChannels, outcome.result.ChannelID)
 			} else {
-				failedChannels = append(failedChannels, outcome.ChannelID)
+				failedChannels = append(failedChannels, outcome.result.ChannelID)
 			}
 
 			// Monotonic, throttled progress: completed only grows, so percent
@@ -149,12 +175,16 @@ func processRecapJob(logger mlog.LoggerIFace, job *model.Job, storeInstance stor
 	var panicValue any
 	for _, channelID := range channelIDs {
 		g.Go(func() (workerErr error) {
+			var semWait time.Duration
 			defer func() {
 				if recovered := recover(); recovered != nil {
 					panicOnce.Do(func() {
 						panicValue = recovered
 					})
-					results <- model.RecapChannelResult{ChannelID: channelID}
+					results <- channelOutcome{
+						result:  model.RecapChannelResult{ChannelID: channelID},
+						semWait: semWait,
+					}
 					workerErr = fmt.Errorf("panic processing recap channel %s: %v", channelID, recovered)
 				}
 			}()
@@ -166,33 +196,62 @@ func processRecapJob(logger mlog.LoggerIFace, job *model.Job, storeInstance stor
 			// abandoning a call would free the slot while the LLM request
 			// keeps running, defeating the cap. Wedged-job recovery (phase 2)
 			// bounds the user-facing blast radius of a hung call.
+			waitStart := time.Now()
 			if err := llmSemaphore.Acquire(gctx, 1); err != nil {
 				logger.Warn("Failed to acquire LLM slot for channel",
 					mlog.String("channel_id", channelID),
 					mlog.Err(err))
-				results <- model.RecapChannelResult{ChannelID: channelID}
+				results <- channelOutcome{result: model.RecapChannelResult{ChannelID: channelID}}
 				return nil
 			}
-			defer llmSemaphore.Release(1)
+			semWait = time.Since(waitStart)
+			if metrics != nil {
+				metrics.IncrementRecapLLMInFlight()
+			}
 
 			// Fresh per-goroutine context with the user's session so
 			// session-dependent code (e.g. auto-translation supplements)
 			// works correctly.
 			rctx := request.EmptyContext(logger).WithSession(&model.Session{UserId: userID})
-			result, err := appInstance.ProcessRecapChannelWithOptions(rctx, recapID, channelID, userID, agentID, options)
+			var result *model.RecapChannelResult
+			var err *model.AppError
+			procStart := time.Now()
+			func() {
+				defer func() {
+					if metrics != nil {
+						metrics.ObserveRecapChannelProcessTime(err == nil && result != nil && result.Success, time.Since(procStart).Seconds())
+						metrics.DecrementRecapLLMInFlight()
+					}
+					llmSemaphore.Release(1)
+				}()
+				result, err = appInstance.ProcessRecapChannelWithOptions(rctx, recapID, channelID, userID, agentID, options)
+			}()
 			if err != nil {
 				logger.Warn("Failed to process channel",
 					mlog.String("channel_id", channelID),
 					mlog.Err(err))
-				results <- model.RecapChannelResult{ChannelID: channelID}
+				results <- channelOutcome{
+					result:  model.RecapChannelResult{ChannelID: channelID},
+					semWait: semWait,
+				}
 				return nil
 			}
 			if !result.Success {
 				logger.Warn("Channel processing unsuccessful", mlog.String("channel_id", channelID))
-				results <- model.RecapChannelResult{ChannelID: channelID}
+				results <- channelOutcome{
+					result:  model.RecapChannelResult{ChannelID: channelID},
+					semWait: semWait,
+				}
 				return nil
 			}
-			results <- model.RecapChannelResult{ChannelID: channelID, MessageCount: result.MessageCount, Success: true}
+			results <- channelOutcome{
+				result: model.RecapChannelResult{
+					ChannelID:    channelID,
+					MessageCount: result.MessageCount,
+					Success:      true,
+				},
+				semWait: semWait,
+			}
 			return nil
 		})
 	}
@@ -245,10 +304,21 @@ func processRecapJob(logger mlog.LoggerIFace, job *model.Job, storeInstance stor
 		publishRecapUpdate(appInstance, recapID, userID)
 	}
 
+	if metrics != nil && scheduledFor > 0 {
+		delaySeconds := float64(model.GetMillis()-scheduledFor) / 1000.0
+		if delaySeconds < 0 {
+			delaySeconds = 0
+		}
+		metrics.ObserveRecapDeliveryDelay(delaySeconds)
+	}
+
 	logger.Info("Recap job completed",
 		mlog.String("recap_id", recapID),
 		mlog.Int("successful_channels", len(successfulChannels)),
-		mlog.Int("failed_channels", len(failedChannels)))
+		mlog.Int("failed_channels", len(failedChannels)),
+		mlog.Duration("job_duration", time.Since(jobStartTime)),
+		mlog.Duration("semaphore_wait_total", semWaitTotal),
+		mlog.Duration("semaphore_wait_max", semWaitMax))
 
 	return nil
 }

--- a/server/channels/jobs/recap/worker_test.go
+++ b/server/channels/jobs/recap/worker_test.go
@@ -4,6 +4,7 @@
 package recap
 
 import (
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -17,6 +18,7 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest"
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
 	"github.com/mattermost/mattermost/server/v8/channels/utils/testutils"
+	"github.com/mattermost/mattermost/server/v8/einterfaces"
 	einterfacesmocks "github.com/mattermost/mattermost/server/v8/einterfaces/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -67,6 +69,79 @@ func matchOptions(want model.RecapProcessingOptions) any {
 	})
 }
 
+func expectRecapChannelMetrics(t *testing.T, successes, failures int) *einterfacesmocks.MetricsInterface {
+	t.Helper()
+
+	mockMetrics := &einterfacesmocks.MetricsInterface{}
+	t.Cleanup(func() {
+		mockMetrics.AssertExpectations(t)
+	})
+
+	total := successes + failures
+	mockMetrics.On("IncrementRecapLLMInFlight").Times(total)
+	mockMetrics.On("DecrementRecapLLMInFlight").Times(total)
+	if successes > 0 {
+		mockMetrics.On("ObserveRecapChannelProcessTime", true, mock.AnythingOfType("float64")).Times(successes)
+	}
+	if failures > 0 {
+		mockMetrics.On("ObserveRecapChannelProcessTime", false, mock.AnythingOfType("float64")).Times(failures)
+	}
+	return mockMetrics
+}
+
+type recapChannelTestOutcome struct {
+	result *model.RecapChannelResult
+	err    *model.AppError
+}
+
+func runRecapJobWithOutcomes(t *testing.T, logger mlog.LoggerIFace, job *model.Job, outcomes map[string]recapChannelTestOutcome, metrics einterfaces.MetricsInterface) error {
+	t.Helper()
+
+	mockStore := &mocks.Store{}
+	mockRecapStore := &mocks.RecapStore{}
+	mockStore.On("Recap").Return(mockRecapStore)
+	mockApp := &MockAppIface{}
+	t.Cleanup(func() {
+		mockApp.AssertExpectations(t)
+		mockRecapStore.AssertExpectations(t)
+	})
+
+	recapID := job.Data["recap_id"]
+	userID := job.Data["user_id"]
+	agentID := job.Data["agent_id"]
+	mockRecapStore.On("UpdateRecapStatus", recapID, model.RecapStatusProcessing).Return(nil)
+	mockApp.On("Publish", mock.Anything).Return()
+	mockApp.On("NewRecapPostBudgetForUser", userID).Return(unlimitedBudget(), nil)
+
+	totalMessages := 0
+	successes := 0
+	for channelID, outcome := range outcomes {
+		var result any
+		if outcome.result != nil {
+			result = outcome.result
+		}
+		mockApp.On("ProcessRecapChannelWithOptions", mock.Anything, recapID, channelID, userID, agentID, matchOptions(model.RecapProcessingOptions{})).
+			Return(result, outcome.err).
+			Once()
+		if outcome.err == nil && outcome.result != nil && outcome.result.Success {
+			successes++
+			totalMessages += outcome.result.MessageCount
+		}
+	}
+
+	expectedStatus := model.RecapStatusCompleted
+	if successes == 0 {
+		expectedStatus = model.RecapStatusFailed
+	}
+	recap := &model.Recap{Id: recapID}
+	mockRecapStore.On("GetRecap", recapID).Return(recap, nil)
+	mockRecapStore.On("UpdateRecap", mock.MatchedBy(func(r *model.Recap) bool {
+		return r.TotalMessageCount == totalMessages && r.Status == expectedStatus
+	})).Return(recap, nil)
+
+	return processRecapJob(logger, job, mockStore, mockApp, metrics, semaphore.NewWeighted(16), nil)
+}
+
 func TestProcessRecapJob(t *testing.T) {
 	logger := mlog.CreateConsoleTestLogger(t)
 	job := &model.Job{
@@ -84,6 +159,7 @@ func TestProcessRecapJob(t *testing.T) {
 		mockStore.On("Recap").Return(mockRecapStore)
 
 		mockApp := &MockAppIface{}
+		mockMetrics := expectRecapChannelMetrics(t, 2, 0)
 
 		// Setup expectations
 		mockRecapStore.On("UpdateRecapStatus", "recap1", model.RecapStatusProcessing).Return(nil)
@@ -108,8 +184,9 @@ func TestProcessRecapJob(t *testing.T) {
 			return r.TotalMessageCount == 15 && r.Status == model.RecapStatusCompleted
 		})).Return(recap, nil)
 
-		err := processRecapJob(logger, job, mockStore, mockApp, semaphore.NewWeighted(16), nil)
+		err := processRecapJob(logger, job, mockStore, mockApp, mockMetrics, semaphore.NewWeighted(16), nil)
 		require.NoError(t, err)
+		mockMetrics.AssertNotCalled(t, "ObserveRecapDeliveryDelay", mock.Anything)
 	})
 
 	t.Run("partial failure", func(t *testing.T) {
@@ -118,6 +195,7 @@ func TestProcessRecapJob(t *testing.T) {
 		mockStore.On("Recap").Return(mockRecapStore)
 
 		mockApp := &MockAppIface{}
+		mockMetrics := expectRecapChannelMetrics(t, 1, 1)
 
 		mockRecapStore.On("UpdateRecapStatus", "recap1", model.RecapStatusProcessing).Return(nil)
 		mockApp.On("Publish", mock.Anything).Return()
@@ -137,8 +215,9 @@ func TestProcessRecapJob(t *testing.T) {
 			return r.TotalMessageCount == 10 && r.Status == model.RecapStatusCompleted
 		})).Return(recap, nil)
 
-		err := processRecapJob(logger, job, mockStore, mockApp, semaphore.NewWeighted(16), nil)
+		err := processRecapJob(logger, job, mockStore, mockApp, mockMetrics, semaphore.NewWeighted(16), nil)
 		require.NoError(t, err)
+		mockMetrics.AssertNotCalled(t, "ObserveRecapDeliveryDelay", mock.Anything)
 	})
 
 	t.Run("complete failure", func(t *testing.T) {
@@ -147,6 +226,7 @@ func TestProcessRecapJob(t *testing.T) {
 		mockStore.On("Recap").Return(mockRecapStore)
 
 		mockApp := &MockAppIface{}
+		mockMetrics := expectRecapChannelMetrics(t, 0, 2)
 
 		mockRecapStore.On("UpdateRecapStatus", "recap1", model.RecapStatusProcessing).Return(nil)
 		mockApp.On("Publish", mock.Anything).Return()
@@ -161,9 +241,10 @@ func TestProcessRecapJob(t *testing.T) {
 			return r.TotalMessageCount == 0 && r.Status == model.RecapStatusFailed
 		})).Return(recap, nil)
 
-		err := processRecapJob(logger, job, mockStore, mockApp, semaphore.NewWeighted(16), nil)
+		err := processRecapJob(logger, job, mockStore, mockApp, mockMetrics, semaphore.NewWeighted(16), nil)
 		require.Error(t, err)
 		require.Equal(t, "all channels failed to process", err.Error())
+		mockMetrics.AssertNotCalled(t, "ObserveRecapDeliveryDelay", mock.Anything)
 	})
 
 	t.Run("passes scheduled options to channel processing", func(t *testing.T) {
@@ -183,6 +264,7 @@ func TestProcessRecapJob(t *testing.T) {
 		mockStore.On("Recap").Return(mockRecapStore)
 
 		mockApp := &MockAppIface{}
+		mockMetrics := expectRecapChannelMetrics(t, 1, 0)
 		mockRecapStore.On("UpdateRecapStatus", "recap1", model.RecapStatusProcessing).Return(nil)
 		mockApp.On("Publish", mock.Anything).Return()
 		mockApp.On("NewRecapPostBudgetForUser", "user1").Return(unlimitedBudget(), nil)
@@ -201,9 +283,96 @@ func TestProcessRecapJob(t *testing.T) {
 			return r.TotalMessageCount == 3 && r.Status == model.RecapStatusCompleted
 		})).Return(recap, nil)
 
-		err := processRecapJob(logger, jobWithOptions, mockStore, mockApp, semaphore.NewWeighted(16), nil)
+		err := processRecapJob(logger, jobWithOptions, mockStore, mockApp, mockMetrics, semaphore.NewWeighted(16), nil)
 		require.NoError(t, err)
 		mockApp.AssertExpectations(t)
+	})
+
+	t.Run("observes delivery delay for scheduled recaps", func(t *testing.T) {
+		scheduledJob := &model.Job{Data: map[string]string{
+			"recap_id":      "recap1",
+			"user_id":       "user1",
+			"channel_ids":   "channel1",
+			"agent_id":      "agent1",
+			"scheduled_for": strconv.FormatInt(model.GetMillis()-90_000, 10),
+		}}
+		mockMetrics := expectRecapChannelMetrics(t, 1, 0)
+		mockMetrics.On("ObserveRecapDeliveryDelay", mock.MatchedBy(func(seconds float64) bool {
+			return seconds >= 90 && seconds < 120
+		})).Once()
+
+		err := runRecapJobWithOutcomes(t, logger, scheduledJob, map[string]recapChannelTestOutcome{
+			"channel1": {result: &model.RecapChannelResult{ChannelID: "channel1", Success: true, MessageCount: 1}},
+		}, mockMetrics)
+		require.NoError(t, err)
+	})
+
+	t.Run("observes delivery delay on partial failure", func(t *testing.T) {
+		scheduledJob := &model.Job{Data: map[string]string{
+			"recap_id":      "recap1",
+			"user_id":       "user1",
+			"channel_ids":   "channel1,channel2",
+			"agent_id":      "agent1",
+			"scheduled_for": strconv.FormatInt(model.GetMillis()-90_000, 10),
+		}}
+		mockMetrics := expectRecapChannelMetrics(t, 1, 1)
+		mockMetrics.On("ObserveRecapDeliveryDelay", mock.AnythingOfType("float64")).Once()
+
+		err := runRecapJobWithOutcomes(t, logger, scheduledJob, map[string]recapChannelTestOutcome{
+			"channel1": {result: &model.RecapChannelResult{ChannelID: "channel1", Success: true, MessageCount: 1}},
+			"channel2": {err: model.NewAppError("fail", "fail", nil, "", 500)},
+		}, mockMetrics)
+		require.NoError(t, err)
+	})
+
+	t.Run("skips delivery delay when all channels fail", func(t *testing.T) {
+		scheduledJob := &model.Job{Data: map[string]string{
+			"recap_id":      "recap1",
+			"user_id":       "user1",
+			"channel_ids":   "channel1,channel2",
+			"agent_id":      "agent1",
+			"scheduled_for": strconv.FormatInt(model.GetMillis()-90_000, 10),
+		}}
+		mockMetrics := expectRecapChannelMetrics(t, 0, 2)
+
+		err := runRecapJobWithOutcomes(t, logger, scheduledJob, map[string]recapChannelTestOutcome{
+			"channel1": {err: model.NewAppError("fail", "fail", nil, "", 500)},
+			"channel2": {err: model.NewAppError("fail", "fail", nil, "", 500)},
+		}, mockMetrics)
+		require.Error(t, err)
+		mockMetrics.AssertNotCalled(t, "ObserveRecapDeliveryDelay", mock.Anything)
+	})
+
+	t.Run("skips delivery delay on malformed scheduled_for", func(t *testing.T) {
+		malformedJob := &model.Job{Data: map[string]string{
+			"recap_id":      "recap1",
+			"user_id":       "user1",
+			"channel_ids":   "channel1",
+			"agent_id":      "agent1",
+			"scheduled_for": "not-a-number",
+		}}
+		mockMetrics := expectRecapChannelMetrics(t, 1, 0)
+
+		err := runRecapJobWithOutcomes(t, logger, malformedJob, map[string]recapChannelTestOutcome{
+			"channel1": {result: &model.RecapChannelResult{ChannelID: "channel1", Success: true, MessageCount: 1}},
+		}, mockMetrics)
+		require.NoError(t, err)
+		mockMetrics.AssertNotCalled(t, "ObserveRecapDeliveryDelay", mock.Anything)
+	})
+
+	t.Run("nil metrics is safe", func(t *testing.T) {
+		scheduledJob := &model.Job{Data: map[string]string{
+			"recap_id":      "recap1",
+			"user_id":       "user1",
+			"channel_ids":   "channel1",
+			"agent_id":      "agent1",
+			"scheduled_for": strconv.FormatInt(model.GetMillis()-90_000, 10),
+		}}
+
+		err := runRecapJobWithOutcomes(t, logger, scheduledJob, map[string]recapChannelTestOutcome{
+			"channel1": {result: &model.RecapChannelResult{ChannelID: "channel1", Success: true, MessageCount: 1}},
+		}, nil)
+		require.NoError(t, err)
 	})
 }
 
@@ -229,7 +398,7 @@ func TestRecapWorkerPanicMarksJobErrorAndReleasesSemaphore(t *testing.T) {
 		assert.NoError(t, logger.Shutdown())
 	})
 	jobServer := jobs.NewJobServer(&testutils.StaticConfigService{Cfg: cfg}, mockStore, mockMetrics, logger, nil)
-	worker := MakeWorker(jobServer, mockStore, mockApp)
+	worker := MakeWorker(jobServer, mockStore, mockApp, func() einterfaces.MetricsInterface { return mockMetrics })
 
 	claimedJob1 := &model.Job{
 		Id:     "job1",
@@ -259,6 +428,10 @@ func TestRecapWorkerPanicMarksJobErrorAndReleasesSemaphore(t *testing.T) {
 	mockStore.JobStore.On("UpdateStatus", "job2", model.JobStatusSuccess).Return(claimedJob2, nil).Once()
 	mockMetrics.On("IncrementJobActive", model.JobTypeRecap).Twice()
 	mockMetrics.On("DecrementJobActive", model.JobTypeRecap).Twice()
+	mockMetrics.On("IncrementRecapLLMInFlight").Twice()
+	mockMetrics.On("DecrementRecapLLMInFlight").Twice()
+	mockMetrics.On("ObserveRecapChannelProcessTime", false, mock.AnythingOfType("float64")).Once()
+	mockMetrics.On("ObserveRecapChannelProcessTime", true, mock.AnythingOfType("float64")).Once()
 
 	mockStore.RecapStore.On("UpdateRecapStatus", "recap1", model.RecapStatusProcessing).Return(nil).Once()
 	mockStore.RecapStore.On("UpdateRecapStatus", "recap2", model.RecapStatusProcessing).Return(nil).Once()
@@ -316,14 +489,33 @@ func TestProcessRecapJobRespectsLLMSemaphore(t *testing.T) {
 	mockRecapStore := &mocks.RecapStore{}
 	mockStore.On("Recap").Return(mockRecapStore)
 	mockApp := &MockAppIface{}
+	mockMetrics := &einterfacesmocks.MetricsInterface{}
+	t.Cleanup(func() {
+		mockMetrics.AssertExpectations(t)
+	})
 	mockRecapStore.On("UpdateRecapStatus", "recap1", model.RecapStatusProcessing).Return(nil)
 	mockApp.On("Publish", mock.Anything).Return()
 	mockApp.On("NewRecapPostBudgetForUser", "user1").Return(unlimitedBudget(), nil)
 
 	var inFlight atomic.Int32
 	var maxInFlight atomic.Int32
+	var metricInFlight atomic.Int64
+	var metricMaxInFlight atomic.Int64
 	var started atomic.Int32
 	release := make(chan struct{})
+	mockMetrics.On("IncrementRecapLLMInFlight").Run(func(mock.Arguments) {
+		current := metricInFlight.Add(1)
+		for {
+			previous := metricMaxInFlight.Load()
+			if current <= previous || metricMaxInFlight.CompareAndSwap(previous, current) {
+				break
+			}
+		}
+	}).Times(6)
+	mockMetrics.On("DecrementRecapLLMInFlight").Run(func(mock.Arguments) {
+		metricInFlight.Add(-1)
+	}).Times(6)
+	mockMetrics.On("ObserveRecapChannelProcessTime", true, mock.AnythingOfType("float64")).Times(6)
 	mockApp.On("ProcessRecapChannelWithOptions", mock.Anything, "recap1", mock.Anything, "user1", "agent1", matchOptions(model.RecapProcessingOptions{})).
 		Run(func(args mock.Arguments) {
 			started.Add(1)
@@ -347,7 +539,7 @@ func TestProcessRecapJobRespectsLLMSemaphore(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- processRecapJob(logger, job, mockStore, mockApp, semaphore.NewWeighted(2), nil)
+		done <- processRecapJob(logger, job, mockStore, mockApp, mockMetrics, semaphore.NewWeighted(2), nil)
 	}()
 
 	require.Eventually(t, func() bool { return inFlight.Load() == 2 }, 5*time.Second, 10*time.Millisecond)
@@ -357,6 +549,8 @@ func TestProcessRecapJobRespectsLLMSemaphore(t *testing.T) {
 	require.Eventually(t, func() bool { return len(done) == 1 }, 10*time.Second, 10*time.Millisecond)
 	require.NoError(t, <-done)
 	assert.LessOrEqual(t, maxInFlight.Load(), int32(2))
+	assert.Zero(t, metricInFlight.Load())
+	assert.LessOrEqual(t, metricMaxInFlight.Load(), int64(2))
 	mockApp.AssertNumberOfCalls(t, "ProcessRecapChannelWithOptions", 6)
 	mockApp.AssertExpectations(t)
 	mockRecapStore.AssertExpectations(t)
@@ -408,7 +602,7 @@ func TestProcessRecapJobFanOutCap(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- processRecapJob(logger, job, mockStore, mockApp, semaphore.NewWeighted(64), nil)
+		done <- processRecapJob(logger, job, mockStore, mockApp, nil, semaphore.NewWeighted(64), nil)
 	}()
 
 	require.Eventually(t, func() bool { return inFlight.Load() == maxChannelWorkersPerJob }, 5*time.Second, 10*time.Millisecond)
@@ -456,7 +650,7 @@ func TestProcessRecapJobOutOfOrderCompletion(t *testing.T) {
 
 	var progressMu sync.Mutex
 	progress := make([]int64, 0, 4)
-	err := processRecapJob(logger, job, mockStore, mockApp, semaphore.NewWeighted(16), func(value int64) {
+	err := processRecapJob(logger, job, mockStore, mockApp, nil, semaphore.NewWeighted(16), func(value int64) {
 		progressMu.Lock()
 		defer progressMu.Unlock()
 		progress = append(progress, value)
@@ -501,7 +695,7 @@ func TestProcessRecapJobBudgetInitFallback(t *testing.T) {
 		return r.TotalMessageCount == 2 && r.Status == model.RecapStatusCompleted
 	})).Return(recap, nil)
 
-	err := processRecapJob(logger, job, mockStore, mockApp, semaphore.NewWeighted(16), nil)
+	err := processRecapJob(logger, job, mockStore, mockApp, nil, semaphore.NewWeighted(16), nil)
 	require.NoError(t, err)
 	mockApp.AssertNumberOfCalls(t, "ProcessRecapChannelWithOptions", 2)
 	mockApp.AssertExpectations(t)
@@ -538,7 +732,7 @@ func TestProcessRecapJobSharedBudgetLimitsTotal(t *testing.T) {
 			r.Status == model.RecapStatusCompleted
 	})).Return(recap, nil)
 
-	err := processRecapJob(logger, job, mockStore, mockApp, semaphore.NewWeighted(16), nil)
+	err := processRecapJob(logger, job, mockStore, mockApp, nil, semaphore.NewWeighted(16), nil)
 	require.NoError(t, err)
 	mockApp.AssertNumberOfCalls(t, "ProcessRecapChannelWithOptions", 6)
 	mockApp.AssertExpectations(t)

--- a/server/channels/jobs/scheduled_recap/scheduler.go
+++ b/server/channels/jobs/scheduled_recap/scheduler.go
@@ -11,6 +11,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/jobs"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
+	"github.com/mattermost/mattermost/server/v8/einterfaces"
 )
 
 // SchedulerPollingInterval defines how often the scheduler polls for due scheduled recaps.
@@ -26,12 +27,13 @@ const dueScheduleBatchSize = 100
 // Scheduler polls for due scheduled recaps and creates jobs for them.
 type Scheduler struct {
 	*jobs.PeriodicScheduler
-	store     store.Store
-	jobServer *jobs.JobServer
+	store      store.Store
+	jobServer  *jobs.JobServer
+	getMetrics func() einterfaces.MetricsInterface
 }
 
 // MakeScheduler creates a new scheduler for scheduled recaps.
-func MakeScheduler(jobServer *jobs.JobServer, storeInstance store.Store) *Scheduler {
+func MakeScheduler(jobServer *jobs.JobServer, storeInstance store.Store, getMetrics func() einterfaces.MetricsInterface) *Scheduler {
 	isEnabled := func(cfg *model.Config) bool {
 		return cfg.AIRecapsEnabled()
 	}
@@ -42,8 +44,9 @@ func MakeScheduler(jobServer *jobs.JobServer, storeInstance store.Store) *Schedu
 			SchedulerPollingInterval,
 			isEnabled,
 		),
-		store:     storeInstance,
-		jobServer: jobServer,
+		store:      storeInstance,
+		jobServer:  jobServer,
+		getMetrics: getMetrics,
 	}
 }
 
@@ -76,10 +79,12 @@ func (s *Scheduler) ScheduleJob(rctx request.CTX, cfg *model.Config, pendingJobs
 
 	var cursorNextRunAt int64
 	var cursorID string
-	processed := 0
+	totalDue := 0
+	enqueuedCount := 0
+	var maxEnqueueLagMs int64
 
 	for {
-		remaining := maxPerTick - processed
+		remaining := maxPerTick - totalDue
 		if remaining <= 0 {
 			mlog.Warn("Reached the per-tick cap while enqueueing due scheduled recaps; remaining due schedules will be enqueued on the next tick",
 				mlog.Int("max_due_schedules_per_tick", maxPerTick))
@@ -91,12 +96,14 @@ func (s *Scheduler) ScheduleJob(rctx request.CTX, cfg *model.Config, pendingJobs
 		if err != nil {
 			// Already-enqueued jobs stand; the next tick restarts from the zero cursor.
 			mlog.Error("Failed to get due scheduled recaps",
-				mlog.Int("enqueued_so_far", processed),
+				mlog.Int("enqueued_so_far", totalDue),
 				mlog.Err(err))
 			return nil, nil
 		}
 
 		for _, sr := range dueRecaps {
+			maxEnqueueLagMs = max(maxEnqueueLagMs, now-sr.NextRunAt)
+
 			// The worker re-fetches the full row by ID, so the job only needs the ID.
 			jobData := model.StringMap{
 				"scheduled_recap_id": sr.Id,
@@ -117,10 +124,15 @@ func (s *Scheduler) ScheduleJob(rctx request.CTX, cfg *model.Config, pendingJobs
 			if job == nil {
 				mlog.Debug("Scheduled recap job already queued",
 					mlog.String("scheduled_recap_id", sr.Id))
+				continue
 			}
+			enqueuedCount++
+			mlog.Debug("Enqueued scheduled recap job",
+				mlog.String("scheduled_recap_id", sr.Id),
+				mlog.Int("enqueue_lag_ms", now-sr.NextRunAt))
 		}
 
-		processed += len(dueRecaps)
+		totalDue += len(dueRecaps)
 
 		if len(dueRecaps) < batchLimit {
 			break
@@ -128,6 +140,16 @@ func (s *Scheduler) ScheduleJob(rctx request.CTX, cfg *model.Config, pendingJobs
 
 		last := dueRecaps[len(dueRecaps)-1]
 		cursorNextRunAt, cursorID = last.NextRunAt, last.Id
+	}
+
+	if metrics := s.getMetrics(); metrics != nil {
+		metrics.ObserveRecapScheduledBacklog(int64(totalDue))
+	}
+	if totalDue > 0 {
+		mlog.Info("Scheduled recap scheduler tick completed",
+			mlog.Int("due_count", totalDue),
+			mlog.Int("enqueued_count", enqueuedCount),
+			mlog.Int("max_enqueue_lag_ms", maxEnqueueLagMs))
 	}
 
 	return nil, nil

--- a/server/channels/jobs/scheduled_recap/scheduler_test.go
+++ b/server/channels/jobs/scheduled_recap/scheduler_test.go
@@ -14,11 +14,13 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/jobs"
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest"
 	"github.com/mattermost/mattermost/server/v8/channels/utils/testutils"
+	"github.com/mattermost/mattermost/server/v8/einterfaces"
+	metricsmocks "github.com/mattermost/mattermost/server/v8/einterfaces/mocks"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
-func newSchedulerTest(t *testing.T, cfg *model.Config) (*Scheduler, *storetest.Store) {
+func newSchedulerTestWithMetrics(t *testing.T, cfg *model.Config, metrics einterfaces.MetricsInterface) (*Scheduler, *storetest.Store) {
 	t.Helper()
 
 	mockStore := &storetest.Store{}
@@ -34,7 +36,18 @@ func newSchedulerTest(t *testing.T, cfg *model.Config) (*Scheduler, *storetest.S
 		func(cfg *model.Config) bool { return true },
 	), nil)
 
-	return MakeScheduler(jobServer, mockStore), mockStore
+	return MakeScheduler(jobServer, mockStore, func() einterfaces.MetricsInterface { return metrics }), mockStore
+}
+
+func newSchedulerTest(t *testing.T, cfg *model.Config) (*Scheduler, *storetest.Store, *metricsmocks.MetricsInterface) {
+	t.Helper()
+
+	mockMetrics := &metricsmocks.MetricsInterface{}
+	t.Cleanup(func() {
+		mockMetrics.AssertExpectations(t)
+	})
+	scheduler, mockStore := newSchedulerTestWithMetrics(t, cfg, mockMetrics)
+	return scheduler, mockStore, mockMetrics
 }
 
 func expectNoWedgedJobs(mockStore *storetest.Store) {
@@ -97,7 +110,7 @@ func TestScheduleJobEnqueuesEachDueRecapAndSkipsDuplicateAtomically(t *testing.T
 	cfg.SetDefaults()
 	cfg.FeatureFlags.EnableAIRecaps = true
 
-	scheduler, mockStore := newSchedulerTest(t, cfg)
+	scheduler, mockStore, mockMetrics := newSchedulerTest(t, cfg)
 
 	dueRecap1 := testScheduledRecap(true)
 	dueRecap2 := testScheduledRecap(true)
@@ -112,6 +125,7 @@ func TestScheduleJobEnqueuesEachDueRecapAndSkipsDuplicateAtomically(t *testing.T
 	}
 
 	expectEnqueueDuplicate(mockStore, dueRecap1)
+	mockMetrics.On("ObserveRecapScheduledBacklog", int64(3)).Once()
 
 	job, appErr := scheduler.ScheduleJob(request.EmptyContext(mlog.CreateConsoleTestLogger(t)), cfg, false, nil)
 	require.Nil(t, appErr)
@@ -123,7 +137,7 @@ func TestScheduleJobResetsWedgedJobThenEnqueuesSameTick(t *testing.T) {
 	cfg.SetDefaults()
 	cfg.FeatureFlags.EnableAIRecaps = true
 
-	scheduler, mockStore := newSchedulerTest(t, cfg)
+	scheduler, mockStore, mockMetrics := newSchedulerTest(t, cfg)
 
 	scheduledRecap := testScheduledRecap(true)
 	stale := model.GetMillis() - (ScheduledRecapJobWedgedTimeout + time.Minute).Milliseconds()
@@ -163,6 +177,7 @@ func TestScheduleJobResetsWedgedJobThenEnqueuesSameTick(t *testing.T) {
 		}).
 		Return(func(job *model.Job, data map[string]string) *model.Job { return job }, nil).
 		Once()
+	mockMetrics.On("ObserveRecapScheduledBacklog", int64(1)).Once()
 
 	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
 	require.Nil(t, appErr)
@@ -175,7 +190,7 @@ func TestScheduleJobContinuesWhenWedgedResetFails(t *testing.T) {
 	cfg.SetDefaults()
 	cfg.FeatureFlags.EnableAIRecaps = true
 
-	scheduler, mockStore := newSchedulerTest(t, cfg)
+	scheduler, mockStore, mockMetrics := newSchedulerTest(t, cfg)
 
 	scheduledRecap := testScheduledRecap(true)
 	mockStore.JobStore.
@@ -190,6 +205,7 @@ func TestScheduleJobContinuesWhenWedgedResetFails(t *testing.T) {
 		On("SaveOnceByTypeAndData", mock.Anything, map[string]string{"scheduled_recap_id": scheduledRecap.Id}).
 		Return(func(job *model.Job, data map[string]string) *model.Job { return job }, nil).
 		Once()
+	mockMetrics.On("ObserveRecapScheduledBacklog", int64(1)).Once()
 
 	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
 	require.Nil(t, appErr)
@@ -200,7 +216,7 @@ func TestScheduleJobDrainsBacklogAcrossBatches(t *testing.T) {
 	cfg := &model.Config{}
 	cfg.SetDefaults()
 	cfg.FeatureFlags.EnableAIRecaps = true
-	scheduler, mockStore := newSchedulerTest(t, cfg)
+	scheduler, mockStore, mockMetrics := newSchedulerTest(t, cfg)
 	expectNoWedgedJobs(mockStore)
 
 	recaps := makeDueRecaps(250, model.GetMillis()-1000)
@@ -210,6 +226,7 @@ func TestScheduleJobDrainsBacklogAcrossBatches(t *testing.T) {
 	for _, sr := range recaps {
 		expectEnqueueOK(mockStore, sr)
 	}
+	mockMetrics.On("ObserveRecapScheduledBacklog", int64(250)).Once()
 
 	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
 	require.Nil(t, appErr)
@@ -261,7 +278,7 @@ func TestScheduleJobStopsAtMaxDueSchedulesPerTick(t *testing.T) {
 			cfg.SetDefaults()
 			cfg.FeatureFlags.EnableAIRecaps = true
 			cfg.AIRecapSettings.Processing.MaxDueSchedulesPerTick = model.NewPointer(tt.cap)
-			scheduler, mockStore := newSchedulerTest(t, cfg)
+			scheduler, mockStore, mockMetrics := newSchedulerTest(t, cfg)
 			expectNoWedgedJobs(mockStore)
 
 			recaps := makeDueRecaps(tt.wantEnqueued, model.GetMillis()-1000)
@@ -278,6 +295,7 @@ func TestScheduleJobStopsAtMaxDueSchedulesPerTick(t *testing.T) {
 			for _, sr := range recaps {
 				expectEnqueueOK(mockStore, sr)
 			}
+			mockMetrics.On("ObserveRecapScheduledBacklog", int64(tt.wantEnqueued)).Once()
 
 			job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
 			require.Nil(t, appErr)
@@ -290,7 +308,7 @@ func TestScheduleJobCountsDuplicatesTowardCapAndContinuesDrain(t *testing.T) {
 	cfg := &model.Config{}
 	cfg.SetDefaults()
 	cfg.FeatureFlags.EnableAIRecaps = true
-	scheduler, mockStore := newSchedulerTest(t, cfg)
+	scheduler, mockStore, mockMetrics := newSchedulerTest(t, cfg)
 	expectNoWedgedJobs(mockStore)
 
 	recaps := makeDueRecaps(120, model.GetMillis()-1000)
@@ -305,6 +323,7 @@ func TestScheduleJobCountsDuplicatesTowardCapAndContinuesDrain(t *testing.T) {
 			expectEnqueueOK(mockStore, sr)
 		}
 	}
+	mockMetrics.On("ObserveRecapScheduledBacklog", int64(120)).Once()
 
 	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
 	require.Nil(t, appErr)
@@ -315,7 +334,7 @@ func TestScheduleJobAbortsTickOnStoreErrorMidDrain(t *testing.T) {
 	cfg := &model.Config{}
 	cfg.SetDefaults()
 	cfg.FeatureFlags.EnableAIRecaps = true
-	scheduler, mockStore := newSchedulerTest(t, cfg)
+	scheduler, mockStore, mockMetrics := newSchedulerTest(t, cfg)
 	expectNoWedgedJobs(mockStore)
 
 	recaps := makeDueRecaps(100, model.GetMillis()-1000)
@@ -331,13 +350,14 @@ func TestScheduleJobAbortsTickOnStoreErrorMidDrain(t *testing.T) {
 	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
 	require.Nil(t, appErr)
 	require.Nil(t, job)
+	mockMetrics.AssertNotCalled(t, "ObserveRecapScheduledBacklog", mock.Anything)
 }
 
 func TestScheduleJobContinuesPastEnqueueErrorMidBatch(t *testing.T) {
 	cfg := &model.Config{}
 	cfg.SetDefaults()
 	cfg.FeatureFlags.EnableAIRecaps = true
-	scheduler, mockStore := newSchedulerTest(t, cfg)
+	scheduler, mockStore, mockMetrics := newSchedulerTest(t, cfg)
 	expectNoWedgedJobs(mockStore)
 
 	recaps := makeDueRecaps(3, model.GetMillis()-1000)
@@ -345,6 +365,53 @@ func TestScheduleJobContinuesPastEnqueueErrorMidBatch(t *testing.T) {
 	expectEnqueueOK(mockStore, recaps[0])
 	expectEnqueueError(mockStore, recaps[1])
 	expectEnqueueOK(mockStore, recaps[2])
+	mockMetrics.On("ObserveRecapScheduledBacklog", int64(3)).Once()
+
+	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
+	require.Nil(t, appErr)
+	require.Nil(t, job)
+}
+
+func TestScheduleJobSetsBacklogGaugeToZeroWhenIdle(t *testing.T) {
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	cfg.FeatureFlags.EnableAIRecaps = true
+	scheduler, mockStore, mockMetrics := newSchedulerTest(t, cfg)
+	expectNoWedgedJobs(mockStore)
+	expectBatch(mockStore, 0, "", 100, []*model.ScheduledRecap{})
+	mockMetrics.On("ObserveRecapScheduledBacklog", int64(0)).Once()
+
+	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
+	require.Nil(t, appErr)
+	require.Nil(t, job)
+}
+
+func TestScheduleJobSkipsBacklogGaugeOnStoreError(t *testing.T) {
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	cfg.FeatureFlags.EnableAIRecaps = true
+	scheduler, mockStore, mockMetrics := newSchedulerTest(t, cfg)
+	expectNoWedgedJobs(mockStore)
+	mockStore.ScheduledRecapStore.
+		On("GetDueBefore", mock.AnythingOfType("int64"), int64(0), "", 100).
+		Return(nil, errors.New("boom")).
+		Once()
+
+	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
+	require.Nil(t, appErr)
+	require.Nil(t, job)
+	mockMetrics.AssertNotCalled(t, "ObserveRecapScheduledBacklog", mock.Anything)
+}
+
+func TestScheduleJobNilMetricsIsSafe(t *testing.T) {
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	cfg.FeatureFlags.EnableAIRecaps = true
+	scheduler, mockStore := newSchedulerTestWithMetrics(t, cfg, nil)
+	expectNoWedgedJobs(mockStore)
+	scheduledRecap := testScheduledRecap(true)
+	expectBatch(mockStore, 0, "", 100, []*model.ScheduledRecap{scheduledRecap})
+	expectEnqueueOK(mockStore, scheduledRecap)
 
 	job, appErr := scheduler.ScheduleJob(request.TestContext(t), cfg, false, nil)
 	require.Nil(t, appErr)

--- a/server/einterfaces/metrics.go
+++ b/server/einterfaces/metrics.go
@@ -150,4 +150,11 @@ type MetricsInterface interface {
 	ObserveAutoTranslateWorkerTaskDuration(elapsed float64)
 	AddAutoTranslateRecoveryStuckFound(count float64)
 	IncrementAutoTranslateNormHash(result string)
+
+	// Recap metrics
+	ObserveRecapDeliveryDelay(seconds float64)
+	ObserveRecapScheduledBacklog(count int64)
+	IncrementRecapLLMInFlight()
+	DecrementRecapLLMInFlight()
+	ObserveRecapChannelProcessTime(success bool, seconds float64)
 }

--- a/server/einterfaces/mocks/MetricsInterface.go
+++ b/server/einterfaces/mocks/MetricsInterface.go
@@ -47,6 +47,11 @@ func (_m *MetricsInterface) DecrementJobActive(jobType string) {
 	_m.Called(jobType)
 }
 
+// DecrementRecapLLMInFlight provides a mock function with no fields
+func (_m *MetricsInterface) DecrementRecapLLMInFlight() {
+	_m.Called()
+}
+
 // DecrementWebSocketBroadcastBufferSize provides a mock function with given fields: hub, amount
 func (_m *MetricsInterface) DecrementWebSocketBroadcastBufferSize(hub string, amount float64) {
 	_m.Called(hub, amount)
@@ -249,6 +254,11 @@ func (_m *MetricsInterface) IncrementPostSentPush() {
 
 // IncrementPostsSearchCounter provides a mock function with no fields
 func (_m *MetricsInterface) IncrementPostsSearchCounter() {
+	_m.Called()
+}
+
+// IncrementRecapLLMInFlight provides a mock function with no fields
+func (_m *MetricsInterface) IncrementRecapLLMInFlight() {
 	_m.Called()
 }
 
@@ -540,6 +550,21 @@ func (_m *MetricsInterface) ObservePluginWebappPerf(platform string, agent strin
 // ObservePostsSearchDuration provides a mock function with given fields: elapsed
 func (_m *MetricsInterface) ObservePostsSearchDuration(elapsed float64) {
 	_m.Called(elapsed)
+}
+
+// ObserveRecapChannelProcessTime provides a mock function with given fields: success, seconds
+func (_m *MetricsInterface) ObserveRecapChannelProcessTime(success bool, seconds float64) {
+	_m.Called(success, seconds)
+}
+
+// ObserveRecapDeliveryDelay provides a mock function with given fields: seconds
+func (_m *MetricsInterface) ObserveRecapDeliveryDelay(seconds float64) {
+	_m.Called(seconds)
+}
+
+// ObserveRecapScheduledBacklog provides a mock function with given fields: count
+func (_m *MetricsInterface) ObserveRecapScheduledBacklog(count int64) {
+	_m.Called(count)
 }
 
 // ObserveRedisEndpointDuration provides a mock function with given fields: cacheName, operation, elapsed

--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -46,6 +46,7 @@ const (
 	MetricsSubsystemClientsDesktopApp  = "desktopapp"
 	MetricsSubsystemAccessControl      = "access_control"
 	MetricsSubsystemAutoTranslation    = "autotranslation"
+	MetricsSubsystemRecaps             = "recaps"
 	MetricsCloudInstallationLabel      = "installationId"
 	MetricsCloudDatabaseClusterLabel   = "databaseClusterName"
 	MetricsCloudInstallationGroupLabel = "installationGroupId"
@@ -255,6 +256,12 @@ type MetricsInterfaceImpl struct {
 	AutoTranslateWorkerTaskDuration      prometheus.Histogram
 	AutoTranslateRecoveryStuckFound      prometheus.Counter
 	AutoTranslateNormHashCounter         *prometheus.CounterVec
+
+	// Recap metrics
+	RecapDeliveryDelayHistogram      prometheus.Histogram
+	RecapScheduledBacklogGauge       prometheus.Gauge
+	RecapLLMInFlightGauge            prometheus.Gauge
+	RecapChannelProcessTimeHistogram *prometheus.HistogramVec
 }
 
 func init() {
@@ -1742,6 +1749,46 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 	)
 	m.Registry.MustRegister(m.AutoTranslateNormHashCounter)
 
+	// Recaps Subsystem
+	m.RecapDeliveryDelayHistogram = prometheus.NewHistogram(withLabels(prometheus.HistogramOpts{
+		Namespace: MetricsNamespace,
+		Subsystem: MetricsSubsystemRecaps,
+		Name:      "delivery_delay_seconds",
+		Help:      "Delay between a scheduled recap's due time and its delivery to the user (seconds)",
+		Buckets:   []float64{5, 15, 30, 60, 90, 120, 180, 300, 600, 1200, 1800, 3600},
+	}))
+	m.Registry.MustRegister(m.RecapDeliveryDelayHistogram)
+
+	m.RecapScheduledBacklogGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace:   MetricsNamespace,
+		Subsystem:   MetricsSubsystemRecaps,
+		Name:        "scheduled_backlog",
+		Help:        "Number of due scheduled recaps found by the last scheduler tick on the cluster leader, capped at MaxDueSchedulesPerTick",
+		ConstLabels: additionalLabels,
+	})
+	m.Registry.MustRegister(m.RecapScheduledBacklogGauge)
+
+	m.RecapLLMInFlightGauge = prometheus.NewGauge(prometheus.GaugeOpts{
+		Namespace:   MetricsNamespace,
+		Subsystem:   MetricsSubsystemRecaps,
+		Name:        "llm_calls_in_flight",
+		Help:        "Current number of in-flight recap channel-summarization LLM calls on this node",
+		ConstLabels: additionalLabels,
+	})
+	m.Registry.MustRegister(m.RecapLLMInFlightGauge)
+
+	m.RecapChannelProcessTimeHistogram = prometheus.NewHistogramVec(
+		withLabels(prometheus.HistogramOpts{
+			Namespace: MetricsNamespace,
+			Subsystem: MetricsSubsystemRecaps,
+			Name:      "channel_process_time_seconds",
+			Help:      "Time to process a single channel within a recap job, including the LLM call (seconds)",
+			Buckets:   []float64{0.5, 1, 2.5, 5, 10, 20, 30, 60, 120, 300},
+		}),
+		[]string{"success"},
+	)
+	m.Registry.MustRegister(m.RecapChannelProcessTimeHistogram)
+
 	return m
 }
 
@@ -2404,6 +2451,26 @@ func (mi *MetricsInterfaceImpl) AddAutoTranslateRecoveryStuckFound(count float64
 
 func (mi *MetricsInterfaceImpl) IncrementAutoTranslateNormHash(result string) {
 	mi.AutoTranslateNormHashCounter.With(prometheus.Labels{"result": result}).Inc()
+}
+
+func (mi *MetricsInterfaceImpl) ObserveRecapDeliveryDelay(seconds float64) {
+	mi.RecapDeliveryDelayHistogram.Observe(seconds)
+}
+
+func (mi *MetricsInterfaceImpl) ObserveRecapScheduledBacklog(count int64) {
+	mi.RecapScheduledBacklogGauge.Set(float64(count))
+}
+
+func (mi *MetricsInterfaceImpl) IncrementRecapLLMInFlight() {
+	mi.RecapLLMInFlightGauge.Inc()
+}
+
+func (mi *MetricsInterfaceImpl) DecrementRecapLLMInFlight() {
+	mi.RecapLLMInFlightGauge.Dec()
+}
+
+func (mi *MetricsInterfaceImpl) ObserveRecapChannelProcessTime(success bool, seconds float64) {
+	mi.RecapChannelProcessTimeHistogram.With(prometheus.Labels{"success": strconv.FormatBool(success)}).Observe(seconds)
 }
 
 func (mi *MetricsInterfaceImpl) ClearMobileClientSessionMetadata() {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Part 5 of 5 in the scheduled-recap concurrency stack (stacked on #37606).

Adds the observability needed to operate concurrent recap processing and tune the knobs introduced earlier in the stack. New Prometheus metrics under a `recaps` subsystem:

- `mattermost_recaps_delivery_delay_seconds` (histogram, buckets 5s–3600s) — scheduled time (`NextRunAt`) to recap delivery; the headline SLO for "did the 9am recap arrive at 9am". Observed only for scheduled recaps that deliver (completed/partial); a `scheduled_for` value is threaded through the recap job data.
- `mattermost_recaps_scheduled_backlog` (gauge) — due schedules found per scheduler tick, explicitly reset to 0 on idle ticks; alerts when the per-tick cap is hit. Leader-only semantics: only the cluster leader sets it, so the value can go stale on an ex-leader after failover (same accepted behavior as the shared-channels queue gauge; noted in help text).
- `mattermost_recaps_llm_calls_in_flight` (gauge) — occupancy of the global LLM semaphore; decrement is paired with the semaphore release in the same defer, so panics cannot leak or drive it negative (pinned by test).
- `mattermost_recaps_channel_process_time_seconds` (histogram, `success` label) — per-channel processing time, excluding semaphore wait.

Log enrichment: per-tick scheduler summary (Info) and per-schedule enqueue-lag (Debug); "Recap job completed" now carries `job_duration`, `semaphore_wait_total`, `semaphore_wait_max`. All metric call sites are nil-safe (metrics can be disabled).

QA steps:
1. Run with metrics enabled (enterprise build); scrape `/metrics` and confirm the four `mattermost_recaps_*` series appear.
2. Fire a scheduled recap and verify a delivery-delay observation and the enriched completion log line.
3. Jobs/scheduler tests assert observed values (e.g. delay computed from `scheduled_for`), not just method calls; enterprise metrics package tests pass.

#### Release Note

```release-note
Added Prometheus metrics for AI recap processing: mattermost_recaps_delivery_delay_seconds, mattermost_recaps_scheduled_backlog, mattermost_recaps_llm_calls_in_flight, and mattermost_recaps_channel_process_time_seconds.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7037e36f-6e9f-4b1a-8cb6-2ce0c4fcf08b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7037e36f-6e9f-4b1a-8cb6-2ce0c4fcf08b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes span shared metrics interfaces, recap scheduling, and worker wiring, introducing contract updates and concurrency-related instrumentation. Existing automated coverage is broad, but scheduler and worker edge cases may still affect recap processing.

**QA Recommendation:** Manual QA can be limited; validate scheduled recap enqueueing and metric emission in a staging environment.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->