### PR TITLE
[Docs Revamp Feedback] Remove/restyle "vibe coded" yellow left-border signal

### DIFF
--- a/docs/site/src/components/CardGrid/styles.module.css
+++ b/docs/site/src/components/CardGrid/styles.module.css
@@ -12,54 +12,84 @@
   position: relative;
   display: flex;
   align-items: flex-start;
-  gap: 0.85rem;
-  padding: 1.1rem 1.25rem;
+  gap: 0.9rem;
+  padding: 1.4rem 1.6rem;
   background: var(--mm-bg-surface);
   border: 1px solid var(--mm-border-subtle);
-  border-radius: 4px;
+  border-radius: 8px;
   text-decoration: none;
   color: inherit;
-  transition: transform 0.12s ease, box-shadow 0.12s ease, border-color 0.12s ease;
+  box-shadow: 0 1px 2px rgba(30, 50, 92, 0.05);
+  transition: transform 0.15s ease, box-shadow 0.15s ease, border-color 0.15s ease,
+    background 0.15s ease;
 }
 .card:hover {
-  transform: translateY(-1px);
-  box-shadow: 0 12px 24px -16px rgba(30, 50, 92, 0.25);
+  transform: translateY(-2px);
+  box-shadow: 0 16px 32px -18px rgba(30, 50, 92, 0.3);
   border-color: var(--mm-border-strong);
+  background: var(--mm-bg-subtle);
   text-decoration: none;
   color: inherit;
+}
+.card:focus-visible {
+  outline: 2px solid var(--mm-focus-ring);
+  outline-offset: 2px;
 }
 
 [data-theme='dark'] .card {
-  background: var(--mm-denim-800);
-  border-color: var(--mm-denim-700);
+  background: rgba(255, 255, 255, 0.035);
+  border-color: rgba(255, 255, 255, 0.14);
+  box-shadow: none;
+}
+[data-theme='dark'] .card:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--mm-denim-300);
 }
 
 .icon {
   flex: 0 0 auto;
-  width: 1.6rem;
-  height: 1.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.1rem;
+  height: 2.1rem;
+  background: var(--mm-bg-subtle);
+  color: var(--mm-color-denim);
+  border-radius: 50%;
+  transition: background 0.15s ease, color 0.15s ease;
+}
+.card:hover .icon {
   background: var(--mm-color-denim);
-  border-radius: 3px;
-  margin-top: 0.15rem;
+  color: var(--mm-color-white);
+}
+
+[data-theme='dark'] .icon {
+  background: rgba(255, 255, 255, 0.06);
+  color: var(--mm-denim-200);
+}
+[data-theme='dark'] .card:hover .icon {
+  background: var(--mm-color-white);
+  color: var(--mm-color-denim);
 }
 
 .body {
   flex: 1 1 auto;
   min-width: 0;
+  padding-right: 1.5rem;
 }
 
 .title {
   font-family: var(--mm-font-heading);
   font-weight: 900;
-  font-size: 1rem;
+  font-size: 1.05rem;
   letter-spacing: 0.01em;
-  margin-bottom: 0.3rem;
+  margin-bottom: 0.35rem;
   color: var(--mm-text-primary);
 }
 
 .description {
   font-size: 0.88rem;
-  line-height: 1.45;
+  line-height: 1.5;
   margin: 0 0 0.4rem;
   color: var(--mm-text-secondary);
 }
@@ -82,13 +112,25 @@
 
 .arrow {
   position: absolute;
-  top: 1.1rem;
-  right: 1rem;
+  top: 1.4rem;
+  right: 1.4rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.6rem;
+  height: 1.6rem;
+  border-radius: 50%;
   color: var(--mm-text-secondary);
-  font-size: 1.1rem;
-  transition: transform 0.12s ease, color 0.12s ease;
+  font-size: 0.95rem;
+  transition: transform 0.15s ease, color 0.15s ease, background 0.15s ease;
 }
 .card:hover .arrow {
-  color: var(--mm-color-marigold);
-  transform: translateX(2px);
+  background: var(--mm-bg-page);
+  color: var(--mm-color-denim);
+  transform: translateX(3px);
+}
+
+[data-theme='dark'] .card:hover .arrow {
+  background: rgba(255, 255, 255, 0.08);
+  color: var(--mm-color-white);
 }

--- a/docs/site/src/components/CardGrid/styles.module.css
+++ b/docs/site/src/components/CardGrid/styles.module.css
@@ -13,10 +13,9 @@
   display: flex;
   align-items: flex-start;
   gap: 0.85rem;
-  padding: 1.1rem 1.25rem 1.1rem 1.1rem;
+  padding: 1.1rem 1.25rem;
   background: var(--mm-bg-surface);
   border: 1px solid var(--mm-border-subtle);
-  border-left: 3px solid var(--mm-color-marigold);
   border-radius: 4px;
   text-decoration: none;
   color: inherit;
@@ -25,7 +24,7 @@
 .card:hover {
   transform: translateY(-1px);
   box-shadow: 0 12px 24px -16px rgba(30, 50, 92, 0.25);
-  border-color: var(--mm-color-marigold);
+  border-color: var(--mm-border-strong);
   text-decoration: none;
   color: inherit;
 }
@@ -33,7 +32,6 @@
 [data-theme='dark'] .card {
   background: var(--mm-denim-800);
   border-color: var(--mm-denim-700);
-  border-left-color: var(--mm-color-marigold);
 }
 
 .icon {

--- a/docs/site/src/components/CardGrid/styles.module.css
+++ b/docs/site/src/components/CardGrid/styles.module.css
@@ -31,9 +31,16 @@
   text-decoration: none;
   color: inherit;
 }
+/* --mm-focus-ring (marigold) is ~1.7:1 against the white card surface,
+ * well under the 3:1 WCAG 1.4.11 minimum for non-text UI indicators.
+ * Use denim instead, which passes on both the light and dark surface. */
 .card:focus-visible {
-  outline: 2px solid var(--mm-focus-ring);
+  outline: 2px solid var(--mm-color-denim);
   outline-offset: 2px;
+}
+
+[data-theme='dark'] .card:focus-visible {
+  outline-color: var(--mm-denim-300, #8499C5);
 }
 
 [data-theme='dark'] .card {

--- a/docs/site/src/components/DeploymentArchitectureBuilder/styles.module.css
+++ b/docs/site/src/components/DeploymentArchitectureBuilder/styles.module.css
@@ -359,7 +359,7 @@
   font-weight: 600;
   color: var(--mm-color-denim, #1E325C);
   background: var(--mm-denim-50, rgba(30, 50, 92, 0.05));
-  border-left: 2px solid var(--mm-color-marigold, #FFBC1F);
+  border-left: 2px solid var(--mm-color-denim, #1E325C);
   padding: 0.15rem 0.45rem;
   border-radius: 2px;
   white-space: nowrap;
@@ -368,6 +368,7 @@
 [data-theme='dark'] .miniFlow {
   color: var(--mm-color-white);
   background: rgba(255, 255, 255, 0.05);
+  border-left-color: var(--mm-denim-300, #8499C5);
 }
 
 .miniArrow {
@@ -388,12 +389,13 @@
   background: var(--mm-denim-50, rgba(30, 50, 92, 0.05));
   padding: 0.18rem 0.55rem;
   border-radius: 2px;
-  border-left: 2px solid var(--mm-color-marigold, #FFBC1F);
+  border-left: 2px solid var(--mm-color-denim, #1E325C);
 }
 
 [data-theme='dark'] .flow {
   background: rgba(255, 255, 255, 0.04);
   color: rgba(255, 255, 255, 0.78);
+  border-left-color: var(--mm-denim-300, #8499C5);
 }
 
 .flowArrow {

--- a/docs/site/src/components/EditionAvailability/styles.module.css
+++ b/docs/site/src/components/EditionAvailability/styles.module.css
@@ -26,6 +26,10 @@
   border-left-color: var(--mm-color-denim, #1E325C);
 }
 
+[data-theme='dark'] .edition {
+  border-left-color: var(--mm-denim-300, #8499C5);
+}
+
 .key {
   font-weight: 700;
   text-transform: uppercase;

--- a/docs/site/src/components/EditionAvailability/styles.module.css
+++ b/docs/site/src/components/EditionAvailability/styles.module.css
@@ -20,8 +20,10 @@
   background: rgba(255, 255, 255, 0.04);
 }
 
+/* Edition and Deployment badges share the same denim left-edge — no color
+ * differentiation between them; the label text already distinguishes them. */
 .edition {
-  border-left-color: var(--mm-color-marigold, #FFBC1F);
+  border-left-color: var(--mm-color-denim, #1E325C);
 }
 
 .key {

--- a/docs/site/src/components/IMEDiagram/styles.module.css
+++ b/docs/site/src/components/IMEDiagram/styles.module.css
@@ -3,7 +3,8 @@
  * Tighter visual match to the brand infographic:
  * - Application zone visibly contained in a denim wash + border
  * - Intro panels are NOT clickable cards; they're text columns with a
- *   marigold left-edge accent (brand-aligned, signals "category label")
+ *   denim left-edge accent (brand-aligned, signals "category label" —
+ *   marigold is reserved for interactive/hover states, per token contract)
  * - Use Case cells use a soft denim-tinted background, not white-on-white
  * - All clickable cells share the same white-with-marigold-on-hover treatment
  * - Section titles get a thin marigold underline for visual rhythm
@@ -91,13 +92,19 @@
 }
 
 /* === Intro panels (Application / Integration / Deployment left column) ===
-   Not clickable. Marigold left-edge accent for visual rhythm. */
+   Not clickable. Denim left-edge accent for visual rhythm. */
 
 .appIntro,
 .intIntro,
 .depIntro {
   padding: 0.25rem 0.6rem 0.25rem 0.7rem;
-  border-left: 3px solid var(--mm-color-marigold, #FFBC1F);
+  border-left: 3px solid var(--mm-color-denim, #1E325C);
+}
+
+[data-theme='dark'] .appIntro,
+[data-theme='dark'] .intIntro,
+[data-theme='dark'] .depIntro {
+  border-left-color: var(--mm-denim-300, #8499C5);
 }
 
 .appIntro h3,
@@ -122,12 +129,18 @@
   flex: 0 0 auto;
   width: 1.2rem;
   height: 1.2rem;
-  color: var(--mm-color-marigold, #FFBC1F);
+  color: var(--mm-color-denim, #1E325C);
 }
 
 .introIcon svg {
   width: 100%;
   height: 100%;
+}
+
+[data-theme='dark'] .appIntro .introIcon,
+[data-theme='dark'] .intIntro .introIcon,
+[data-theme='dark'] .depIntro .introIcon {
+  color: var(--mm-denim-300, #8499C5);
 }
 
 [data-theme='dark'] .appIntro h3,

--- a/docs/site/src/components/IMEDiagram/styles.module.css
+++ b/docs/site/src/components/IMEDiagram/styles.module.css
@@ -4,7 +4,8 @@
  * - Application zone visibly contained in a denim wash + border
  * - Intro panels are NOT clickable cards; they're text columns with a
  *   denim left-edge accent (brand-aligned, signals "category label" —
- *   marigold is reserved for interactive/hover states, per token contract)
+ *   marigold is a sparse CTA/interactive accent per the token contract,
+ *   not decoration for static, non-interactive panels)
  * - Use Case cells use a soft denim-tinted background, not white-on-white
  * - All clickable cells share the same white-with-marigold-on-hover treatment
  * - Section titles get a thin marigold underline for visual rhythm

--- a/docs/site/src/components/PlanAvailability/styles.module.css
+++ b/docs/site/src/components/PlanAvailability/styles.module.css
@@ -21,6 +21,7 @@
 
 [data-theme='dark'] .plan {
   background: rgba(255, 255, 255, 0.04);
+  border-left-color: var(--mm-denim-300, #8499C5);
   color: var(--mm-text-primary);
 }
 

--- a/docs/site/src/components/PlanAvailability/styles.module.css
+++ b/docs/site/src/components/PlanAvailability/styles.module.css
@@ -10,16 +10,17 @@
   font-size: 0.95rem;
 }
 
-/* Plan-availability — flat denim-tinted strip, marigold flag on the left. */
+/* Plan-availability — flat denim-tinted strip, denim flag on the left
+ * (matches the Edition/Deployment/Attestation badge family). */
 .plan {
   padding: 0.55rem 0.85rem;
   background: var(--mm-denim-50, rgba(30, 50, 92, 0.05));
-  border-left: 3px solid var(--mm-color-marigold);
+  border-left: 3px solid var(--mm-color-denim, #1E325C);
   color: var(--mm-text-primary);
 }
 
 [data-theme='dark'] .plan {
-  background: rgba(255, 188, 31, 0.07);
+  background: rgba(255, 255, 255, 0.04);
   color: var(--mm-text-primary);
 }
 

--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -512,10 +512,13 @@ table tbody tr:nth-child(even) {
   background: var(--mm-bg-surface);
 }
 
-/* === Blockquote === */
+/* === Blockquote ===
+ * Neutral denim border + subtle tint — marigold is reserved for CTAs and
+ * interactive accents (see tokens.css), not an unconditional bar on every
+ * quoted paragraph. */
 
 blockquote {
-  border-left: 4px solid var(--mm-color-marigold);
+  border-left: 3px solid var(--mm-border-strong);
   background: var(--mm-bg-subtle);
   padding: 1rem 1.25rem;
   margin: 1.5rem 0;


### PR DESCRIPTION
#### Summary

**Changed (removed or restyled):**

| File | What changed | Why |
|---|---|---|
| `docs/site/src/components/CardGrid/styles.module.css` | Removed the always-on `border-left: 3px solid marigold` on `.card` (this is the exact "For Administrators"/"For Developers" grid from the screenshot). Hover state now uses `border-color: var(--mm-border-strong)` instead of marigold. Removed the dark-theme override that forced the marigold left border too. | This was the primary offender — a static + hover-reinforced yellow left border on a generic card grid, the textbook "vibe coded" signal. |
| `docs/site/src/components/PlanAvailability/styles.module.css` | `.plan` badge left border: marigold → denim. Updated the dark-theme background tint to match (was a marigold-tinted wash, now a neutral white-tinted wash). | Brings it in line with the sibling `EditionAvailability`/`DeploymentAvailability`/`AttestationStatus` badges, which already default to denim. |
| `docs/site/src/components/EditionAvailability/styles.module.css` | Dropped the marigold override on the `.edition` variant; it now shares the same denim left edge as `.deployment`. | There was no real semantic reason for Edition badges to be yellow and Deployment badges to be blue — the label text already differentiates them, so the color difference was arbitrary decoration. |
| `docs/site/src/components/IMEDiagram/styles.module.css` | Intro-panel (Application/Integration/Deployment) left border and icon color: marigold → denim, with a lighter denim tint (`--mm-denim-300`) added for dark mode (previously relied on marigold's brightness working in both themes). Updated the file's header comment accordingly. | These are static, non-interactive text panels — marigold as a permanent "category label" decoration is the same signal as the card grid, just skinnier. Interactive/hover marigold treatment elsewhere in this diagram (clickable cell borders, footer icons) was left alone — see below. |
| `docs/site/src/components/DeploymentArchitectureBuilder/styles.module.css` | `.miniFlow`/`.flow` protocol/port chips: left border marigold → denim, with a dark-theme override added. | These small inline chips all got the same marigold border regardless of type — pure decoration, not semantic. Left the `.boxLb`/`.boxApp`/`.boxDb`/etc. per-role legend untouched (see below), since that *is* semantically color-coded. |
| `docs/site/src/css/custom.css` | `blockquote` left border: `4px solid marigold` → `3px solid var(--mm-border-strong)` (neutral denim-tinted border). | This was flagged explicitly in the request — an unconditional yellow bar on every blockquote site-wide is a strong instance of the same "vibe coded" tell, since blockquotes appear across many pages regardless of content importance. |

**Marigold accents deliberately left unchanged** (with reasoning):

- **Navbar bottom border** (`.navbar { border-bottom: 2px solid marigold }`) and **active nav-link underline** (`.navbar__link--active::after`) — a clear, deliberate brand element (denim navbar + marigold underline), not a generic AI-scaffolding tell.
- **`.mm-cta` pill** and **copy-button hover state** — marigold is explicitly documented in `tokens.css` as "accent — CTAs only", and these *are* the CTAs it's meant for.
- **`.mm-section-rule`** and the **`.markdown h2::before` rule accent** — small top-rule brand flourishes above headings/section breaks, not left-border card decoration.
- **`AttestationStatus.inProcess`** (`#FFBC1F`) — one color in a genuine 4-color status legend (authorized=green, in-process=marigold, roadmap=denim, not-pursued=gray); this is semantic status-coding, not decorative.
- **`DeploymentArchitectureBuilder` `.boxLb`/`.boxApp`/`.boxDb`/`.boxRedis`/`.boxSearch`/`.boxStorage`/`.boxCalls`/`.boxPush`** — a deliberate multi-color legend distinguishing 8 different infrastructure component types in a technical diagram (load balancer=marigold, app=denim, postgres=green, redis=red, opensearch=purple, etc.). Removing this would remove real information, not decoration.
- **`.unknown` variant borders** (`#ffc107`) across `DeploymentAvailability`/`EditionAvailability`/`AttestationStatus`/`PlanAvailability` — a distinct warning-amber hex (not the brand marigold token) used to flag missing/unknown metadata; a conventional warning-color use, not the brand accent.
- **`UpgradeNotesFilter.error`** (`#e74c3c`) — red, not yellow/marigold at all; out of scope for this feedback item.
- **`Callout` component** (`note`/`tip`/`important`/`warning`/`security` variants) — uses a full-width colored bar + icon column (not a thin left border) as part of an already well-designed, intentional multi-kind semantic callout system; `important` uses marigold as one of five deliberate kind colors here. Left untouched as a good example of intentional color use, in contrast to what was removed elsewhere.

**Cross-workstream conflict note:** This PR touches `docs/site/src/css/custom.css` (specifically the `blockquote` rule, lines ~390-399 in the diff). A parallel "readability & accessibility" workstream is also editing this same file to adjust contrast for callouts/links/code and content-panel visual distinction. Reviewers/mergers should expect a possible merge conflict in `custom.css` and reconcile the blockquote border treatment with whatever contrast changes that workstream makes.

#### Release Note

```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes are limited to documentation CSS styling and do not affect application logic, APIs, or critical user flows. The main risk is visual/theme regressions (including focus-ring contrast) across the affected docs components.  
**QA Recommendation:** Automated checks are sufficient; optionally perform a brief visual review in light and dark themes for CardGrid, availability badges, IME diagram panels, and blockquotes.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->