### PR TITLE
Fix broken API reference URL in api/README.md and api/package.json

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,6 +1,6 @@
 # Mattermost API Documentation
 
-This repository holds the API reference documentation for Mattermost available at [https://developers.mattermost.com/api-reference](https://developers.mattermost.com/api-reference).
+This repository holds the API reference documentation for Mattermost available at [https://developers.mattermost.com/api-documentation/](https://developers.mattermost.com/api-documentation/).
 
 The Mattermost API reference uses the [OpenAPI standard](https://openapis.org/) and the [ReDoc document generator](https://github.com/Rebilly/ReDoc).
 
@@ -25,4 +25,4 @@ To test locally, run `make build`, `make run` and navigate to `http://127.0.0.1:
 
 ## Deployment
 
-Deployment is handled automatically by our Github Actions. When a pull request is merged, it will automatically be deployed to [https://developers.mattermost.com/api-reference](https://developers.mattermost.com/api-reference).
+Deployment is handled automatically by our Github Actions. When a pull request is merged, it will automatically be deployed to [https://developers.mattermost.com/api-documentation/](https://developers.mattermost.com/api-documentation/).

--- a/api/package.json
+++ b/api/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mattermost-api-reference",
   "version": "1.0.0",
-  "description": "This repository holds the API reference documentation for Mattermost available at https://developers.mattermost.com/api-reference",
+  "description": "This repository holds the API reference documentation for Mattermost available at https://developers.mattermost.com/api-documentation/",
   "main": "index.js",
   "dependencies": {
     "@redocly/cli": "^1.13.0",


### PR DESCRIPTION
#### Summary

`https://developers.mattermost.com/api-reference` returns 404; the API reference now lives at `https://developers.mattermost.com/api-documentation/`. Updated the three references: two in `api/README.md`, one in `api/package.json`.

Also checked the other 33 unique URLs in `api/` (yaml, md, html) while here: everything else resolves. The `forum.mattermost.org/c/dev` link originally reported in #29193 is no longer present in the source.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/29193

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are limited to documentation links and package metadata, with no runtime logic or public API behavior affected.  
**QA Recommendation:** Manual QA can be skipped; a link validation check is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->