### PR TITLE
[GH-18483] E2E/Playwright: Add test for emoji skin tone selector (MM-T4110)

### DIFF
--- a/e2e-tests/playwright/lib/src/ui/components/channels/emoji_gif_picker.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/emoji_gif_picker.ts
@@ -4,6 +4,14 @@
 import type {Locator} from '@playwright/test';
 import {expect} from '@playwright/test';
 
+/**
+ * Skin tone values as used by the emoji picker's skin tone selector, either
+ * 'default' or the unified codepoint of the skin tone modifier.
+ */
+export const skinTones = ['default', '1F3FB', '1F3FC', '1F3FD', '1F3FE', '1F3FF'] as const;
+
+export type SkinTone = (typeof skinTones)[number];
+
 export default class EmojiGifPicker {
     readonly container: Locator;
 
@@ -12,6 +20,10 @@ export default class EmojiGifPicker {
     readonly gifPickerItems: Locator;
     readonly emojiSearchInput: Locator;
 
+    readonly skinToneExpandButton: Locator;
+    readonly skinToneCloseButton: Locator;
+    readonly skinToneChoices: Locator;
+
     constructor(container: Locator) {
         this.container = container;
 
@@ -19,6 +31,10 @@ export default class EmojiGifPicker {
         this.gifSearchInput = container.getByPlaceholder('Search GIPHY');
         this.gifPickerItems = container.getByTestId('gif-picker-items');
         this.emojiSearchInput = container.getByPlaceholder('Search emojis');
+
+        this.skinToneExpandButton = container.getByRole('button', {name: 'Skin tone', exact: true});
+        this.skinToneCloseButton = container.getByRole('button', {name: 'Close skin tones', exact: true});
+        this.skinToneChoices = container.getByRole('region', {name: 'Skin tone icons'});
     }
 
     async toBeVisible() {
@@ -46,6 +62,58 @@ export default class EmojiGifPicker {
 
     async clickEmoji(emojiName: string) {
         await this.getEmoji(emojiName).click();
+    }
+
+    /**
+     * Returns the collapsed skin tone selector button for the given skin tone.
+     * The button carries the "skin-picked" test ID only while the selector is
+     * collapsed, so this also verifies the collapsed state.
+     */
+    getSelectedSkinTone(skinTone: SkinTone) {
+        return this.container.getByTestId(`skin-picked-${skinTone}`);
+    }
+
+    /**
+     * Returns the button for a skin tone in the expanded skin tone selector.
+     */
+    getSkinToneChoice(skinTone: SkinTone) {
+        return this.container.getByTestId(`skin-pick-${skinTone}`);
+    }
+
+    /**
+     * Expands the skin tone selector so that all skin tone choices are visible.
+     */
+    async openSkinToneSelector() {
+        await expect(this.skinToneExpandButton).toBeVisible();
+        await this.skinToneExpandButton.click();
+        await expect(this.skinToneChoices).toBeVisible();
+    }
+
+    /**
+     * Collapses the skin tone selector without changing the selected skin tone.
+     */
+    async closeSkinToneSelector() {
+        await expect(this.skinToneCloseButton).toBeVisible();
+        await this.skinToneCloseButton.click();
+        await expect(this.skinToneChoices).not.toBeVisible();
+    }
+
+    /**
+     * Selects a skin tone from the expanded skin tone selector, then verifies
+     * that the selector collapses with the chosen skin tone applied.
+     */
+    async selectSkinTone(skinTone: SkinTone) {
+        await expect(this.skinToneChoices).toBeVisible();
+        await this.getSkinToneChoice(skinTone).click();
+        await expect(this.skinToneChoices).not.toBeVisible();
+        await this.verifySelectedSkinTone(skinTone);
+    }
+
+    /**
+     * Verifies that the skin tone selector is collapsed with the given skin tone selected.
+     */
+    async verifySelectedSkinTone(skinTone: SkinTone) {
+        await expect(this.getSelectedSkinTone(skinTone)).toBeVisible();
     }
 
     async openGifTab() {

--- a/e2e-tests/playwright/specs/functional/channels/emoji_picker/emoji_picker_skin_tone.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/emoji_picker/emoji_picker_skin_tone.spec.ts
@@ -1,0 +1,85 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+const allSkinTones = ['default', '1F3FB', '1F3FC', '1F3FD', '1F3FE', '1F3FF'] as const;
+
+/**
+ * @objective Verify that the emoji picker's skin tone selector shows all skin tones, applies the selected
+ * skin tone to inserted emojis and posted messages, persists the selection across picker reopens and page
+ * reloads, and allows restoring the default skin tone.
+ */
+test(
+    'MM-T4110 Should select a skin tone, apply it to posted emojis and persist it',
+    {tag: '@emoji_picker'},
+    async ({pw}) => {
+        // # Initialize a test user
+        const {user} = await pw.initSetup();
+
+        // # Log in as a user in new browser context
+        const {channelsPage} = await pw.testBrowser.login(user);
+        const {emojiGifPickerPopup} = channelsPage;
+        const {postCreate} = channelsPage.centerView;
+
+        // # Navigate to default channel page
+        await channelsPage.goto();
+        await channelsPage.toBeVisible();
+
+        // # Open emoji picker from center textbox
+        await postCreate.openEmojiPicker();
+        await emojiGifPickerPopup.toBeVisible();
+
+        // * Verify the skin tone selector is collapsed with the default skin tone selected
+        await emojiGifPickerPopup.verifySelectedSkinTone('default');
+
+        // # Expand the skin tone selector
+        await emojiGifPickerPopup.openSkinToneSelector();
+
+        // * Verify all six skin tone choices are visible
+        for (const skinTone of allSkinTones) {
+            await expect(emojiGifPickerPopup.getSkinToneChoice(skinTone)).toBeVisible();
+        }
+
+        // # Select the dark skin tone
+        // * Verify the selector collapses with the dark skin tone applied (asserted by selectSkinTone)
+        await emojiGifPickerPopup.selectSkinTone('1F3FF');
+
+        // # Search for the thumbs up emoji and click it
+        await emojiGifPickerPopup.searchEmoji('thumbsup');
+        await emojiGifPickerPopup.clickEmoji('+1 dark skin tone');
+
+        // * Verify emoji picker popup disappears and the inserted emoji carries the dark skin tone
+        await emojiGifPickerPopup.notToBeVisible();
+        await expect(postCreate.input).toHaveValue('👍🏿 ');
+
+        // # Send the message
+        await postCreate.sendMessage();
+
+        // * Verify the posted emoji renders with the dark skin tone
+        const lastPost = await channelsPage.getLastPost();
+        await expect(lastPost.container.getByTestId('postEmoji.:+1_dark_skin_tone:')).toBeVisible();
+
+        // # Reopen the emoji picker
+        await postCreate.openEmojiPicker();
+        await emojiGifPickerPopup.toBeVisible();
+
+        // * Verify the dark skin tone persists on picker reopen
+        await emojiGifPickerPopup.verifySelectedSkinTone('1F3FF');
+
+        // # Reload the page and reopen the emoji picker
+        await channelsPage.goto();
+        await channelsPage.toBeVisible();
+        await postCreate.openEmojiPicker();
+        await emojiGifPickerPopup.toBeVisible();
+
+        // * Verify the dark skin tone persists across page reload (skin tone is saved as a user preference)
+        await emojiGifPickerPopup.verifySelectedSkinTone('1F3FF');
+
+        // # Expand the skin tone selector and restore the default skin tone
+        await emojiGifPickerPopup.openSkinToneSelector();
+
+        // * Verify the selector collapses with the default skin tone applied (asserted by selectSkinTone)
+        await emojiGifPickerPopup.selectSkinTone('default');
+    },
+);


### PR DESCRIPTION
#### Summary

Adds net-new Playwright coverage for the emoji picker **skin tone selector** (MM-T4110). This area had no coverage in the Playwright suite, so this is net-new coverage in the target framework rather than a Cypress migration.

**Page object** — extends `EmojiGifPicker` with skin tone selector support:
- Locators for the expand button (`Skin tone`), close button (`Close skin tones`), and the choices region (`Skin tone icons`).
- `openSkinToneSelector()` / `closeSkinToneSelector()`, `selectSkinTone(tone)`, `getSelectedSkinTone(tone)` / `getSkinToneChoice(tone)`, and `verifySelectedSkinTone(tone)`. Selectors are keyed off the component test IDs (`skin-pick-<tone>` for choices, `skin-picked-<tone>` for the collapsed/selected state — the latter only renders while collapsed, so it doubles as a collapsed-state assertion).

**Spec** — `emoji_picker_skin_tone.spec.ts` covers the full flow:
1. Default skin tone selected on open.
2. Expand the selector → all six tones visible.
3. Select a tone → the picker collapses with the tone applied.
4. The inserted emoji carries the tone (`👍🏿`).
5. The posted emoji renders with the tone (`postEmoji.:+1_dark_skin_tone:`).
6. The tone persists on picker reopen **and across a full page reload** (it is stored as the `emoji--emoji_skintone` user preference).
7. Restoring the default tone.

#### QA / Testing evidence

Run against a local server (`TEST=playwright`), chrome project:

- First run: **passed** (~14s).
- Flake check: **`--repeat-each=10` run twice → 20/20 passed, zero flakes.**
- `eslint`, `prettier --check`, and `npm run lint:test-docs` all pass on both files.

```
✓ [chrome] › emoji_picker_skin_tone.spec.ts › MM-T4110 Should select a skin tone, apply it to posted emojis and persist it @emoji_picker
13 passed (repeat-each=10)
```

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/18483

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to Playwright page-object helpers and end-to-end coverage, with no production behavior or shared application logic affected.  
**QA Recommendation:** Manual QA can be skipped; automated coverage and repeated Chrome runs provide sufficient validation.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->