### PR TITLE
[MM-70223] Migrate GetAllProfilesInChannel to request context

### DIFF
--- a/server/channels/app/notification.go
+++ b/server/channels/app/notification.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 	"sort"
@@ -63,7 +62,7 @@ func (a *App) SendNotifications(rctx request.CTX, post *model.Post, team *model.
 
 	pchan := make(chan store.StoreResult[map[string]*model.User], 1)
 	go func() {
-		props, err := a.Srv().Store().User().GetAllProfilesInChannel(context.Background(), channel.Id, true)
+		props, err := a.Srv().Store().User().GetAllProfilesInChannel(rctx, channel.Id, true)
 		pchan <- store.StoreResult[map[string]*model.User]{Data: props, NErr: err}
 		close(pchan)
 	}()
@@ -932,7 +931,7 @@ func (a *App) RemoveNotifications(rctx request.CTX, post *model.Post, channel *m
 
 		pCh := make(chan store.StoreResult[map[string]*model.User], 1)
 		go func() {
-			props, err := a.Srv().Store().User().GetAllProfilesInChannel(context.Background(), channel.Id, true)
+			props, err := a.Srv().Store().User().GetAllProfilesInChannel(rctx, channel.Id, true)
 			pCh <- store.StoreResult[map[string]*model.User]{Data: props, NErr: err}
 			close(pCh)
 		}()

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -229,7 +229,7 @@ func (a *App) CreatePost(rctx request.CTX, post *model.Post, channel *model.Chan
 
 	// Validate recipients counts in case it's not DM
 	if persistentNotification := post.GetPersistentNotification(); persistentNotification != nil && *persistentNotification && channel.Type != model.ChannelTypeDirect {
-		err := a.forEachPersistentNotificationPost([]*model.Post{post}, func(_ *model.Post, _ *model.Channel, _ *model.Team, mentions *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
+		err := a.forEachPersistentNotificationPost(rctx, []*model.Post{post}, func(_ *model.Post, _ *model.Channel, _ *model.Team, mentions *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
 			if maxRecipients := *a.Config().ServiceSettings.PersistentNotificationMaxRecipients; len(mentions.Mentions) > maxRecipients {
 				return model.NewAppError("CreatePost", "api.post.post_priority.max_recipients_persistent_notification_post.request_error", map[string]any{"MaxRecipients": maxRecipients}, "", http.StatusBadRequest)
 			} else if len(mentions.Mentions) == 0 {

--- a/server/channels/app/post_persistent_notification.go
+++ b/server/channels/app/post_persistent_notification.go
@@ -57,7 +57,7 @@ func (a *App) ResolvePersistentNotification(rctx request.CTX, post *model.Post, 
 	}
 
 	stopNotifications := false
-	if err := a.forEachPersistentNotificationPost([]*model.Post{post}, func(_ *model.Post, _ *model.Channel, _ *model.Team, mentions *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
+	if err := a.forEachPersistentNotificationPost(rctx, []*model.Post{post}, func(_ *model.Post, _ *model.Channel, _ *model.Team, mentions *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
 		if mentions.isUserMentioned(loggedInUserID) {
 			stopNotifications = true
 		}
@@ -104,6 +104,7 @@ func (a *App) DeletePersistentNotification(rctx request.CTX, post *model.Post) *
 }
 
 func (a *App) SendPersistentNotifications() error {
+	rctx := request.EmptyContext(a.Log())
 	notificationInterval := time.Duration(*a.Config().ServiceSettings.PersistentNotificationIntervalMinutes) * time.Minute
 	notificationMaxCount := int16(*a.Config().ServiceSettings.PersistentNotificationMaxCount)
 
@@ -136,7 +137,7 @@ func (a *App) SendPersistentNotifications() error {
 		}
 
 		// Send notifications
-		if err := a.forEachPersistentNotificationPost(posts, a.sendPersistentNotifications); err != nil {
+		if err := a.forEachPersistentNotificationPost(rctx, posts, a.sendPersistentNotifications); err != nil {
 			return err
 		}
 
@@ -152,13 +153,13 @@ func (a *App) SendPersistentNotifications() error {
 	return nil
 }
 
-func (a *App) forEachPersistentNotificationPost(posts []*model.Post, fn func(post *model.Post, channel *model.Channel, team *model.Team, mentions *MentionResults, profileMap model.UserMap, channelNotifyProps map[string]map[string]model.StringMap) error) error {
+func (a *App) forEachPersistentNotificationPost(rctx request.CTX, posts []*model.Post, fn func(post *model.Post, channel *model.Channel, team *model.Team, mentions *MentionResults, profileMap model.UserMap, channelNotifyProps map[string]map[string]model.StringMap) error) error {
 	channelsMap, teamsMap, err := a.channelTeamMapsForPosts(posts)
 	if err != nil {
 		return err
 	}
 
-	channelGroupMap, channelProfileMap, channelKeywords, channelNotifyProps, err := a.persistentNotificationsAuxiliaryData(channelsMap, teamsMap)
+	channelGroupMap, channelProfileMap, channelKeywords, channelNotifyProps, err := a.persistentNotificationsAuxiliaryData(rctx, channelsMap, teamsMap)
 	if err != nil {
 		return err
 	}
@@ -229,7 +230,7 @@ func (a *App) forEachPersistentNotificationPost(posts []*model.Post, fn func(pos
 
 	if len(postsForPersistentNotificationCleanup) > 0 {
 		for _, post := range postsForPersistentNotificationCleanup {
-			if appErr := a.DeletePersistentNotification(request.EmptyContext(a.Log()), post); appErr != nil {
+			if appErr := a.DeletePersistentNotification(rctx, post); appErr != nil {
 				a.Log().Warn("Failed to delete persistent notification for post", mlog.String("post_id", post.Id), mlog.String("channel_id", post.ChannelId), mlog.Err(appErr))
 			}
 		}
@@ -238,7 +239,7 @@ func (a *App) forEachPersistentNotificationPost(posts []*model.Post, fn func(pos
 	return nil
 }
 
-func (a *App) persistentNotificationsAuxiliaryData(channelsMap map[string]*model.Channel, teamsMap map[string]*model.Team) (map[string]map[string]*model.Group, map[string]model.UserMap, map[string]MentionKeywords, map[string]map[string]model.StringMap, error) {
+func (a *App) persistentNotificationsAuxiliaryData(rctx request.CTX, channelsMap map[string]*model.Channel, teamsMap map[string]*model.Team) (map[string]map[string]*model.Group, map[string]model.UserMap, map[string]MentionKeywords, map[string]map[string]model.StringMap, error) {
 	channelGroupMap := make(map[string]map[string]*model.Group, len(channelsMap))
 	channelProfileMap := make(map[string]model.UserMap, len(channelsMap))
 	channelKeywords := make(map[string]MentionKeywords, len(channelsMap))
@@ -264,7 +265,7 @@ func (a *App) persistentNotificationsAuxiliaryData(channelsMap map[string]*model
 			channelNotifyProps[c.Id] = props
 		}
 
-		profileMap, err := a.Srv().Store().User().GetAllProfilesInChannel(context.Background(), c.Id, true)
+		profileMap, err := a.Srv().Store().User().GetAllProfilesInChannel(rctx, c.Id, true)
 		if err != nil {
 			return nil, nil, nil, nil, errors.Wrapf(err, "failed to get profiles for channel %s", c.Id)
 		}

--- a/server/channels/app/post_persistent_notification_test.go
+++ b/server/channels/app/post_persistent_notification_test.go
@@ -239,7 +239,7 @@ func TestForEachPersistentNotificationPost(t *testing.T) {
 		*cfg.ServiceSettings.AllowPersistentNotifications = true
 
 		fnCalled := []string{}
-		err := th.App.forEachPersistentNotificationPost([]*model.Post{post1, post2}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
+		err := th.App.forEachPersistentNotificationPost(th.Context, []*model.Post{post1, post2}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
 			fnCalled = append(fnCalled, post.Id)
 			return nil
 		})
@@ -297,7 +297,7 @@ func TestForEachPersistentNotificationPost(t *testing.T) {
 		*cfg.ServiceSettings.AllowPersistentNotifications = true
 
 		fnCalled := []string{}
-		err := th.App.forEachPersistentNotificationPost([]*model.Post{post1, post2}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
+		err := th.App.forEachPersistentNotificationPost(th.Context, []*model.Post{post1, post2}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
 			fnCalled = append(fnCalled, post.Id)
 			return nil
 		})
@@ -346,7 +346,7 @@ func TestForEachPersistentNotificationPost(t *testing.T) {
 		*cfg.ServiceSettings.AllowPersistentNotifications = true
 
 		fnCalled := []string{}
-		err := th.App.forEachPersistentNotificationPost([]*model.Post{post1}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
+		err := th.App.forEachPersistentNotificationPost(th.Context, []*model.Post{post1}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
 			fnCalled = append(fnCalled, post.Id)
 			return nil
 		})
@@ -397,7 +397,7 @@ func TestForEachPersistentNotificationPost(t *testing.T) {
 		*cfg.ServiceSettings.AllowPersistentNotifications = true
 
 		fnCalled := []string{}
-		err := th.App.forEachPersistentNotificationPost([]*model.Post{post1}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
+		err := th.App.forEachPersistentNotificationPost(th.Context, []*model.Post{post1}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
 			fnCalled = append(fnCalled, post.Id)
 			return nil
 		})

--- a/server/channels/store/localcachelayer/user_layer.go
+++ b/server/channels/store/localcachelayer/user_layer.go
@@ -141,7 +141,7 @@ func (s *LocalCacheUserStore) GetAllProfiles(options *model.UserGetOptions) ([]*
 	return s.UserStore.GetAllProfiles(options)
 }
 
-func (s *LocalCacheUserStore) GetAllProfilesInChannel(ctx context.Context, channelId string, allowFromCache bool) (map[string]*model.User, error) {
+func (s *LocalCacheUserStore) GetAllProfilesInChannel(rctx request.CTX, channelId string, allowFromCache bool) (map[string]*model.User, error) {
 	if allowFromCache {
 		var cachedMap model.UserMap
 		if err := s.rootStore.doStandardReadCache(s.rootStore.profilesInChannelCache, channelId, &cachedMap); err == nil {
@@ -149,7 +149,7 @@ func (s *LocalCacheUserStore) GetAllProfilesInChannel(ctx context.Context, chann
 		}
 	}
 
-	userMap, err := s.UserStore.GetAllProfilesInChannel(ctx, channelId, allowFromCache)
+	userMap, err := s.UserStore.GetAllProfilesInChannel(rctx, channelId, allowFromCache)
 	if err != nil {
 		return nil, err
 	}

--- a/server/channels/store/localcachelayer/user_layer_test.go
+++ b/server/channels/store/localcachelayer/user_layer_test.go
@@ -184,6 +184,7 @@ func TestUserStoreGetAllProfiles(t *testing.T) {
 }
 
 func TestUserStoreProfilesInChannelCache(t *testing.T) {
+	rctx := request.TestContext(t)
 	fakeChannelId := "123"
 	fakeUserId := "456"
 	fakeMap := map[string]*model.User{
@@ -197,12 +198,12 @@ func TestUserStoreProfilesInChannelCache(t *testing.T) {
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider, logger)
 		require.NoError(t, err)
 
-		gotMap, err := cachedStore.User().GetAllProfilesInChannel(context.Background(), fakeChannelId, true)
+		gotMap, err := cachedStore.User().GetAllProfilesInChannel(rctx, fakeChannelId, true)
 		require.NoError(t, err)
 		assert.Equal(t, fakeMap, gotMap)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "GetAllProfilesInChannel", 1)
 
-		_, _ = cachedStore.User().GetAllProfilesInChannel(context.Background(), fakeChannelId, true)
+		_, _ = cachedStore.User().GetAllProfilesInChannel(rctx, fakeChannelId, true)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "GetAllProfilesInChannel", 1)
 	})
 
@@ -212,12 +213,12 @@ func TestUserStoreProfilesInChannelCache(t *testing.T) {
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider, logger)
 		require.NoError(t, err)
 
-		gotMap, err := cachedStore.User().GetAllProfilesInChannel(context.Background(), fakeChannelId, true)
+		gotMap, err := cachedStore.User().GetAllProfilesInChannel(rctx, fakeChannelId, true)
 		require.NoError(t, err)
 		assert.Equal(t, fakeMap, gotMap)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "GetAllProfilesInChannel", 1)
 
-		_, _ = cachedStore.User().GetAllProfilesInChannel(context.Background(), fakeChannelId, false)
+		_, _ = cachedStore.User().GetAllProfilesInChannel(rctx, fakeChannelId, false)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "GetAllProfilesInChannel", 2)
 	})
 
@@ -227,14 +228,14 @@ func TestUserStoreProfilesInChannelCache(t *testing.T) {
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider, logger)
 		require.NoError(t, err)
 
-		gotMap, err := cachedStore.User().GetAllProfilesInChannel(context.Background(), fakeChannelId, true)
+		gotMap, err := cachedStore.User().GetAllProfilesInChannel(rctx, fakeChannelId, true)
 		require.NoError(t, err)
 		assert.Equal(t, fakeMap, gotMap)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "GetAllProfilesInChannel", 1)
 
 		cachedStore.User().InvalidateProfilesInChannelCache("123")
 
-		_, _ = cachedStore.User().GetAllProfilesInChannel(context.Background(), fakeChannelId, true)
+		_, _ = cachedStore.User().GetAllProfilesInChannel(rctx, fakeChannelId, true)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "GetAllProfilesInChannel", 2)
 	})
 
@@ -244,14 +245,14 @@ func TestUserStoreProfilesInChannelCache(t *testing.T) {
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider, logger)
 		require.NoError(t, err)
 
-		gotMap, err := cachedStore.User().GetAllProfilesInChannel(context.Background(), fakeChannelId, true)
+		gotMap, err := cachedStore.User().GetAllProfilesInChannel(rctx, fakeChannelId, true)
 		require.NoError(t, err)
 		assert.Equal(t, fakeMap, gotMap)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "GetAllProfilesInChannel", 1)
 
 		cachedStore.User().InvalidateProfilesInChannelCacheByUser("456")
 
-		_, _ = cachedStore.User().GetAllProfilesInChannel(context.Background(), fakeChannelId, true)
+		_, _ = cachedStore.User().GetAllProfilesInChannel(rctx, fakeChannelId, true)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "GetAllProfilesInChannel", 2)
 	})
 }

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -17092,11 +17092,11 @@ func (s *RetryLayerUserStore) GetAllProfiles(options *model.UserGetOptions) ([]*
 
 }
 
-func (s *RetryLayerUserStore) GetAllProfilesInChannel(ctx context.Context, channelID string, allowFromCache bool) (map[string]*model.User, error) {
+func (s *RetryLayerUserStore) GetAllProfilesInChannel(rctx request.CTX, channelID string, allowFromCache bool) (map[string]*model.User, error) {
 
 	tries := 0
 	for {
-		result, err := s.UserStore.GetAllProfilesInChannel(ctx, channelID, allowFromCache)
+		result, err := s.UserStore.GetAllProfilesInChannel(rctx, channelID, allowFromCache)
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/searchlayer/channel_layer.go
+++ b/server/channels/store/searchlayer/channel_layer.go
@@ -4,8 +4,6 @@
 package searchlayer
 
 import (
-	"context"
-
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -354,7 +352,7 @@ func (c *SearchChannelStore) PermanentDeleteMembersByUser(rctx request.CTX, user
 }
 
 func (c *SearchChannelStore) RemoveAllDeactivatedMembers(rctx request.CTX, channelId string) error {
-	profiles, errProfiles := c.rootStore.User().GetAllProfilesInChannel(context.Background(), channelId, true)
+	profiles, errProfiles := c.rootStore.User().GetAllProfilesInChannel(rctx, channelId, true)
 	if errProfiles != nil {
 		rctx.Logger().Warn("Encountered error indexing users for channel", mlog.String("channel_id", channelId), mlog.Err(errProfiles))
 	}
@@ -371,7 +369,7 @@ func (c *SearchChannelStore) RemoveAllDeactivatedMembers(rctx request.CTX, chann
 }
 
 func (c *SearchChannelStore) PermanentDeleteMembersByChannel(rctx request.CTX, channelId string) error {
-	profiles, errProfiles := c.rootStore.User().GetAllProfilesInChannel(context.Background(), channelId, true)
+	profiles, errProfiles := c.rootStore.User().GetAllProfilesInChannel(rctx, channelId, true)
 	if errProfiles != nil {
 		rctx.Logger().Warn("Encountered error indexing users for channel", mlog.String("channel_id", channelId), mlog.Err(errProfiles))
 	}

--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -959,7 +959,7 @@ func (us SqlUserStore) GetProfilesInChannelByAdmin(options *model.UserGetOptions
 	return users, nil
 }
 
-func (us SqlUserStore) GetAllProfilesInChannel(ctx context.Context, channelID string, allowFromCache bool) (map[string]*model.User, error) {
+func (us SqlUserStore) GetAllProfilesInChannel(rctx request.CTX, channelID string, allowFromCache bool) (map[string]*model.User, error) {
 	query := us.usersQuery.
 		Join("ChannelMembers cm ON ( cm.UserId = Users.Id )").
 		Where("cm.ChannelId = ?", channelID).
@@ -972,7 +972,7 @@ func (us SqlUserStore) GetAllProfilesInChannel(ctx context.Context, channelID st
 	}
 
 	users := []*model.User{}
-	rows, err := us.SqlStore.DBXFromContext(ctx).Query(queryString, args...)
+	rows, err := us.SqlStore.DBXFromContext(rctx.Context()).QueryContext(rctx.Context(), queryString, args...)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to find Users")
 	}

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -469,7 +469,7 @@ type UserStore interface {
 	GetProfilesInChannel(options *model.UserGetOptions) ([]*model.User, error)
 	GetProfilesInChannelByStatus(options *model.UserGetOptions) ([]*model.User, error)
 	GetProfilesInChannelByAdmin(options *model.UserGetOptions) ([]*model.User, error)
-	GetAllProfilesInChannel(ctx context.Context, channelID string, allowFromCache bool) (map[string]*model.User, error)
+	GetAllProfilesInChannel(rctx request.CTX, channelID string, allowFromCache bool) (map[string]*model.User, error)
 	GetProfilesNotInChannel(teamID string, channelID string, groupConstrained bool, offset int, limit int, viewRestrictions *model.ViewUsersRestrictions) ([]*model.User, error)
 	GetProfilesWithoutTeam(options *model.UserGetOptions) ([]*model.User, error)
 	GetProfilesByUsernames(usernames []string, viewRestrictions *model.ViewUsersRestrictions) ([]*model.User, error)

--- a/server/channels/store/storetest/mocks/UserStore.go
+++ b/server/channels/store/storetest/mocks/UserStore.go
@@ -553,9 +553,9 @@ func (_m *UserStore) GetAllProfiles(options *model.UserGetOptions) ([]*model.Use
 	return r0, r1
 }
 
-// GetAllProfilesInChannel provides a mock function with given fields: ctx, channelID, allowFromCache
-func (_m *UserStore) GetAllProfilesInChannel(ctx context.Context, channelID string, allowFromCache bool) (map[string]*model.User, error) {
-	ret := _m.Called(ctx, channelID, allowFromCache)
+// GetAllProfilesInChannel provides a mock function with given fields: rctx, channelID, allowFromCache
+func (_m *UserStore) GetAllProfilesInChannel(rctx request.CTX, channelID string, allowFromCache bool) (map[string]*model.User, error) {
+	ret := _m.Called(rctx, channelID, allowFromCache)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetAllProfilesInChannel")
@@ -563,19 +563,19 @@ func (_m *UserStore) GetAllProfilesInChannel(ctx context.Context, channelID stri
 
 	var r0 map[string]*model.User
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, bool) (map[string]*model.User, error)); ok {
-		return rf(ctx, channelID, allowFromCache)
+	if rf, ok := ret.Get(0).(func(request.CTX, string, bool) (map[string]*model.User, error)); ok {
+		return rf(rctx, channelID, allowFromCache)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, bool) map[string]*model.User); ok {
-		r0 = rf(ctx, channelID, allowFromCache)
+	if rf, ok := ret.Get(0).(func(request.CTX, string, bool) map[string]*model.User); ok {
+		r0 = rf(rctx, channelID, allowFromCache)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string]*model.User)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, bool) error); ok {
-		r1 = rf(ctx, channelID, allowFromCache)
+	if rf, ok := ret.Get(1).(func(request.CTX, string, bool) error); ok {
+		r1 = rf(rctx, channelID, allowFromCache)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/user_store.go
+++ b/server/channels/store/storetest/user_store.go
@@ -1650,7 +1650,7 @@ func testUserStoreGetAllProfilesInChannel(t *testing.T, rctx request.CTX, ss sto
 
 	t.Run("all profiles in channel 1, no caching", func(t *testing.T) {
 		var profiles map[string]*model.User
-		profiles, err = ss.User().GetAllProfilesInChannel(context.Background(), c1.Id, false)
+		profiles, err = ss.User().GetAllProfilesInChannel(rctx, c1.Id, false)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]*model.User{
 			u1.Id: sanitized(u1),
@@ -1661,7 +1661,7 @@ func testUserStoreGetAllProfilesInChannel(t *testing.T, rctx request.CTX, ss sto
 
 	t.Run("all profiles in channel 2, no caching", func(t *testing.T) {
 		var profiles map[string]*model.User
-		profiles, err = ss.User().GetAllProfilesInChannel(context.Background(), c2.Id, false)
+		profiles, err = ss.User().GetAllProfilesInChannel(rctx, c2.Id, false)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]*model.User{
 			u1.Id: sanitized(u1),
@@ -1670,7 +1670,7 @@ func testUserStoreGetAllProfilesInChannel(t *testing.T, rctx request.CTX, ss sto
 
 	t.Run("all profiles in channel 2, caching", func(t *testing.T) {
 		var profiles map[string]*model.User
-		profiles, err = ss.User().GetAllProfilesInChannel(context.Background(), c2.Id, true)
+		profiles, err = ss.User().GetAllProfilesInChannel(rctx, c2.Id, true)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]*model.User{
 			u1.Id: sanitized(u1),
@@ -1679,7 +1679,7 @@ func testUserStoreGetAllProfilesInChannel(t *testing.T, rctx request.CTX, ss sto
 
 	t.Run("all profiles in channel 2, caching [repeated]", func(t *testing.T) {
 		var profiles map[string]*model.User
-		profiles, err = ss.User().GetAllProfilesInChannel(context.Background(), c2.Id, true)
+		profiles, err = ss.User().GetAllProfilesInChannel(rctx, c2.Id, true)
 		require.NoError(t, err)
 		assert.Equal(t, map[string]*model.User{
 			u1.Id: sanitized(u1),

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -13470,10 +13470,10 @@ func (s *TimerLayerUserStore) GetAllProfiles(options *model.UserGetOptions) ([]*
 	return result, err
 }
 
-func (s *TimerLayerUserStore) GetAllProfilesInChannel(ctx context.Context, channelID string, allowFromCache bool) (map[string]*model.User, error) {
+func (s *TimerLayerUserStore) GetAllProfilesInChannel(rctx request.CTX, channelID string, allowFromCache bool) (map[string]*model.User, error) {
 	start := time.Now()
 
-	result, err := s.UserStore.GetAllProfilesInChannel(ctx, channelID, allowFromCache)
+	result, err := s.UserStore.GetAllProfilesInChannel(rctx, channelID, allowFromCache)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {


### PR DESCRIPTION

#### Summary
Migrates `UserStore.GetAllProfilesInChannel` from `context.Context` to `request.CTX`, updates SQL/cache/search/notification callers, and regenerates store layers and mocks.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70223

#### Release Note
```release-note
NONE
```


<a href="https://cursor.com/agents/bc-b38cf2f7-f53b-4bc6-abd3-e279b7741f56" rel="nofollow noreferrer noopener" target="_blank"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></a> <a href="https://cursor.com/background-agent?bcId=bc-b38cf2f7-f53b-4bc6-abd3-e279b7741f56" rel="nofollow noreferrer noopener" target="_blank"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></a> 





## Change Impact: 🟡 Medium

**Regression Risk:** The request-context signature change spans shared store interfaces, wrappers, callers, and mocks, creating moderate compile-time and integration risk across channel, cache, search, notification, and SQL layers. Automated coverage exists for key paths, and runtime behavior is otherwise unchanged.

**QA Recommendation:** Skip manual QA; run the full automated test suite and verify affected channel profile and notification flows.

*Generated by CodeRabbitAI*
