### PR TITLE
Fix two Session Attribute issues

### DIFF
--- a/server/channels/api4/properties.go
+++ b/server/channels/api4/properties.go
@@ -50,8 +50,11 @@ func getV2Group(c *Context, callerName string) *model.PropertyGroup {
 		c.Err = model.NewAppError(callerName, "api.property.v2_group_not_found.app_error", nil, "", http.StatusNotFound)
 		return nil
 	}
-	// Session attribute schema management requires Enterprise Advanced.
-	if group.Name == model.SessionAttributesPropertyGroupName && !model.MinimumEnterpriseAdvancedLicense(c.App.License()) {
+	// Session attributes require both the feature flag and Enterprise
+	// Advanced. This mirrors the dedicated manifest endpoint's gate so the
+	// generic Properties API cannot expose the schema when the feature is off.
+	if group.Name == model.SessionAttributesPropertyGroupName &&
+		(!c.App.Config().FeatureFlags.SessionAttributes || !model.MinimumEnterpriseAdvancedLicense(c.App.License())) {
 		c.Err = model.NewAppError(callerName, "api.property.session_attributes.license.app_error", nil, "", http.StatusNotImplemented)
 		return nil
 	}

--- a/server/channels/api4/properties_test.go
+++ b/server/channels/api4/properties_test.go
@@ -89,6 +89,39 @@ func TestSessionAttributesFieldEditing(t *testing.T) {
 	})
 }
 
+func TestSessionAttributesFeatureFlagGate(t *testing.T) {
+	// Routes are registered through the ClassificationMarkings flag so the
+	// generic Properties API is reachable while the SessionAttributes feature
+	// flag stays off.
+	th := SetupConfig(t, func(cfg *model.Config) {
+		cfg.FeatureFlags.SessionAttributes = false
+		cfg.FeatureFlags.ClassificationMarkings = true
+	}).InitBasic(t)
+	th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
+
+	groupName := model.SessionAttributesPropertyGroupName
+	objectType := model.PropertyFieldObjectTypeSession
+	search := model.PropertyFieldSearch{
+		TargetType: string(model.PropertyFieldTargetLevelSystem),
+		PerPage:    100,
+	}
+
+	t.Run("admin read returns 501 when feature flag is off", func(t *testing.T) {
+		_, resp, err := th.SystemAdminClient.GetPropertyFields(context.Background(), groupName, objectType, search)
+		require.Error(t, err)
+		CheckErrorID(t, err, "api.property.session_attributes.license.app_error")
+		require.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+	})
+
+	t.Run("non-admin read returns 501 when feature flag is off", func(t *testing.T) {
+		th.LoginBasic(t)
+		_, resp, err := th.Client.GetPropertyFields(context.Background(), groupName, objectType, search)
+		require.Error(t, err)
+		CheckErrorID(t, err, "api.property.session_attributes.license.app_error")
+		require.Equal(t, http.StatusNotImplemented, resp.StatusCode)
+	})
+}
+
 func TestPropertyRoutesWithClassificationMarkingsFlag(t *testing.T) {
 	mainHelper.Parallel(t)
 

--- a/server/channels/app/session_attributes.go
+++ b/server/channels/app/session_attributes.go
@@ -81,8 +81,11 @@ func (a *App) ProcessSessionAttributesRequest(rctx request.CTX, r *http.Request)
 		return
 	}
 
-	// Only process session attributes for actual user sessions.
-	if rctx.Session().Local {
+	// Only process session attributes for actual end-user sessions. Local
+	// sessions and OAuth app sessions do not correspond to a physical device
+	// with a real security posture, so they must not be able to self-attest
+	// session attributes.
+	if rctx.Session().Local || rctx.Session().IsOAuth {
 		return
 	}
 	switch rctx.Session().Props[model.SessionPropType] {

--- a/server/channels/app/session_attributes_test.go
+++ b/server/channels/app/session_attributes_test.go
@@ -218,6 +218,24 @@ func TestProcessSessionAttributesRequest(t *testing.T) {
 		}
 	})
 
+	t.Run("skips OAuth app sessions", func(t *testing.T) {
+		th := Setup(t).InitBasic(t)
+		enableSessionAttributesCollection(t, th)
+
+		session, appErr := th.App.CreateSession(th.Context, &model.Session{
+			UserId:  th.BasicUser.Id,
+			IsOAuth: true,
+			Props:   model.StringMap{},
+		})
+		require.Nil(t, appErr)
+		rctx := th.Context.WithSession(session)
+
+		r := newSessionAttributesRequest(t, testUserAgentChrome, "192.0.2.10:1234")
+		th.App.ProcessSessionAttributesRequest(rctx, r)
+
+		require.Empty(t, sessionAttributeValuesByFieldName(t, th, session.Id))
+	})
+
 	t.Run("skips when session id is empty", func(t *testing.T) {
 		th := Setup(t).InitBasic(t)
 		enableSessionAttributesCollection(t, th)


### PR DESCRIPTION
#### Summary
The generic Properties API only checked the Enterprise Advanced license for the `session_attributes` group, not the `SessionAttributes` feature flag, so it stayed reachable even with the flag off. This PR adds the feature flag check to `getV2Group` for the `session_attributes` group, so it now returns 501 whenever the flag is off.

Separately, `ProcessSessionAttributesRequest` excluded local and token-based sessions from attribute processing but not OAuth app sessions, so OAuth sessions were merged in the same way as regular user sessions. This PR updates the exclusion guard in `ProcessSessionAttributesRequest` to also skip OAuth sessions.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes affect session-management behavior and the API’s feature-flag gate, but targeted automated tests cover both paths.  
**QA Recommendation:** Manual QA can be skipped; rely on the added automated coverage and CI validation.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->