### PR TITLE
[MM-70222] Migrate UserStore Get to request context

### DIFF
--- a/server/channels/api4/license.go
+++ b/server/channels/api4/license.go
@@ -256,7 +256,7 @@ func requestTrialLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 	if !trialRequest.IsLegacy() {
 		appErr = c.App.Channels().RequestTrialLicenseWithExtraFields(c.AppContext, c.AppContext.Session().UserId, trialRequest)
 	} else {
-		appErr = c.App.Channels().RequestTrialLicense(c.AppContext.Session().UserId, trialRequest.Users, trialRequest.TermsAccepted, trialRequest.ReceiveEmailsAccepted)
+		appErr = c.App.Channels().RequestTrialLicense(c.AppContext, c.AppContext.Session().UserId, trialRequest.Users, trialRequest.TermsAccepted, trialRequest.ReceiveEmailsAccepted)
 	}
 
 	if appErr != nil {

--- a/server/channels/api4/license.go
+++ b/server/channels/api4/license.go
@@ -254,7 +254,7 @@ func requestTrialLicense(c *Context, w http.ResponseWriter, r *http.Request) {
 	var appErr *model.AppError
 	// If any of the newly supported trial request fields are set (ie, not a legacy request), process this as a new trial request (requiring the new fields) otherwise fall back on the old method.
 	if !trialRequest.IsLegacy() {
-		appErr = c.App.Channels().RequestTrialLicenseWithExtraFields(c.AppContext.Session().UserId, trialRequest)
+		appErr = c.App.Channels().RequestTrialLicenseWithExtraFields(c.AppContext, c.AppContext.Session().UserId, trialRequest)
 	} else {
 		appErr = c.App.Channels().RequestTrialLicense(c.AppContext.Session().UserId, trialRequest.Users, trialRequest.TermsAccepted, trialRequest.ReceiveEmailsAccepted)
 	}

--- a/server/channels/app/board.go
+++ b/server/channels/app/board.go
@@ -73,7 +73,7 @@ func (a *App) CreateBoardChannel(rctx request.CTX, channel *model.Channel) (*mod
 	}
 
 	// Add creator as admin member
-	user, nErr := a.Srv().Store().User().Get(rctx.Context(), channel.CreatorId)
+	user, nErr := a.Srv().Store().User().Get(rctx, channel.CreatorId)
 	if nErr != nil {
 		return nil, model.NewAppError("CreateBoardChannel", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 	}

--- a/server/channels/app/bot.go
+++ b/server/channels/app/bot.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"

--- a/server/channels/app/bot.go
+++ b/server/channels/app/bot.go
@@ -138,7 +138,7 @@ func (a *App) CreateBot(rctx request.CTX, bot *model.Bot) (*model.Bot, *model.Ap
 	}
 
 	// Get the owner of the bot, if one exists. If not, don't send a message
-	ownerUser, err := a.Srv().Store().User().Get(context.Background(), bot.OwnerId)
+	ownerUser, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), bot.OwnerId)
 	var nfErr *store.ErrNotFound
 	if err != nil && !errors.As(err, &nfErr) {
 		return nil, model.NewAppError("CreateBot", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -273,7 +273,7 @@ func (a *App) PatchBot(rctx request.CTX, botUserId string, botPatch *model.BotPa
 
 	bot.Patch(botPatch)
 
-	user, nErr := a.Srv().Store().User().Get(context.Background(), botUserId)
+	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), botUserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -395,7 +395,7 @@ func (a *App) IsBotExemptFromDMRestrictions(rctx request.CTX, userID string) (bo
 
 // UpdateBotActive marks a bot as active or inactive, along with its corresponding user.
 func (a *App) UpdateBotActive(rctx request.CTX, botUserId string, active bool) (*model.Bot, *model.AppError) {
-	user, nErr := a.Srv().Store().User().Get(context.Background(), botUserId)
+	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), botUserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/server/channels/app/bot.go
+++ b/server/channels/app/bot.go
@@ -137,7 +137,7 @@ func (a *App) CreateBot(rctx request.CTX, bot *model.Bot) (*model.Bot, *model.Ap
 	}
 
 	// Get the owner of the bot, if one exists. If not, don't send a message
-	ownerUser, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), bot.OwnerId)
+	ownerUser, err := a.Srv().Store().User().Get(rctx, bot.OwnerId)
 	var nfErr *store.ErrNotFound
 	if err != nil && !errors.As(err, &nfErr) {
 		return nil, model.NewAppError("CreateBot", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -272,7 +272,7 @@ func (a *App) PatchBot(rctx request.CTX, botUserId string, botPatch *model.BotPa
 
 	bot.Patch(botPatch)
 
-	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), botUserId)
+	user, nErr := a.Srv().Store().User().Get(rctx, botUserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -394,7 +394,7 @@ func (a *App) IsBotExemptFromDMRestrictions(rctx request.CTX, userID string) (bo
 
 // UpdateBotActive marks a bot as active or inactive, along with its corresponding user.
 func (a *App) UpdateBotActive(rctx request.CTX, botUserId string, active bool) (*model.Bot, *model.AppError) {
-	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), botUserId)
+	user, nErr := a.Srv().Store().User().Get(rctx, botUserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -61,7 +61,7 @@ func (a *App) JoinDefaultChannels(rctx request.CTX, teamID string, user *model.U
 	var requestor *model.User
 	var nErr error
 	if userRequestorId != "" {
-		requestor, nErr = a.Srv().Store().User().Get(context.Background(), userRequestorId)
+		requestor, nErr = a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userRequestorId)
 		if nErr != nil {
 			var nfErr *store.ErrNotFound
 			switch {
@@ -276,7 +276,7 @@ func (a *App) CreateChannel(rctx request.CTX, channel *model.Channel, addMember 
 	}
 
 	if addMember {
-		user, nErr := a.Srv().Store().User().Get(context.Background(), channel.CreatorId)
+		user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), channel.CreatorId)
 		if nErr != nil {
 			var nfErr *store.ErrNotFound
 			switch {
@@ -1012,7 +1012,7 @@ func (a *App) RestoreChannel(rctx request.CTX, channel *model.Channel, userID st
 	var user *model.User
 	if userID != "" {
 		var nErr error
-		user, nErr = a.Srv().Store().User().Get(context.Background(), userID)
+		user, nErr = a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 		if nErr != nil {
 			var nfErr *store.ErrNotFound
 			switch {
@@ -1705,7 +1705,7 @@ func (a *App) DeleteChannel(rctx request.CTX, channel *model.Channel, userID str
 	var user *model.User
 	if userID != "" {
 		var nErr error
-		user, nErr = a.Srv().Store().User().Get(context.Background(), userID)
+		user, nErr = a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 		if nErr != nil {
 			var nfErr *store.ErrNotFound
 			switch {
@@ -2095,7 +2095,7 @@ func (a *App) AddDirectChannels(rctx request.CTX, teamID string, user *model.Use
 }
 
 func (a *App) PostUpdateChannelHeaderMessage(rctx request.CTX, userID string, channel *model.Channel, oldChannelHeader, newChannelHeader string) *model.AppError {
-	user, err := a.Srv().Store().User().Get(context.Background(), userID)
+	user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 	if err != nil {
 		return model.NewAppError("PostUpdateChannelHeaderMessage", "api.channel.post_update_channel_header_message_and_forget.retrieve_user.error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
@@ -2129,7 +2129,7 @@ func (a *App) PostUpdateChannelHeaderMessage(rctx request.CTX, userID string, ch
 }
 
 func (a *App) PostUpdateChannelPurposeMessage(rctx request.CTX, userID string, channel *model.Channel, oldChannelPurpose string, newChannelPurpose string) *model.AppError {
-	user, err := a.Srv().Store().User().Get(context.Background(), userID)
+	user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 	if err != nil {
 		return model.NewAppError("PostUpdateChannelPurposeMessage", "app.channel.post_update_channel_purpose_message.retrieve_user.error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
@@ -2162,7 +2162,7 @@ func (a *App) PostUpdateChannelPurposeMessage(rctx request.CTX, userID string, c
 }
 
 func (a *App) postUpdateChannelAutotranslationMessage(rctx request.CTX, userID string, channel *model.Channel, newChannelAutotranslation bool) *model.AppError {
-	user, err := a.Srv().Store().User().Get(context.Background(), userID)
+	user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 	if err != nil {
 		return model.NewAppError("PostUpdateChannelAutotranslationMessage", "api.channel.post_update_channel_autotranslation_message.retrieve_user.error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
@@ -2193,7 +2193,7 @@ func (a *App) postUpdateChannelAutotranslationMessage(rctx request.CTX, userID s
 }
 
 func (a *App) PostUpdateChannelDisplayNameMessage(rctx request.CTX, userID string, channel *model.Channel, oldChannelDisplayName, newChannelDisplayName string) *model.AppError {
-	user, err := a.Srv().Store().User().Get(context.Background(), userID)
+	user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 	if err != nil {
 		return model.NewAppError("PostUpdateChannelDisplayNameMessage", "api.channel.post_update_channel_displayname_message_and_forget.retrieve_user.error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
@@ -2717,7 +2717,7 @@ func (a *App) JoinChannel(rctx request.CTX, channel *model.Channel, userID strin
 	userChan := make(chan store.StoreResult[*model.User], 1)
 	memberChan := make(chan store.StoreResult[*model.ChannelMember], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(context.Background(), userID)
+		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 		userChan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(userChan)
 	}()
@@ -2824,7 +2824,7 @@ func (a *App) LeaveChannel(rctx request.CTX, channelID string, userID string) *m
 
 	uc := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(context.Background(), userID)
+		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 		uc <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uc)
 	}()
@@ -2994,7 +2994,7 @@ func (a *App) removeChannelMembership(rctx request.CTX, userID, channelID, calle
 }
 
 func (a *App) removeUserFromChannel(rctx request.CTX, userIDToRemove string, removerUserId string, channel *model.Channel) *model.AppError {
-	user, nErr := a.Srv().Store().User().Get(context.Background(), userIDToRemove)
+	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userIDToRemove)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -3551,7 +3551,7 @@ func (a *App) SearchChannelsUserNotIn(rctx request.CTX, teamID string, userID st
 }
 
 func (a *App) MarkTeamChannelsAndThreadsViewed(rctx request.CTX, teamID string, userID string, currentSessionID string, isCRTEnabled bool) (map[string]int64, *model.AppError) {
-	user, err := a.Srv().Store().User().Get(rctx.Context(), userID)
+	user, err := a.Srv().Store().User().Get(rctx, userID)
 	if err != nil {
 		return nil, model.NewAppError("MarkTeamChannelsAndThreadsViewed", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -3611,7 +3611,7 @@ func (a *App) MarkTeamChannelsAndThreadsViewed(rctx request.CTX, teamID string, 
 }
 
 func (a *App) MarkAllDirectAndGroupMessagesViewed(rctx request.CTX, userID string, currentSessionID string, isCRTEnabled bool) (map[string]int64, *model.AppError) {
-	user, err := a.Srv().Store().User().Get(rctx.Context(), userID)
+	user, err := a.Srv().Store().User().Get(rctx, userID)
 	if err != nil {
 		return nil, model.NewAppError("MarkAllDirectAndGroupMessagesViewed", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -3676,7 +3676,7 @@ func (a *App) MarkAllDirectAndGroupMessagesViewed(rctx request.CTX, userID strin
 func (a *App) MarkChannelsAsViewed(rctx request.CTX, channelIDs []string, userID string, currentSessionID string, collapsedThreadsSupported, isCRTEnabled bool) (map[string]int64, *model.AppError) {
 	var err error
 
-	user, err := a.Srv().Store().User().Get(rctx.Context(), userID)
+	user, err := a.Srv().Store().User().Get(rctx, userID)
 	if err != nil {
 		return nil, model.NewAppError("MarkChannelsAsViewed", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -60,7 +60,7 @@ func (a *App) JoinDefaultChannels(rctx request.CTX, teamID string, user *model.U
 	var requestor *model.User
 	var nErr error
 	if userRequestorId != "" {
-		requestor, nErr = a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userRequestorId)
+		requestor, nErr = a.Srv().Store().User().Get(rctx, userRequestorId)
 		if nErr != nil {
 			var nfErr *store.ErrNotFound
 			switch {
@@ -275,7 +275,7 @@ func (a *App) CreateChannel(rctx request.CTX, channel *model.Channel, addMember 
 	}
 
 	if addMember {
-		user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), channel.CreatorId)
+		user, nErr := a.Srv().Store().User().Get(rctx, channel.CreatorId)
 		if nErr != nil {
 			var nfErr *store.ErrNotFound
 			switch {
@@ -1011,7 +1011,7 @@ func (a *App) RestoreChannel(rctx request.CTX, channel *model.Channel, userID st
 	var user *model.User
 	if userID != "" {
 		var nErr error
-		user, nErr = a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+		user, nErr = a.Srv().Store().User().Get(rctx, userID)
 		if nErr != nil {
 			var nfErr *store.ErrNotFound
 			switch {
@@ -1704,7 +1704,7 @@ func (a *App) DeleteChannel(rctx request.CTX, channel *model.Channel, userID str
 	var user *model.User
 	if userID != "" {
 		var nErr error
-		user, nErr = a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+		user, nErr = a.Srv().Store().User().Get(rctx, userID)
 		if nErr != nil {
 			var nfErr *store.ErrNotFound
 			switch {
@@ -2094,7 +2094,7 @@ func (a *App) AddDirectChannels(rctx request.CTX, teamID string, user *model.Use
 }
 
 func (a *App) PostUpdateChannelHeaderMessage(rctx request.CTX, userID string, channel *model.Channel, oldChannelHeader, newChannelHeader string) *model.AppError {
-	user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+	user, err := a.Srv().Store().User().Get(rctx, userID)
 	if err != nil {
 		return model.NewAppError("PostUpdateChannelHeaderMessage", "api.channel.post_update_channel_header_message_and_forget.retrieve_user.error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
@@ -2128,7 +2128,7 @@ func (a *App) PostUpdateChannelHeaderMessage(rctx request.CTX, userID string, ch
 }
 
 func (a *App) PostUpdateChannelPurposeMessage(rctx request.CTX, userID string, channel *model.Channel, oldChannelPurpose string, newChannelPurpose string) *model.AppError {
-	user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+	user, err := a.Srv().Store().User().Get(rctx, userID)
 	if err != nil {
 		return model.NewAppError("PostUpdateChannelPurposeMessage", "app.channel.post_update_channel_purpose_message.retrieve_user.error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
@@ -2161,7 +2161,7 @@ func (a *App) PostUpdateChannelPurposeMessage(rctx request.CTX, userID string, c
 }
 
 func (a *App) postUpdateChannelAutotranslationMessage(rctx request.CTX, userID string, channel *model.Channel, newChannelAutotranslation bool) *model.AppError {
-	user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+	user, err := a.Srv().Store().User().Get(rctx, userID)
 	if err != nil {
 		return model.NewAppError("PostUpdateChannelAutotranslationMessage", "api.channel.post_update_channel_autotranslation_message.retrieve_user.error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
@@ -2192,7 +2192,7 @@ func (a *App) postUpdateChannelAutotranslationMessage(rctx request.CTX, userID s
 }
 
 func (a *App) PostUpdateChannelDisplayNameMessage(rctx request.CTX, userID string, channel *model.Channel, oldChannelDisplayName, newChannelDisplayName string) *model.AppError {
-	user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+	user, err := a.Srv().Store().User().Get(rctx, userID)
 	if err != nil {
 		return model.NewAppError("PostUpdateChannelDisplayNameMessage", "api.channel.post_update_channel_displayname_message_and_forget.retrieve_user.error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
@@ -2716,7 +2716,7 @@ func (a *App) JoinChannel(rctx request.CTX, channel *model.Channel, userID strin
 	userChan := make(chan store.StoreResult[*model.User], 1)
 	memberChan := make(chan store.StoreResult[*model.ChannelMember], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+		user, err := a.Srv().Store().User().Get(rctx, userID)
 		userChan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(userChan)
 	}()
@@ -2823,7 +2823,7 @@ func (a *App) LeaveChannel(rctx request.CTX, channelID string, userID string) *m
 
 	uc := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+		user, err := a.Srv().Store().User().Get(rctx, userID)
 		uc <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uc)
 	}()
@@ -2993,7 +2993,7 @@ func (a *App) removeChannelMembership(rctx request.CTX, userID, channelID, calle
 }
 
 func (a *App) removeUserFromChannel(rctx request.CTX, userIDToRemove string, removerUserId string, channel *model.Channel) *model.AppError {
-	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userIDToRemove)
+	user, nErr := a.Srv().Store().User().Get(rctx, userIDToRemove)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"

--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"

--- a/server/channels/app/channel_test.go
+++ b/server/channels/app/channel_test.go
@@ -3465,7 +3465,7 @@ func TestConvertGroupMessageToChannel(t *testing.T) {
 
 	mockUserStore := mocks.UserStore{}
 	mockStore.On("User").Return(&mockUserStore)
-	mockUserStore.On("Get", context.Background(), "user_id_1").Return(&model.User{Username: "username_1"}, nil)
+	mockUserStore.On("Get", mock.Anything, "user_id_1").Return(&model.User{Username: "username_1"}, nil)
 	mockUserStore.On("GetProfilesInChannel", mock.AnythingOfType("*model.UserGetOptions")).Return([]*model.User{
 		{Id: "user_id_1", Username: "user_id_1"},
 		{Id: "user_id_2", Username: "user_id_2"},

--- a/server/channels/app/command.go
+++ b/server/channels/app/command.go
@@ -422,7 +422,7 @@ func (a *App) tryExecuteCustomCommand(rctx request.CTX, args *model.CommandArgs,
 
 	userChan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(context.Background(), args.UserId)
+		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), args.UserId)
 		userChan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(userChan)
 	}()

--- a/server/channels/app/command.go
+++ b/server/channels/app/command.go
@@ -422,7 +422,7 @@ func (a *App) tryExecuteCustomCommand(rctx request.CTX, args *model.CommandArgs,
 
 	userChan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), args.UserId)
+		user, err := a.Srv().Store().User().Get(rctx, args.UserId)
 		userChan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(userChan)
 	}()

--- a/server/channels/app/draft.go
+++ b/server/channels/app/draft.go
@@ -60,7 +60,7 @@ func (a *App) UpsertDraft(rctx request.CTX, draft *model.Draft, connectionID str
 		return nil, err
 	}
 
-	_, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), draft.UserId)
+	_, nErr := a.Srv().Store().User().Get(rctx, draft.UserId)
 	if nErr != nil {
 		return nil, model.NewAppError("CreateDraft", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 	}

--- a/server/channels/app/draft.go
+++ b/server/channels/app/draft.go
@@ -61,7 +61,7 @@ func (a *App) UpsertDraft(rctx request.CTX, draft *model.Draft, connectionID str
 		return nil, err
 	}
 
-	_, nErr := a.Srv().Store().User().Get(context.Background(), draft.UserId)
+	_, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), draft.UserId)
 	if nErr != nil {
 		return nil, model.NewAppError("CreateDraft", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)
 	}

--- a/server/channels/app/draft.go
+++ b/server/channels/app/draft.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"net/http"

--- a/server/channels/app/email/email_batching.go
+++ b/server/channels/app/email/email_batching.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/i18n"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
 )
 
@@ -250,7 +251,7 @@ func truncateUserNames(name string, i int) string {
 }
 
 func (es *Service) sendBatchedEmailNotification(userID string, notifications []*batchedNotification) {
-	user, err := es.userService.GetUser(userID)
+	user, err := es.userService.GetUser(request.EmptyContext(nil), userID)
 	if err != nil {
 		mlog.Warn("Unable to find recipient for batched email notification")
 		return
@@ -288,7 +289,7 @@ func (es *Service) sendBatchedEmailNotification(userID string, notifications []*
 
 	if emailNotificationContentsType == model.EmailNotificationContentsFull {
 		for i, notification := range notifications {
-			sender, errSender := es.userService.GetUser(notification.post.UserId)
+			sender, errSender := es.userService.GetUser(request.EmptyContext(nil), notification.post.UserId)
 			if errSender != nil {
 				mlog.Warn("Unable to find sender of post for batched email notification")
 			}

--- a/server/channels/app/email/email_batching.go
+++ b/server/channels/app/email/email_batching.go
@@ -251,7 +251,7 @@ func truncateUserNames(name string, i int) string {
 }
 
 func (es *Service) sendBatchedEmailNotification(userID string, notifications []*batchedNotification) {
-	user, err := es.userService.GetUser(request.EmptyContext(nil), userID)
+	user, err := es.userService.GetUser(request.EmptyContext(es.logger), userID)
 	if err != nil {
 		mlog.Warn("Unable to find recipient for batched email notification")
 		return
@@ -289,7 +289,7 @@ func (es *Service) sendBatchedEmailNotification(userID string, notifications []*
 
 	if emailNotificationContentsType == model.EmailNotificationContentsFull {
 		for i, notification := range notifications {
-			sender, errSender := es.userService.GetUser(request.EmptyContext(nil), notification.post.UserId)
+			sender, errSender := es.userService.GetUser(request.EmptyContext(es.logger), notification.post.UserId)
 			if errSender != nil {
 				mlog.Warn("Unable to find sender of post for batched email notification")
 			}

--- a/server/channels/app/email/helper_test.go
+++ b/server/channels/app/email/helper_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest/mock"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/app/users"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
@@ -106,12 +107,14 @@ func setupTestHelper(s store.Store, tb testing.TB) *TestHelper {
 	require.True(tb, ok)
 	htmlTemplates, err := templates.New(templatesDir)
 	require.NoError(tb, err)
+	logger := mlog.CreateConsoleTestLogger(tb)
 
 	service := &Service{
 		store:              s,
 		userService:        us,
 		license:            licenseFn,
 		config:             configStore.Get,
+		logger:             logger,
 		templatesContainer: htmlTemplates,
 	}
 

--- a/server/channels/app/email/helper_test.go
+++ b/server/channels/app/email/helper_test.go
@@ -143,17 +143,17 @@ func (th *TestHelper) InitBasic(tb testing.TB) *TestHelper {
 	th.BasicTeam = th.CreateTeam(tb)
 
 	th.SystemAdminUser = th.CreateUser(tb)
-	th.SystemAdminUser, err = th.service.userService.GetUser(th.SystemAdminUser.Id)
+	th.SystemAdminUser, err = th.service.userService.GetUser(th.Context, th.SystemAdminUser.Id)
 	require.NoError(tb, err)
 	th.addUserToTeam(tb, th.BasicTeam, th.SystemAdminUser)
 
 	th.BasicUser = th.CreateUser(tb)
-	th.BasicUser, err = th.service.userService.GetUser(th.BasicUser.Id)
+	th.BasicUser, err = th.service.userService.GetUser(th.Context, th.BasicUser.Id)
 	require.NoError(tb, err)
 	th.addUserToTeam(tb, th.BasicTeam, th.BasicUser)
 
 	th.BasicUser2 = th.CreateUser(tb)
-	th.BasicUser2, err = th.service.userService.GetUser(th.BasicUser2.Id)
+	th.BasicUser2, err = th.service.userService.GetUser(th.Context, th.BasicUser2.Id)
 	require.NoError(tb, err)
 	th.addUserToTeam(tb, th.BasicTeam, th.BasicUser2)
 

--- a/server/channels/app/email/service.go
+++ b/server/channels/app/email/service.go
@@ -49,6 +49,7 @@ func condenseSiteURL(siteURL string) string {
 type Service struct {
 	config  func() *model.Config
 	license func() *model.License
+	logger  mlog.LoggerIFace
 
 	userService *users.UserService
 	store       store.Store
@@ -66,6 +67,7 @@ type ServiceConfig struct {
 	TemplatesContainer *templates.Container
 	UserService        *users.UserService
 	Store              store.Store
+	Logger             mlog.LoggerIFace
 }
 
 func NewService(config ServiceConfig) (*Service, error) {
@@ -76,6 +78,7 @@ func NewService(config ServiceConfig) (*Service, error) {
 		config:             config.ConfigFn,
 		templatesContainer: config.TemplatesContainer,
 		license:            config.LicenseFn,
+		logger:             config.Logger,
 		store:              config.Store,
 		userService:        config.UserService,
 	}

--- a/server/channels/app/export.go
+++ b/server/channels/app/export.go
@@ -5,7 +5,6 @@ package app
 
 import (
 	"archive/zip"
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"

--- a/server/channels/app/export.go
+++ b/server/channels/app/export.go
@@ -1016,7 +1016,7 @@ func (a *App) exportAllDirectChannels(rctx request.CTX, job *model.Job, writer i
 				}
 			}
 
-			favoritedBy, err := a.buildFavoritedByList(channel.Id)
+			favoritedBy, err := a.buildFavoritedByList(rctx, channel.Id)
 			if err != nil {
 				return err
 			}
@@ -1036,7 +1036,7 @@ func (a *App) exportAllDirectChannels(rctx request.CTX, job *model.Job, writer i
 	return nil
 }
 
-func (a *App) buildFavoritedByList(channelID string) ([]string, *model.AppError) {
+func (a *App) buildFavoritedByList(rctx request.CTX, channelID string) ([]string, *model.AppError) {
 	prefs, err := a.Srv().Store().Preference().GetCategoryAndName(model.PreferenceCategoryFavoriteChannel, channelID)
 	if err != nil {
 		return nil, model.NewAppError("buildFavoritedByList", "app.preference.get_category.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -1048,7 +1048,7 @@ func (a *App) buildFavoritedByList(channelID string) ([]string, *model.AppError)
 			continue
 		}
 
-		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), pref.UserId)
+		user, err := a.Srv().Store().User().Get(rctx, pref.UserId)
 		if err != nil {
 			return nil, model.NewAppError("buildFavoritedByList", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}

--- a/server/channels/app/export.go
+++ b/server/channels/app/export.go
@@ -1021,7 +1021,7 @@ func (a *App) exportAllDirectChannels(rctx request.CTX, job *model.Job, writer i
 				return err
 			}
 
-			shownBy, err := a.buildShownByList(channel)
+			shownBy, err := a.buildShownByList(rctx, channel)
 			if err != nil {
 				return err
 			}
@@ -1059,7 +1059,7 @@ func (a *App) buildFavoritedByList(channelID string) ([]string, *model.AppError)
 	return userIDs, nil
 }
 
-func (a *App) buildShownByList(channel *model.DirectChannelForExport) ([]string, *model.AppError) {
+func (a *App) buildShownByList(rctx request.CTX, channel *model.DirectChannelForExport) ([]string, *model.AppError) {
 	shownBy := make([]string, 0)
 	switch channel.Type {
 	case model.ChannelTypeGroup:
@@ -1071,7 +1071,7 @@ func (a *App) buildShownByList(channel *model.DirectChannelForExport) ([]string,
 
 			for i := range prefs {
 				if prefs[i].Name == channel.Id && prefs[i].Value == "true" {
-					user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), member.UserId)
+					user, err := a.Srv().Store().User().Get(rctx, member.UserId)
 					if err != nil {
 						return nil, model.NewAppError("buildShownByList", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 					}
@@ -1094,7 +1094,7 @@ func (a *App) buildShownByList(channel *model.DirectChannelForExport) ([]string,
 
 			for _, pref := range prefs {
 				if pref.Value == "true" && pref.UserId == member.UserId {
-					user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), member.UserId)
+					user, err := a.Srv().Store().User().Get(rctx, member.UserId)
 					if err != nil {
 						return nil, model.NewAppError("buildShownByList", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 					}

--- a/server/channels/app/export.go
+++ b/server/channels/app/export.go
@@ -591,7 +591,7 @@ func (a *App) exportAllBots(rctx request.CTX, job *model.Job, writer io.Writer, 
 			afterId = bot.UserId
 
 			var ownerUsername string
-			owner, err := a.Srv().Store().User().Get(rctx.Context(), bot.OwnerId)
+			owner, err := a.Srv().Store().User().Get(rctx, bot.OwnerId)
 			if err != nil {
 				var nfErr *store.ErrNotFound
 				if errors.As(err, &nfErr) {
@@ -844,7 +844,7 @@ func (a *App) BuildPostReactions(rctx request.CTX, postID string) (*[]ReactionIm
 	}
 
 	for _, reaction := range reactions {
-		user, err := a.Srv().Store().User().Get(context.Background(), reaction.UserId)
+		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), reaction.UserId)
 		if err != nil {
 			var nfErr *store.ErrNotFound
 			if errors.As(err, &nfErr) { // this is a valid case, the user that reacted might've been deleted by now
@@ -1049,7 +1049,7 @@ func (a *App) buildFavoritedByList(channelID string) ([]string, *model.AppError)
 			continue
 		}
 
-		user, err := a.Srv().Store().User().Get(context.Background(), pref.UserId)
+		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), pref.UserId)
 		if err != nil {
 			return nil, model.NewAppError("buildFavoritedByList", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		}
@@ -1072,7 +1072,7 @@ func (a *App) buildShownByList(channel *model.DirectChannelForExport) ([]string,
 
 			for i := range prefs {
 				if prefs[i].Name == channel.Id && prefs[i].Value == "true" {
-					user, err := a.Srv().Store().User().Get(context.Background(), member.UserId)
+					user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), member.UserId)
 					if err != nil {
 						return nil, model.NewAppError("buildShownByList", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 					}
@@ -1095,7 +1095,7 @@ func (a *App) buildShownByList(channel *model.DirectChannelForExport) ([]string,
 
 			for _, pref := range prefs {
 				if pref.Value == "true" && pref.UserId == member.UserId {
-					user, err := a.Srv().Store().User().Get(context.Background(), member.UserId)
+					user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), member.UserId)
 					if err != nil {
 						return nil, model.NewAppError("buildShownByList", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 					}

--- a/server/channels/app/export.go
+++ b/server/channels/app/export.go
@@ -843,7 +843,7 @@ func (a *App) BuildPostReactions(rctx request.CTX, postID string) (*[]ReactionIm
 	}
 
 	for _, reaction := range reactions {
-		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), reaction.UserId)
+		user, err := a.Srv().Store().User().Get(rctx, reaction.UserId)
 		if err != nil {
 			var nfErr *store.ErrNotFound
 			if errors.As(err, &nfErr) { // this is a valid case, the user that reacted might've been deleted by now

--- a/server/channels/app/import_functions.go
+++ b/server/channels/app/import_functions.go
@@ -954,7 +954,7 @@ func (a *App) importBot(rctx request.CTX, data *imports.BotImportData, dryRun bo
 	// so Bot().Update() alone doesn't persist it. Update the user record
 	// if the DisplayName has diverged.
 	if data.DisplayName != nil && savedBot.UserId != "" {
-		botUser, userErr := a.Srv().Store().User().Get(rctx.Context(), savedBot.UserId)
+		botUser, userErr := a.Srv().Store().User().Get(rctx, savedBot.UserId)
 		if userErr != nil {
 			rctx.Logger().Warn("Failed to fetch bot user for DisplayName update",
 				mlog.String("user_id", savedBot.UserId),

--- a/server/channels/app/integration_action.go
+++ b/server/channels/app/integration_action.go
@@ -546,7 +546,7 @@ func (a *App) ExecuteDialogAction(rctx request.CTX, userID string, req model.Exe
 		Context:   ctx,
 	}
 
-	user, userErr := a.Srv().Store().User().Get(context.Background(), userID)
+	user, userErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 	if userErr != nil {
 		return "", model.NewAppError("ExecuteDialogAction", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(userErr)
 	}

--- a/server/channels/app/integration_action.go
+++ b/server/channels/app/integration_action.go
@@ -546,7 +546,7 @@ func (a *App) ExecuteDialogAction(rctx request.CTX, userID string, req model.Exe
 		Context:   ctx,
 	}
 
-	user, userErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+	user, userErr := a.Srv().Store().User().Get(rctx, userID)
 	if userErr != nil {
 		return "", model.NewAppError("ExecuteDialogAction", "app.user.get.app_error", nil, "", http.StatusInternalServerError).Wrap(userErr)
 	}

--- a/server/channels/app/integration_action_setup.go
+++ b/server/channels/app/integration_action_setup.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"maps"

--- a/server/channels/app/integration_action_setup.go
+++ b/server/channels/app/integration_action_setup.go
@@ -89,7 +89,7 @@ func (a *App) resolvePostActionSetup(
 		PostId: postID,
 	}
 
-	userChan := a.startUpstreamUserFetch(userID)
+	userChan := a.startUpstreamUserFetch(rctx, userID)
 	postChan := a.startUpstreamPostFetch(rctx, postID)
 	channelChan := a.startUpstreamChannelFetch(postID)
 
@@ -129,10 +129,10 @@ func (a *App) startUpstreamChannelFetch(postID string) <-chan store.StoreResult[
 	return channelChan
 }
 
-func (a *App) startUpstreamUserFetch(userID string) <-chan store.StoreResult[*model.User] {
+func (a *App) startUpstreamUserFetch(rctx request.CTX, userID string) <-chan store.StoreResult[*model.User] {
 	userChan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+		user, err := a.Srv().Store().User().Get(rctx, userID)
 		userChan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(userChan)
 	}()

--- a/server/channels/app/integration_action_setup.go
+++ b/server/channels/app/integration_action_setup.go
@@ -133,7 +133,7 @@ func (a *App) startUpstreamChannelFetch(postID string) <-chan store.StoreResult[
 func (a *App) startUpstreamUserFetch(userID string) <-chan store.StoreResult[*model.User] {
 	userChan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(context.Background(), userID)
+		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 		userChan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(userChan)
 	}()

--- a/server/channels/app/license.go
+++ b/server/channels/app/license.go
@@ -60,7 +60,7 @@ func (ch *Channels) RequestTrialLicenseWithExtraFields(rctx request.CTX, request
 }
 
 // Deprecated: Use RequestTrialLicenseWithExtraFields instead. This function remains to support the Plugin API.
-func (ch *Channels) RequestTrialLicense(requesterID string, users int, termsAccepted bool, receiveEmailsAccepted bool) *model.AppError {
+func (ch *Channels) RequestTrialLicense(rctx request.CTX, requesterID string, users int, termsAccepted bool, receiveEmailsAccepted bool) *model.AppError {
 	if !termsAccepted {
 		return model.NewAppError("RequestTrialLicense", "api.license.request-trial.bad-request.terms-not-accepted", nil, "", http.StatusBadRequest)
 	}
@@ -69,7 +69,7 @@ func (ch *Channels) RequestTrialLicense(requesterID string, users int, termsAcce
 		return model.NewAppError("RequestTrialLicense", "api.license.request-trial.bad-request", nil, "", http.StatusBadRequest)
 	}
 
-	requester, err := ch.srv.userService.GetUser(request.EmptyContext(ch.srv.Log()), requesterID)
+	requester, err := ch.srv.userService.GetUser(rctx, requesterID)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/server/channels/app/license.go
+++ b/server/channels/app/license.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 )
 
@@ -18,7 +19,7 @@ func (ch *Channels) License() *model.License {
 }
 
 func (ch *Channels) RequestTrialLicenseWithExtraFields(requesterID string, trialRequest *model.TrialLicenseRequest) *model.AppError {
-	requester, err := ch.srv.userService.GetUser(requesterID)
+	requester, err := ch.srv.userService.GetUser(request.EmptyContext(ch.srv.Log()), requesterID)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -68,7 +69,7 @@ func (ch *Channels) RequestTrialLicense(requesterID string, users int, termsAcce
 		return model.NewAppError("RequestTrialLicense", "api.license.request-trial.bad-request", nil, "", http.StatusBadRequest)
 	}
 
-	requester, err := ch.srv.userService.GetUser(requesterID)
+	requester, err := ch.srv.userService.GetUser(request.EmptyContext(ch.srv.Log()), requesterID)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/server/channels/app/license.go
+++ b/server/channels/app/license.go
@@ -18,8 +18,8 @@ func (ch *Channels) License() *model.License {
 	return ch.srv.License()
 }
 
-func (ch *Channels) RequestTrialLicenseWithExtraFields(requesterID string, trialRequest *model.TrialLicenseRequest) *model.AppError {
-	requester, err := ch.srv.userService.GetUser(request.EmptyContext(ch.srv.Log()), requesterID)
+func (ch *Channels) RequestTrialLicenseWithExtraFields(rctx request.CTX, requesterID string, trialRequest *model.TrialLicenseRequest) *model.AppError {
+	requester, err := ch.srv.userService.GetUser(rctx, requesterID)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/server/channels/app/oauth.go
+++ b/server/channels/app/oauth.go
@@ -357,7 +357,7 @@ func (a *App) handleAuthorizationCodeGrant(rctx request.CTX, oauthApp *model.OAu
 		return nil, err
 	}
 
-	user, nErr := a.Srv().Store().User().Get(context.Background(), authData.UserId)
+	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), authData.UserId)
 	if nErr != nil {
 		return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.internal_user.app_error", nil, "", http.StatusNotFound).Wrap(nErr)
 	}
@@ -407,7 +407,7 @@ func (a *App) handleRefreshTokenGrant(rctx request.CTX, oauthApp *model.OAuthApp
 		return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.client_id_mismatch.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	user, nErr := a.Srv().Store().User().Get(context.Background(), accessData.UserId)
+	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), accessData.UserId)
 	if nErr != nil {
 		return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.internal_user.app_error", nil, "", http.StatusNotFound).Wrap(nErr)
 	}

--- a/server/channels/app/oauth.go
+++ b/server/channels/app/oauth.go
@@ -5,7 +5,6 @@ package app
 
 import (
 	"bytes"
-	"context"
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"

--- a/server/channels/app/oauth.go
+++ b/server/channels/app/oauth.go
@@ -356,7 +356,7 @@ func (a *App) handleAuthorizationCodeGrant(rctx request.CTX, oauthApp *model.OAu
 		return nil, err
 	}
 
-	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), authData.UserId)
+	user, nErr := a.Srv().Store().User().Get(rctx, authData.UserId)
 	if nErr != nil {
 		return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.internal_user.app_error", nil, "", http.StatusNotFound).Wrap(nErr)
 	}
@@ -406,7 +406,7 @@ func (a *App) handleRefreshTokenGrant(rctx request.CTX, oauthApp *model.OAuthApp
 		return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.client_id_mismatch.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), accessData.UserId)
+	user, nErr := a.Srv().Store().User().Get(rctx, accessData.UserId)
 	if nErr != nil {
 		return nil, model.NewAppError("GetOAuthAccessToken", "api.oauth.get_access_token.internal_user.app_error", nil, "", http.StatusNotFound).Wrap(nErr)
 	}

--- a/server/channels/app/platform/session_test.go
+++ b/server/channels/app/platform/session_test.go
@@ -190,7 +190,7 @@ func TestUpdateSessionsIsGuest(t *testing.T) {
 
 		session, _ = th.Service.CreateSession(th.Context, session)
 
-		err := th.Service.Store.User().PromoteGuestToUser(user.Id)
+		err := th.Service.Store.User().PromoteGuestToUser(th.Context, user.Id)
 		require.NoError(t, err)
 
 		promotedUser, err := th.Service.Store.User().Get(th.Context, user.Id)

--- a/server/channels/app/platform/session_test.go
+++ b/server/channels/app/platform/session_test.go
@@ -165,7 +165,7 @@ func TestUpdateSessionsIsGuest(t *testing.T) {
 
 		session, _ = th.Service.CreateSession(th.Context, session)
 
-		demotedUser, err := th.Service.Store.User().DemoteUserToGuest(user.Id)
+		demotedUser, err := th.Service.Store.User().DemoteUserToGuest(th.Context, user.Id)
 		require.NoError(t, err)
 		require.Equal(t, model.SystemGuestRoleId, demotedUser.Roles)
 

--- a/server/channels/app/platform/session_test.go
+++ b/server/channels/app/platform/session_test.go
@@ -193,7 +193,7 @@ func TestUpdateSessionsIsGuest(t *testing.T) {
 		err := th.Service.Store.User().PromoteGuestToUser(user.Id)
 		require.NoError(t, err)
 
-		promotedUser, err := th.Service.Store.User().Get(th.Context.Context(), user.Id)
+		promotedUser, err := th.Service.Store.User().Get(th.Context, user.Id)
 		require.NoError(t, err)
 		err = th.Service.UpdateSessionsIsGuest(th.Context, promotedUser, false)
 		require.NoError(t, err)

--- a/server/channels/app/platform/shared_channel_notifier.go
+++ b/server/channels/app/platform/shared_channel_notifier.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/platform/services/sharedchannel"
 )
 
@@ -156,7 +157,7 @@ func getUserFromEvent(ps *PlatformService, event *model.WebSocketEvent, key stri
 		return nil, fmt.Errorf("received websocket message that is eligible for sending an invitation but message does not have `%s` present", key)
 	}
 
-	user, err := ps.Store.User().Get(context.Background(), userID)
+	user, err := ps.Store.User().Get(request.EmptyContext(ps.logger), userID)
 	if err != nil {
 		return nil, errors.Wrap(err, "couldn't find user for creating shared channel invitation for a DM")
 	}

--- a/server/channels/app/platform/shared_channel_notifier.go
+++ b/server/channels/app/platform/shared_channel_notifier.go
@@ -4,7 +4,6 @@
 package platform
 
 import (
-	"context"
 	"fmt"
 	"slices"
 

--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -1557,7 +1557,7 @@ func (api *PluginAPI) RequestTrialLicense(requesterID string, users int, termsAc
 		return model.NewAppError("RequestTrialLicense", "api.restricted_system_admin", nil, "", http.StatusForbidden)
 	}
 
-	return api.app.Channels().RequestTrialLicense(request.EmptyContext(api.app.Log()), requesterID, users, termsAccepted, receiveEmailsAccepted)
+	return api.app.Channels().RequestTrialLicense(api.ctx, requesterID, users, termsAccepted, receiveEmailsAccepted)
 }
 
 // GetCloudLimits returns any limits associated with the cloud instance

--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -1557,7 +1557,7 @@ func (api *PluginAPI) RequestTrialLicense(requesterID string, users int, termsAc
 		return model.NewAppError("RequestTrialLicense", "api.restricted_system_admin", nil, "", http.StatusForbidden)
 	}
 
-	return api.app.Channels().RequestTrialLicense(requesterID, users, termsAccepted, receiveEmailsAccepted)
+	return api.app.Channels().RequestTrialLicense(request.EmptyContext(api.app.Log()), requesterID, users, termsAccepted, receiveEmailsAccepted)
 }
 
 // GetCloudLimits returns any limits associated with the cloud instance

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -228,7 +228,7 @@ func (a *App) CreatePost(rctx request.CTX, post *model.Post, channel *model.Chan
 
 	// Validate recipients counts in case it's not DM
 	if persistentNotification := post.GetPersistentNotification(); persistentNotification != nil && *persistentNotification && channel.Type != model.ChannelTypeDirect {
-		err := a.forEachPersistentNotificationPost([]*model.Post{post}, func(_ *model.Post, _ *model.Channel, _ *model.Team, mentions *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
+		err := a.forEachPersistentNotificationPost(rctx, []*model.Post{post}, func(_ *model.Post, _ *model.Channel, _ *model.Team, mentions *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
 			if maxRecipients := *a.Config().ServiceSettings.PersistentNotificationMaxRecipients; len(mentions.Mentions) > maxRecipients {
 				return model.NewAppError("CreatePost", "api.post.post_priority.max_recipients_persistent_notification_post.request_error", map[string]any{"MaxRecipients": maxRecipients}, "", http.StatusBadRequest)
 			} else if len(mentions.Mentions) == 0 {
@@ -255,7 +255,7 @@ func (a *App) CreatePost(rctx request.CTX, post *model.Post, channel *model.Chan
 		}()
 	}
 
-	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), post.UserId)
+	user, nErr := a.Srv().Store().User().Get(rctx, post.UserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -256,7 +256,7 @@ func (a *App) CreatePost(rctx request.CTX, post *model.Post, channel *model.Chan
 		}()
 	}
 
-	user, nErr := a.Srv().Store().User().Get(context.Background(), post.UserId)
+	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), post.UserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"

--- a/server/channels/app/post_persistent_notification.go
+++ b/server/channels/app/post_persistent_notification.go
@@ -41,7 +41,7 @@ func (a *App) ResolvePersistentNotification(rctx request.CTX, post *model.Post, 
 	}
 
 	if !*a.Config().ServiceSettings.AllowPersistentNotificationsForGuests {
-		user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), loggedInUserID)
+		user, nErr := a.Srv().Store().User().Get(rctx, loggedInUserID)
 		if nErr != nil {
 			var nfErr *store.ErrNotFound
 			switch {
@@ -57,7 +57,7 @@ func (a *App) ResolvePersistentNotification(rctx request.CTX, post *model.Post, 
 	}
 
 	stopNotifications := false
-	if err := a.forEachPersistentNotificationPost([]*model.Post{post}, func(_ *model.Post, _ *model.Channel, _ *model.Team, mentions *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
+	if err := a.forEachPersistentNotificationPost(rctx, []*model.Post{post}, func(_ *model.Post, _ *model.Channel, _ *model.Team, mentions *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
 		if mentions.isUserMentioned(loggedInUserID) {
 			stopNotifications = true
 		}
@@ -104,6 +104,7 @@ func (a *App) DeletePersistentNotification(rctx request.CTX, post *model.Post) *
 }
 
 func (a *App) SendPersistentNotifications() error {
+	rctx := request.EmptyContext(a.Log())
 	notificationInterval := time.Duration(*a.Config().ServiceSettings.PersistentNotificationIntervalMinutes) * time.Minute
 	notificationMaxCount := int16(*a.Config().ServiceSettings.PersistentNotificationMaxCount)
 
@@ -136,7 +137,7 @@ func (a *App) SendPersistentNotifications() error {
 		}
 
 		// Send notifications
-		if err := a.forEachPersistentNotificationPost(posts, a.sendPersistentNotifications); err != nil {
+		if err := a.forEachPersistentNotificationPost(rctx, posts, a.sendPersistentNotifications); err != nil {
 			return err
 		}
 
@@ -152,7 +153,7 @@ func (a *App) SendPersistentNotifications() error {
 	return nil
 }
 
-func (a *App) forEachPersistentNotificationPost(posts []*model.Post, fn func(post *model.Post, channel *model.Channel, team *model.Team, mentions *MentionResults, profileMap model.UserMap, channelNotifyProps map[string]map[string]model.StringMap) error) error {
+func (a *App) forEachPersistentNotificationPost(rctx request.CTX, posts []*model.Post, fn func(post *model.Post, channel *model.Channel, team *model.Team, mentions *MentionResults, profileMap model.UserMap, channelNotifyProps map[string]map[string]model.StringMap) error) error {
 	channelsMap, teamsMap, err := a.channelTeamMapsForPosts(posts)
 	if err != nil {
 		return err
@@ -193,7 +194,7 @@ func (a *App) forEachPersistentNotificationPost(posts []*model.Post, fn func(pos
 		// without being a member.
 		if _, ok := profileMap[post.UserId]; !ok {
 			var sender *model.User
-			sender, err = a.Srv().Store().User().Get(request.EmptyContext(a.Log()), post.UserId)
+			sender, err = a.Srv().Store().User().Get(rctx, post.UserId)
 			if err != nil {
 				return errors.Wrapf(err, "failed to get profile for sender user %s for post %s", post.UserId, post.Id)
 			}

--- a/server/channels/app/post_persistent_notification.go
+++ b/server/channels/app/post_persistent_notification.go
@@ -41,7 +41,7 @@ func (a *App) ResolvePersistentNotification(rctx request.CTX, post *model.Post, 
 	}
 
 	if !*a.Config().ServiceSettings.AllowPersistentNotificationsForGuests {
-		user, nErr := a.Srv().Store().User().Get(context.Background(), loggedInUserID)
+		user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), loggedInUserID)
 		if nErr != nil {
 			var nfErr *store.ErrNotFound
 			switch {
@@ -193,7 +193,7 @@ func (a *App) forEachPersistentNotificationPost(posts []*model.Post, fn func(pos
 		// without being a member.
 		if _, ok := profileMap[post.UserId]; !ok {
 			var sender *model.User
-			sender, err = a.Srv().Store().User().Get(context.Background(), post.UserId)
+			sender, err = a.Srv().Store().User().Get(request.EmptyContext(a.Log()), post.UserId)
 			if err != nil {
 				return errors.Wrapf(err, "failed to get profile for sender user %s for post %s", post.UserId, post.Id)
 			}

--- a/server/channels/app/post_persistent_notification_test.go
+++ b/server/channels/app/post_persistent_notification_test.go
@@ -239,7 +239,7 @@ func TestForEachPersistentNotificationPost(t *testing.T) {
 		*cfg.ServiceSettings.AllowPersistentNotifications = true
 
 		fnCalled := []string{}
-		err := th.App.forEachPersistentNotificationPost([]*model.Post{post1, post2}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
+		err := th.App.forEachPersistentNotificationPost(th.Context, []*model.Post{post1, post2}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
 			fnCalled = append(fnCalled, post.Id)
 			return nil
 		})
@@ -297,7 +297,7 @@ func TestForEachPersistentNotificationPost(t *testing.T) {
 		*cfg.ServiceSettings.AllowPersistentNotifications = true
 
 		fnCalled := []string{}
-		err := th.App.forEachPersistentNotificationPost([]*model.Post{post1, post2}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
+		err := th.App.forEachPersistentNotificationPost(th.Context, []*model.Post{post1, post2}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
 			fnCalled = append(fnCalled, post.Id)
 			return nil
 		})
@@ -346,7 +346,7 @@ func TestForEachPersistentNotificationPost(t *testing.T) {
 		*cfg.ServiceSettings.AllowPersistentNotifications = true
 
 		fnCalled := []string{}
-		err := th.App.forEachPersistentNotificationPost([]*model.Post{post1}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
+		err := th.App.forEachPersistentNotificationPost(th.Context, []*model.Post{post1}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
 			fnCalled = append(fnCalled, post.Id)
 			return nil
 		})
@@ -397,7 +397,7 @@ func TestForEachPersistentNotificationPost(t *testing.T) {
 		*cfg.ServiceSettings.AllowPersistentNotifications = true
 
 		fnCalled := []string{}
-		err := th.App.forEachPersistentNotificationPost([]*model.Post{post1}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
+		err := th.App.forEachPersistentNotificationPost(th.Context, []*model.Post{post1}, func(post *model.Post, _ *model.Channel, _ *model.Team, _ *MentionResults, _ model.UserMap, _ map[string]map[string]model.StringMap) error {
 			fnCalled = append(fnCalled, post.Id)
 			return nil
 		})

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -463,6 +463,7 @@ func NewServer(options ...Option) (*Server, error) {
 		TemplatesContainer: s.TemplatesContainer(),
 		UserService:        s.userService,
 		Store:              s.GetStore(),
+		Logger:             s.Log(),
 	})
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to initialize email service")

--- a/server/channels/app/session.go
+++ b/server/channels/app/session.go
@@ -551,7 +551,7 @@ func (a *App) validateUserAccessTokenExpiry(token *model.UserAccessToken) *model
 }
 
 func (a *App) CreateUserAccessToken(rctx request.CTX, token *model.UserAccessToken) (*model.UserAccessToken, *model.AppError) {
-	user, nErr := a.ch.srv.userService.GetUser(token.UserId)
+	user, nErr := a.ch.srv.userService.GetUser(rctx, token.UserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -609,7 +609,7 @@ func (a *App) createSessionForUserAccessToken(rctx request.CTX, tokenString stri
 		return nil, model.NewAppError("createSessionForUserAccessToken", "app.user_access_token.invalid_or_missing", nil, "inactive_token", http.StatusUnauthorized)
 	}
 
-	user, nErr := a.Srv().Store().User().Get(rctx.Context(), token.UserId)
+	user, nErr := a.Srv().Store().User().Get(rctx, token.UserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -822,7 +822,7 @@ func (a *App) EnableUserAccessToken(rctx request.CTX, token *model.UserAccessTok
 // expiry, and immediately invalidates the old secret and its sessions.  The
 // returned token carries the new secret (shown once, like CreateUserAccessToken).
 func (a *App) RotateUserAccessToken(rctx request.CTX, token *model.UserAccessToken, expiresAt int64) (*model.UserAccessToken, *model.AppError) {
-	user, nErr := a.ch.srv.userService.GetUser(token.UserId)
+	user, nErr := a.ch.srv.userService.GetUser(rctx, token.UserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/server/channels/app/shared_channel.go
+++ b/server/channels/app/shared_channel.go
@@ -308,7 +308,7 @@ func (a *App) ReceiveSharedChannelAttachmentSyncMsg(rctx request.CTX, pluginID, 
 	}
 
 	// Validate the file creator belongs to this remote
-	creator, creatorErr := a.Srv().Store().User().Get(rctx.Context(), fi.CreatorId)
+	creator, creatorErr := a.Srv().Store().User().Get(rctx, fi.CreatorId)
 	if creatorErr != nil {
 		if isNotFoundError(creatorErr) {
 			return nil, fmt.Errorf("creator %s not found: %w", fi.CreatorId, creatorErr)
@@ -441,7 +441,7 @@ func (a *App) ReceiveSharedChannelProfileImageSyncMsg(rctx request.CTX, pluginID
 	}
 
 	// Validate user exists and belongs to this remote
-	user, userErr := a.Srv().Store().User().Get(rctx.Context(), userID)
+	user, userErr := a.Srv().Store().User().Get(rctx, userID)
 	if userErr != nil {
 		if isNotFoundError(userErr) {
 			return fmt.Errorf("user %s not found: %w", userID, userErr)

--- a/server/channels/app/shared_channel_global_user_sync_self_referential_test.go
+++ b/server/channels/app/shared_channel_global_user_sync_self_referential_test.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"io"

--- a/server/channels/app/shared_channel_global_user_sync_self_referential_test.go
+++ b/server/channels/app/shared_channel_global_user_sync_self_referential_test.go
@@ -190,7 +190,7 @@ func TestSharedChannelGlobalUserSyncSelfReferential(t *testing.T) {
 		require.NoError(t, err)
 
 		// Verify the user was actually updated with the old timestamp
-		verifiedUser, pErr := ss.User().Get(context.Background(), userWithOldTimestamp.Id)
+		verifiedUser, pErr := ss.User().Get(th.Context, userWithOldTimestamp.Id)
 		require.NoError(t, pErr)
 		userWithOldTimestamp = verifiedUser
 

--- a/server/channels/app/shared_channel_test.go
+++ b/server/channels/app/shared_channel_test.go
@@ -1936,7 +1936,7 @@ func TestPluginRPCSharedChannelSync(t *testing.T) {
 	// the detailed DB verification for attachment persistence.
 
 	// Verify profile image was saved for the synced user
-	updatedUser, err := th.App.Srv().Store().User().Get(th.Context.Context(), syncUserID)
+	updatedUser, err := th.App.Srv().Store().User().Get(th.Context, syncUserID)
 	require.NoError(t, err)
 	assert.Greater(t, updatedUser.LastPictureUpdate, int64(0), "LastPictureUpdate should be set after profile image sync")
 

--- a/server/channels/app/syncables_test.go
+++ b/server/channels/app/syncables_test.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"context"
 	"fmt"
 	"testing"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 )
 
@@ -537,7 +537,7 @@ type mokeUserStore struct {
 	store.UserStore
 }
 
-func (us *mokeUserStore) Get(_ context.Context, id string) (*model.User, error) {
+func (us *mokeUserStore) Get(_ request.CTX, id string) (*model.User, error) {
 	return nil, fmt.Errorf("some error for %s", id)
 }
 

--- a/server/channels/app/team.go
+++ b/server/channels/app/team.go
@@ -5,7 +5,6 @@ package app
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"

--- a/server/channels/app/team.go
+++ b/server/channels/app/team.go
@@ -579,7 +579,7 @@ func (a *App) AddUserToTeam(rctx request.CTX, teamID string, userID string, user
 
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+		user, err := a.Srv().Store().User().Get(rctx, userID)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()

--- a/server/channels/app/team.go
+++ b/server/channels/app/team.go
@@ -665,7 +665,7 @@ func (a *App) AddUserToTeamWithToken(rctx request.CTX, userID string, token *mod
 
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+		user, err := a.Srv().Store().User().Get(rctx, userID)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
@@ -741,7 +741,7 @@ func (a *App) AddUserToTeamByInviteId(rctx request.CTX, inviteId string, userID 
 
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+		user, err := a.Srv().Store().User().Get(rctx, userID)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
@@ -1278,7 +1278,7 @@ func (a *App) RemoveUserFromTeam(rctx request.CTX, teamID string, userID string,
 
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
+		user, err := a.Srv().Store().User().Get(rctx, userID)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
@@ -1328,7 +1328,7 @@ func (a *App) postProcessTeamMemberLeave(rctx request.CTX, teamMember *model.Tea
 		}, plugin.UserHasLeftTeamID)
 	})
 
-	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), teamMember.UserId)
+	user, nErr := a.Srv().Store().User().Get(rctx, teamMember.UserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -1504,7 +1504,7 @@ func (a *App) postRemoveFromTeamMessage(rctx request.CTX, user *model.User, chan
 	return nil
 }
 
-func (a *App) prepareInviteNewUsersToTeam(teamID, senderId string, channelIds []string) (*model.User, *model.Team, []*model.Channel, *model.AppError) {
+func (a *App) prepareInviteNewUsersToTeam(rctx request.CTX, teamID, senderId string, channelIds []string) (*model.User, *model.Team, []*model.Channel, *model.AppError) {
 	tchan := make(chan store.StoreResult[*model.Team], 1)
 	go func() {
 		team, err := a.Srv().Store().Team().Get(teamID)
@@ -1514,7 +1514,7 @@ func (a *App) prepareInviteNewUsersToTeam(teamID, senderId string, channelIds []
 
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), senderId)
+		user, err := a.Srv().Store().User().Get(rctx, senderId)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
@@ -1580,7 +1580,7 @@ func (a *App) InviteNewUsersToTeamGracefully(rctx request.CTX, memberInvite *mod
 		err := model.NewAppError("InviteNewUsersToTeam", "api.team.invite_members.no_one.app_error", nil, "", http.StatusBadRequest)
 		return nil, err
 	}
-	user, team, channels, err := a.prepareInviteNewUsersToTeam(teamID, senderId, memberInvite.ChannelIds)
+	user, team, channels, err := a.prepareInviteNewUsersToTeam(rctx, teamID, senderId, memberInvite.ChannelIds)
 	if err != nil {
 		return nil, err
 	}
@@ -1738,7 +1738,7 @@ func (a *App) prepareInviteGuestsToChannels(rctx request.CTX, teamID string, gue
 	}()
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), senderId)
+		user, err := a.Srv().Store().User().Get(rctx, senderId)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
@@ -1866,7 +1866,7 @@ func (a *App) InviteNewUsersToTeam(rctx request.CTX, emailList []string, teamID,
 		return err
 	}
 
-	user, team, _, err := a.prepareInviteNewUsersToTeam(teamID, senderId, []string{})
+	user, team, _, err := a.prepareInviteNewUsersToTeam(rctx, teamID, senderId, []string{})
 	if err != nil {
 		return err
 	}

--- a/server/channels/app/team.go
+++ b/server/channels/app/team.go
@@ -580,7 +580,7 @@ func (a *App) AddUserToTeam(rctx request.CTX, teamID string, userID string, user
 
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(context.Background(), userID)
+		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
@@ -666,7 +666,7 @@ func (a *App) AddUserToTeamWithToken(rctx request.CTX, userID string, token *mod
 
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(context.Background(), userID)
+		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
@@ -742,7 +742,7 @@ func (a *App) AddUserToTeamByInviteId(rctx request.CTX, inviteId string, userID 
 
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(context.Background(), userID)
+		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
@@ -1279,7 +1279,7 @@ func (a *App) RemoveUserFromTeam(rctx request.CTX, teamID string, userID string,
 
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(context.Background(), userID)
+		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), userID)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
@@ -1329,7 +1329,7 @@ func (a *App) postProcessTeamMemberLeave(rctx request.CTX, teamMember *model.Tea
 		}, plugin.UserHasLeftTeamID)
 	})
 
-	user, nErr := a.Srv().Store().User().Get(context.Background(), teamMember.UserId)
+	user, nErr := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), teamMember.UserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -1515,7 +1515,7 @@ func (a *App) prepareInviteNewUsersToTeam(teamID, senderId string, channelIds []
 
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(context.Background(), senderId)
+		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), senderId)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()
@@ -1739,7 +1739,7 @@ func (a *App) prepareInviteGuestsToChannels(rctx request.CTX, teamID string, gue
 	}()
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(context.Background(), senderId)
+		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), senderId)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()

--- a/server/channels/app/team_test.go
+++ b/server/channels/app/team_test.go
@@ -1210,7 +1210,7 @@ func TestLeaveTeamPanic(t *testing.T) {
 
 	mockStore := th.App.Srv().Store().(*mocks.Store)
 	mockUserStore := mocks.UserStore{}
-	mockUserStore.On("Get", context.Background(), "userID").Return(&model.User{Id: "userID"}, nil)
+	mockUserStore.On("Get", mock.Anything, "userID").Return(&model.User{Id: "userID"}, nil)
 	mockUserStore.On("Count", mock.Anything).Return(int64(10), nil)
 
 	mockChannelStore := mocks.ChannelStore{}

--- a/server/channels/app/teams/service.go
+++ b/server/channels/app/teams/service.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 )
 
@@ -34,7 +35,7 @@ type ServiceConfig struct {
 
 // Users is a subset of UserService interface
 type Users interface {
-	GetUser(userID string) (*model.User, error)
+	GetUser(rctx request.CTX, userID string) (*model.User, error)
 }
 
 // WebHub is used to publish events, the name should be given appropriately

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -2844,7 +2844,7 @@ func (a *App) DemoteUserToGuest(rctx request.CTX, user *model.User) *model.AppEr
 		return model.NewAppError("DemoteUserToGuest", "api.user.demote_user_to_guest.bot_not_allowed.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	demotedUser, nErr := a.ch.srv.userService.DemoteUserToGuest(user)
+	demotedUser, nErr := a.ch.srv.userService.DemoteUserToGuest(rctx, user)
 	a.InvalidateCacheForUser(user.Id)
 	if nErr != nil {
 		return model.NewAppError("DemoteUserToGuest", "app.user.demote_user_to_guest.user_update.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -539,6 +539,7 @@ func (a *App) AddUserToTeamByInviteIfNeeded(rctx request.CTX, user *model.User, 
 	return nil
 }
 
+// TODO: Migrate this compatibility wrapper to accept request.CTX.
 func (a *App) GetUser(userID string) (*model.User, *model.AppError) {
 	user, err := a.ch.srv.userService.GetUser(request.EmptyContext(a.Log()), userID)
 	if err != nil {

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -2778,7 +2778,7 @@ func (a *App) GetViewUsersRestrictions(rctx request.CTX, userID string) (*model.
 // PromoteGuestToUser Convert user's roles and all his membership's roles from
 // guest roles to regular user roles.
 func (a *App) PromoteGuestToUser(rctx request.CTX, user *model.User, requestorId string) *model.AppError {
-	nErr := a.ch.srv.userService.PromoteGuestToUser(user)
+	nErr := a.ch.srv.userService.PromoteGuestToUser(rctx, user)
 	a.InvalidateCacheForUser(user.Id)
 	if nErr != nil {
 		return model.NewAppError("PromoteGuestToUser", "app.user.promote_guest.user_update.app_error", nil, "", http.StatusInternalServerError).Wrap(nErr)

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -387,7 +387,7 @@ func (a *App) createUserOrGuest(rctx request.CTX, user *model.User, guest bool) 
 	a.InvalidateCacheForUser(ruser.Id)
 
 	if user.EmailVerified {
-		nUser, err := a.ch.srv.userService.GetUser(ruser.Id)
+		nUser, err := a.ch.srv.userService.GetUser(rctx, ruser.Id)
 		if err != nil {
 			var nfErr *store.ErrNotFound
 			switch {
@@ -540,7 +540,7 @@ func (a *App) AddUserToTeamByInviteIfNeeded(rctx request.CTX, user *model.User, 
 }
 
 func (a *App) GetUser(userID string) (*model.User, *model.AppError) {
-	user, err := a.ch.srv.userService.GetUser(userID)
+	user, err := a.ch.srv.userService.GetUser(request.EmptyContext(a.Log()), userID)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -1545,7 +1545,7 @@ func (a *App) isUniqueToGroupNames(val string) *model.AppError {
 }
 
 func (a *App) UpdateUser(rctx request.CTX, user *model.User, sendNotifications bool) (*model.User, *model.AppError) {
-	prev, err := a.ch.srv.userService.GetUser(user.Id)
+	prev, err := a.ch.srv.userService.GetUser(rctx, user.Id)
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {
@@ -2932,7 +2932,7 @@ func (a *App) GetKnownUsers(userID string) ([]string, *model.AppError) {
 
 // ConvertBotToUser converts a bot to user.
 func (a *App) ConvertBotToUser(rctx request.CTX, bot *model.Bot, userPatch *model.UserPatch, sysadmin bool) (*model.User, *model.AppError) {
-	user, nErr := a.Srv().Store().User().Get(rctx.Context(), bot.UserId)
+	user, nErr := a.Srv().Store().User().Get(rctx, bot.UserId)
 	if nErr != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/server/channels/app/users/helper_test.go
+++ b/server/channels/app/users/helper_test.go
@@ -94,15 +94,15 @@ func (th *TestHelper) InitBasic(tb testing.TB) *TestHelper {
 	var err error
 
 	th.SystemAdminUser = th.CreateUser(tb)
-	th.SystemAdminUser, err = th.service.GetUser(th.SystemAdminUser.Id)
+	th.SystemAdminUser, err = th.service.GetUser(th.Context, th.SystemAdminUser.Id)
 	require.NoError(tb, err)
 
 	th.BasicUser = th.CreateUser(tb)
-	th.BasicUser, err = th.service.GetUser(th.BasicUser.Id)
+	th.BasicUser, err = th.service.GetUser(th.Context, th.BasicUser.Id)
 	require.NoError(tb, err)
 
 	th.BasicUser2 = th.CreateUser(tb)
-	th.BasicUser2, err = th.service.GetUser(th.BasicUser2.Id)
+	th.BasicUser2, err = th.service.GetUser(th.Context, th.BasicUser2.Id)
 	require.NoError(tb, err)
 
 	return th

--- a/server/channels/app/users/users.go
+++ b/server/channels/app/users/users.go
@@ -4,7 +4,6 @@
 package users
 
 import (
-	"context"
 	"encoding/base64"
 	"fmt"
 
@@ -95,8 +94,8 @@ func (us *UserService) verifyUserEmail(userID, email string) error {
 	return nil
 }
 
-func (us *UserService) GetUser(userID string) (*model.User, error) {
-	return us.store.Get(context.Background(), userID)
+func (us *UserService) GetUser(rctx request.CTX, userID string) (*model.User, error) {
+	return us.store.Get(rctx, userID)
 }
 
 func (us *UserService) GetUsers(rctx request.CTX, userIDs []string) ([]*model.User, error) {

--- a/server/channels/app/users/users.go
+++ b/server/channels/app/users/users.go
@@ -267,8 +267,8 @@ func (us *UserService) DeactivateMfa(user *model.User) error {
 	return mfa.New(us.store).Deactivate(user.Id)
 }
 
-func (us *UserService) PromoteGuestToUser(user *model.User) error {
-	return us.store.PromoteGuestToUser(user.Id)
+func (us *UserService) PromoteGuestToUser(rctx request.CTX, user *model.User) error {
+	return us.store.PromoteGuestToUser(rctx, user.Id)
 }
 
 func (us *UserService) DemoteUserToGuest(user *model.User) (*model.User, error) {

--- a/server/channels/app/users/users.go
+++ b/server/channels/app/users/users.go
@@ -271,6 +271,6 @@ func (us *UserService) PromoteGuestToUser(rctx request.CTX, user *model.User) er
 	return us.store.PromoteGuestToUser(rctx, user.Id)
 }
 
-func (us *UserService) DemoteUserToGuest(user *model.User) (*model.User, error) {
-	return us.store.DemoteUserToGuest(user.Id)
+func (us *UserService) DemoteUserToGuest(rctx request.CTX, user *model.User) (*model.User, error) {
+	return us.store.DemoteUserToGuest(rctx, user.Id)
 }

--- a/server/channels/app/webhook.go
+++ b/server/channels/app/webhook.go
@@ -921,7 +921,7 @@ func (a *App) HandleIncomingWebhook(rctx request.CTX, hookID string, req *model.
 
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(context.Background(), hook.UserId)
+		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), hook.UserId)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()

--- a/server/channels/app/webhook.go
+++ b/server/channels/app/webhook.go
@@ -921,7 +921,7 @@ func (a *App) HandleIncomingWebhook(rctx request.CTX, hookID string, req *model.
 
 	uchan := make(chan store.StoreResult[*model.User], 1)
 	go func() {
-		user, err := a.Srv().Store().User().Get(request.EmptyContext(a.Log()), hook.UserId)
+		user, err := a.Srv().Store().User().Get(rctx, hook.UserId)
 		uchan <- store.StoreResult[*model.User]{Data: user, NErr: err}
 		close(uchan)
 	}()

--- a/server/channels/store/doc.go
+++ b/server/channels/store/doc.go
@@ -96,7 +96,7 @@ The cache layer is transparent to callers but provides significant performance
 benefits for read-heavy operations:
 
 	// This call may be served from cache
-	user, err := store.User().Get(ctx, userID)
+	user, err := store.User().Get(rctx, userID)
 
 	// Cache is automatically invalidated on updates
 	updatedUser, err := store.User().Update(ctx, user, allowRoleUpdate)

--- a/server/channels/store/localcachelayer/user_layer.go
+++ b/server/channels/store/localcachelayer/user_layer.go
@@ -245,7 +245,7 @@ func (s *LocalCacheUserStore) DecrementFailedPasswordAttempts(userID string) err
 // It checks if the user entry is present in the cache, returning the entry from cache
 // if it is present. Otherwise, it fetches the entry from the store and stores it in the
 // cache.
-func (s *LocalCacheUserStore) Get(ctx context.Context, id string) (*model.User, error) {
+func (s *LocalCacheUserStore) Get(rctx request.CTX, id string) (*model.User, error) {
 	var cacheItem model.User
 	if err := s.rootStore.doStandardReadCache(s.rootStore.userProfileByIdsCache, id, &cacheItem); err == nil {
 		return &cacheItem, nil
@@ -254,13 +254,13 @@ func (s *LocalCacheUserStore) Get(ctx context.Context, id string) (*model.User, 
 	// If it was invalidated, then we need to query master.
 	s.userProfileByIdsMut.Lock()
 	if s.userProfileByIdsInvalidations[id] {
-		ctx = sqlstore.WithMaster(ctx)
+		rctx = sqlstore.RequestContextWithMaster(rctx)
 		// And then remove the key from the map.
 		delete(s.userProfileByIdsInvalidations, id)
 	}
 	s.userProfileByIdsMut.Unlock()
 
-	user, err := s.UserStore.Get(ctx, id)
+	user, err := s.UserStore.Get(rctx, id)
 	if err != nil {
 		return nil, err
 	}

--- a/server/channels/store/localcachelayer/user_layer_test.go
+++ b/server/channels/store/localcachelayer/user_layer_test.go
@@ -270,12 +270,12 @@ func TestUserStoreGetCache(t *testing.T) {
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider, logger)
 		require.NoError(t, err)
 
-		gotUser, err := cachedStore.User().Get(context.Background(), fakeUserId)
+		gotUser, err := cachedStore.User().Get(rctx, fakeUserId)
 		require.NoError(t, err)
 		assert.Equal(t, fakeUser, gotUser)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "Get", 1)
 
-		_, _ = cachedStore.User().Get(context.Background(), fakeUserId)
+		_, _ = cachedStore.User().Get(rctx, fakeUserId)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "Get", 1)
 	})
 
@@ -285,14 +285,14 @@ func TestUserStoreGetCache(t *testing.T) {
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider, logger)
 		require.NoError(t, err)
 
-		gotUser, err := cachedStore.User().Get(context.Background(), fakeUserId)
+		gotUser, err := cachedStore.User().Get(rctx, fakeUserId)
 		require.NoError(t, err)
 		assert.Equal(t, fakeUser, gotUser)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "Get", 1)
 
 		cachedStore.User().InvalidateProfileCacheForUser("123")
 
-		_, _ = cachedStore.User().Get(context.Background(), fakeUserId)
+		_, _ = cachedStore.User().Get(rctx, fakeUserId)
 		mockStore.User().(*mocks.UserStore).AssertNumberOfCalls(t, "Get", 2)
 	})
 
@@ -302,20 +302,20 @@ func TestUserStoreGetCache(t *testing.T) {
 		cachedStore, err := NewLocalCacheLayer(mockStore, nil, nil, mockCacheProvider, logger)
 		require.NoError(t, err)
 
-		storedUser, err := mockStore.User().Get(context.Background(), fakeUserId)
+		storedUser, err := mockStore.User().Get(rctx, fakeUserId)
 		require.NoError(t, err)
 		originalProps := storedUser.NotifyProps
 
 		storedUser.NotifyProps = map[string]string{}
 		storedUser.NotifyProps["key"] = "somevalue"
 
-		cachedUser, err := cachedStore.User().Get(context.Background(), fakeUserId)
+		cachedUser, err := cachedStore.User().Get(rctx, fakeUserId)
 		require.NoError(t, err)
 		assert.Equal(t, storedUser, cachedUser)
 
 		storedUser.Props = model.StringMap{}
 		storedUser.Timezone = model.StringMap{}
-		cachedUser, err = cachedStore.User().Get(context.Background(), fakeUserId)
+		cachedUser, err = cachedStore.User().Get(rctx, fakeUserId)
 		require.NoError(t, err)
 		assert.Equal(t, storedUser, cachedUser)
 		if storedUser == cachedUser {
@@ -338,7 +338,7 @@ func TestUserStoreGetCache(t *testing.T) {
 
 		cachedStore.user.rootStore.userProfileByIdsCache = cmock
 
-		_, err = cachedStore.User().Get(context.Background(), fakeUserId)
+		_, err = cachedStore.User().Get(rctx, fakeUserId)
 		require.NoError(t, err)
 	})
 }

--- a/server/channels/store/localcachelayer/user_layer_test.go
+++ b/server/channels/store/localcachelayer/user_layer_test.go
@@ -257,6 +257,8 @@ func TestUserStoreProfilesInChannelCache(t *testing.T) {
 }
 
 func TestUserStoreGetCache(t *testing.T) {
+	rctx := request.TestContext(t)
+
 	fakeUserId := "123"
 	fakeUser := &model.User{
 		Id:          "123",

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -16966,11 +16966,11 @@ func (s *RetryLayerUserStore) DecrementFailedPasswordAttempts(userID string) err
 
 }
 
-func (s *RetryLayerUserStore) DemoteUserToGuest(userID string) (*model.User, error) {
+func (s *RetryLayerUserStore) DemoteUserToGuest(rctx request.CTX, userID string) (*model.User, error) {
 
 	tries := 0
 	for {
-		result, err := s.UserStore.DemoteUserToGuest(userID)
+		result, err := s.UserStore.DemoteUserToGuest(rctx, userID)
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -17905,11 +17905,11 @@ func (s *RetryLayerUserStore) PermanentDelete(rctx request.CTX, userID string) e
 
 }
 
-func (s *RetryLayerUserStore) PromoteGuestToUser(userID string) error {
+func (s *RetryLayerUserStore) PromoteGuestToUser(rctx request.CTX, userID string) error {
 
 	tries := 0
 	for {
-		err := s.UserStore.PromoteGuestToUser(userID)
+		err := s.UserStore.PromoteGuestToUser(rctx, userID)
 		if err == nil {
 			return nil
 		}

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -16987,11 +16987,11 @@ func (s *RetryLayerUserStore) DemoteUserToGuest(userID string) (*model.User, err
 
 }
 
-func (s *RetryLayerUserStore) Get(ctx context.Context, id string) (*model.User, error) {
+func (s *RetryLayerUserStore) Get(rctx request.CTX, id string) (*model.User, error) {
 
 	tries := 0
 	for {
-		result, err := s.UserStore.Get(ctx, id)
+		result, err := s.UserStore.Get(rctx, id)
 		if err == nil {
 			return result, nil
 		}

--- a/server/channels/store/searchlayer/layer.go
+++ b/server/channels/store/searchlayer/layer.go
@@ -69,7 +69,7 @@ func (s *SearchStore) User() store.UserStore {
 }
 
 func (s *SearchStore) indexUserFromID(rctx request.CTX, userId string) {
-	user, err := s.User().Get(rctx.Context(), userId)
+	user, err := s.User().Get(rctx, userId)
 	if err != nil {
 		return
 	}

--- a/server/channels/store/searchlayer/user_layer.go
+++ b/server/channels/store/searchlayer/user_layer.go
@@ -4,7 +4,6 @@
 package searchlayer
 
 import (
-	"context"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -91,7 +90,7 @@ func (s *SearchUserStore) Save(rctx request.CTX, user *model.User) (*model.User,
 }
 
 func (s *SearchUserStore) PermanentDelete(rctx request.CTX, userId string) error {
-	user, userErr := s.UserStore.Get(context.Background(), userId)
+	user, userErr := s.UserStore.Get(rctx, userId)
 	if userErr != nil {
 		rctx.Logger().Warn("Encountered error deleting user", mlog.String("user_id", userId), mlog.Err(userErr))
 	}

--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -2193,14 +2193,14 @@ func applyViewRestrictionsFilter(query sq.SelectBuilder, restrictions *model.Vie
 	return resultQuery
 }
 
-func (us SqlUserStore) PromoteGuestToUser(userId string) (err error) {
+func (us SqlUserStore) PromoteGuestToUser(rctx request.CTX, userId string) (err error) {
 	transaction, err := us.GetMaster().Begin()
 	if err != nil {
 		return errors.Wrap(err, "begin_transaction")
 	}
 	defer finalizeTransactionX(transaction, &err)
 
-	user, err := us.Get(request.EmptyContext(us.logger), userId)
+	user, err := us.Get(rctx, userId)
 	if err != nil {
 		return err
 	}

--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -607,13 +607,13 @@ func (us SqlUserStore) GetMany(rctx request.CTX, ids []string) ([]*model.User, e
 	return users, nil
 }
 
-func (us SqlUserStore) Get(ctx context.Context, id string) (*model.User, error) {
+func (us SqlUserStore) Get(rctx request.CTX, id string) (*model.User, error) {
 	query := us.usersQuery.Where("Id = ?", id)
 	queryString, args, err := query.ToSql()
 	if err != nil {
 		return nil, errors.Wrap(err, "users_get_tosql")
 	}
-	row := us.SqlStore.DBXFromContext(ctx).QueryRow(queryString, args...)
+	row := us.SqlStore.DBXFromContext(rctx.Context()).QueryRow(queryString, args...)
 
 	var user model.User
 	var props, notifyProps, timezone []byte
@@ -2200,7 +2200,7 @@ func (us SqlUserStore) PromoteGuestToUser(userId string) (err error) {
 	}
 	defer finalizeTransactionX(transaction, &err)
 
-	user, err := us.Get(context.Background(), userId)
+	user, err := us.Get(request.EmptyContext(us.logger), userId)
 	if err != nil {
 		return err
 	}
@@ -2269,7 +2269,7 @@ func (us SqlUserStore) DemoteUserToGuest(userID string) (_ *model.User, err erro
 	}
 	defer finalizeTransactionX(transaction, &err)
 
-	user, err := us.Get(context.Background(), userID)
+	user, err := us.Get(request.EmptyContext(us.logger), userID)
 	if err != nil {
 		return nil, err
 	}

--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -2262,14 +2262,14 @@ func (us SqlUserStore) PromoteGuestToUser(rctx request.CTX, userId string) (err 
 	return nil
 }
 
-func (us SqlUserStore) DemoteUserToGuest(userID string) (_ *model.User, err error) {
+func (us SqlUserStore) DemoteUserToGuest(rctx request.CTX, userID string) (_ *model.User, err error) {
 	transaction, err := us.GetMaster().Begin()
 	if err != nil {
 		return nil, errors.Wrap(err, "begin_transaction")
 	}
 	defer finalizeTransactionX(transaction, &err)
 
-	user, err := us.Get(request.EmptyContext(us.logger), userID)
+	user, err := us.Get(rctx, userID)
 	if err != nil {
 		return nil, err
 	}

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -523,7 +523,7 @@ type UserStore interface {
 	GetTeamGroupUsers(teamID string) ([]*model.User, error)
 	GetChannelGroupUsers(channelID string) ([]*model.User, error)
 	PromoteGuestToUser(rctx request.CTX, userID string) error
-	DemoteUserToGuest(userID string) (*model.User, error)
+	DemoteUserToGuest(rctx request.CTX, userID string) (*model.User, error)
 	DeactivateGuests() ([]string, error)
 	DeactivateMagicLinkGuests() ([]string, error)
 	AutocompleteUsersInChannel(rctx request.CTX, teamID, channelID, term string, options *model.UserSearchOptions) (*model.UserAutocompleteInChannel, error)

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -522,7 +522,7 @@ type UserStore interface {
 	Count(options model.UserCountOptions) (int64, error)
 	GetTeamGroupUsers(teamID string) ([]*model.User, error)
 	GetChannelGroupUsers(channelID string) ([]*model.User, error)
-	PromoteGuestToUser(userID string) error
+	PromoteGuestToUser(rctx request.CTX, userID string) error
 	DemoteUserToGuest(userID string) (*model.User, error)
 	DeactivateGuests() ([]string, error)
 	DeactivateMagicLinkGuests() ([]string, error)

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -460,7 +460,7 @@ type UserStore interface {
 	UpdateMfaActive(userID string, active bool) error
 	StoreMfaUsedTimestamps(userID string, ts []int) error
 	GetMfaUsedTimestamps(userID string) ([]int, error)
-	Get(ctx context.Context, id string) (*model.User, error)
+	Get(rctx request.CTX, id string) (*model.User, error)
 	GetMany(rctx request.CTX, ids []string) ([]*model.User, error)
 	GetAll() ([]*model.User, error)
 	ClearCaches()

--- a/server/channels/store/storetest/mocks/UserStore.go
+++ b/server/channels/store/storetest/mocks/UserStore.go
@@ -1696,17 +1696,17 @@ func (_m *UserStore) PermanentDelete(rctx request.CTX, userID string) error {
 	return r0
 }
 
-// PromoteGuestToUser provides a mock function with given fields: userID
-func (_m *UserStore) PromoteGuestToUser(userID string) error {
-	ret := _m.Called(userID)
+// PromoteGuestToUser provides a mock function with given fields: rctx, userID
+func (_m *UserStore) PromoteGuestToUser(rctx request.CTX, userID string) error {
+	ret := _m.Called(rctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for PromoteGuestToUser")
 	}
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string) error); ok {
-		r0 = rf(userID)
+	if rf, ok := ret.Get(0).(func(request.CTX, string) error); ok {
+		r0 = rf(rctx, userID)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/server/channels/store/storetest/mocks/UserStore.go
+++ b/server/channels/store/storetest/mocks/UserStore.go
@@ -373,9 +373,9 @@ func (_m *UserStore) DecrementFailedPasswordAttempts(userID string) error {
 	return r0
 }
 
-// DemoteUserToGuest provides a mock function with given fields: userID
-func (_m *UserStore) DemoteUserToGuest(userID string) (*model.User, error) {
-	ret := _m.Called(userID)
+// DemoteUserToGuest provides a mock function with given fields: rctx, userID
+func (_m *UserStore) DemoteUserToGuest(rctx request.CTX, userID string) (*model.User, error) {
+	ret := _m.Called(rctx, userID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for DemoteUserToGuest")
@@ -383,19 +383,19 @@ func (_m *UserStore) DemoteUserToGuest(userID string) (*model.User, error) {
 
 	var r0 *model.User
 	var r1 error
-	if rf, ok := ret.Get(0).(func(string) (*model.User, error)); ok {
-		return rf(userID)
+	if rf, ok := ret.Get(0).(func(request.CTX, string) (*model.User, error)); ok {
+		return rf(rctx, userID)
 	}
-	if rf, ok := ret.Get(0).(func(string) *model.User); ok {
-		r0 = rf(userID)
+	if rf, ok := ret.Get(0).(func(request.CTX, string) *model.User); ok {
+		r0 = rf(rctx, userID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.User)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(userID)
+	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
+		r1 = rf(rctx, userID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/mocks/UserStore.go
+++ b/server/channels/store/storetest/mocks/UserStore.go
@@ -403,9 +403,9 @@ func (_m *UserStore) DemoteUserToGuest(userID string) (*model.User, error) {
 	return r0, r1
 }
 
-// Get provides a mock function with given fields: ctx, id
-func (_m *UserStore) Get(ctx context.Context, id string) (*model.User, error) {
-	ret := _m.Called(ctx, id)
+// Get provides a mock function with given fields: rctx, id
+func (_m *UserStore) Get(rctx request.CTX, id string) (*model.User, error) {
+	ret := _m.Called(rctx, id)
 
 	if len(ret) == 0 {
 		panic("no return value specified for Get")
@@ -413,19 +413,19 @@ func (_m *UserStore) Get(ctx context.Context, id string) (*model.User, error) {
 
 	var r0 *model.User
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (*model.User, error)); ok {
-		return rf(ctx, id)
+	if rf, ok := ret.Get(0).(func(request.CTX, string) (*model.User, error)); ok {
+		return rf(rctx, id)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) *model.User); ok {
-		r0 = rf(ctx, id)
+	if rf, ok := ret.Get(0).(func(request.CTX, string) *model.User); ok {
+		r0 = rf(rctx, id)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.User)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, id)
+	if rf, ok := ret.Get(1).(func(request.CTX, string) error); ok {
+		r1 = rf(rctx, id)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/server/channels/store/storetest/team_store.go
+++ b/server/channels/store/storetest/team_store.go
@@ -4,7 +4,6 @@
 package storetest
 
 import (
-	"context"
 	"errors"
 	"strings"
 	"testing"

--- a/server/channels/store/storetest/team_store.go
+++ b/server/channels/store/storetest/team_store.go
@@ -3089,7 +3089,7 @@ func testSaveTeamMemberMaxMembers(t *testing.T, rctx request.CTX, ss store.Store
 	require.Equal(t, maxUsersPerTeam, int(totalMemberCount), "should have 5 team members again, had %v instead", totalMemberCount)
 
 	// Deactivating a user should make them stop counting against max members
-	user2, nErr := ss.User().Get(context.Background(), userIds[1])
+	user2, nErr := ss.User().Get(rctx, userIds[1])
 	require.NoError(t, nErr)
 	user2.DeleteAt = 1234
 	_, nErr = ss.User().Update(rctx, user2, true)

--- a/server/channels/store/storetest/thread_store.go
+++ b/server/channels/store/storetest/thread_store.go
@@ -4,7 +4,6 @@
 package storetest
 
 import (
-	"context"
 	"testing"
 	"time"
 

--- a/server/channels/store/storetest/thread_store.go
+++ b/server/channels/store/storetest/thread_store.go
@@ -1284,7 +1284,7 @@ func testVarious(t *testing.T, rctx request.CTX, ss store.Store) {
 			require.NoError(t, err)
 			require.Len(t, userIDs, 1)
 
-			u, err := ss.User().Get(context.Background(), userIDs[0])
+			u, err := ss.User().Get(rctx, userIDs[0])
 			require.NoError(t, err)
 
 			assert.Equal(t, u.Username, members[0].Username)
@@ -1300,7 +1300,7 @@ func testVarious(t *testing.T, rctx request.CTX, ss store.Store) {
 			require.Len(t, userIDs, 2)
 
 			for i := range userIDs {
-				u, err := ss.User().Get(context.Background(), userIDs[i])
+				u, err := ss.User().Get(rctx, userIDs[i])
 				require.NoError(t, err)
 
 				assert.Equal(t, u.Username, members[i].Username)
@@ -1334,7 +1334,7 @@ func testVarious(t *testing.T, rctx request.CTX, ss store.Store) {
 			require.NoError(t, err)
 			require.Len(t, userIDs, 1)
 
-			u, err := ss.User().Get(context.Background(), userIDs[0])
+			u, err := ss.User().Get(rctx, userIDs[0])
 			require.NoError(t, err)
 
 			assert.Equal(t, u.Username, members[0].Username)

--- a/server/channels/store/storetest/user_store.go
+++ b/server/channels/store/storetest/user_store.go
@@ -6122,7 +6122,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{ChannelId: channel.Id, UserId: user.Id, SchemeGuest: false, SchemeUser: true, NotifyProps: model.GetDefaultChannelNotifyProps()})
 		require.NoError(t, nErr)
 
-		updatedUser, err := ss.User().DemoteUserToGuest(user.Id)
+		updatedUser, err := ss.User().DemoteUserToGuest(rctx, user.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_guest", updatedUser.Roles)
 		require.True(t, user.UpdateAt < updatedUser.UpdateAt)
@@ -6166,7 +6166,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{ChannelId: channel.Id, UserId: user.Id, SchemeGuest: true, SchemeUser: false, NotifyProps: model.GetDefaultChannelNotifyProps()})
 		require.NoError(t, nErr)
 
-		updatedUser, err := ss.User().DemoteUserToGuest(user.Id)
+		updatedUser, err := ss.User().DemoteUserToGuest(rctx, user.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_guest", updatedUser.Roles)
 
@@ -6195,7 +6195,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 		require.NoError(t, err)
 		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
-		updatedUser, err := ss.User().DemoteUserToGuest(user.Id)
+		updatedUser, err := ss.User().DemoteUserToGuest(rctx, user.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_guest", updatedUser.Roles)
 	})
@@ -6218,7 +6218,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamID, UserId: user.Id, SchemeGuest: false, SchemeUser: true}, 999)
 		require.NoError(t, nErr)
 
-		updatedUser, err := ss.User().DemoteUserToGuest(user.Id)
+		updatedUser, err := ss.User().DemoteUserToGuest(rctx, user.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_guest", updatedUser.Roles)
 
@@ -6256,7 +6256,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{ChannelId: channel.Id, UserId: user.Id, SchemeGuest: false, SchemeUser: true, NotifyProps: model.GetDefaultChannelNotifyProps()})
 		require.NoError(t, nErr)
 
-		updatedUser, err := ss.User().DemoteUserToGuest(user.Id)
+		updatedUser, err := ss.User().DemoteUserToGuest(rctx, user.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_guest", updatedUser.Roles)
 
@@ -6299,7 +6299,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{ChannelId: channel.Id, UserId: user.Id, SchemeGuest: false, SchemeUser: true, NotifyProps: model.GetDefaultChannelNotifyProps()})
 		require.NoError(t, nErr)
 
-		updatedUser, err := ss.User().DemoteUserToGuest(user.Id)
+		updatedUser, err := ss.User().DemoteUserToGuest(rctx, user.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_guest", updatedUser.Roles)
 
@@ -6363,7 +6363,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{ChannelId: channel.Id, UserId: user2.Id, SchemeGuest: false, SchemeUser: true, NotifyProps: model.GetDefaultChannelNotifyProps()})
 		require.NoError(t, nErr)
 
-		updatedUser, err := ss.User().DemoteUserToGuest(user1.Id)
+		updatedUser, err := ss.User().DemoteUserToGuest(rctx, user1.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_guest", updatedUser.Roles)
 

--- a/server/channels/store/storetest/user_store.go
+++ b/server/channels/store/storetest/user_store.go
@@ -232,7 +232,7 @@ func testUserStoreUpdate(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, err, "Update should not have failed")
 
 		t.Run("UpdateNotifyProps", func(t *testing.T) {
-			u1, err = ss.User().Get(context.Background(), u1.Id)
+			u1, err = ss.User().Get(rctx, u1.Id)
 			require.NoError(t, err)
 
 			props := u1.NotifyProps
@@ -243,7 +243,7 @@ func testUserStoreUpdate(t *testing.T, rctx request.CTX, ss store.Store) {
 
 			ss.User().InvalidateProfileCacheForUser(u1.Id)
 
-			uNew, err := ss.User().Get(context.Background(), u1.Id)
+			uNew, err := ss.User().Get(rctx, u1.Id)
 			require.NoError(t, err)
 			assert.Equal(t, props, uNew.NotifyProps)
 
@@ -332,7 +332,7 @@ func testUserStoreUpdateUpdateAt(t *testing.T, rctx request.CTX, ss store.Store)
 	_, err = ss.User().UpdateUpdateAt(u1.Id)
 	require.NoError(t, err)
 
-	user, err := ss.User().Get(context.Background(), u1.Id)
+	user, err := ss.User().Get(rctx, u1.Id)
 	require.NoError(t, err)
 	require.Less(t, u1.UpdateAt, user.UpdateAt, "UpdateAt not updated correctly")
 }
@@ -349,7 +349,7 @@ func testUserStoreUpdateFailedPasswordAttempts(t *testing.T, rctx request.CTX, s
 	err = ss.User().UpdateFailedPasswordAttempts(u1.Id, 3)
 	require.NoError(t, err)
 
-	user, err := ss.User().Get(context.Background(), u1.Id)
+	user, err := ss.User().Get(rctx, u1.Id)
 	require.NoError(t, err)
 	require.Equal(t, 3, user.FailedAttempts, "FailedAttempts not updated correctly")
 }
@@ -372,7 +372,7 @@ func testUserStoreTryIncrementFailedPasswordAttempts(t *testing.T, rctx request.
 		require.NoError(t, err)
 		require.True(t, claimed)
 
-		user, err := ss.User().Get(context.Background(), u1.Id)
+		user, err := ss.User().Get(rctx, u1.Id)
 		require.NoError(t, err)
 		require.Equal(t, 1, user.FailedAttempts)
 	})
@@ -384,7 +384,7 @@ func testUserStoreTryIncrementFailedPasswordAttempts(t *testing.T, rctx request.
 		require.NoError(t, err)
 		require.False(t, claimed)
 
-		user, err := ss.User().Get(context.Background(), u1.Id)
+		user, err := ss.User().Get(rctx, u1.Id)
 		require.NoError(t, err)
 		require.Equal(t, maxAttempts, user.FailedAttempts, "counter must not advance past the cap")
 	})
@@ -396,7 +396,7 @@ func testUserStoreTryIncrementFailedPasswordAttempts(t *testing.T, rctx request.
 		require.NoError(t, err)
 		require.False(t, claimed)
 
-		user, err := ss.User().Get(context.Background(), u1.Id)
+		user, err := ss.User().Get(rctx, u1.Id)
 		require.NoError(t, err)
 		require.Equal(t, maxAttempts+5, user.FailedAttempts)
 	})
@@ -432,7 +432,7 @@ func testUserStoreTryIncrementFailedPasswordAttempts(t *testing.T, rctx request.
 
 		require.Equal(t, int64(maxAttempts), claimed.Load(), "exactly maxAttempts goroutines must have claimed a slot")
 
-		user, err := ss.User().Get(context.Background(), u1.Id)
+		user, err := ss.User().Get(rctx, u1.Id)
 		require.NoError(t, err)
 		require.Equal(t, maxAttempts, user.FailedAttempts)
 	})
@@ -452,7 +452,7 @@ func testUserStoreDecrementFailedPasswordAttempts(t *testing.T, rctx request.CTX
 
 		require.NoError(t, ss.User().DecrementFailedPasswordAttempts(u1.Id))
 
-		user, err := ss.User().Get(context.Background(), u1.Id)
+		user, err := ss.User().Get(rctx, u1.Id)
 		require.NoError(t, err)
 		require.Equal(t, 2, user.FailedAttempts)
 	})
@@ -462,7 +462,7 @@ func testUserStoreDecrementFailedPasswordAttempts(t *testing.T, rctx request.CTX
 
 		require.NoError(t, ss.User().DecrementFailedPasswordAttempts(u1.Id))
 
-		user, err := ss.User().Get(context.Background(), u1.Id)
+		user, err := ss.User().Get(rctx, u1.Id)
 		require.NoError(t, err)
 		require.Equal(t, 0, user.FailedAttempts)
 	})
@@ -487,7 +487,7 @@ func testUserStoreDecrementFailedPasswordAttempts(t *testing.T, rctx request.CTX
 		close(start)
 		require.NoError(t, g.Wait())
 
-		user, err := ss.User().Get(context.Background(), u1.Id)
+		user, err := ss.User().Get(rctx, u1.Id)
 		require.NoError(t, err)
 		require.Equal(t, 0, user.FailedAttempts, "decrement must clamp at zero under contention")
 	})
@@ -521,19 +521,19 @@ func testUserStoreGet(t *testing.T, rctx request.CTX, ss store.Store) {
 	require.NoError(t, nErr)
 
 	t.Run("fetch empty id", func(t *testing.T) {
-		_, err := ss.User().Get(context.Background(), "")
+		_, err := ss.User().Get(rctx, "")
 		require.Error(t, err)
 	})
 
 	t.Run("fetch user 1", func(t *testing.T) {
-		actual, err := ss.User().Get(context.Background(), u1.Id)
+		actual, err := ss.User().Get(rctx, u1.Id)
 		require.NoError(t, err)
 		require.Equal(t, u1, actual)
 		require.False(t, actual.IsBot)
 	})
 
 	t.Run("fetch user 2, also a bot", func(t *testing.T) {
-		actual, err := ss.User().Get(context.Background(), u2.Id)
+		actual, err := ss.User().Get(rctx, u2.Id)
 		require.NoError(t, err)
 		require.Equal(t, u2, actual)
 		require.True(t, actual.IsBot)
@@ -2694,7 +2694,7 @@ func testUserStoreResetAuthDataToEmailForUsers(t *testing.T, rctx request.CTX, s
 	numAffected, err = ss.User().ResetAuthDataToEmailForUsers(model.UserAuthServiceSaml, nil, false, false)
 	require.NoError(t, err)
 	require.Equal(t, 1, numAffected)
-	user, appErr := ss.User().Get(context.Background(), user.Id)
+	user, appErr := ss.User().Get(rctx, user.Id)
 	require.NoError(t, appErr)
 	require.Equal(t, *user.AuthData, user.Email)
 
@@ -5809,7 +5809,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 
 		err = ss.User().PromoteGuestToUser(user.Id)
 		require.NoError(t, err)
-		updatedUser, err := ss.User().Get(context.Background(), user.Id)
+		updatedUser, err := ss.User().Get(rctx, user.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_user", updatedUser.Roles)
 		require.True(t, user.UpdateAt < updatedUser.UpdateAt)
@@ -5855,7 +5855,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 
 		err = ss.User().PromoteGuestToUser(user.Id)
 		require.NoError(t, err)
-		updatedUser, err := ss.User().Get(context.Background(), user.Id)
+		updatedUser, err := ss.User().Get(rctx, user.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_user system_admin", updatedUser.Roles)
 
@@ -5886,7 +5886,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 
 		err = ss.User().PromoteGuestToUser(user.Id)
 		require.NoError(t, err)
-		updatedUser, err := ss.User().Get(context.Background(), user.Id)
+		updatedUser, err := ss.User().Get(rctx, user.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_user", updatedUser.Roles)
 	})
@@ -5911,7 +5911,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 
 		err = ss.User().PromoteGuestToUser(user.Id)
 		require.NoError(t, err)
-		updatedUser, err := ss.User().Get(context.Background(), user.Id)
+		updatedUser, err := ss.User().Get(rctx, user.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_user", updatedUser.Roles)
 
@@ -5951,7 +5951,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 
 		err = ss.User().PromoteGuestToUser(user.Id)
 		require.NoError(t, err)
-		updatedUser, err := ss.User().Get(context.Background(), user.Id)
+		updatedUser, err := ss.User().Get(rctx, user.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_user", updatedUser.Roles)
 
@@ -5996,7 +5996,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 
 		err = ss.User().PromoteGuestToUser(user.Id)
 		require.NoError(t, err)
-		updatedUser, err := ss.User().Get(context.Background(), user.Id)
+		updatedUser, err := ss.User().Get(rctx, user.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_user custom_role", updatedUser.Roles)
 
@@ -6062,7 +6062,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 
 		err = ss.User().PromoteGuestToUser(user1.Id)
 		require.NoError(t, err)
-		updatedUser, err := ss.User().Get(context.Background(), user1.Id)
+		updatedUser, err := ss.User().Get(rctx, user1.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_user", updatedUser.Roles)
 
@@ -6076,7 +6076,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 		require.False(t, updatedChannelMember.SchemeGuest)
 		require.True(t, updatedChannelMember.SchemeUser)
 
-		notUpdatedUser, err := ss.User().Get(context.Background(), user2.Id)
+		notUpdatedUser, err := ss.User().Get(rctx, user2.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_guest", notUpdatedUser.Roles)
 
@@ -6377,7 +6377,7 @@ func testUserStoreDemoteUserToGuest(t *testing.T, rctx request.CTX, ss store.Sto
 		require.True(t, updatedChannelMember.SchemeGuest)
 		require.False(t, updatedChannelMember.SchemeUser)
 
-		notUpdatedUser, err := ss.User().Get(context.Background(), user2.Id)
+		notUpdatedUser, err := ss.User().Get(rctx, user2.Id)
 		require.NoError(t, err)
 		require.Equal(t, "system_user", notUpdatedUser.Roles)
 
@@ -6453,19 +6453,19 @@ func testDeactivateGuests(t *testing.T, rctx request.CTX, ss store.Store) {
 		require.NoError(t, err)
 		assert.ElementsMatch(t, []string{guest1.Id, guest2.Id}, ids)
 
-		u, err := ss.User().Get(context.Background(), guest1.Id)
+		u, err := ss.User().Get(rctx, guest1.Id)
 		require.NoError(t, err)
 		assert.NotEqual(t, u.DeleteAt, int64(0))
 
-		u, err = ss.User().Get(context.Background(), guest2.Id)
+		u, err = ss.User().Get(rctx, guest2.Id)
 		require.NoError(t, err)
 		assert.NotEqual(t, u.DeleteAt, int64(0))
 
-		u, err = ss.User().Get(context.Background(), guest3.Id)
+		u, err = ss.User().Get(rctx, guest3.Id)
 		require.NoError(t, err)
 		assert.Equal(t, u.DeleteAt, int64(10))
 
-		u, err = ss.User().Get(context.Background(), regularUser.Id)
+		u, err = ss.User().Get(rctx, regularUser.Id)
 		require.NoError(t, err)
 		assert.Equal(t, u.DeleteAt, int64(0))
 	})
@@ -6484,7 +6484,7 @@ func testUserStoreResetLastPictureUpdate(t *testing.T, rctx request.CTX, ss stor
 	err = ss.User().UpdateLastPictureUpdate(u1.Id)
 	require.NoError(t, err)
 
-	user, err := ss.User().Get(context.Background(), u1.Id)
+	user, err := ss.User().Get(rctx, u1.Id)
 	require.NoError(t, err)
 
 	assert.GreaterOrEqual(t, user.LastPictureUpdate, startTime)
@@ -6497,7 +6497,7 @@ func testUserStoreResetLastPictureUpdate(t *testing.T, rctx request.CTX, ss stor
 
 	ss.User().InvalidateProfileCacheForUser(u1.Id)
 
-	user2, err := ss.User().Get(context.Background(), u1.Id)
+	user2, err := ss.User().Get(rctx, u1.Id)
 	require.NoError(t, err)
 
 	assert.Greater(t, user2.UpdateAt, user.UpdateAt)
@@ -6709,7 +6709,7 @@ func testUpdateLastLogin(t *testing.T, rctx request.CTX, ss store.Store) {
 	err = ss.User().UpdateLastLogin(u1.Id, 1234567890)
 	require.NoError(t, err)
 
-	user, err := ss.User().Get(context.Background(), u1.Id)
+	user, err := ss.User().Get(rctx, u1.Id)
 	require.NoError(t, err)
 	require.Equal(t, int64(1234567890), user.LastLogin)
 }

--- a/server/channels/store/storetest/user_store.go
+++ b/server/channels/store/storetest/user_store.go
@@ -5807,7 +5807,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{ChannelId: channel.Id, UserId: user.Id, SchemeGuest: true, SchemeUser: false, NotifyProps: model.GetDefaultChannelNotifyProps()})
 		require.NoError(t, nErr)
 
-		err = ss.User().PromoteGuestToUser(user.Id)
+		err = ss.User().PromoteGuestToUser(rctx, user.Id)
 		require.NoError(t, err)
 		updatedUser, err := ss.User().Get(rctx, user.Id)
 		require.NoError(t, err)
@@ -5853,7 +5853,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{ChannelId: channel.Id, UserId: user.Id, SchemeGuest: true, SchemeUser: false, NotifyProps: model.GetDefaultChannelNotifyProps()})
 		require.NoError(t, nErr)
 
-		err = ss.User().PromoteGuestToUser(user.Id)
+		err = ss.User().PromoteGuestToUser(rctx, user.Id)
 		require.NoError(t, err)
 		updatedUser, err := ss.User().Get(rctx, user.Id)
 		require.NoError(t, err)
@@ -5884,7 +5884,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 		require.NoError(t, err)
 		defer func() { require.NoError(t, ss.User().PermanentDelete(rctx, user.Id)) }()
 
-		err = ss.User().PromoteGuestToUser(user.Id)
+		err = ss.User().PromoteGuestToUser(rctx, user.Id)
 		require.NoError(t, err)
 		updatedUser, err := ss.User().Get(rctx, user.Id)
 		require.NoError(t, err)
@@ -5909,7 +5909,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 		_, nErr := ss.Team().SaveMember(rctx, &model.TeamMember{TeamId: teamID, UserId: user.Id, SchemeGuest: true, SchemeUser: false}, 999)
 		require.NoError(t, nErr)
 
-		err = ss.User().PromoteGuestToUser(user.Id)
+		err = ss.User().PromoteGuestToUser(rctx, user.Id)
 		require.NoError(t, err)
 		updatedUser, err := ss.User().Get(rctx, user.Id)
 		require.NoError(t, err)
@@ -5949,7 +5949,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{ChannelId: channel.Id, UserId: user.Id, SchemeGuest: true, SchemeUser: false, NotifyProps: model.GetDefaultChannelNotifyProps()})
 		require.NoError(t, nErr)
 
-		err = ss.User().PromoteGuestToUser(user.Id)
+		err = ss.User().PromoteGuestToUser(rctx, user.Id)
 		require.NoError(t, err)
 		updatedUser, err := ss.User().Get(rctx, user.Id)
 		require.NoError(t, err)
@@ -5994,7 +5994,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{ChannelId: channel.Id, UserId: user.Id, SchemeGuest: true, SchemeUser: false, NotifyProps: model.GetDefaultChannelNotifyProps()})
 		require.NoError(t, nErr)
 
-		err = ss.User().PromoteGuestToUser(user.Id)
+		err = ss.User().PromoteGuestToUser(rctx, user.Id)
 		require.NoError(t, err)
 		updatedUser, err := ss.User().Get(rctx, user.Id)
 		require.NoError(t, err)
@@ -6060,7 +6060,7 @@ func testUserStorePromoteGuestToUser(t *testing.T, rctx request.CTX, ss store.St
 		_, nErr = ss.Channel().SaveMember(rctx, &model.ChannelMember{ChannelId: channel.Id, UserId: user2.Id, SchemeGuest: true, SchemeUser: false, NotifyProps: model.GetDefaultChannelNotifyProps()})
 		require.NoError(t, nErr)
 
-		err = ss.User().PromoteGuestToUser(user1.Id)
+		err = ss.User().PromoteGuestToUser(rctx, user1.Id)
 		require.NoError(t, err)
 		updatedUser, err := ss.User().Get(rctx, user1.Id)
 		require.NoError(t, err)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -14155,10 +14155,10 @@ func (s *TimerLayerUserStore) PermanentDelete(rctx request.CTX, userID string) e
 	return err
 }
 
-func (s *TimerLayerUserStore) PromoteGuestToUser(userID string) error {
+func (s *TimerLayerUserStore) PromoteGuestToUser(rctx request.CTX, userID string) error {
 	start := time.Now()
 
-	err := s.UserStore.PromoteGuestToUser(userID)
+	err := s.UserStore.PromoteGuestToUser(rctx, userID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -13374,10 +13374,10 @@ func (s *TimerLayerUserStore) DecrementFailedPasswordAttempts(userID string) err
 	return err
 }
 
-func (s *TimerLayerUserStore) DemoteUserToGuest(userID string) (*model.User, error) {
+func (s *TimerLayerUserStore) DemoteUserToGuest(rctx request.CTX, userID string) (*model.User, error) {
 	start := time.Now()
 
-	result, err := s.UserStore.DemoteUserToGuest(userID)
+	result, err := s.UserStore.DemoteUserToGuest(rctx, userID)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -13390,10 +13390,10 @@ func (s *TimerLayerUserStore) DemoteUserToGuest(userID string) (*model.User, err
 	return result, err
 }
 
-func (s *TimerLayerUserStore) Get(ctx context.Context, id string) (*model.User, error) {
+func (s *TimerLayerUserStore) Get(rctx request.CTX, id string) (*model.User, error) {
 	start := time.Now()
 
-	result, err := s.UserStore.Get(ctx, id)
+	result, err := s.UserStore.Get(rctx, id)
 
 	elapsed := float64(time.Since(start)) / float64(time.Second)
 	if s.Root.Metrics != nil {

--- a/server/channels/web/context_test.go
+++ b/server/channels/web/context_test.go
@@ -4,7 +4,6 @@
 package web
 
 import (
-	"context"
 	"net/http"
 	"testing"
 

--- a/server/channels/web/context_test.go
+++ b/server/channels/web/context_test.go
@@ -55,7 +55,7 @@ func TestMfaRequired(t *testing.T) {
 	mockStore := th.App.Srv().Store().(*mocks.Store)
 	mockUserStore := mocks.UserStore{}
 	mockUserStore.On("Count", mock.Anything).Return(int64(10), nil)
-	mockUserStore.On("Get", context.Background(), "userid").Return(nil, model.NewAppError("Userstore.Get", "storeerror", nil, "store error", http.StatusInternalServerError))
+	mockUserStore.On("Get", mock.Anything, "userid").Return(nil, model.NewAppError("Userstore.Get", "storeerror", nil, "store error", http.StatusInternalServerError))
 	mockPostStore := mocks.PostStore{}
 	mockPostStore.On("GetMaxPostSize").Return(65535, nil)
 	mockSystemStore := mocks.SystemStore{}

--- a/server/platform/services/remotecluster/mocks_test.go
+++ b/server/platform/services/remotecluster/mocks_test.go
@@ -4,7 +4,6 @@
 package remotecluster
 
 import (
-	"context"
 	"slices"
 	"sync"
 	"testing"

--- a/server/platform/services/remotecluster/mocks_test.go
+++ b/server/platform/services/remotecluster/mocks_test.go
@@ -75,7 +75,7 @@ func (ms *mockServer) GetStore() store.Store {
 	remoteClusterStoreMock.On("SetLastPingAt", anyId).Return(nil)
 
 	userStoreMock := &mocks.UserStore{}
-	userStoreMock.On("Get", context.Background(), anyUserId).Return(ms.user, nil)
+	userStoreMock.On("Get", mock.Anything, anyUserId).Return(ms.user, nil)
 
 	storeMock := &mocks.Store{}
 	storeMock.On("RemoteCluster").Return(remoteClusterStoreMock)

--- a/server/platform/services/remotecluster/sendprofileImage.go
+++ b/server/platform/services/remotecluster/sendprofileImage.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 )
 
 type SendProfileImageResultFunc func(userId string, rc *model.RemoteCluster, resp *Response, err error)
@@ -91,7 +92,7 @@ func (rcs *Service) sendProfileImageToRemote(timeout time.Duration, task sendPro
 		mlog.String("UserId", task.userID),
 	)
 
-	user, err := rcs.server.GetStore().User().Get(context.Background(), task.userID)
+	user, err := rcs.server.GetStore().User().Get(request.EmptyContext(rcs.server.Log()), task.userID)
 	if err != nil {
 		return fmt.Errorf("error fetching user while sending profile image to remote %s: %w", task.rc.RemoteId, err)
 	}

--- a/server/platform/services/sharedchannel/channelinvite.go
+++ b/server/platform/services/sharedchannel/channelinvite.go
@@ -440,7 +440,7 @@ func (scs *Service) handleChannelCreation(invite channelInviteMsg, rc *model.Rem
 // database and if it fails, it will try to create it if is present in
 // the participantsMap
 func (scs *Service) getOrCreateUser(userID string, participantsMap map[string]*model.User, rc *model.RemoteCluster) (*model.User, error) {
-	user, err := scs.server.GetStore().User().Get(context.TODO(), userID)
+	user, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), userID)
 	if err == nil {
 		return user, nil
 	}

--- a/server/platform/services/sharedchannel/channelinvite_test.go
+++ b/server/platform/services/sharedchannel/channelinvite_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest/mock"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
 	"github.com/mattermost/mattermost/server/v8/platform/services/remotecluster"
@@ -27,7 +28,7 @@ var (
 	mockTypeUser       = mock.AnythingOfType("*model.User")
 	mockTypeString     = mock.AnythingOfType("string")
 	mockTypeReqContext = mock.AnythingOfType("*request.Context")
-	mockTypeContext    = mock.MatchedBy(func(ctx context.Context) bool { return true })
+	mockTypeContext    = mock.MatchedBy(func(ctx request.CTX) bool { return true })
 )
 
 // stubRemoteClusterService is a no-op implementation of RemoteClusterServiceIFace for tests

--- a/server/platform/services/sharedchannel/membership_recv.go
+++ b/server/platform/services/sharedchannel/membership_recv.go
@@ -113,7 +113,7 @@ func (scs *Service) processMemberAdd(change *model.MembershipChangeMsg, channel 
 		}
 	} else {
 		// Fallback to existing lookup for users not in sync message
-		user, err = scs.server.GetStore().User().Get(rctx.Context(), change.UserId)
+		user, err = scs.server.GetStore().User().Get(rctx, change.UserId)
 		if err != nil {
 			return fmt.Errorf("cannot get user for channel add: %w", err)
 		}
@@ -166,7 +166,7 @@ func (scs *Service) processMemberRemove(change *model.MembershipChangeMsg, rc *m
 	}
 
 	rctx := request.EmptyContext(scs.server.Log())
-	user, userErr := scs.server.GetStore().User().Get(rctx.Context(), change.UserId)
+	user, userErr := scs.server.GetStore().User().Get(rctx, change.UserId)
 	if userErr != nil {
 		return fmt.Errorf("cannot get user for channel remove: %w", userErr)
 	}

--- a/server/platform/services/sharedchannel/sync_recv.go
+++ b/server/platform/services/sharedchannel/sync_recv.go
@@ -4,7 +4,6 @@
 package sharedchannel
 
 import (
-	"context"
 	"encoding/json"
 	"errors"
 	"fmt"

--- a/server/platform/services/sharedchannel/sync_recv.go
+++ b/server/platform/services/sharedchannel/sync_recv.go
@@ -301,7 +301,7 @@ func (scs *Service) upsertSyncUser(rctx request.CTX, user *model.User, channel *
 	var err error
 
 	// Check if user already exists
-	euser, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), user.Id)
+	euser, err := scs.server.GetStore().User().Get(rctx, user.Id)
 	if err != nil {
 		if _, ok := err.(errNotFound); !ok {
 			return nil, fmt.Errorf("error checking sync user: %w", err)
@@ -496,7 +496,7 @@ func (scs *Service) upsertSyncPost(post *model.Post, targetChannel *model.Channe
 	if rpost == nil {
 		// post doesn't exist; check that user belongs to remote and create post.
 		// user is not checked for edit/delete because admins can perform those actions
-		user, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), post.UserId)
+		user, err := scs.server.GetStore().User().Get(rctx, post.UserId)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching user for post sync: %w", err)
 		}
@@ -712,7 +712,7 @@ func (scs *Service) upsertSyncReaction(reaction *model.Reaction, targetChannel *
 	if existingReaction == nil {
 		// reaction does not exist; check that user belongs to remote and create reaction
 		// this is not done for delete since deletion can be done by admins on the remote
-		user, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), reaction.UserId)
+		user, err := scs.server.GetStore().User().Get(rctx, reaction.UserId)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching user for reaction sync: %w", err)
 		}
@@ -759,7 +759,7 @@ func (scs *Service) upsertSyncAcknowledgement(acknowledgement *model.PostAcknowl
 	if existingAcknowledgement == nil {
 		// acknowledgement does not exist; check that user belongs to remote and create acknowledgement
 		// this is not done for delete since deletion can be done by admins on the remote
-		user, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), acknowledgement.UserId)
+		user, err := scs.server.GetStore().User().Get(rctx, acknowledgement.UserId)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching user for acknowledgement sync: %w", err)
 		}
@@ -819,7 +819,7 @@ func (scs *Service) transformMentionsOnReceive(rctx request.CTX, post *model.Pos
 		var newMention string
 
 		// Get the user to determine transformation type
-		if user, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), userID); err == nil && user != nil {
+		if user, err := scs.server.GetStore().User().Get(rctx, userID); err == nil && user != nil {
 			// User exists in receiver's database
 			if strings.Contains(mention, ":") {
 				// Colon mention (e.g., "@admin:remote1") - always use the user's actual username

--- a/server/platform/services/sharedchannel/sync_recv.go
+++ b/server/platform/services/sharedchannel/sync_recv.go
@@ -302,7 +302,7 @@ func (scs *Service) upsertSyncUser(rctx request.CTX, user *model.User, channel *
 	var err error
 
 	// Check if user already exists
-	euser, err := scs.server.GetStore().User().Get(context.Background(), user.Id)
+	euser, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), user.Id)
 	if err != nil {
 		if _, ok := err.(errNotFound); !ok {
 			return nil, fmt.Errorf("error checking sync user: %w", err)
@@ -497,7 +497,7 @@ func (scs *Service) upsertSyncPost(post *model.Post, targetChannel *model.Channe
 	if rpost == nil {
 		// post doesn't exist; check that user belongs to remote and create post.
 		// user is not checked for edit/delete because admins can perform those actions
-		user, err := scs.server.GetStore().User().Get(context.TODO(), post.UserId)
+		user, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), post.UserId)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching user for post sync: %w", err)
 		}
@@ -713,7 +713,7 @@ func (scs *Service) upsertSyncReaction(reaction *model.Reaction, targetChannel *
 	if existingReaction == nil {
 		// reaction does not exist; check that user belongs to remote and create reaction
 		// this is not done for delete since deletion can be done by admins on the remote
-		user, err := scs.server.GetStore().User().Get(context.TODO(), reaction.UserId)
+		user, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), reaction.UserId)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching user for reaction sync: %w", err)
 		}
@@ -760,7 +760,7 @@ func (scs *Service) upsertSyncAcknowledgement(acknowledgement *model.PostAcknowl
 	if existingAcknowledgement == nil {
 		// acknowledgement does not exist; check that user belongs to remote and create acknowledgement
 		// this is not done for delete since deletion can be done by admins on the remote
-		user, err := scs.server.GetStore().User().Get(context.TODO(), acknowledgement.UserId)
+		user, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), acknowledgement.UserId)
 		if err != nil {
 			return nil, fmt.Errorf("error fetching user for acknowledgement sync: %w", err)
 		}
@@ -789,7 +789,7 @@ func (scs *Service) upsertSyncAcknowledgement(acknowledgement *model.PostAcknowl
 }
 
 func (scs *Service) upsertSyncUserStatus(rctx request.CTX, status *model.Status, rc *model.RemoteCluster) error {
-	user, err := scs.server.GetStore().User().Get(rctx.Context(), status.UserId)
+	user, err := scs.server.GetStore().User().Get(rctx, status.UserId)
 	if err != nil {
 		return fmt.Errorf("error getting user when syncing status: %w", err)
 	}
@@ -820,7 +820,7 @@ func (scs *Service) transformMentionsOnReceive(rctx request.CTX, post *model.Pos
 		var newMention string
 
 		// Get the user to determine transformation type
-		if user, err := scs.server.GetStore().User().Get(context.Background(), userID); err == nil && user != nil {
+		if user, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), userID); err == nil && user != nil {
 			// User exists in receiver's database
 			if strings.Contains(mention, ":") {
 				// Colon mention (e.g., "@admin:remote1") - always use the user's actual username

--- a/server/platform/services/sharedchannel/sync_recv.go
+++ b/server/platform/services/sharedchannel/sync_recv.go
@@ -361,7 +361,7 @@ func (scs *Service) upsertSyncUser(rctx request.CTX, user *model.User, channel *
 	// added and exit quickly.  Not needed for DMs where teamId is empty.
 	if channel != nil && channel.TeamId != "" {
 		// add user to team
-		if err := scs.app.AddUserToTeamByTeamId(request.EmptyContext(scs.server.Log()), channel.TeamId, userSaved); err != nil {
+		if err := scs.app.AddUserToTeamByTeamId(rctx, channel.TeamId, userSaved); err != nil {
 			return nil, fmt.Errorf("error adding sync user to Team: %w", err)
 		}
 		// add user to channel

--- a/server/platform/services/sharedchannel/sync_send.go
+++ b/server/platform/services/sharedchannel/sync_send.go
@@ -636,7 +636,7 @@ func (scs *Service) updateCursorForRemote(scrId string, rc *model.RemoteCluster,
 
 func (scs *Service) getUserTranslations(userId string) i18n.TranslateFunc {
 	var locale string
-	user, err := scs.server.GetStore().User().Get(context.Background(), userId)
+	user, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), userId)
 	if err == nil {
 		locale = user.Locale
 	}

--- a/server/platform/services/sharedchannel/sync_send_remote.go
+++ b/server/platform/services/sharedchannel/sync_send_remote.go
@@ -417,7 +417,7 @@ func (scs *Service) fetchMembershipsForSync(sd *syncData) error {
 
 	// Build MembershipChangeMsg entries
 	for userID, state := range byUser {
-		user, userErr := scs.server.GetStore().User().Get(context.Background(), userID)
+		user, userErr := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), userID)
 		if userErr != nil {
 			scs.server.Log().LogM(mlog.MlvlSharedChannelServiceWarn, "Failed to get user for membership sync",
 				mlog.String("user_id", userID),
@@ -620,7 +620,7 @@ func (scs *Service) fetchPostUsersForSync(sd *syncData) error {
 
 		// Skip notifications for remote users unless mentioned with @username:remote format
 		for mention, userID := range mentionMap {
-			user, err := scs.server.GetStore().User().Get(context.Background(), userID)
+			user, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), userID)
 			if err != nil {
 				continue
 			}
@@ -648,7 +648,7 @@ func (scs *Service) fetchPostUsersForSync(sd *syncData) error {
 
 	merr := merror.New()
 	for userID, v := range userIDs {
-		user, err := scs.server.GetStore().User().Get(context.Background(), userID)
+		user, err := scs.server.GetStore().User().Get(request.EmptyContext(scs.server.Log()), userID)
 		if err != nil {
 			merr.Append(fmt.Errorf("could not get user %s: %w", userID, err))
 			continue


### PR DESCRIPTION

#### Summary
Migrate `UserStore.Get` from `context.Context` to `request.CTX` across the store interface, SQL store, local cache layer, generated layers, mocks, and direct callers.

Regenerate store layers and mocks with `make store-layers` and `make store-mocks`.

Thread existing request contexts through reviewed `UserStore.Get` call paths where available, including team flows, trial license flows, plugin API, and direct channel export helpers; use the email service logger for batched-email request contexts; add `request.CTX` to `PromoteGuestToUser` and `DemoteUserToGuest`; and document the future `App.GetUser` request-context migration.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70222

#### Release Note
```release-note
NONE
```


<a href="https://cursor.com/agents/bc-59f3d850-fb99-4453-97ae-0d995bfcdc80" rel="nofollow noreferrer noopener" target="_blank"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></a> <a href="https://cursor.com/background-agent?bcId=bc-59f3d850-fb99-4453-97ae-0d995bfcdc80" rel="nofollow noreferrer noopener" target="_blank"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></a> 




## Change Impact: 🟡 Medium

**Regression Risk:** The request-context contract changes affect shared store interfaces, generated layers, mocks, and many callers, including authentication and session flows. Automated coverage is broad, but the wide blast radius warrants regression monitoring.

**QA Recommendation:** Manual QA may be skipped. Run the full automated test suite and prioritize authentication, session, user lookup, and shared-channel tests.

*Generated by CodeRabbitAI*
