### PR TITLE
ci: run yamllint on ubuntu-24.04

### DIFF
--- a/.github/workflows/yamllint.yml
+++ b/.github/workflows/yamllint.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   yamllint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:


### PR DESCRIPTION
#### Summary
- ci: run yamllint on ubuntu-24.04

#### Ticket Link
https://github.com/mattermost/mattermost/actions

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The isolated CI runner update affects only the `yamllint` workflow and does not modify application code or shared dependencies. Rollback is straightforward if Ubuntu 24.04 introduces compatibility issues.
**QA Recommendation:** No manual QA is recommended; validate the workflow through CI execution.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->