### PR TITLE
docs: mark scale partial pages as unlisted with proper titles

### DIFF
--- a/docs/main/administration-guide/scale/additional-ha-considerations.mdx
+++ b/docs/main/administration-guide/scale/additional-ha-considerations.mdx
@@ -1,4 +1,6 @@
 ---
+title: Additional HA considerations
+unlisted: true
 ---
 [Elasticsearch](https://www.elastic.co) provides enterprise-scale deployments with optimized search performance and prevents performance degradation and timeouts. Elasticsearch allows you to search large volumes of data quickly, in near real-time, by creating and managing an index of post data. Mattermost’s implementation uses [Elasticsearch](https://www.elastic.co) as a distributed, RESTful search engine supporting highly efficient database searches in a [cluster environment](/administration-guide/scale/high-availability-cluster-based-deployment). Visit the [Mattermost Elasticsearch product documentation](/administration-guide/scale/elasticsearch-setup) for deployment and configuration details.
 

--- a/docs/main/administration-guide/scale/estimated-storage-per-user-per-month.mdx
+++ b/docs/main/administration-guide/scale/estimated-storage-per-user-per-month.mdx
@@ -1,4 +1,6 @@
 ---
+title: Estimated storage per user, per month
+unlisted: true
 ---
 File usage per user varies significantly across industries. The below benchmarks are recommended:
 

--- a/docs/main/administration-guide/scale/lifetime-storage.mdx
+++ b/docs/main/administration-guide/scale/lifetime-storage.mdx
@@ -1,4 +1,6 @@
 ---
+title: Lifetime storage
+unlisted: true
 ---
 To forecast your own storage usage, begin with a Mattermost server approximately 600 MB to 800 MB in size including operating system and database, then add the multiplied product of:
 


### PR DESCRIPTION
#### Summary
The `additional-ha-considerations.mdx`, `lifetime-storage.mdx`, and `estimated-storage-per-user-per-month.mdx` files under `docs/main/administration-guide/scale/` are content partials imported into the `scale-to-*-users` pages, mirroring the `:orphan:`/`:nosearch:` Sphinx pages they were migrated from.

Without frontmatter, Docusaurus rendered them as full standalone pages with an ugly slug-derived title (e.g. literally `additional-ha-considerations`), breadcrumbs, and pagination — which doesn't match how these pages looked in production (Sphinx).

Adds `title` and `unlisted: true` frontmatter to each partial:
- `unlisted: true` keeps the routes alive (needed by the PDF book builder in `docs/pdf/books/administration-guide.json`, which fetches these URLs directly, and by legacy redirects in `active-redirects.json`) while hiding them from the sidebar, breadcrumbs, pagination, and search indexing — matching the old Sphinx `:orphan:`/`:nosearch:` behavior.
- `title` avoids the auto-derived slug heading and gives the PDF book's table-of-contents scraper a proper chapter title.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Documentation-only frontmatter changes are isolated and do not affect application logic or shared dependencies. Existing routes remain available, with only discoverability and indexing behavior changing.
**QA Recommendation:** Manual QA can be skipped; automated validation is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->