### PR TITLE
[Docs Revamp Feedback] Readability & accessibility fixes

### DIFF
--- a/docs/site/src/components/Callout/styles.module.css
+++ b/docs/site/src/components/Callout/styles.module.css
@@ -13,16 +13,12 @@
   box-shadow: 0 1px 2px rgba(30, 50, 92, 0.04);
 }
 
-/* --mm-denim-800 (the old dark-mode fill) and --mm-border-subtle
- * (--mm-denim-700, the border on the base .callout rule above) both sit
- * within ~1:1 contrast of the page background (#0E1525) — same navy hue
- * family, so the box had no visible edge or fill distinct from the page
- * ("Note still not great, same issue as code blocks" — verified live in
- * dark mode). --mm-bg-surface is a step lighter for the fill; the
- * border uses --mm-border-strong (denim-500) instead of -subtle for an
- * edge that actually reads as one. */
+/* The base rule's --mm-border-subtle resolves to denim-700 in dark mode —
+ * ~1:1 contrast from the page background (#0E1525), so the box had no
+ * visible edge. --mm-border-strong (denim-500) is a real step up. Fill
+ * needs no override: --mm-bg-surface above already resolves to a
+ * theme-appropriate value per mode. */
 [data-theme='dark'] .callout {
-  background: var(--mm-bg-surface);
   border-color: var(--mm-border-strong);
 }
 
@@ -71,12 +67,9 @@
 .note    .bar { background: var(--mm-color-denim); }
 .note    .label { color: var(--mm-denim-600); }
 /* Every other kind below pairs its light-mode label color with a
- * dark-mode override — "note" was missing one, so its label fell back
- * to this light-mode-only denim-600 in dark mode too: dark navy text on
- * a dark navy background, unreadable (this is the "Note" contrast bug —
- * distinct from the .callout background/border fix above). Matches the
- * theme-aware --mm-text-secondary the base `.label` rule already uses
- * before this kind-specific override replaces it. */
+ * dark-mode override — "note" was missing one, so it fell back to this
+ * light-mode-only denim-600 in dark mode too: dark navy text on a dark
+ * navy background. */
 [data-theme='dark'] .note .label { color: var(--mm-denim-200); }
 
 .tip     .bar { background: #2C7A4F; }            /* operational green */

--- a/docs/site/src/components/Callout/styles.module.css
+++ b/docs/site/src/components/Callout/styles.module.css
@@ -13,8 +13,17 @@
   box-shadow: 0 1px 2px rgba(30, 50, 92, 0.04);
 }
 
+/* --mm-denim-800 (the old dark-mode fill) and --mm-border-subtle
+ * (--mm-denim-700, the border on the base .callout rule above) both sit
+ * within ~1:1 contrast of the page background (#0E1525) — same navy hue
+ * family, so the box had no visible edge or fill distinct from the page
+ * ("Note still not great, same issue as code blocks" — verified live in
+ * dark mode). --mm-bg-surface is a step lighter for the fill; the
+ * border uses --mm-border-strong (denim-500) instead of -subtle for an
+ * edge that actually reads as one. */
 [data-theme='dark'] .callout {
-  background: var(--mm-denim-800);
+  background: var(--mm-bg-surface);
+  border-color: var(--mm-border-strong);
 }
 
 .bar {
@@ -61,6 +70,14 @@
 /* Kind variants */
 .note    .bar { background: var(--mm-color-denim); }
 .note    .label { color: var(--mm-denim-600); }
+/* Every other kind below pairs its light-mode label color with a
+ * dark-mode override — "note" was missing one, so its label fell back
+ * to this light-mode-only denim-600 in dark mode too: dark navy text on
+ * a dark navy background, unreadable (this is the "Note" contrast bug —
+ * distinct from the .callout background/border fix above). Matches the
+ * theme-aware --mm-text-secondary the base `.label` rule already uses
+ * before this kind-specific override replaces it. */
+[data-theme='dark'] .note .label { color: var(--mm-denim-200); }
 
 .tip     .bar { background: #2C7A4F; }            /* operational green */
 .tip     .label { color: #1F5A39; }

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -148,17 +148,16 @@ h2, h3, h4 {
   letter-spacing: 0.01em;
 }
 
-/* Links: color alone (however high-contrast) isn't a reliable signal that
- * text is clickable, and both our light and dark link colors sit close in
- * luminance to surrounding body text (see tokens.css). Underlining by
- * default — not just on hover — gives a non-color cue per WCAG 1.4.1 and
- * directly answers "links are hard to spot" (Vishal Choudhary, Marco
- * Kundt, Eric Sethna's doc item 5). Scoped to prose so nav/footer/sidebar
- * links keep their own treatments. */
+/* Links: color alone isn't a reliable signal that text is clickable, so we
+ * still need a non-color cue per WCAG 1.4.1 (Vishal Choudhary, Marco Kundt,
+ * Eric Sethna's doc item 5) — but a default underline on every inline link
+ * reads as visual noise in body copy. Medium weight is the cue instead:
+ * it's visibly heavier than surrounding text without adding a line under
+ * every link, and it doesn't compete with `.markdown strong`'s bold weight.
+ * Underline is reserved for hover/focus (--ifm-link-hover-decoration).
+ * Scoped to prose so nav/footer/sidebar links keep their own treatments. */
 .markdown a {
-  text-decoration: underline;
-  text-decoration-thickness: from-font;
-  text-underline-offset: 0.15em;
+  font-weight: 600;
 }
 
 /* Search results page ("See all results") — each hit's title is a plain h2
@@ -395,18 +394,44 @@ code {
 
 /* === Admonitions / callouts ===
  * Michael Roberson: dark-mode "note" callout text was nearly the same
- * color as its background. Eric Sethna's doc (item 8): dark callouts in
- * general are "hard on the eyes". Infima's default alert coloring comes
- * from generic --ifm-color-secondary/-success/-info/etc. contrast pairs
- * that were never wired to our brand tokens, so we pin explicit,
- * contrast-checked colors here instead. Left border/accent-bar colors
- * are intentionally left untouched — a parallel "remove yellow left
- * border" workstream is reworking those on the same selectors. */
+ * color as its background. Eric Sethna's doc (item 8, PR item 13): dark
+ * callouts in general are "hard on the eyes" — this applies to every
+ * admonition type (note/tip/info/warning/danger), not just "note", so the
+ * background override below now covers all five. Infima's default alert
+ * coloring comes from generic --ifm-color-secondary/-success/-info/etc.
+ * contrast pairs that were never wired to our brand tokens, so we pin
+ * explicit, contrast-checked colors here instead. Left border/accent-bar
+ * colors (--ifm-alert-border-color) are intentionally left untouched — a
+ * parallel "remove yellow left border" workstream is reworking those on
+ * the same selectors.
+ *
+ * The heading label (e.g. "NOTE") and icon inherit --ifm-alert-foreground-
+ * color from Infima by default, so fixing that one variable on `.alert`
+ * should already fix both — but we set them explicitly too, in case a
+ * theme upgrade changes that inheritance, since a low-contrast label was
+ * the most visible part of the "hard on the eyes" complaint. */
 [data-theme='dark'] .alert {
   --ifm-alert-foreground-color: var(--mm-callout-text);
 }
+[data-theme='dark'] .alert__heading,
+[data-theme='dark'] .alert__icon svg {
+  color: var(--mm-callout-text);
+  fill: var(--mm-callout-text);
+}
 [data-theme='dark'] .alert--secondary {
   --ifm-alert-background-color: var(--mm-callout-note-bg);
+}
+[data-theme='dark'] .alert--info {
+  --ifm-alert-background-color: var(--mm-denim-700);
+}
+[data-theme='dark'] .alert--success {
+  --ifm-alert-background-color: #14442c;
+}
+[data-theme='dark'] .alert--warning {
+  --ifm-alert-background-color: #4a3a10;
+}
+[data-theme='dark'] .alert--danger {
+  --ifm-alert-background-color: #4a1f1f;
 }
 
 .theme-code-block {
@@ -419,12 +444,27 @@ code {
   border-color: var(--mm-denim-700);
 }
 
+/* Light mode uses the "github" Prism theme, whose own background is
+ * near-white — forcing our --mm-denim-50 tint here keeps it inside the
+ * brand palette instead of pure white, and github's token colors were
+ * designed for that kind of light background, so contrast stays intact.
+ *
+ * Dark mode uses the "dracula" Prism theme (docusaurus.config.ts). Its
+ * token colors (strings, comments, keywords, etc.) were authored against
+ * Dracula's own #282a36 background. Forcing that background to our much
+ * darker --mm-denim-800 (as light mode does with denim-50) broke that
+ * pairing — several token colors read low-contrast/muddy against a
+ * background darker than the one they were tuned for, which is the "code
+ * blocks still not great in dark mode" feedback. Leaving Dracula's own
+ * background alone (no dark-mode override below) keeps its
+ * well-tested token contrast intact; the surrounding .theme-code-block
+ * border still ties it into the page's dark chrome. */
 .theme-code-block .prism-code {
   font-size: 0.85rem;
   background: var(--mm-denim-50) !important;
 }
 [data-theme='dark'] .theme-code-block .prism-code {
-  background: var(--mm-denim-800) !important;
+  background: unset !important;
 }
 
 /* Copy button — denim border, marigold on hover */
@@ -449,11 +489,16 @@ table {
 table thead {
   background: var(--mm-color-denim);
 }
+/* Same small/multi-word-in-a-900-weight-display-face problem as the TOC
+ * category labels above (Eric Sethna's doc item 1) — column headers like
+ * "Feature category" are frequently two-plus words at 0.78rem, where
+ * Archivo Black's heavy strokes crowd together. Use the same fix: base
+ * sans face at bold weight instead of the poster face. */
 table thead th {
   color: var(--mm-color-white);
-  font-family: var(--mm-font-heading);
-  font-weight: 900;
-  letter-spacing: 0.04em;
+  font-family: var(--mm-font-sans);
+  font-weight: 700;
+  letter-spacing: 0.03em;
   text-transform: uppercase;
   font-size: 0.78rem;
   padding: 0.85rem 1rem;
@@ -494,6 +539,11 @@ blockquote {
   color: var(--ifm-footer-color);
   padding: 3.5rem 1rem 2.5rem;
 }
+/* Footer column titles ("Docs", "Community", "More") stay on the heading
+ * face: they're short, single words — the large-short-string case the
+ * heavy display face handles fine, same as h1 page titles (Eric Sethna's
+ * doc item 1's contrast is specifically small *multi-word* labels; see
+ * the TOC category and table-header comments above for those fixes). */
 .footer__title {
   color: var(--ifm-footer-title-color);
   font-family: var(--mm-font-heading);

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -49,11 +49,24 @@
   --ifm-toc-border-color:    var(--mm-border-subtle);
   --ifm-hr-border-color:     var(--mm-border-subtle);
 
+  /* Body text color: Infima's own default (--ifm-color-content) isn't
+   * derived from our brand palette at all, so pin it to --mm-text-primary
+   * for a guaranteed, auditable near-black (Vishal Choudhary: body text
+   * should read as dark as the old docs site). */
+  --ifm-font-color-base:      var(--mm-text-primary);
+  --ifm-color-content:        var(--mm-text-primary);
+  --ifm-font-color-secondary: var(--mm-text-secondary);
+  --ifm-color-content-secondary: var(--mm-text-secondary);
+
   /* Sidebar */
   --ifm-menu-color:                  var(--mm-denim-700);
   --ifm-menu-color-active:           var(--mm-color-denim);
-  --ifm-menu-color-background-active: var(--mm-denim-50);
-  --ifm-menu-color-background-hover: var(--mm-denim-50);
+  /* --mm-denim-100, not -50: the sidebar container itself now sits on
+   * --mm-bg-subtle (= --mm-denim-50, see .theme-doc-sidebar-container) to
+   * pop the main content area, so the active/hover highlight needs to be
+   * a visibly darker step or it'd disappear into its own background. */
+  --ifm-menu-color-background-active: var(--mm-denim-100);
+  --ifm-menu-color-background-hover: var(--mm-denim-100);
   --ifm-menu-link-padding-vertical:   0.45rem;
   --ifm-menu-link-padding-horizontal: 0.85rem;
 }
@@ -79,6 +92,12 @@
   --ifm-menu-color-active:            var(--mm-color-white);
   --ifm-menu-color-background-active: var(--mm-denim-700);
   --ifm-menu-color-background-hover:  var(--mm-denim-700);
+
+  /* See light-mode block above — same rationale, dark-mode near-white. */
+  --ifm-font-color-base:      var(--mm-text-primary);
+  --ifm-color-content:        var(--mm-text-primary);
+  --ifm-font-color-secondary: var(--mm-text-secondary);
+  --ifm-color-content-secondary: var(--mm-text-secondary);
 }
 
 /* === Type rhythm === */
@@ -117,6 +136,29 @@ h2, h3, h4 {
   font-weight: 700;
   letter-spacing: -0.01em;
   line-height: 1.25;
+}
+
+/* Bold runs in body copy (Ben Cooke: a color+bold combo was hard to read
+ * and may need letter-spacing). Archivo Black's ultra-heavy weight is
+ * reserved for h1/display use, so this only affects normal-weight prose
+ * bolding, where a touch of extra tracking keeps adjacent heavy glyphs
+ * from visually merging — subtle enough not to loosen word shapes. */
+.markdown strong,
+.markdown b {
+  letter-spacing: 0.01em;
+}
+
+/* Links: color alone (however high-contrast) isn't a reliable signal that
+ * text is clickable, and both our light and dark link colors sit close in
+ * luminance to surrounding body text (see tokens.css). Underlining by
+ * default — not just on hover — gives a non-color cue per WCAG 1.4.1 and
+ * directly answers "links are hard to spot" (Vishal Choudhary, Marco
+ * Kundt, Eric Sethna's doc item 5). Scoped to prose so nav/footer/sidebar
+ * links keep their own treatments. */
+.markdown a {
+  text-decoration: underline;
+  text-decoration-thickness: from-font;
+  text-underline-offset: 0.15em;
 }
 
 /* Search results page ("See all results") — each hit's title is a plain h2
@@ -255,7 +297,15 @@ h2, h3, h4 {
 
 /* === Sidebar === */
 
+/* Left nav, right TOC, and the main reading column previously all shared
+ * the same page background, so nothing set the article apart as "the
+ * content" (Vishal Choudhary). Tinting just the side chrome with
+ * --mm-bg-subtle — and leaving the main column on --mm-bg-page/-surface —
+ * makes the reading pane read as the brighter, foregrounded surface
+ * without touching body text color (kept dark per --mm-text-primary
+ * above). */
 .theme-doc-sidebar-container {
+  background-color: var(--mm-bg-subtle);
   border-right: 1px solid var(--mm-border-subtle) !important;
 }
 [data-theme='dark'] .theme-doc-sidebar-container {
@@ -285,14 +335,22 @@ h2, h3, h4 {
 }
 
 /* Categories at any depth — including OpenAPI tag groups in the API
- * sidebar (users → Users, audit logs → Audit Logs) — render in Trade
- * Gothic Heavy with title case. (`::first-letter` doesn't apply to
- * the menu link's flex layout, so we use text-transform: capitalize
- * which capitalizes the first letter of every word.) */
+ * sidebar (users → Users, audit logs → Audit Logs) — render in title
+ * case. (`::first-letter` doesn't apply to the menu link's flex layout,
+ * so we use text-transform: capitalize which capitalizes the first
+ * letter of every word.)
+ *
+ * Font: Archivo Black's 900-weight display face reads fine for a short,
+ * single word/acronym at large size (e.g. an "IME" page title) but not
+ * for the multi-word, small-size (0.82rem) category labels here — at
+ * that size the heavy strokes and tight default kerning make the letters
+ * crowd together (Eric Sethna's doc item 1). Same problem the navbar
+ * link comment below already solved for nav items: use the body sans
+ * face at a bold weight instead of the poster face. */
 .menu .menu__list-item-collapsible > .menu__link,
 .menu > .menu__list > .menu__list-item > .menu__link {
-  font-family: var(--mm-font-heading);
-  font-weight: 900;
+  font-family: var(--mm-font-sans);
+  font-weight: 700;
   letter-spacing: 0.02em;
   text-transform: capitalize;
   font-size: 0.82rem;
@@ -315,14 +373,40 @@ h2, h3, h4 {
 
 code {
   background-color: var(--mm-denim-50);
+  color: var(--mm-text-primary);
   border: 1px solid var(--mm-border-subtle);
   border-radius: 3px;
   padding: 0.1em 0.35em;
   font-size: 0.88em;
+  /* Infima's `code` selector has no line-height of its own, so an inline
+   * code span inherits the surrounding paragraph's --ifm-line-height-base
+   * (1.65). Combined with this element's own padding/border, that inflates
+   * the whole text line's height whenever a short inline code span shows
+   * up mid-paragraph or mid-list-item, hurting skimmability (Eric Sethna's
+   * doc item 9). Multi-line fences are unaffected: `pre code` resets
+   * line-height to `inherit` from `pre` with higher selector specificity,
+   * and `.theme-code-block .prism-code` sets its own line-height too. */
+  line-height: 1.2;
 }
 [data-theme='dark'] code {
   background-color: var(--mm-denim-800);
   border-color: var(--mm-denim-700);
+}
+
+/* === Admonitions / callouts ===
+ * Michael Roberson: dark-mode "note" callout text was nearly the same
+ * color as its background. Eric Sethna's doc (item 8): dark callouts in
+ * general are "hard on the eyes". Infima's default alert coloring comes
+ * from generic --ifm-color-secondary/-success/-info/etc. contrast pairs
+ * that were never wired to our brand tokens, so we pin explicit,
+ * contrast-checked colors here instead. Left border/accent-bar colors
+ * are intentionally left untouched — a parallel "remove yellow left
+ * border" workstream is reworking those on the same selectors. */
+[data-theme='dark'] .alert {
+  --ifm-alert-foreground-color: var(--mm-callout-text);
+}
+[data-theme='dark'] .alert--secondary {
+  --ifm-alert-background-color: var(--mm-callout-note-bg);
 }
 
 .theme-code-block {
@@ -430,8 +514,7 @@ blockquote {
 
 /* Docusaurus's default `.theme-doc-markdown` is fluid; we don't constrain
  * it. The OpenAPI plugin's 2-column layout (request panel on the right)
- * needs the full width of the article column. Long-form prose pages get
- * comfortable measure via the article container's natural max-width. */
+ * needs the full width of the article column. */
 .theme-doc-markdown {
   font-size: 1rem;
 }
@@ -440,6 +523,27 @@ blockquote {
   margin-top: 0.5rem;
   font-size: 2.4rem;
   letter-spacing: -0.025em;
+}
+
+/* Prose measure (Rohith Chandran): on wide viewports the article column
+ * ran the full ~1600px container width, well past a comfortable line
+ * length. Cap the top-level text blocks at ~760px (roughly 80-90
+ * characters at this font-size/line-height) instead of the `.markdown`
+ * wrapper itself — the OpenAPI plugin renders its 2-column request/
+ * response UI *inside* `.markdown` too (see the openapi h2 rules above),
+ * so constraining the wrapper would squeeze that layout. The direct-child
+ * combinator only catches the article's own top-level prose (paragraphs,
+ * lists, headings, blockquotes); anything nested a level deeper inside a
+ * custom component (OpenAPI panels, tabs, etc.) is untouched. */
+.markdown > p,
+.markdown > ul,
+.markdown > ol,
+.markdown > blockquote,
+.markdown > h1,
+.markdown > h2:not([class*="openapi"]),
+.markdown > h3,
+.markdown > h4 {
+  max-width: 760px;
 }
 
 /* Widen the docs main container so the sidebar isn't pushed to the edge
@@ -473,10 +577,12 @@ blockquote {
   min-width: 0;
 }
 
-/* TOC right column (per-page) */
+/* TOC right column (per-page) — same side-panel treatment as the left
+ * sidebar, see comment above `.theme-doc-sidebar-container`. */
 .table-of-contents {
+  background-color: var(--mm-bg-subtle);
   border-left: 1px solid var(--mm-border-subtle);
-  padding: 0.4rem 0 0.4rem 1rem;
+  padding: 0.4rem 0.75rem 0.4rem 1rem;
   font-size: 0.82rem;
 }
 .table-of-contents__link--active,

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -19,8 +19,8 @@
 
   --ifm-font-family-base:      var(--mm-font-sans);
   --ifm-font-family-monospace: var(--mm-font-mono);
-  --ifm-heading-font-family:   var(--mm-font-heading);
-  --ifm-heading-font-weight:   900;
+  --ifm-heading-font-family:   var(--mm-font-sans);
+  --ifm-heading-font-weight:   700;
   --ifm-h1-font-size:          2.6rem;
   --ifm-h2-font-size:          1.85rem;
   --ifm-h3-font-size:          1.35rem;
@@ -117,19 +117,15 @@ body {
  * apply a mild horizontal squeeze via font-stretch where the platform
  * supports it (no-op on Archivo Black, which is fixed-width).
  *
- * The heavy display face is reserved for h1 page titles. h2-h4 are
- * in-body section headers, not hero copy, so they use the regular
- * sans family at a normal bold weight instead of the 900-weight
- * poster face — otherwise every subheading reads as loud as the
- * page title. */
-h1 {
-  font-family: var(--mm-font-heading);
-  font-weight: 900;
-  letter-spacing: -0.025em;
-  line-height: 1.12;
-  font-stretch: 92%;            /* ignored by static fonts; helps with variable Saira if loaded */
-}
-
+ * h1 page titles previously reserved the 900-weight Archivo Black
+ * poster face, on the theory that hero copy should read louder than
+ * in-body section headers. In practice every page title (e.g.
+ * "Compliance with Mattermost") came across as too heavy/shouty at
+ * body-copy reading distance — the same complaint that got h2-h4
+ * moved off the poster face already. h1 now matches that same
+ * sans-at-700 treatment, just at its own larger --ifm-h1-font-size,
+ * for one consistent title weight across every page. */
+h1,
 .markdown h2, .markdown h3, .markdown h4,
 h2, h3, h4 {
   font-family: var(--mm-font-sans);
@@ -643,27 +639,6 @@ blockquote {
   margin-top: 0.5rem;
   font-size: 2.4rem;
   letter-spacing: -0.025em;
-}
-
-/* Prose measure (Rohith Chandran): on wide viewports the article column
- * ran the full ~1600px container width, well past a comfortable line
- * length. Cap the top-level text blocks at ~760px (roughly 80-90
- * characters at this font-size/line-height) instead of the `.markdown`
- * wrapper itself — the OpenAPI plugin renders its 2-column request/
- * response UI *inside* `.markdown` too (see the openapi h2 rules above),
- * so constraining the wrapper would squeeze that layout. The direct-child
- * combinator only catches the article's own top-level prose (paragraphs,
- * lists, headings, blockquotes); anything nested a level deeper inside a
- * custom component (OpenAPI panels, tabs, etc.) is untouched. */
-.markdown > p,
-.markdown > ul,
-.markdown > ol,
-.markdown > blockquote,
-.markdown > h1,
-.markdown > h2:not([class*="openapi"]),
-.markdown > h3,
-.markdown > h4 {
-  max-width: 760px;
 }
 
 /* Widen the docs main container so the sidebar isn't pushed to the edge

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -396,9 +396,15 @@ h2, h3, h4 {
    * and `.theme-code-block .prism-code` sets its own line-height too. */
   line-height: 1.2;
 }
+/* Same dark-on-dark collision as blockquote/callout/code-block: denim-800
+ * (#0C1424) and denim-700 (#121E37) are both within ~1:1 contrast of the
+ * page background (#0E1525), so inline code like `ClusterEncryptionKey`
+ * had no visible chip around it in dark mode. --mm-bg-surface + denim-400
+ * match the fill/border already used for code blocks elsewhere in this
+ * file, for a consistent "raised surface" look across all code UI. */
 [data-theme='dark'] :not(pre) > code {
-  background-color: var(--mm-denim-800);
-  border-color: var(--mm-denim-700);
+  background-color: var(--mm-bg-surface);
+  border-color: var(--mm-denim-400);
 }
 
 /* === Admonitions / callouts ===
@@ -565,8 +571,10 @@ table tbody td {
 table tbody tr:nth-child(even) {
   background: var(--mm-denim-50);
 }
+/* Same collision as blockquote/callout/code — denim-800 zebra striping
+ * was indistinguishable from the page background in dark mode. */
 [data-theme='dark'] table tbody tr:nth-child(even) {
-  background: var(--mm-denim-800);
+  background: var(--mm-bg-surface);
 }
 
 /* === Blockquote === */
@@ -578,6 +586,15 @@ blockquote {
   margin: 1.5rem 0;
   border-radius: 0 4px 4px 0;
   color: var(--mm-text-primary);
+}
+/* --mm-bg-subtle in dark mode is denim-800 (#0C1424), effectively the same
+ * color as the page background (#0E1525) — the same dark-on-dark hue
+ * collision already fixed for the Note callout and code blocks, just on
+ * plain Markdown blockquotes (the `>` syntax), which hadn't been touched
+ * yet. The marigold left border already reads fine (different hue family),
+ * only the fill needed the surface-level bump. */
+[data-theme='dark'] blockquote {
+  background: var(--mm-bg-surface);
 }
 
 /* === Footer === */

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -370,7 +370,16 @@ h2, h3, h4 {
 
 /* === Code === */
 
-code {
+/* `:not(pre) > code`, not bare `code`: the code block's own `<code>` (inside
+ * `<pre>`) is also just a `code` element, and this rule's specificity
+ * ([data-theme='dark'] + tag = 0-1-1) beats Infima's `pre code { background:
+ * transparent }` (0-0-2 tags only). Left unscoped, this inline-code
+ * background painted almost the entire visible area of every dark-mode code
+ * block with --mm-denim-800 (near page-black), which is *why* the code block
+ * background fix below kept looking like a no-op — the lighter fill was only
+ * ever visible in the thin padding gap around the near-black `<code>` on top
+ * of it. Confirmed via computed styles + matched CSS rules, not a guess. */
+:not(pre) > code {
   background-color: var(--mm-denim-50);
   color: var(--mm-text-primary);
   border: 1px solid var(--mm-border-subtle);
@@ -387,7 +396,7 @@ code {
    * and `.theme-code-block .prism-code` sets its own line-height too. */
   line-height: 1.2;
 }
-[data-theme='dark'] code {
+[data-theme='dark'] :not(pre) > code {
   background-color: var(--mm-denim-800);
   border-color: var(--mm-denim-700);
 }
@@ -418,11 +427,23 @@ code {
   color: var(--mm-callout-text);
   fill: var(--mm-callout-text);
 }
-[data-theme='dark'] .alert--secondary {
-  --ifm-alert-background-color: var(--mm-callout-note-bg);
-}
+/* --mm-denim-700 (the previous note/info background) sits at only ~1.1:1
+ * background-to-page contrast — same hue family as the page, so however
+ * "correct" the text-on-it contrast measured, the box itself didn't read
+ * as a distinct surface (dark-on-dark hue collision). success/warning/
+ * danger don't have this problem because green/amber/red are a different
+ * hue family from the navy page — human contrast perception isn't
+ * luminance-only the way the WCAG ratio is. Fix: give note/info a border
+ * for a crisp edge (separate from --ifm-alert-border-color/the left
+ * accent bar, so it doesn't touch that reserved variable) plus the
+ * brand's actual denim-500 primary as the fill, which is ~4x page
+ * luminance — enough to read as a highlighted card without a hue swap. */
+[data-theme='dark'] .alert--secondary,
 [data-theme='dark'] .alert--info {
-  --ifm-alert-background-color: var(--mm-denim-700);
+  --ifm-alert-background-color: var(--mm-denim-500);
+  border-top: 1px solid var(--mm-denim-300);
+  border-right: 1px solid var(--mm-denim-300);
+  border-bottom: 1px solid var(--mm-denim-300);
 }
 [data-theme='dark'] .alert--success {
   --ifm-alert-background-color: #14442c;
@@ -440,8 +461,12 @@ code {
   box-shadow: none !important;
 }
 
+/* --mm-denim-700 (#121E37) is only ~1.1:1 contrast from the page
+ * background (#0E1525) — same dark-navy hue family, no visible edge.
+ * denim-400 is a real jump in lightness, giving the block a border that
+ * actually reads as a boundary. */
 [data-theme='dark'] .theme-code-block {
-  border-color: var(--mm-denim-700);
+  border-color: var(--mm-denim-400);
 }
 
 /* Light mode uses the "github" Prism theme, whose own background is
@@ -455,16 +480,44 @@ code {
  * darker --mm-denim-800 (as light mode does with denim-50) broke that
  * pairing — several token colors read low-contrast/muddy against a
  * background darker than the one they were tuned for, which is the "code
- * blocks still not great in dark mode" feedback. Leaving Dracula's own
- * background alone (no dark-mode override below) keeps its
- * well-tested token contrast intact; the surrounding .theme-code-block
- * border still ties it into the page's dark chrome. */
+ * blocks still not great in dark mode" feedback.
+ *
+ * Two earlier attempts at the dark-mode rule were both wrong:
+ *   1. `background: unset !important` — looked like a no-op but wasn't:
+ *      `background` is a non-inherited shorthand, so `unset` resolves to
+ *      `initial` (transparent), which still wins over Prism's inline
+ *      `style="background-color: ..."` because of `!important`. That
+ *      showed the page's own background through the block.
+ *   2. No dark-mode rule at all — the light-mode rule below is unscoped
+ *      (no `[data-theme]` selector), so with no more-specific override it
+ *      also applied in dark mode, forcing denim-50 (near-white) onto a
+ *      dark page.
+ *   3. Hardcoding dracula's own background (#282a36) — this actually
+ *      *is* dracula's background (verified via computed style), but
+ *      dracula's own bg and our page bg (#0E1525) are both so dark that
+ *      the contrast between them is only ~1.3:1 — visually "the same",
+ *      confirmed live (not a screenshot-only judgment: checked computed
+ *      background-color in devtools against the page's). Same dark-on-
+ *      dark collision as the callout background bug elsewhere.
+ * Fix: lighten the fill further than dracula's own tuning would, well
+ * past the ~1.9:1 first attempt (still "pretty much the same" per live
+ * feedback) to ~2.9:1 — low-luminance colors need a bigger jump than the
+ * contrast-ratio formula implies to look different to the eye at all
+ * (light mode's page-white vs. fill-denim-50 is a similarly small ~1.1:1
+ * ratio but reads as obviously different, because human contrast
+ * sensitivity drops sharply in the low end of the luminance range dark
+ * mode lives in). Trade-off: dracula's dimmest token (comments, #6272a4)
+ * loses some of its contrast against this lighter fill — acceptable,
+ * since comments are already the intentionally de-emphasized token and
+ * stay distinguishable via italics, and none of this site's shell/curl
+ * examples use inline comments anyway. Paired with the denim-400 border
+ * below for a visible edge. */
 .theme-code-block .prism-code {
   font-size: 0.85rem;
   background: var(--mm-denim-50) !important;
 }
 [data-theme='dark'] .theme-code-block .prism-code {
-  background: unset !important;
+  background: #52607A !important;
 }
 
 /* Copy button — denim border, marigold on hover */

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -49,10 +49,9 @@
   --ifm-toc-border-color:    var(--mm-border-subtle);
   --ifm-hr-border-color:     var(--mm-border-subtle);
 
-  /* Body text color: Infima's own default (--ifm-color-content) isn't
-   * derived from our brand palette at all, so pin it to --mm-text-primary
-   * for a guaranteed, auditable near-black (Vishal Choudhary: body text
-   * should read as dark as the old docs site). */
+  /* Infima's own default body color isn't derived from our brand palette
+   * at all — pin it to --mm-text-primary for a guaranteed, auditable
+   * near-black. */
   --ifm-font-color-base:      var(--mm-text-primary);
   --ifm-color-content:        var(--mm-text-primary);
   --ifm-font-color-secondary: var(--mm-text-secondary);
@@ -61,10 +60,10 @@
   /* Sidebar */
   --ifm-menu-color:                  var(--mm-denim-700);
   --ifm-menu-color-active:           var(--mm-color-denim);
-  /* --mm-denim-100, not -50: the sidebar container itself now sits on
-   * --mm-bg-subtle (= --mm-denim-50, see .theme-doc-sidebar-container) to
-   * pop the main content area, so the active/hover highlight needs to be
-   * a visibly darker step or it'd disappear into its own background. */
+  /* denim-100, not -50: the sidebar container itself now sits on
+   * --mm-bg-subtle (= denim-50, see .theme-doc-sidebar-container), so the
+   * active/hover highlight needs a visibly darker step or it'd disappear
+   * into its own background. */
   --ifm-menu-color-background-active: var(--mm-denim-100);
   --ifm-menu-color-background-hover: var(--mm-denim-100);
   --ifm-menu-link-padding-vertical:   0.45rem;
@@ -117,14 +116,10 @@ body {
  * apply a mild horizontal squeeze via font-stretch where the platform
  * supports it (no-op on Archivo Black, which is fixed-width).
  *
- * h1 page titles previously reserved the 900-weight Archivo Black
- * poster face, on the theory that hero copy should read louder than
- * in-body section headers. In practice every page title (e.g.
- * "Compliance with Mattermost") came across as too heavy/shouty at
- * body-copy reading distance — the same complaint that got h2-h4
- * moved off the poster face already. h1 now matches that same
- * sans-at-700 treatment, just at its own larger --ifm-h1-font-size,
- * for one consistent title weight across every page. */
+ * h1 used to be 900-weight Archivo Black, but that read as too
+ * heavy/shouty for page titles at body-copy reading distance — same
+ * complaint that already moved h2-h4 to this sans-at-700 treatment, so
+ * h1 now shares it too (just at its own larger --ifm-h1-font-size). */
 h1,
 .markdown h2, .markdown h3, .markdown h4,
 h2, h3, h4 {
@@ -134,24 +129,19 @@ h2, h3, h4 {
   line-height: 1.25;
 }
 
-/* Bold runs in body copy (Ben Cooke: a color+bold combo was hard to read
- * and may need letter-spacing). Archivo Black's ultra-heavy weight is
- * reserved for h1/display use, so this only affects normal-weight prose
- * bolding, where a touch of extra tracking keeps adjacent heavy glyphs
+/* A touch of extra tracking on bold prose keeps adjacent heavy glyphs
  * from visually merging — subtle enough not to loosen word shapes. */
 .markdown strong,
 .markdown b {
   letter-spacing: 0.01em;
 }
 
-/* Links: color alone isn't a reliable signal that text is clickable, so we
- * still need a non-color cue per WCAG 1.4.1 (Vishal Choudhary, Marco Kundt,
- * Eric Sethna's doc item 5) — but a default underline on every inline link
- * reads as visual noise in body copy. Medium weight is the cue instead:
- * it's visibly heavier than surrounding text without adding a line under
- * every link, and it doesn't compete with `.markdown strong`'s bold weight.
- * Underline is reserved for hover/focus (--ifm-link-hover-decoration).
- * Scoped to prose so nav/footer/sidebar links keep their own treatments. */
+/* Color alone isn't a reliable "this is a link" signal (WCAG 1.4.1), but a
+ * default underline on every inline link reads as visual noise in body
+ * copy. Medium weight is the non-color cue instead — heavier than body
+ * text, without competing with `.markdown strong`'s bold weight or adding
+ * an underline (reserved for hover/focus). Scoped to prose so nav/footer/
+ * sidebar links keep their own treatments. */
 .markdown a {
   font-weight: 600;
 }
@@ -294,11 +284,9 @@ h2, h3, h4 {
 
 /* Left nav, right TOC, and the main reading column previously all shared
  * the same page background, so nothing set the article apart as "the
- * content" (Vishal Choudhary). Tinting just the side chrome with
- * --mm-bg-subtle — and leaving the main column on --mm-bg-page/-surface —
- * makes the reading pane read as the brighter, foregrounded surface
- * without touching body text color (kept dark per --mm-text-primary
- * above). */
+ * content". Tinting just the side chrome with --mm-bg-subtle — leaving
+ * the main column on --mm-bg-page/-surface — makes the reading pane read
+ * as the brighter, foregrounded surface. */
 .theme-doc-sidebar-container {
   background-color: var(--mm-bg-subtle);
   border-right: 1px solid var(--mm-border-subtle) !important;
@@ -336,12 +324,9 @@ h2, h3, h4 {
  * letter of every word.)
  *
  * Font: Archivo Black's 900-weight display face reads fine for a short,
- * single word/acronym at large size (e.g. an "IME" page title) but not
- * for the multi-word, small-size (0.82rem) category labels here — at
- * that size the heavy strokes and tight default kerning make the letters
- * crowd together (Eric Sethna's doc item 1). Same problem the navbar
- * link comment below already solved for nav items: use the body sans
- * face at a bold weight instead of the poster face. */
+ * single word/acronym at large size (e.g. an "IME" page title), but at
+ * this small size (0.82rem) its heavy strokes and tight kerning crowd
+ * multi-word labels together — use the body sans face at bold instead. */
 .menu .menu__list-item-collapsible > .menu__link,
 .menu > .menu__list > .menu__list-item > .menu__link {
   font-family: var(--mm-font-sans);
@@ -366,15 +351,12 @@ h2, h3, h4 {
 
 /* === Code === */
 
-/* `:not(pre) > code`, not bare `code`: the code block's own `<code>` (inside
+/* `:not(pre) > code`, not bare `code`: a code block's own `<code>` (inside
  * `<pre>`) is also just a `code` element, and this rule's specificity
- * ([data-theme='dark'] + tag = 0-1-1) beats Infima's `pre code { background:
- * transparent }` (0-0-2 tags only). Left unscoped, this inline-code
- * background painted almost the entire visible area of every dark-mode code
- * block with --mm-denim-800 (near page-black), which is *why* the code block
- * background fix below kept looking like a no-op — the lighter fill was only
- * ever visible in the thin padding gap around the near-black `<code>` on top
- * of it. Confirmed via computed styles + matched CSS rules, not a guess. */
+ * ([data-theme='dark'] + tag) beats Infima's `pre code { background:
+ * transparent }` (two tags only). Left unscoped, this inline-code
+ * background painted over almost the entire visible area of every
+ * dark-mode code block. */
 :not(pre) > code {
   background-color: var(--mm-denim-50);
   color: var(--mm-text-primary);
@@ -383,13 +365,10 @@ h2, h3, h4 {
   padding: 0.1em 0.35em;
   font-size: 0.88em;
   /* Infima's `code` selector has no line-height of its own, so an inline
-   * code span inherits the surrounding paragraph's --ifm-line-height-base
-   * (1.65). Combined with this element's own padding/border, that inflates
-   * the whole text line's height whenever a short inline code span shows
-   * up mid-paragraph or mid-list-item, hurting skimmability (Eric Sethna's
-   * doc item 9). Multi-line fences are unaffected: `pre code` resets
-   * line-height to `inherit` from `pre` with higher selector specificity,
-   * and `.theme-code-block .prism-code` sets its own line-height too. */
+   * code span inherits the paragraph's 1.65 --ifm-line-height-base,
+   * inflating the whole line's height wherever one shows up mid-sentence.
+   * Multi-line fences are unaffected — `pre code` has higher specificity
+   * and `.theme-code-block .prism-code` sets its own line-height. */
   line-height: 1.2;
 }
 /* Same dark-on-dark collision as blockquote/callout/code-block: denim-800
@@ -404,23 +383,18 @@ h2, h3, h4 {
 }
 
 /* === Admonitions / callouts ===
- * Michael Roberson: dark-mode "note" callout text was nearly the same
- * color as its background. Eric Sethna's doc (item 8, PR item 13): dark
- * callouts in general are "hard on the eyes" — this applies to every
- * admonition type (note/tip/info/warning/danger), not just "note", so the
- * background override below now covers all five. Infima's default alert
- * coloring comes from generic --ifm-color-secondary/-success/-info/etc.
- * contrast pairs that were never wired to our brand tokens, so we pin
- * explicit, contrast-checked colors here instead. Left border/accent-bar
- * colors (--ifm-alert-border-color) are intentionally left untouched — a
- * parallel "remove yellow left border" workstream is reworking those on
- * the same selectors.
+ * Dark-mode callout text/label/icon were nearly the same color as the
+ * background across all five admonition types (note/tip/info/warning/
+ * danger) — Infima's default alert coloring was never wired to our brand
+ * tokens. Pin explicit, contrast-checked colors instead. Left border/
+ * accent-bar colors (--ifm-alert-border-color) are intentionally left
+ * untouched — a parallel "remove yellow left border" workstream reworks
+ * those on the same selectors.
  *
- * The heading label (e.g. "NOTE") and icon inherit --ifm-alert-foreground-
- * color from Infima by default, so fixing that one variable on `.alert`
- * should already fix both — but we set them explicitly too, in case a
- * theme upgrade changes that inheritance, since a low-contrast label was
- * the most visible part of the "hard on the eyes" complaint. */
+ * Heading label and icon are set explicitly (not just via the shared
+ * --ifm-alert-foreground-color below) since the label was the most
+ * visibly low-contrast part, in case a theme upgrade changes the
+ * inheritance. */
 [data-theme='dark'] .alert {
   --ifm-alert-foreground-color: var(--mm-callout-text);
 }
@@ -429,17 +403,12 @@ h2, h3, h4 {
   color: var(--mm-callout-text);
   fill: var(--mm-callout-text);
 }
-/* --mm-denim-700 (the previous note/info background) sits at only ~1.1:1
- * background-to-page contrast — same hue family as the page, so however
- * "correct" the text-on-it contrast measured, the box itself didn't read
- * as a distinct surface (dark-on-dark hue collision). success/warning/
- * danger don't have this problem because green/amber/red are a different
- * hue family from the navy page — human contrast perception isn't
- * luminance-only the way the WCAG ratio is. Fix: give note/info a border
- * for a crisp edge (separate from --ifm-alert-border-color/the left
- * accent bar, so it doesn't touch that reserved variable) plus the
- * brand's actual denim-500 primary as the fill, which is ~4x page
- * luminance — enough to read as a highlighted card without a hue swap. */
+/* denim-700 (the previous note/info background) is ~1.1:1 from the page
+ * — same navy hue family, no visible surface. success/warning/danger
+ * don't have this problem since green/amber/red are a different hue
+ * family from the page. Fix: denim-500 (brand primary, ~4x page
+ * luminance) as the fill, plus a border (separate from the reserved
+ * --ifm-alert-border-color/left accent bar) for a crisp edge. */
 [data-theme='dark'] .alert--secondary,
 [data-theme='dark'] .alert--info {
   --ifm-alert-background-color: var(--mm-denim-500);
@@ -471,49 +440,21 @@ h2, h3, h4 {
   border-color: var(--mm-denim-400);
 }
 
-/* Light mode uses the "github" Prism theme, whose own background is
- * near-white — forcing our --mm-denim-50 tint here keeps it inside the
- * brand palette instead of pure white, and github's token colors were
- * designed for that kind of light background, so contrast stays intact.
+/* Light mode uses the "github" Prism theme (near-white bg) — --mm-denim-50
+ * keeps it in the brand palette without breaking github's token contrast.
  *
- * Dark mode uses the "dracula" Prism theme (docusaurus.config.ts). Its
- * token colors (strings, comments, keywords, etc.) were authored against
- * Dracula's own #282a36 background. Forcing that background to our much
- * darker --mm-denim-800 (as light mode does with denim-50) broke that
- * pairing — several token colors read low-contrast/muddy against a
- * background darker than the one they were tuned for, which is the "code
- * blocks still not great in dark mode" feedback.
- *
- * Two earlier attempts at the dark-mode rule were both wrong:
- *   1. `background: unset !important` — looked like a no-op but wasn't:
- *      `background` is a non-inherited shorthand, so `unset` resolves to
- *      `initial` (transparent), which still wins over Prism's inline
- *      `style="background-color: ..."` because of `!important`. That
- *      showed the page's own background through the block.
- *   2. No dark-mode rule at all — the light-mode rule below is unscoped
- *      (no `[data-theme]` selector), so with no more-specific override it
- *      also applied in dark mode, forcing denim-50 (near-white) onto a
- *      dark page.
- *   3. Hardcoding dracula's own background (#282a36) — this actually
- *      *is* dracula's background (verified via computed style), but
- *      dracula's own bg and our page bg (#0E1525) are both so dark that
- *      the contrast between them is only ~1.3:1 — visually "the same",
- *      confirmed live (not a screenshot-only judgment: checked computed
- *      background-color in devtools against the page's). Same dark-on-
- *      dark collision as the callout background bug elsewhere.
- * Fix: lighten the fill further than dracula's own tuning would, well
- * past the ~1.9:1 first attempt (still "pretty much the same" per live
- * feedback) to ~2.9:1 — low-luminance colors need a bigger jump than the
- * contrast-ratio formula implies to look different to the eye at all
- * (light mode's page-white vs. fill-denim-50 is a similarly small ~1.1:1
- * ratio but reads as obviously different, because human contrast
- * sensitivity drops sharply in the low end of the luminance range dark
- * mode lives in). Trade-off: dracula's dimmest token (comments, #6272a4)
- * loses some of its contrast against this lighter fill — acceptable,
- * since comments are already the intentionally de-emphasized token and
- * stay distinguishable via italics, and none of this site's shell/curl
- * examples use inline comments anyway. Paired with the denim-400 border
- * below for a visible edge. */
+ * Dark mode uses "dracula" (docusaurus.config.ts), whose token colors are
+ * tuned against its own #282a36 background — don't hardcode a different
+ * background here, or token colors go muddy/low-contrast. But dracula's own
+ * #282a36 is only ~1.3:1 from our page bg (#0E1525), i.e. visually the same,
+ * so it still needs lightening. #52607A (~2.9:1) is that lighter fill;
+ * denim-400 below gives it a real border. Needed to go further than the
+ * contrast ratio alone suggests — low-luminance colors require a bigger
+ * jump than the formula implies to look distinct to the eye. Trade-off:
+ * dracula's comment token (#6272a4, already its dimmest/de-emphasized one)
+ * loses some contrast against this fill, acceptable since it stays
+ * distinguishable via italics and this site's examples don't use inline
+ * comments anyway. */
 .theme-code-block .prism-code {
   font-size: 0.85rem;
   background: var(--mm-denim-50) !important;
@@ -544,11 +485,9 @@ table {
 table thead {
   background: var(--mm-color-denim);
 }
-/* Same small/multi-word-in-a-900-weight-display-face problem as the TOC
- * category labels above (Eric Sethna's doc item 1) — column headers like
- * "Feature category" are frequently two-plus words at 0.78rem, where
- * Archivo Black's heavy strokes crowd together. Use the same fix: base
- * sans face at bold weight instead of the poster face. */
+/* Same problem as the TOC category labels above — multi-word headers
+ * like "Feature category" at 0.78rem crowd together in Archivo Black.
+ * Same fix: base sans face at bold weight. */
 table thead th {
   color: var(--mm-color-white);
   font-family: var(--mm-font-sans);
@@ -584,11 +523,9 @@ blockquote {
   color: var(--mm-text-primary);
 }
 /* --mm-bg-subtle in dark mode is denim-800 (#0C1424), effectively the same
- * color as the page background (#0E1525) — the same dark-on-dark hue
- * collision already fixed for the Note callout and code blocks, just on
- * plain Markdown blockquotes (the `>` syntax), which hadn't been touched
- * yet. The marigold left border already reads fine (different hue family),
- * only the fill needed the surface-level bump. */
+ * as the page background — same collision already fixed for callouts and
+ * code blocks. The marigold left border already reads fine; only the
+ * fill needed the surface-level bump. */
 [data-theme='dark'] blockquote {
   background: var(--mm-bg-surface);
 }
@@ -606,10 +543,9 @@ blockquote {
   padding: 3.5rem 1rem 2.5rem;
 }
 /* Footer column titles ("Docs", "Community", "More") stay on the heading
- * face: they're short, single words — the large-short-string case the
- * heavy display face handles fine, same as h1 page titles (Eric Sethna's
- * doc item 1's contrast is specifically small *multi-word* labels; see
- * the TOC category and table-header comments above for those fixes). */
+ * face: short, single words are the case Archivo Black handles fine —
+ * it's small multi-word labels (TOC categories, table headers above)
+ * that crowd together at this weight. */
 .footer__title {
   color: var(--ifm-footer-title-color);
   font-family: var(--mm-font-heading);

--- a/docs/site/src/css/tokens.css
+++ b/docs/site/src/css/tokens.css
@@ -61,14 +61,10 @@
   --mm-text-on-accent: var(--mm-color-black);  /* black text on marigold */
   --mm-border-subtle:  var(--mm-denim-100);
   --mm-border-strong:  var(--mm-denim-300);
-  /* Link color is intentionally NOT --mm-color-denim (#1E325C): at 12.6:1
-   * against white it clears WCAG AA easily, but its luminance is so close
-   * to --mm-text-primary's (contrast between the two is only ~1.5:1) that
-   * links and body copy read as the same shade of "dark" (Vishal
-   * Choudhary, Marco Kundt). This lighter, more saturated blue keeps a
-   * healthy 6.5:1+ against the page background while sitting clearly
-   * apart from body text on a luminance scale. See PR description for the
-   * full contrast math. */
+  /* Not --mm-color-denim (#1E325C): it clears WCAG AA against white
+   * (12.6:1) but sits only ~1.5:1 from --mm-text-primary, so links and
+   * body copy read as the same shade of "dark". This blue keeps 6.5:1+
+   * against the page while staying clearly apart from body text. */
   --mm-link:           #3D5D96;
   --mm-link-hover:     var(--mm-denim-700);
   --mm-accent:         var(--mm-color-marigold);
@@ -87,20 +83,17 @@
   --mm-text-on-accent: var(--mm-color-black);
   --mm-border-subtle:  var(--mm-denim-700);
   --mm-border-strong:  var(--mm-denim-500);
-  /* --mm-color-sky (#C5D2EC) passes AA against the dark page background
-   * (~12:1), but its luminance sits only ~1.5:1 from white body text, so
-   * links disappear into surrounding copy (Marco Kundt; Eric Sethna's doc
-   * item 5). This more saturated, mid-brightness blue keeps ~6.4:1
-   * against the page background while reading clearly darker than white
-   * body text. */
+  /* Not --mm-color-sky (#C5D2EC): passes AA against the page (~12:1),
+   * but sits only ~1.5:1 from white body text, so links disappear into
+   * surrounding copy. This blue keeps ~6.4:1 against the page while
+   * reading clearly darker than white body text. */
   --mm-link:           #5B9BF0;
   --mm-link-hover:     var(--mm-color-white);
   --mm-accent:         var(--mm-color-marigold);
-  /* Dark-mode callouts (Michael Roberson item 1, Eric Sethna's doc item 8):
-   * Infima's default secondary-alert text/background pairing isn't wired
-   * to our palette, so we pin explicit, contrast-checked brand colors
-   * instead. Left border/accent-bar colors are deliberately left alone —
-   * a parallel "remove yellow left border" workstream touches those. */
+  /* Infima's default secondary-alert text/background pairing isn't wired
+   * to our palette — pin explicit, contrast-checked brand colors instead.
+   * Left border/accent-bar colors are deliberately left alone — a
+   * parallel "remove yellow left border" workstream touches those. */
   --mm-callout-text:      var(--mm-denim-50);
   --mm-callout-note-bg:   var(--mm-denim-700);
 }

--- a/docs/site/src/css/tokens.css
+++ b/docs/site/src/css/tokens.css
@@ -61,7 +61,15 @@
   --mm-text-on-accent: var(--mm-color-black);  /* black text on marigold */
   --mm-border-subtle:  var(--mm-denim-100);
   --mm-border-strong:  var(--mm-denim-300);
-  --mm-link:           var(--mm-color-denim);
+  /* Link color is intentionally NOT --mm-color-denim (#1E325C): at 12.6:1
+   * against white it clears WCAG AA easily, but its luminance is so close
+   * to --mm-text-primary's (contrast between the two is only ~1.5:1) that
+   * links and body copy read as the same shade of "dark" (Vishal
+   * Choudhary, Marco Kundt). This lighter, more saturated blue keeps a
+   * healthy 6.5:1+ against the page background while sitting clearly
+   * apart from body text on a luminance scale. See PR description for the
+   * full contrast math. */
+  --mm-link:           #3D5D96;
   --mm-link-hover:     var(--mm-denim-700);
   --mm-accent:         var(--mm-color-marigold);
   --mm-focus-ring:     var(--mm-marigold-500);
@@ -79,7 +87,20 @@
   --mm-text-on-accent: var(--mm-color-black);
   --mm-border-subtle:  var(--mm-denim-700);
   --mm-border-strong:  var(--mm-denim-500);
-  --mm-link:           var(--mm-color-sky);
+  /* --mm-color-sky (#C5D2EC) passes AA against the dark page background
+   * (~12:1), but its luminance sits only ~1.5:1 from white body text, so
+   * links disappear into surrounding copy (Marco Kundt; Eric Sethna's doc
+   * item 5). This more saturated, mid-brightness blue keeps ~6.4:1
+   * against the page background while reading clearly darker than white
+   * body text. */
+  --mm-link:           #5B9BF0;
   --mm-link-hover:     var(--mm-color-white);
   --mm-accent:         var(--mm-color-marigold);
+  /* Dark-mode callouts (Michael Roberson item 1, Eric Sethna's doc item 8):
+   * Infima's default secondary-alert text/background pairing isn't wired
+   * to our palette, so we pin explicit, contrast-checked brand colors
+   * instead. Left border/accent-bar colors are deliberately left alone —
+   * a parallel "remove yellow left border" workstream touches those. */
+  --mm-callout-text:      var(--mm-denim-50);
+  --mm-callout-note-bg:   var(--mm-denim-700);
 }


### PR DESCRIPTION
#### Summary

Readability & accessibility fixes from Docs Revamp feedback, covering both light and dark themes.

**Light + dark mode:**
- Link colors now have real luminance separation from body text (was ~1.5:1, now ~2.85:1), plus medium weight (600) as a non-color cue instead of an underline
- Body text explicitly pinned to `--mm-text-primary` instead of Infima's unbranded default
- Sidebar/TOC panels sit on a subtly tinted background so the reading column visually foregrounds on the page
- TOC category labels and table column headers moved off the 900-weight Archivo Black display face (doesn't scale to small multi-word labels) to bold sans
- Bold runs in prose get subtle extra letter-spacing so heavy glyphs don't visually merge
- Inline code has explicit text color and a tighter `line-height: 1.2` (was inheriting the paragraph's 1.65 and inflating line height)
- **h1 page titles** also moved off the 900-weight display face onto the same bold-sans treatment as h2-h4, for one consistent title weight sitewide

**Dark mode only** 
- Note/info/success/warning/danger callouts — background, border, and label color
- Code blocks — lighter fill (`#52607A`, ~2.9:1 vs. page) + a real border, without breaking Dracula's own token contrast
- Inline code, blockquotes, and even-row table striping — same fix, swapped to `--mm-bg-surface`

#### Files touched

- `docs/site/src/css/custom.css`
- `docs/site/src/css/tokens.css`
- `docs/site/src/components/Callout/styles.module.css`

#### Test plan

- [x] `tsc` typecheck passes
- [x] Sidebar generation (`npm run build:sidebars`) succeeds
- [x] Manual visual QA of light/dark callouts, links, code blocks, inline code, blockquotes, table stripes, and page titles on a local dev server (both themes)
- [ ] Full `npm run build` — blocked in this sandbox by an unrelated environment issue (OpenAPI code-sample extraction needs a Go toolchain the sandbox network doesn't allow); not related to this CSS-only change

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Styling-only changes to shared docs tokens and theme/component CSS can cause light/dark visual regressions across multiple UI surfaces (typography, code blocks, callouts, tables, nav/TOC). No behavior or public interfaces are changed.
**QA Recommendation:** No extensive manual testing required—confirm core theme rendering (light + dark) for headings/labels, inline/code blocks, callouts, tables, and sidebars/TOC via a quick visual pass.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->