### PR TITLE
Update Playbooks plugin to v2.10.1 (incl. FIPS)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -160,7 +160,7 @@ PLUGIN_PACKAGES += mattermost-plugin-calls-v1.12.1
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.1
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.1
-PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.10.0
+PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.10.1
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.2
@@ -176,7 +176,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # download the package from to work. This will no longer be needed when we unify
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
-	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.10.0%2B090a26d-fips
+	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.10.1%2B42a4753-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.2%2B1305067-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.1%2B29b4688-fips
 endif


### PR DESCRIPTION
#### Summary
Update Playbooks plugin to v2.10.1 (FIPS and non-FIPS). The non-FIPS pin is bumped from v2.10.0 to v2.10.1 in the same commit.

#### Ticket Link
--

#### Screenshots
--

#### Release Note
```release-note
Bump Playbooks to version v2.10.1.
```