### PR TITLE
Update Playbooks plugin to v2.9.4 for Mattermost 11.8 (incl. FIPS)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -160,7 +160,7 @@ PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.5
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.1
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.2
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.0
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.9.1
+PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.9.4
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.5
@@ -176,7 +176,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.9.1%2B885dcf9-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.9.4%2B39a72fa-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.5%2B4ad0d7d-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.6%2B99b712c-fips
 endif


### PR DESCRIPTION
#### Summary
Update Playbooks plugin to v2.9.4 (FIPS and non-FIPS). The non-FIPS pin is bumped from v2.9.1 to v2.9.4 in the same commit.

The FIPS build is produced from the [`fips.v2.9.4` branch](https://github.com/mattermost/mattermost-plugin-playbooks/pull/2375) of \`mattermost-plugin-playbooks\`, signed and uploaded via the [\`Sign Plugin PR Artifacts\` workflow](https://github.com/mattermost/delivery-platform/actions/runs/30023608731).

Source commit on the Playbooks repo: [\`39a72fa\`](https://github.com/mattermost/mattermost-plugin-playbooks/commit/39a72fa834f3e7a26a3f65fea74dc11cfd759bd5).

The signed FIPS bundle is reachable at [https://plugins.releases.mattermost.com/release/mattermost-plugin-playbooks-v2.9.4%2B39a72fa-fips-linux-amd64.tar.gz](https://plugins.releases.mattermost.com/release/mattermost-plugin-playbooks-v2.9.4%2B39a72fa-fips-linux-amd64.tar.gz).

#### Ticket Link
--

#### Screenshots
--

#### Release Note
```release-note
Bump Playbooks to version v2.9.4.
```