### PR TITLE
MM-66940 Fix layout shift in ChannelView during loading

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.scss
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.scss
@@ -2,7 +2,7 @@
 
 .AdvancedTextEditor__skeleton {
     display: flex;
-    height: 122px;
+    height: 98px;
     align-items: center;
     justify-content: center;
     padding-left: 10px;

--- a/webapp/channels/src/components/channel_header/__snapshots__/channel_header.test.tsx.snap
+++ b/webapp/channels/src/components/channel_header/__snapshots__/channel_header.test.tsx.snap
@@ -84,7 +84,7 @@ exports[`components/ChannelHeader should match snapshot with last active display
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -165,7 +165,7 @@ exports[`components/ChannelHeader should match snapshot with no last active disp
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -259,7 +259,7 @@ exports[`components/ChannelHeader should render active channel files 1`] = `
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -353,7 +353,7 @@ exports[`components/ChannelHeader should render active flagged posts 1`] = `
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -447,7 +447,7 @@ exports[`components/ChannelHeader should render active mentions posts 1`] = `
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -541,7 +541,7 @@ exports[`components/ChannelHeader should render active pinned posts 1`] = `
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -635,7 +635,7 @@ exports[`components/ChannelHeader should render archived view 1`] = `
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -739,7 +739,7 @@ exports[`components/ChannelHeader should render correct menu when muted 1`] = `
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -833,7 +833,7 @@ exports[`components/ChannelHeader should render not active channel files 1`] = `
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -925,7 +925,7 @@ exports[`components/ChannelHeader should render properly when custom status is e
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -1020,7 +1020,7 @@ exports[`components/ChannelHeader should render properly when custom status is s
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -1114,7 +1114,7 @@ exports[`components/ChannelHeader should render properly when empty 1`] = `
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -1208,7 +1208,7 @@ exports[`components/ChannelHeader should render properly when populated 1`] = `
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -1302,7 +1302,7 @@ exports[`components/ChannelHeader should render properly when populated with cha
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -1396,7 +1396,7 @@ exports[`components/ChannelHeader should render shared view 1`] = `
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>
@@ -1506,7 +1506,7 @@ exports[`components/ChannelHeader should render the pinned icon with the pinned 
         id="channel-info-btn"
       >
         <i
-          class="Icon-esDcos cHAVtG icon-information-outline"
+          class="Icon-clPswv hCFmLO icon-information-outline"
         />
       </button>
     </div>

--- a/webapp/channels/src/components/channel_header/channel_header.tsx
+++ b/webapp/channels/src/components/channel_header/channel_header.tsx
@@ -9,7 +9,6 @@ import type {WrappedComponentProps} from 'react-intl';
 
 import {WithTooltip} from '@mattermost/shared/components/tooltip';
 
-import {getPopoutChannelTitle} from 'components/channel_popout/channel_popout';
 import CustomStatusEmoji from 'components/custom_status/custom_status_emoji';
 import CustomStatusText from 'components/custom_status/custom_status_text';
 import PopoutButton from 'components/popout_button';
@@ -25,7 +24,7 @@ import {
     NotificationLevels,
     RHSStates,
 } from 'utils/constants';
-import {canPopout, isChannelPopoutWindow, popoutChannel} from 'utils/popouts/popout_windows';
+import {canPopout, getPopoutChannelTitle, isChannelPopoutWindow, popoutChannel} from 'utils/popouts/popout_windows';
 import {isEmptyObject} from 'utils/utils';
 
 import ChannelHeaderText from './channel_header_text';

--- a/webapp/channels/src/components/channel_header_menu/menu_items/open_in_new_window.test.tsx
+++ b/webapp/channels/src/components/channel_header_menu/menu_items/open_in_new_window.test.tsx
@@ -13,11 +13,8 @@ import {TestHelper} from 'utils/test_helper';
 
 import MenuItemOpenInNewWindow from './open_in_new_window';
 
-jest.mock('components/channel_popout/channel_popout', () => ({
-    getPopoutChannelTitle: jest.fn(() => ({id: 'test.title', defaultMessage: 'Test Title'})),
-}));
-
 jest.mock('utils/popouts/popout_windows', () => ({
+    getPopoutChannelTitle: jest.fn(() => ({id: 'test.title', defaultMessage: 'Test Title'})),
     isChannelPopoutWindow: jest.fn(() => false),
     popoutChannel: jest.fn(),
     canPopout: jest.fn(() => true),

--- a/webapp/channels/src/components/channel_header_menu/menu_items/open_in_new_window.tsx
+++ b/webapp/channels/src/components/channel_header_menu/menu_items/open_in_new_window.tsx
@@ -11,13 +11,12 @@ import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
 import {getCurrentUserId, getUser} from 'mattermost-redux/selectors/entities/users';
 import {getUserIdFromChannelName} from 'mattermost-redux/utils/channel_utils';
 
-import {getPopoutChannelTitle} from 'components/channel_popout/channel_popout';
 import * as Menu from 'components/menu';
 import PopoutMenuItem, {type PopoutMenuItemProps} from 'components/popout_menu_item';
 
 import {getChannelRoutePathAndIdentifier} from 'utils/channel_utils';
 import {Constants} from 'utils/constants';
-import {popoutChannel} from 'utils/popouts/popout_windows';
+import {getPopoutChannelTitle, popoutChannel} from 'utils/popouts/popout_windows';
 
 import type {GlobalState} from 'types/store';
 

--- a/webapp/channels/src/components/channel_popout/channel_popout.test.tsx
+++ b/webapp/channels/src/components/channel_popout/channel_popout.test.tsx
@@ -12,9 +12,8 @@ import {selectTeam} from 'mattermost-redux/actions/teams';
 import {useTeamByName} from 'components/common/hooks/use_team';
 
 import {renderWithContext, screen, waitFor} from 'tests/react_testing_utils';
+import {getPopoutChannelTitle} from 'utils/popouts/popout_windows';
 import {TestHelper} from 'utils/test_helper';
-
-import {getPopoutChannelTitle} from './channel_popout';
 
 import ChannelPopout from './index';
 

--- a/webapp/channels/src/components/channel_popout/channel_popout.tsx
+++ b/webapp/channels/src/components/channel_popout/channel_popout.tsx
@@ -7,7 +7,6 @@ import {useDispatch, useSelector} from 'react-redux';
 import {useParams} from 'react-router-dom';
 
 import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
-import type {ChannelType} from '@mattermost/types/channels';
 
 import {fetchMyCategories} from 'mattermost-redux/actions/channel_categories';
 import {fetchChannelsAndMembers, getChannelStats} from 'mattermost-redux/actions/channels';
@@ -23,18 +22,11 @@ import LoadingScreen from 'components/loading_screen';
 import SidebarRight from 'components/sidebar_right';
 import UnreadsStatusHandler from 'components/unreads_status_handler';
 
-import Constants from 'utils/constants';
+import {getPopoutChannelTitle} from 'utils/popouts/popout_windows';
 import usePopoutFocus from 'utils/popouts/use_popout_focus';
 import usePopoutTitle from 'utils/popouts/use_popout_title';
 
 import './channel_popout.scss';
-
-export function getPopoutChannelTitle(channelType?: ChannelType) {
-    if (channelType === Constants.DM_CHANNEL || channelType === Constants.GM_CHANNEL) {
-        return {id: 'channel_popout.title.dm', defaultMessage: '{channelName} - {serverName}'};
-    }
-    return {id: 'channel_popout.title', defaultMessage: '{channelName} - {teamName} - {serverName}'};
-}
 
 export default function ChannelPopout() {
     const dispatch = useDispatch();

--- a/webapp/channels/src/components/channel_view/__snapshots__/channel_view.test.tsx.snap
+++ b/webapp/channels/src/components/channel_view/__snapshots__/channel_view.test.tsx.snap
@@ -7,14 +7,25 @@ exports[`components/channel_view Should match snapshot if channel is archived 1`
     id="app-content"
   >
     <div
-      data-testid="FileUploadOverlay"
-    />
-    <div
-      data-testid="ChannelHeader"
-    />
-    <div
-      data-testid="ChannelBanner"
-    />
+      class="file-overlay hidden center-file-overlay"
+      id="centerChannelFileDropOverlay"
+    >
+      <div
+        class="overlay__indent"
+      >
+        <div
+          class="overlay__circle vertical"
+        >
+          <img
+            alt=""
+            class="overlay__files"
+            loading="lazy"
+            src=""
+          />
+          Drop a file to upload it.
+        </div>
+      </div>
+    </div>
     <div
       data-channel-id="channelId"
       data-testid="deferred-post-view"
@@ -50,14 +61,25 @@ exports[`components/channel_view Should match snapshot if channel is deactivated
     id="app-content"
   >
     <div
-      data-testid="FileUploadOverlay"
-    />
-    <div
-      data-testid="ChannelHeader"
-    />
-    <div
-      data-testid="ChannelBanner"
-    />
+      class="file-overlay hidden center-file-overlay"
+      id="centerChannelFileDropOverlay"
+    >
+      <div
+        class="overlay__indent"
+      >
+        <div
+          class="overlay__circle vertical"
+        >
+          <img
+            alt=""
+            class="overlay__files"
+            loading="lazy"
+            src=""
+          />
+          Drop a file to upload it.
+        </div>
+      </div>
+    </div>
     <div
       data-channel-id="channelId"
       data-testid="deferred-post-view"
@@ -92,14 +114,25 @@ exports[`components/channel_view Should match snapshot with base props 1`] = `
     id="app-content"
   >
     <div
-      data-testid="FileUploadOverlay"
-    />
-    <div
-      data-testid="ChannelHeader"
-    />
-    <div
-      data-testid="ChannelBanner"
-    />
+      class="file-overlay hidden center-file-overlay"
+      id="centerChannelFileDropOverlay"
+    >
+      <div
+        class="overlay__indent"
+      >
+        <div
+          class="overlay__circle vertical"
+        >
+          <img
+            alt=""
+            class="overlay__files"
+            loading="lazy"
+            src=""
+          />
+          Drop a file to upload it.
+        </div>
+      </div>
+    </div>
     <div
       data-channel-id="channelId"
       data-testid="deferred-post-view"
@@ -108,11 +141,7 @@ exports[`components/channel_view Should match snapshot with base props 1`] = `
       class="post-create__container AdvancedTextEditor__ctr"
       data-testid="post-create"
       id="post-create"
-    >
-      <div
-        data-testid="AdvancedCreatePost"
-      />
-    </div>
+    />
   </div>
 </div>
 `;

--- a/webapp/channels/src/components/channel_view/channel_view.tsx
+++ b/webapp/channels/src/components/channel_view/channel_view.tsx
@@ -1,15 +1,18 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {lazy} from 'react';
+import React from 'react';
 import {FormattedMessage} from 'react-intl';
 import type {RouteComponentProps} from 'react-router-dom';
 
 import {Button} from '@mattermost/shared/components/button';
 
-import {makeAsyncComponent} from 'components/async_load';
+import AdvancedCreatePost from 'components/advanced_create_post';
+import ChannelBanner from 'components/channel_banner/channel_banner';
+import ChannelBookmarks from 'components/channel_bookmarks';
+import ChannelHeader from 'components/channel_header';
 import deferComponentRender from 'components/deferComponentRender';
-import {DropOverlayIdCenterChannel} from 'components/file_upload_overlay/file_upload_overlay';
+import {DropOverlayIdCenterChannel, FileUploadOverlay} from 'components/file_upload_overlay/file_upload_overlay';
 import PostView from 'components/post_view';
 
 import WebSocketClient from 'client/web_websocket_client';
@@ -18,12 +21,6 @@ import {ChannelComposerBanner} from './channel_composer_banner';
 import InputLoading from './input_loading';
 
 import type {PropsFromRedux} from './index';
-
-const ChannelHeader = makeAsyncComponent('ChannelHeader', lazy(() => import('components/channel_header')));
-const FileUploadOverlay = makeAsyncComponent('FileUploadOverlay', lazy(() => import('components/file_upload_overlay')));
-const ChannelBookmarks = makeAsyncComponent('ChannelBookmarks', lazy(() => import('components/channel_bookmarks')));
-const AdvancedCreatePost = makeAsyncComponent('AdvancedCreatePost', lazy(() => import('components/advanced_create_post')));
-const ChannelBanner = makeAsyncComponent('ChannelBanner', lazy(() => import('components/channel_banner/channel_banner')));
 
 export type Props = PropsFromRedux & RouteComponentProps<{
     postid?: string;

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -134,7 +134,6 @@
 
 #post-list {
     position: relative;
-    height: 100%;
     flex: 1 1 auto;
     overflow-y: hidden;
 

--- a/webapp/channels/src/utils/popouts/popout_windows.ts
+++ b/webapp/channels/src/utils/popouts/popout_windows.ts
@@ -3,10 +3,11 @@
 
 import type {PopoutViewProps} from '@mattermost/desktop-api';
 import {isDesktopApp} from '@mattermost/shared/utils/user_agent';
+import type {ChannelType} from '@mattermost/types/channels';
 
 import {Client4} from 'mattermost-redux/client';
 
-import {RHSStates} from 'utils/constants';
+import Constants, {RHSStates} from 'utils/constants';
 import DesktopApp from 'utils/desktop_api';
 import {getBasePath} from 'utils/url';
 
@@ -22,6 +23,13 @@ import {
 const pluginPopoutListeners: Map<string, (teamName: string, channelName: string | undefined, listeners: Partial<PopoutListeners>) => void> = new Map();
 export function registerRHSPluginPopoutListener(pluginId: string, onPopoutOpened: (teamName: string, channelName: string | undefined, listeners: Partial<PopoutListeners>) => void) {
     pluginPopoutListeners.set(pluginId, onPopoutOpened);
+}
+
+export function getPopoutChannelTitle(channelType?: ChannelType) {
+    if (channelType === Constants.DM_CHANNEL || channelType === Constants.GM_CHANNEL) {
+        return {id: 'channel_popout.title.dm', defaultMessage: '{channelName} - {serverName}'};
+    }
+    return {id: 'channel_popout.title', defaultMessage: '{channelName} - {teamName} - {serverName}'};
 }
 
 export const FOCUS_REPLY_POST = 'focus-reply-post';


### PR DESCRIPTION
#### Summary
When opening the web app, the height of the post list can sometimes change because the elements above and below them are still loading. The post textbox does have a placeholder for it, but the height of it is incorrect (it had its margin doubled) and it still disappears while the post textbox is actively loading.

Instead of that, I decided to stop code splitting those off from the `ChannelView` because they're almost always used when the `ChannelView` is mounted, so I don't think we need to split them off. The post textbox at least is already loaded at that point because it's exported on the window for plugins.

#### Ticket Link
MM-66940

#### Screenshots
<details>
<summary>Video comparison of initial load</summary>
Before:

https://github.com/user-attachments/assets/76167308-e690-43d7-98a3-1f9bdb1316e5

After:

https://github.com/user-attachments/assets/d336d688-bbae-4b47-b7cb-a0d5a8f7a09d
</details>

#### Release Note
```release-note
Changed web app to load channel header and post textbox earlier
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes are confined to Channel UI rendering/loading and popout title helper wiring within the channels webapp; no auth/session/data logic is touched. The only shared utility change (`getPopoutChannelTitle`) is already covered by targeted unit tests and used consistently by header/popout components.
**QA Recommendation:** Manual QA can be skipped; optionally run a quick channel header/post loading + popout open-in-new-window smoke test.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->