### PR TITLE
Update Playbooks plugin to v2.4.8

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -148,7 +148,7 @@ PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.3
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.1
 # We need to prepackage both versions of playbooks and install the correct one based on the server license. See MM-60025.
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v1.41.1
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.4.7
+PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.4.8
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.3.4
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v1.14.2


### PR DESCRIPTION
#### Summary
This PR bumps the version of the prepackaged Playbooks plugin to v2.4.8.

#### Ticket Link
N/A

#### Release Note
```release-note
Bump Playbooks to version v2.4.8.
```