### PR TITLE
Normalize whitespace to underscores in emoji picker search

### DIFF
--- a/webapp/channels/src/components/emoji_picker/emoji_picker.tsx
+++ b/webapp/channels/src/components/emoji_picker/emoji_picker.tsx
@@ -30,7 +30,7 @@ import {
 } from 'components/emoji_picker/constants';
 import {NavigationDirection} from 'components/emoji_picker/types';
 import type {CategoryOrEmojiRow, Categories, EmojiCursor, EmojiPosition, EmojiRow} from 'components/emoji_picker/types';
-import {createCategoryAndEmojiRows, getCursorProperties, getUpdatedCategoriesAndAllEmojis} from 'components/emoji_picker/utils';
+import {createCategoryAndEmojiRows, getCursorProperties, getUpdatedCategoriesAndAllEmojis, normalizeEmojiSearchTerm} from 'components/emoji_picker/utils';
 import NoResultsIndicator from 'components/no_results_indicator';
 import {NoResultsVariant} from 'components/no_results_indicator/types';
 
@@ -91,7 +91,9 @@ const EmojiPicker = ({
 
     const throttledSearchCustomEmoji = useRef(throttle((newFilter, customEmojisEnabled) => {
         if (customEmojisEnabled && newFilter && newFilter.trim().length) {
-            searchCustomEmojis(newFilter);
+            // Custom emoji names never contain spaces, so normalize the search term the
+            // same way the client-side filter does before querying the server
+            searchCustomEmojis(normalizeEmojiSearchTerm(newFilter));
         }
     }, CUSTOM_EMOJI_SEARCH_THROTTLE_TIME_MS));
 

--- a/webapp/channels/src/components/emoji_picker/utils/index.test.ts
+++ b/webapp/channels/src/components/emoji_picker/utils/index.test.ts
@@ -436,6 +436,24 @@ describe('createCategoryAndEmojiRows', () => {
         expect(createCategoryAndEmojiRows(allEmojis as any, [] as any, '', '')).toEqual([[], []]);
     });
 
+    test('Should treat a whitespace-only filter the same as an empty filter', () => {
+        const allEmojis = {
+            smile: smileEmoji,
+            thumbsup: thumbsupEmoji,
+        };
+
+        const categories = {
+            'people-body': {
+                id: 'people-body',
+                name: 'people-body',
+                emojiIds: ['smile', 'thumbsup'],
+            },
+        };
+
+        expect(createCategoryAndEmojiRows(allEmojis as any, categories as any, '   ', '')).
+            toEqual(createCategoryAndEmojiRows(allEmojis as any, categories as any, '', ''));
+    });
+
     test('Should return search results on filter is on', () => {
         const allEmojis = {
             smile: smileEmoji,

--- a/webapp/channels/src/components/emoji_picker/utils/index.test.ts
+++ b/webapp/channels/src/components/emoji_picker/utils/index.test.ts
@@ -23,6 +23,13 @@ const smileEmoji = {
     short_names: 'smile',
     name: 'smile',
 };
+const umbrellaWithRainDropsEmoji = {
+    unified: '2614',
+    short_names: [
+        'umbrella_with_rain_drops',
+    ],
+    name: 'UMBRELLA WITH RAIN DROPS',
+};
 const thumbsupEmoji = {
     name: 'THUMBS UP SIGN',
     unified: '1F44D',
@@ -172,6 +179,31 @@ describe('getFilteredEmojis', () => {
         ];
 
         expect(getFilteredEmojis(allEmojis as any, filter, recentEmojisString, userSkinTone)).toEqual(filteredResults);
+    });
+
+    test('Should match emojis when the filter uses spaces instead of underscores', () => {
+        const allEmojis = {
+            smile: smileEmoji,
+            thumbsup: thumbsupEmoji,
+            umbrella_with_rain_drops: umbrellaWithRainDropsEmoji,
+        };
+        const recentEmojisString: string[] = [];
+        const userSkinTone = '';
+
+        expect(getFilteredEmojis(allEmojis as any, 'umbrella with rain drops', recentEmojisString, userSkinTone)).toStrictEqual([umbrellaWithRainDropsEmoji]);
+        expect(getFilteredEmojis(allEmojis as any, 'with rain', recentEmojisString, userSkinTone)).toStrictEqual([umbrellaWithRainDropsEmoji]);
+        expect(getFilteredEmojis(allEmojis as any, 'umbrella  with  rain', recentEmojisString, userSkinTone)).toStrictEqual([umbrellaWithRainDropsEmoji]);
+    });
+
+    test('Should keep matching emojis when the filter uses underscores', () => {
+        const allEmojis = {
+            smile: smileEmoji,
+            umbrella_with_rain_drops: umbrellaWithRainDropsEmoji,
+        };
+        const recentEmojisString: string[] = [];
+        const userSkinTone = '';
+
+        expect(getFilteredEmojis(allEmojis as any, 'umbrella_with_rain_drops', recentEmojisString, userSkinTone)).toStrictEqual([umbrellaWithRainDropsEmoji]);
     });
 
     test('Should return correct order of result when filter is applied and contains recently used emojis', () => {

--- a/webapp/channels/src/components/emoji_picker/utils/index.ts
+++ b/webapp/channels/src/components/emoji_picker/utils/index.ts
@@ -264,8 +264,10 @@ export function createCategoryAndEmojiRows(
         return [[], []];
     }
 
-    // If search is active, return filtered emojis
-    if (filter.length) {
+    // If search is active, return filtered emojis. Use the normalized term so
+    // whitespace-only input behaves like an empty search.
+    const normalizedFilter = normalizeEmojiSearchTerm(filter);
+    if (normalizedFilter.length) {
         const searchCategoryRow: CategoryHeaderRow = {
             index: 0,
             type: CATEGORY_HEADER_ROW,
@@ -279,7 +281,7 @@ export function createCategoryAndEmojiRows(
         };
 
         const recentEmojiIds = categories?.[RECENT]?.emojiIds ?? [];
-        const filteredEmojis = getFilteredEmojis(allEmojis, filter, recentEmojiIds, userSkinTone);
+        const filteredEmojis = getFilteredEmojis(allEmojis, normalizedFilter, recentEmojiIds, userSkinTone);
         const [searchEmojisRows] = splitEmojisToRows(filteredEmojis, 0, SEARCH_RESULTS, 1);
 
         const searchEmojiRowsWithCategoryHeader: CategoryOrEmojiRow[] = [searchCategoryRow, ...searchEmojisRows];

--- a/webapp/channels/src/components/emoji_picker/utils/index.ts
+++ b/webapp/channels/src/components/emoji_picker/utils/index.ts
@@ -58,12 +58,21 @@ function isEmojiIdEqual(firstEmoji: Emoji, secondEmoji: Emoji): boolean {
     return firstEmojiId === secondEmojId;
 }
 
+// Emoji names never contain spaces, so treat whitespace in the search term as the
+// underscores used in emoji names (e.g. "umbrella with rain drops" matches
+// :umbrella_with_rain_drops:).
+export function normalizeEmojiSearchTerm(searchTerm: string): string {
+    return searchTerm.toLowerCase().trim().replace(/\s+/g, '_');
+}
+
 export function getFilteredEmojis(allEmojis: Record<string, Emoji>, filter: string, recentEmojisString: string[], userSkinTone: string): Emoji[] {
+    const normalizedFilter = normalizeEmojiSearchTerm(filter);
+
     const filteredEmojisWithRecent = Object.values(allEmojis).filter((emoji) => {
         const aliases = isSystemEmoji(emoji) ? emoji.short_names : [emoji.name];
 
         for (let i = 0; i < aliases.length; i++) {
-            if (aliases[i].toLowerCase().includes(filter.toLowerCase())) {
+            if (aliases[i].toLowerCase().includes(normalizedFilter)) {
                 return true;
             }
         }
@@ -79,7 +88,7 @@ export function getFilteredEmojis(allEmojis: Record<string, Emoji>, filter: stri
     });
 
     const sortedRecentEmojis = filteredRecentEmojis.sort((firstEmoji, secondEmoji) =>
-        compareEmojis(firstEmoji, secondEmoji, filter),
+        compareEmojis(firstEmoji, secondEmoji, normalizedFilter),
     );
 
     // Seprate out recent emojis from the rest of the emoji result
@@ -88,7 +97,7 @@ export function getFilteredEmojis(allEmojis: Record<string, Emoji>, filter: stri
     });
 
     const sortedFiltertedEmojisMinusRecent = filtertedEmojisMinusRecent.sort((firstEmoji, secondEmoji) =>
-        compareEmojis(firstEmoji, secondEmoji, filter),
+        compareEmojis(firstEmoji, secondEmoji, normalizedFilter),
     );
 
     const filteredEmojis = [...sortedRecentEmojis, ...sortedFiltertedEmojisMinusRecent];


### PR DESCRIPTION
#### Summary

Searching the emoji picker with spaces returned nothing, because emoji names use underscores ("umbrella with rain drops" vs `:umbrella_with_rain_drops:`). The search term is now normalized (lowercased, trimmed, whitespace runs converted to underscores) in one helper used for client-side filtering, result ranking, and the custom emoji server query, so system and custom emojis both match regardless of spaces or underscores.

Kept the change webapp-only: the custom emoji server search receives the already-normalized term from this client, so no SQL change is needed for the picker. If space-tolerance is wanted at the API level for other clients too, happy to do that as a follow-up.

QA steps: open the emoji picker and search "umbrella with rain drops" — `:umbrella_with_rain_drops:` appears. "with rain" and a double-spaced "umbrella  with  rain" also match. Underscore searches behave exactly as before.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/19792

#### Release Note

```release-note
Fixed emoji picker search returning no results when the search term contained spaces.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes are limited to emoji picker search normalization/filtering and custom-emoji query term preparation in the webapp, with no server/API or persistence involvement. Added unit tests cover space-vs-underscore matching and whitespace-only behavior, reducing the chance of regressions.

**QA Recommendation:** Manual QA can be skipped (or limited to a quick smoke check of emoji search with spaces/underscores in the UI), as automated tests provide sufficient coverage.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->