### PR TITLE
fix(files): add AVIF and JXL to image preview MIME type list

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/constants/files.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/constants/files.ts
@@ -4,7 +4,7 @@
 const Files: Record<string, string[]> = {
     AUDIO_TYPES: ['mp3', 'wav', 'wma', 'm4a', 'flac', 'aac', 'ogg'],
     CODE_TYPES: ['as', 'applescript', 'osascript', 'scpt', 'bash', 'sh', 'zsh', 'clj', 'boot', 'cl2', 'cljc', 'cljs', 'cljs.hl', 'cljscm', 'cljx', 'hic', 'coffee', '_coffee', 'cake', 'cjsx', 'cson', 'iced', 'cpp', 'c', 'cc', 'h', 'c++', 'h++', 'hpp', 'cs', 'csharp', 'css', 'd', 'di', 'dart', 'delphi', 'dpr', 'dfm', 'pas', 'pascal', 'freepascal', 'lazarus', 'lpr', 'lfm', 'diff', 'django', 'jinja', 'dockerfile', 'docker', 'erl', 'f90', 'f95', 'fsharp', 'fs', 'gcode', 'nc', 'go', 'groovy', 'handlebars', 'hbs', 'html.hbs', 'html.handlebars', 'hs', 'hx', 'java', 'jsp', 'js', 'jsx', 'json', 'jl', 'kt', 'ktm', 'kts', 'less', 'lisp', 'lua', 'mk', 'mak', 'md', 'mkdown', 'mkd', 'matlab', 'm', 'mm', 'objc', 'obj-c', 'ml', 'perl', 'pl', 'php', 'php3', 'php4', 'php5', 'php6', 'ps', 'ps1', 'pp', 'py', 'gyp', 'r', 'ruby', 'rb', 'gemspec', 'podspec', 'thor', 'irb', 'rs', 'scala', 'scm', 'sld', 'scss', 'st', 'sql', 'swift', 'tex', 'vbnet', 'vb', 'bas', 'vbs', 'v', 'veo', 'xml', 'html', 'xhtml', 'rss', 'atom', 'xsl', 'plist', 'yaml'],
-    IMAGE_TYPES: ['jpg', 'gif', 'bmp', 'png', 'jpeg', 'tiff', 'tif'],
+    IMAGE_TYPES: ['jpg', 'gif', 'bmp', 'png', 'jpeg', 'tiff', 'tif', 'webp', 'avif', 'jxl'],
     PATCH_TYPES: ['patch'],
     PDF_TYPES: ['pdf'],
     PRESENTATION_TYPES: ['ppt', 'pptx'],

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -1521,7 +1521,7 @@ export const Constants = {
     DEFAULT_CHARACTER_LIMIT: 4000,
     IMAGE_TYPE_GIF: 'gif',
     TEXT_TYPES: ['txt', 'rtf', 'vtt'],
-    IMAGE_TYPES: ['jpg', 'gif', 'bmp', 'png', 'jpeg', 'tiff', 'tif', 'webp'],
+    IMAGE_TYPES: ['jpg', 'gif', 'bmp', 'png', 'jpeg', 'tiff', 'tif', 'webp', 'avif', 'jxl'],
     AUDIO_TYPES: ['mp3', 'wav', 'wma', 'm4a', 'flac', 'aac', 'ogg', 'm4r'],
     VIDEO_TYPES: ['mp4', 'avi', 'webm', 'mkv', 'wmv', 'mpg', 'mov', 'flv'],
     PRESENTATION_TYPES: ['ppt', 'pptx'],


### PR DESCRIPTION
AVIF and JXL files attached in channels are not treated as images — they download instead of rendering an inline preview.

`IMAGE_TYPES` in `webapp/channels/src/utils/constants.tsx` is the canonical list used for preview detection, but it was missing `avif` and `jxl`. Also synced `webapp/channels/src/packages/mattermost-redux/src/constants/files.ts` which was missing both `avif`/`jxl` and `webp` (already in the main list).

Both arrays are now consistent:
`['jpg', 'gif', 'bmp', 'png', 'jpeg', 'tiff', 'tif', 'webp', 'avif', 'jxl']`

`AcceptedProfileImageTypes` and `ACCEPTED_TEAM_IMAGE_TYPES` are intentionally left unchanged — those restrict avatar uploads to jpeg/png/bmp by design.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are limited to image MIME-type constants and only expand inline preview support. Existing behavior and avatar restrictions remain unchanged.  
**QA Recommendation:** Manual QA can be skipped; automated coverage should be sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->