### PR TITLE
Automated cherry pick of #37583

### DIFF
--- a/server/channels/app/integration_action_test.go
+++ b/server/channels/app/integration_action_test.go
@@ -2777,7 +2777,7 @@ func TestUpdatePostMmBlocksActionsGuard(t *testing.T) {
 
 	t.Run("non-integration edit of bot post reverts mm_blocks_actions", func(t *testing.T) {
 		botPost := &model.Post{
-			Message:       "bot post with inline actions",
+			Message:       "bot post with inline actions [keep](mmaction://keep)",
 			ChannelId:     th.BasicChannel.Id,
 			PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
 			UserId:        botUser.Id,
@@ -2790,13 +2790,15 @@ func TestUpdatePostMmBlocksActionsGuard(t *testing.T) {
 		require.NotNil(t, created.GetProp(model.PostPropsMmBlocksActions))
 
 		// A non-integration session tries to swap mm_blocks_actions wholesale.
+		// The message keeps referencing "keep" so reconciliation retains the
+		// (reverted) original action; only the guard is under test here.
 		newInline := buildMmBlocksActionsProp(
 			"swap",
 			"http://127.0.0.1/plugins/myplugin/swapped",
 			map[string]any{"k": "attacker"},
 		)
 		edit := created.Clone()
-		edit.Message = "edited message"
+		edit.Message = "edited message [keep](mmaction://keep)"
 		edit.AddProp(model.PostPropsMmBlocksActions, newInline)
 
 		// th.Context has an empty/zero session — not an integration.
@@ -2812,7 +2814,7 @@ func TestUpdatePostMmBlocksActionsGuard(t *testing.T) {
 		assert.Nil(t, updated.GetMmBlocksActionSpec("swap"))
 
 		// Message change should still be applied.
-		assert.Equal(t, "edited message", updated.Message)
+		assert.Equal(t, "edited message [keep](mmaction://keep)", updated.Message)
 	})
 
 	t.Run("non-integration edit cannot add mm_blocks_actions when original had none", func(t *testing.T) {
@@ -2845,7 +2847,7 @@ func TestUpdatePostMmBlocksActionsGuard(t *testing.T) {
 		// mm_blocks_actions. A PAT-holding user could otherwise inject
 		// mm_blocks_actions on any post they can edit.
 		botPost := &model.Post{
-			Message:       "bot post for integration edit",
+			Message:       "bot post for integration edit [keep](mmaction://keep)",
 			ChannelId:     th.BasicChannel.Id,
 			PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
 			UserId:        botUser.Id,
@@ -2880,7 +2882,7 @@ func TestUpdatePostMmBlocksActionsGuard(t *testing.T) {
 
 	t.Run("AllowMmBlocksActionsUpdate option accepts new mm_blocks_actions", func(t *testing.T) {
 		botPost := &model.Post{
-			Message:       "bot post for plugin-path edit",
+			Message:       "bot post for plugin-path edit [keep](mmaction://keep)",
 			ChannelId:     th.BasicChannel.Id,
 			PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
 			UserId:        botUser.Id,
@@ -2897,6 +2899,8 @@ func TestUpdatePostMmBlocksActionsGuard(t *testing.T) {
 			map[string]any{"k": "plugin"},
 		)
 		edit := created.Clone()
+		// Point the content at the new action so reconciliation keeps it.
+		edit.Message = "plugin-path edit [plugin](mmaction://plugin)"
 		edit.AddProp(model.PostPropsMmBlocksActions, newInline)
 
 		// Non-integration session, but AllowMmBlocksActionsUpdate grants write.
@@ -2907,6 +2911,116 @@ func TestUpdatePostMmBlocksActionsGuard(t *testing.T) {
 		integration := updated.GetMmBlocksActionSpec("plugin")
 		require.NotNil(t, integration)
 		assert.Equal(t, "http://127.0.0.1/plugins/myplugin/plugin", integration.URL)
+	})
+
+	t.Run("integration session can modify mm_blocks_actions on its own post", func(t *testing.T) {
+		// A bot editing its OWN post over REST may change its buttons — this is
+		// the case the freeze previously blocked with no available flag.
+		botPost := &model.Post{
+			Message:       "bot post for own-post edit [keep](mmaction://keep)",
+			ChannelId:     th.BasicChannel.Id,
+			PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
+			UserId:        botUser.Id,
+			Props: model.StringInterface{
+				model.PostPropsMmBlocksActions: originalInline,
+			},
+		}
+		created, _, cErr := th.App.CreatePostAsUser(intSeedCtx, botPost, "", true)
+		require.Nil(t, cErr)
+
+		// Integration session belonging to the post's own bot author.
+		ownSession := &model.Session{UserId: botUser.Id, IsOAuth: true}
+		ownCtx := th.Context.WithSession(ownSession)
+		require.True(t, ownCtx.Session().IsIntegration())
+
+		newInline := buildMmBlocksActionsProp(
+			"refreshed",
+			"http://127.0.0.1/plugins/myplugin/refreshed",
+			map[string]any{"k": "new"},
+		)
+		edit := created.Clone()
+		// New content references the new action; reconciliation keeps it and
+		// drops the now-unreferenced "keep".
+		edit.Message = "refreshed message [refreshed](mmaction://refreshed)"
+		edit.AddProp(model.PostPropsMmBlocksActions, newInline)
+
+		updated, _, uErr := th.App.UpdatePost(ownCtx, edit, &model.UpdatePostOptions{SafeUpdate: false})
+		require.Nil(t, uErr)
+
+		// The new value lands; the old one is gone.
+		refreshed := updated.GetMmBlocksActionSpec("refreshed")
+		require.NotNil(t, refreshed, "bot editing its own post should be able to change mm_blocks_actions")
+		assert.Equal(t, "http://127.0.0.1/plugins/myplugin/refreshed", refreshed.URL)
+		assert.Nil(t, updated.GetMmBlocksActionSpec("keep"))
+		assert.Equal(t, "refreshed message [refreshed](mmaction://refreshed)", updated.Message)
+	})
+
+	t.Run("message-only edit that keeps the button preserves mm_blocks_actions", func(t *testing.T) {
+		// A message-only edit that still references the action must not wipe
+		// its button — the update carries no mm_blocks_actions, so the original
+		// is preserved, and the content still references it, so reconciliation
+		// keeps it.
+		botPost := &model.Post{
+			Message:       "bot post for message-only edit [keep](mmaction://keep)",
+			ChannelId:     th.BasicChannel.Id,
+			PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
+			UserId:        botUser.Id,
+			Props: model.StringInterface{
+				model.PostPropsMmBlocksActions: originalInline,
+			},
+		}
+		created, _, cErr := th.App.CreatePostAsUser(intSeedCtx, botPost, "", true)
+		require.Nil(t, cErr)
+
+		ownSession := &model.Session{UserId: botUser.Id, IsOAuth: true}
+		ownCtx := th.Context.WithSession(ownSession)
+
+		edit := created.Clone()
+		edit.Message = "message only change [keep](mmaction://keep)"
+		edit.DelProp(model.PostPropsMmBlocksActions)
+
+		updated, _, uErr := th.App.UpdatePost(ownCtx, edit, &model.UpdatePostOptions{SafeUpdate: false})
+		require.Nil(t, uErr)
+
+		keep := updated.GetMmBlocksActionSpec("keep")
+		require.NotNil(t, keep, "message-only edit that keeps the button must not wipe mm_blocks_actions")
+		assert.Equal(t, "http://127.0.0.1/plugins/myplugin/original", keep.URL)
+		assert.Equal(t, "message only change [keep](mmaction://keep)", updated.Message)
+	})
+
+	t.Run("dropping the button from content revokes the lingering action", func(t *testing.T) {
+		// The reviewer's scenario: a post with an action is edited to remove
+		// the button from its content while the update omits mm_blocks_actions.
+		// The guard preserves the old registry value, but reconciliation prunes
+		// it against the new content — since nothing references the action any
+		// more, it is genuinely revoked rather than left callable-but-invisible.
+		botPost := &model.Post{
+			Message:       "bot post that will lose its button [keep](mmaction://keep)",
+			ChannelId:     th.BasicChannel.Id,
+			PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
+			UserId:        botUser.Id,
+			Props: model.StringInterface{
+				model.PostPropsMmBlocksActions: originalInline,
+			},
+		}
+		created, _, cErr := th.App.CreatePostAsUser(intSeedCtx, botPost, "", true)
+		require.Nil(t, cErr)
+		require.NotNil(t, created.GetMmBlocksActionSpec("keep"))
+
+		ownSession := &model.Session{UserId: botUser.Id, IsOAuth: true}
+		ownCtx := th.Context.WithSession(ownSession)
+
+		// The edit removes the button reference and does not carry the prop.
+		edit := created.Clone()
+		edit.Message = "the button is gone now"
+		edit.DelProp(model.PostPropsMmBlocksActions)
+
+		updated, _, uErr := th.App.UpdatePost(ownCtx, edit, &model.UpdatePostOptions{SafeUpdate: false})
+		require.Nil(t, uErr)
+
+		assert.Nil(t, updated.GetMmBlocksActionSpec("keep"), "action unreferenced by content must be pruned")
+		assert.Nil(t, updated.GetAction("keep"), "pruned action must not be dispatchable at click time")
+		assert.Equal(t, "the button is gone now", updated.Message)
 	})
 }
 
@@ -3416,7 +3530,7 @@ func TestDoPostActionPluginResponseInvalidMmBlocksActionsRestored(t *testing.T) 
 		w.WriteHeader(http.StatusOK)
 		resp := `{
 			"update": {
-				"message": "updated via plugin",
+				"message": "updated via plugin [orig](mmaction://orig)",
 				"props": {
 					"mm_blocks_actions": {
 						"broken": {"type": "external", "url": ""}
@@ -3437,7 +3551,7 @@ func TestDoPostActionPluginResponseInvalidMmBlocksActionsRestored(t *testing.T) 
 		nil,
 	)
 	botPost := &model.Post{
-		Message:       "bot post with valid inline actions",
+		Message:       "bot post with valid inline actions [orig](mmaction://orig)",
 		ChannelId:     th.BasicChannel.Id,
 		PendingPostId: model.NewId() + ":" + fmt.Sprint(model.GetMillis()),
 		UserId:        botUser.Id,
@@ -3474,7 +3588,7 @@ func TestDoPostActionPluginResponseInvalidMmBlocksActionsRestored(t *testing.T) 
 	// Message update still applied — the invalid mm_blocks_actions were
 	// restored to the original value with a warning, so the rest of the
 	// response.Update is persisted.
-	assert.Equal(t, "updated via plugin", stored.Message)
+	assert.Equal(t, "updated via plugin [orig](mmaction://orig)", stored.Message)
 	// The broken action from the plugin response must never be stored.
 	assert.Nil(t, stored.GetMmBlocksActionSpec("broken"), "invalid mm_blocks action from plugin response must not be persisted")
 	// The original valid mm_blocks_actions must survive — an invalid plugin

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -924,20 +924,36 @@ func (a *App) UpdatePost(rctx request.CTX, receivedUpdatedPost *model.Post, upda
 		newPost.SetProps(receivedUpdatedPost.GetProps())
 		newPost.PreserveIdentityPropsFrom(oldPost)
 
-		// mm_blocks_actions can only be modified by trusted paths that have
-		// pre-validated the new value (AllowMmBlocksActionsUpdate). Session
-		// type is intentionally not a sufficient signal: a PAT/OAuth session
-		// from a regular user would otherwise bypass the freeze and inject
-		// mm_blocks_actions on edit, since from_bot on the original post is
-		// user-forgeable. All other callers keep whatever mm_blocks_actions
-		// the original post had (or none).
-		if !updatePostOptions.AllowMmBlocksActionsUpdate {
+		// mm_blocks_actions is a trusted, click-resolved prop. It may only be
+		// *changed* by a caller that is both permitted and actually supplying a
+		// new value. Permission comes either from an explicit flag
+		// (AllowMmBlocksActionsUpdate — the plugin API and post-action
+		// responses) or, for REST callers, from the same authority create
+		// requires plus an ownership check: an integration session (bot / user
+		// access token / OAuth) editing its OWN post. The ownership check is
+		// what makes session type safe here — a user access token cannot inject
+		// mm_blocks_actions onto someone else's post, and from_bot on the
+		// original post is never consulted (it is user-forgeable). An update
+		// that does not carry the prop (e.g. a message-only edit) keeps whatever
+		// the original post had, so buttons are never silently wiped.
+		allowMmBlocksChange := updatePostOptions.AllowMmBlocksActionsUpdate ||
+			(newPost.GetProp(model.PostPropsMmBlocksActions) != nil &&
+				a.sessionMayUpdateMmBlocksActions(rctx, oldPost))
+		if !allowMmBlocksChange {
 			if oldVal, ok := oldPost.GetProps()[model.PostPropsMmBlocksActions]; ok {
 				newPost.AddProp(model.PostPropsMmBlocksActions, oldVal)
 			} else {
 				newPost.DelProp(model.PostPropsMmBlocksActions)
 			}
 		}
+
+		// Prune mm_blocks_actions to only the actions still referenced by the
+		// post's content. Dispatch authorizes clicks from this registry, not
+		// from whether a button renders, so a preserved entry whose button was
+		// removed would stay callable by any reader. Update-only by design:
+		// only an edit can strand an entry (we preserve the old registry while
+		// content changes); create writes both together. Mirrors webhook.go.
+		model.RefreshInteractiveActionsOnPost(newPost, newPost.GetProp(model.PostPropsMmBlocksActions))
 
 		var fileIds []string
 		fileIds, appErr = a.processPostFileChanges(rctx, receivedUpdatedPost, oldPost, updatePostOptions)
@@ -1062,6 +1078,21 @@ func (a *App) UpdatePost(rctx request.CTX, receivedUpdatedPost *model.Post, upda
 	rpost = sanitizedPost
 
 	return rpost, isMemberForPreviews, nil
+}
+
+// sessionMayUpdateMmBlocksActions reports whether the current session is
+// allowed to add, remove, or modify the mm_blocks_actions prop on oldPost via a
+// REST update/patch. It mirrors the create-time authority — an integration
+// session (bot user, user access token, or OAuth) — and adds an ownership
+// check so a caller can only change buttons on its OWN post. The ownership
+// check is essential: without it a user access token with edit_others_posts
+// could inject action buttons onto another user's or bot's post.
+func (a *App) sessionMayUpdateMmBlocksActions(rctx request.CTX, oldPost *model.Post) bool {
+	session := rctx.Session()
+	if session == nil || session.UserId == "" {
+		return false
+	}
+	return session.UserId == oldPost.UserId && session.IsIntegration()
 }
 
 func (a *App) publishWebsocketEventForPost(rctx request.CTX, post *model.Post, message *model.WebSocketEvent) *model.AppError {

--- a/server/platform/services/sharedchannel/sync_recv.go
+++ b/server/platform/services/sharedchannel/sync_recv.go
@@ -507,7 +507,16 @@ func (scs *Service) upsertSyncPost(post *model.Post, targetChannel *model.Channe
 
 		scs.transformMentionsOnReceive(rctx, post, targetChannel, rc, mentionTransforms)
 
-		rpost, _, appErr = scs.app.CreatePost(rctx, post, targetChannel, model.CreatePostFlags{TriggerWebhooks: true, SetOnline: true})
+		// The post is federated (RemoteId set) and its author is verified above
+		// to belong to the remote, which already enforced mm_blocks_actions
+		// authority. Preserve the prop through the create-time strip, mirroring
+		// how SanitizeProps preserves integration/notification props for
+		// federated posts.
+		rpost, _, appErr = scs.app.CreatePost(rctx, post, targetChannel, model.CreatePostFlags{
+			TriggerWebhooks:      true,
+			SetOnline:            true,
+			AllowMmBlocksActions: post.GetProp(model.PostPropsMmBlocksActions) != nil,
+		})
 		if appErr == nil {
 			scs.server.Log().Log(mlog.LvlSharedChannelServiceDebug, "Created sync post",
 				mlog.String("post_id", post.Id),
@@ -548,8 +557,11 @@ func (scs *Service) upsertSyncPost(post *model.Post, targetChannel *model.Channe
 			}
 		}
 
-		// First update the basic post
-		rpost, _, appErr = scs.app.UpdatePost(rctx, post, nil)
+		// First update the basic post. The post is federated and remote-owned
+		// (verified above); the origin cluster already enforced mm_blocks_actions
+		// authority, so allow the synced value through the UpdatePost freeze so
+		// button edits (or removals) made upstream propagate to this cluster.
+		rpost, _, appErr = scs.app.UpdatePost(rctx, post, &model.UpdatePostOptions{AllowMmBlocksActionsUpdate: true})
 		if appErr != nil {
 			rerr := errors.New(appErr.Error())
 			return nil, rerr

--- a/server/platform/services/sharedchannel/sync_recv_test.go
+++ b/server/platform/services/sharedchannel/sync_recv_test.go
@@ -355,11 +355,17 @@ func TestUpsertSyncPost(t *testing.T) {
 
 		scs, mockApp := setup(t, existing)
 		updated := &model.Post{Id: postID, ChannelId: channelID, Message: "updated"}
-		mockApp.On("UpdatePost", mock.Anything, mock.Anything, mock.Anything).Return(updated, false, (*model.AppError)(nil))
+		// A federated, remote-owned edit must be allowed to carry mm_blocks_actions
+		// changes through the UpdatePost freeze — the origin cluster is the trust
+		// boundary. Assert the option is set so a revert to nil options is caught.
+		allowsMmBlocks := mock.MatchedBy(func(opts *model.UpdatePostOptions) bool {
+			return opts != nil && opts.AllowMmBlocksActionsUpdate
+		})
+		mockApp.On("UpdatePost", mock.Anything, mock.Anything, allowsMmBlocks).Return(updated, false, (*model.AppError)(nil))
 
 		_, err := scs.upsertSyncPost(&model.Post{Id: postID, ChannelId: channelID, Message: "updated"}, channel, rc, nil)
 
 		require.NoError(t, err)
-		mockApp.AssertCalled(t, "UpdatePost", mock.Anything, mock.Anything, mock.Anything)
+		mockApp.AssertCalled(t, "UpdatePost", mock.Anything, mock.Anything, allowsMmBlocks)
 	})
 }


### PR DESCRIPTION
Cherry pick of #37583 on release-11.10.

/cc  @sbishel

```release-note
NONE
```