### PR TITLE
Render emoji picker with individual PNGs instead of the sprite sheet

### DIFF
--- a/webapp/channels/src/components/emoji_picker/__snapshots__/emoji_picker.test.tsx.snap
+++ b/webapp/channels/src/components/emoji_picker/__snapshots__/emoji_picker.test.tsx.snap
@@ -168,10 +168,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="grinning face emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f600"
+                class="emoji-category emoji-category--system"
                 data-testid="grinning"
                 id="emoji-1f600"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f600.png"
               />
             </button>
             <button
@@ -184,10 +185,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="smiling face with open mouth emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f603"
+                class="emoji-category emoji-category--system"
                 data-testid="smiley"
                 id="emoji-1f603"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f603.png"
               />
             </button>
             <button
@@ -200,10 +202,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="smiling face with open mouth and smiling eyes emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f604"
+                class="emoji-category emoji-category--system"
                 data-testid="smile"
                 id="emoji-1f604"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f604.png"
               />
             </button>
             <button
@@ -216,10 +219,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="grinning face with smiling eyes emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f601"
+                class="emoji-category emoji-category--system"
                 data-testid="grin"
                 id="emoji-1f601"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f601.png"
               />
             </button>
             <button
@@ -232,10 +236,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="smiling face with open mouth and tightly-closed eyes emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f606"
+                class="emoji-category emoji-category--system"
                 data-testid="laughing,satisfied"
                 id="emoji-1f606"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f606.png"
               />
             </button>
             <button
@@ -248,10 +253,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="smiling face with open mouth and cold sweat emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f605"
+                class="emoji-category emoji-category--system"
                 data-testid="sweat_smile"
                 id="emoji-1f605"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f605.png"
               />
             </button>
             <button
@@ -264,10 +270,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="rolling on the floor laughing emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f923"
+                class="emoji-category emoji-category--system"
                 data-testid="rolling_on_the_floor_laughing,rofl"
                 id="emoji-1f923"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f923.png"
               />
             </button>
             <button
@@ -280,10 +287,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="face with tears of joy emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f602"
+                class="emoji-category emoji-category--system"
                 data-testid="joy"
                 id="emoji-1f602"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f602.png"
               />
             </button>
             <button
@@ -296,10 +304,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="slightly smiling face emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f642"
+                class="emoji-category emoji-category--system"
                 data-testid="slightly_smiling_face"
                 id="emoji-1f642"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f642.png"
               />
             </button>
           </div>
@@ -318,10 +327,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="upside-down face emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f643"
+                class="emoji-category emoji-category--system"
                 data-testid="upside_down_face"
                 id="emoji-1f643"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f643.png"
               />
             </button>
             <button
@@ -334,10 +344,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="winking face emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f609"
+                class="emoji-category emoji-category--system"
                 data-testid="wink"
                 id="emoji-1f609"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f609.png"
               />
             </button>
             <button
@@ -350,10 +361,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="smiling face with smiling eyes emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f60a"
+                class="emoji-category emoji-category--system"
                 data-testid="blush"
                 id="emoji-1f60a"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f60a.png"
               />
             </button>
             <button
@@ -366,10 +378,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="smiling face with halo emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f607"
+                class="emoji-category emoji-category--system"
                 data-testid="innocent"
                 id="emoji-1f607"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f607.png"
               />
             </button>
             <button
@@ -382,10 +395,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="smiling face with smiling eyes and three hearts emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f970"
+                class="emoji-category emoji-category--system"
                 data-testid="smiling_face_with_3_hearts"
                 id="emoji-1f970"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f970.png"
               />
             </button>
             <button
@@ -398,10 +412,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="smiling face with heart-shaped eyes emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f60d"
+                class="emoji-category emoji-category--system"
                 data-testid="heart_eyes"
                 id="emoji-1f60d"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f60d.png"
               />
             </button>
             <button
@@ -414,10 +429,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="grinning face with star eyes emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f929"
+                class="emoji-category emoji-category--system"
                 data-testid="star-struck,grinning_face_with_star_eyes"
                 id="emoji-1f929"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f929.png"
               />
             </button>
             <button
@@ -430,10 +446,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="face throwing a kiss emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f618"
+                class="emoji-category emoji-category--system"
                 data-testid="kissing_heart"
                 id="emoji-1f618"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f618.png"
               />
             </button>
             <button
@@ -446,10 +463,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="kissing face emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f617"
+                class="emoji-category emoji-category--system"
                 data-testid="kissing"
                 id="emoji-1f617"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f617.png"
               />
             </button>
           </div>
@@ -468,10 +486,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="white smiling face emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-263a-fe0f"
+                class="emoji-category emoji-category--system"
                 data-testid="relaxed"
                 id="emoji-263a-fe0f"
-                src=""
+                loading="lazy"
+                src="/static/emoji/263a-fe0f.png"
               />
             </button>
             <button
@@ -484,10 +503,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="kissing face with closed eyes emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f61a"
+                class="emoji-category emoji-category--system"
                 data-testid="kissing_closed_eyes"
                 id="emoji-1f61a"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f61a.png"
               />
             </button>
             <button
@@ -500,10 +520,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="kissing face with smiling eyes emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f619"
+                class="emoji-category emoji-category--system"
                 data-testid="kissing_smiling_eyes"
                 id="emoji-1f619"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f619.png"
               />
             </button>
             <button
@@ -516,10 +537,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="smiling face with tear emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f972"
+                class="emoji-category emoji-category--system"
                 data-testid="smiling_face_with_tear"
                 id="emoji-1f972"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f972.png"
               />
             </button>
             <button
@@ -532,10 +554,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="face savouring delicious food emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f60b"
+                class="emoji-category emoji-category--system"
                 data-testid="yum"
                 id="emoji-1f60b"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f60b.png"
               />
             </button>
             <button
@@ -548,10 +571,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="face with stuck-out tongue emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f61b"
+                class="emoji-category emoji-category--system"
                 data-testid="stuck_out_tongue"
                 id="emoji-1f61b"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f61b.png"
               />
             </button>
             <button
@@ -564,10 +588,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="face with stuck-out tongue and winking eye emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f61c"
+                class="emoji-category emoji-category--system"
                 data-testid="stuck_out_tongue_winking_eye"
                 id="emoji-1f61c"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f61c.png"
               />
             </button>
             <button
@@ -580,10 +605,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="grinning face with one large and one small eye emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f92a"
+                class="emoji-category emoji-category--system"
                 data-testid="zany_face,grinning_face_with_one_large_and_one_small_eye"
                 id="emoji-1f92a"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f92a.png"
               />
             </button>
             <button
@@ -596,10 +622,11 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
             >
               <img
                 alt="face with stuck-out tongue and tightly-closed eyes emoji"
-                class="emojisprite emoji-category-smileys-emotion emoji-1f61d"
+                class="emoji-category emoji-category--system"
                 data-testid="stuck_out_tongue_closed_eyes"
                 id="emoji-1f61d"
-                src=""
+                loading="lazy"
+                src="/static/emoji/1f61d.png"
               />
             </button>
           </div>

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_item.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_item.tsx
@@ -13,8 +13,6 @@ import {getEmojiImageUrl, isSystemEmoji} from 'mattermost-redux/utils/emoji_util
 import {EMOJI_SCROLL_THROTTLE_DELAY} from 'components/emoji_picker/constants';
 import type {EmojiCursor} from 'components/emoji_picker/types';
 
-import imgTrans from 'images/img_trans.gif';
-
 interface Props {
     emoji: Emoji;
     rowIndex: number;
@@ -61,8 +59,9 @@ function EmojiPickerItem({emoji, rowIndex, isSelected, onClick, onMouseOver}: Pr
             <img
                 alt={`${emoji.name.toLocaleLowerCase()} emoji`}
                 data-testid={emoji.short_names}
-                src={imgTrans}
-                className={`emojisprite emoji-category-${emoji.category} emoji-${emojiUnified}`}
+                src={getEmojiImageUrl(emoji)}
+                loading='lazy'
+                className={'emoji-category emoji-category--system'}
                 id={`emoji-${emojiUnified}`}
             />
         );
@@ -72,7 +71,8 @@ function EmojiPickerItem({emoji, rowIndex, isSelected, onClick, onMouseOver}: Pr
                 alt={'custom emoji'}
                 data-testid={emoji.name}
                 src={getEmojiImageUrl(emoji)}
-                className={'emoji-category--custom'}
+                loading='lazy'
+                className={'emoji-category emoji-category--custom'}
             />
         );
     }

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_preview.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_preview.tsx
@@ -28,7 +28,7 @@ function EmojiPickerPreview({emoji}: Props) {
     const previewImage = (
         <img
             id='emojiPickerSpritePreview'
-            alt={'emoji preview image'}
+            alt=''
             className='emoji-picker__preview-image'
             src={getEmojiImageUrl(emoji)}
         />

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_preview.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_preview.tsx
@@ -8,8 +8,6 @@ import type {Emoji} from '@mattermost/types/emojis';
 
 import {getEmojiImageUrl, isSystemEmoji} from 'mattermost-redux/utils/emoji_utils';
 
-import imgTrans from 'images/img_trans.gif';
-
 interface Props {
     emoji?: Emoji;
 }
@@ -26,32 +24,15 @@ function EmojiPickerPreview({emoji}: Props) {
         );
     }
 
-    let aliases;
-    let previewImage;
-
-    if (isSystemEmoji(emoji)) {
-        aliases = emoji.short_names;
-        previewImage = (
-            <span className='sprite-preview'>
-                <img
-                    id='emojiPickerSpritePreview'
-                    alt={'emoji category image'}
-                    src={imgTrans}
-                    className={'emojisprite-preview emoji-category-' + emoji.category + ' emoji-' + emoji.unified.toLowerCase()}
-                />
-            </span>
-        );
-    } else {
-        aliases = [emoji.name];
-        previewImage = (
-            <img
-                id='emojiPickerSpritePreview'
-                alt={'emoji preview image'}
-                className='emoji-picker__preview-image'
-                src={getEmojiImageUrl(emoji)}
-            />
-        );
-    }
+    const aliases = isSystemEmoji(emoji) ? emoji.short_names : [emoji.name];
+    const previewImage = (
+        <img
+            id='emojiPickerSpritePreview'
+            alt={'emoji preview image'}
+            className='emoji-picker__preview-image'
+            src={getEmojiImageUrl(emoji)}
+        />
+    );
 
     return (
         <div className='emoji-picker__preview'>

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_skin.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_skin.tsx
@@ -11,7 +11,8 @@ import {CloseIcon} from '@mattermost/compass-icons/components';
 import {WithTooltip} from '@mattermost/shared/components/tooltip';
 import type {SystemEmoji} from '@mattermost/types/emojis';
 
-import imgTrans from 'images/img_trans.gif';
+import {getEmojiImageUrl} from 'mattermost-redux/utils/emoji_utils';
+
 import * as Emoji from 'utils/emoji';
 
 interface SkinTone {
@@ -137,7 +138,6 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
         const emoji = skinTones.find(({value}) => value === this.props.userSkinTone)!.emoji;
 
         const buttonClassName = classNames('style--none', {'skin-tones__close-icon': pickerExtended, 'skin-tones__icon skin-tones__expand-icon': !pickerExtended});
-        const spriteClassName = classNames('emojisprite', `emoji-category-${emoji?.category}`, `emoji-${emoji?.unified.toLowerCase()}`);
 
         const handleOnClick = () => {
             if (pickerExtended) {
@@ -167,8 +167,8 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
                     >
                         <img
                             alt={'emoji skin tone picker'}
-                            src={imgTrans}
-                            className={spriteClassName}
+                            src={getEmojiImageUrl(emoji)}
+                            className={'emoji-category emoji-category--system'}
                         />
                     </WithTooltip>
                 )}
@@ -180,7 +180,6 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
         return skinTones.map((skinTone) => {
             const skin = skinTone.value;
             const emoji = skinTone.emoji;
-            const spriteClassName = classNames('emojisprite', `emoji-category-${emoji.category}`, `emoji-${emoji.unified.toLowerCase()}`);
 
             return (
                 <button
@@ -192,8 +191,8 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
                 >
                     <img
                         alt={skinTone.label.defaultMessage}
-                        src={imgTrans}
-                        className={spriteClassName}
+                        src={getEmojiImageUrl(emoji)}
+                        className={'emoji-category emoji-category--system'}
                     />
                 </button>
             );

--- a/webapp/channels/src/sass/components/_emoticons.scss
+++ b/webapp/channels/src/sass/components/_emoticons.scss
@@ -309,6 +309,11 @@
             &:last-child {
                 margin-right: 0;
             }
+
+            img.emoji-category {
+                width: 20px;
+                height: 20px;
+            }
         }
 
         .skin-tones__expand-icon {
@@ -531,46 +536,18 @@ $emoji-footer-height:  $emoji-footer-border-width + $emoji-half-height + $emoji-
     &.selected,
     &:hover {
         background-color: rgba(var(--center-channel-color-rgb), 0.16);
-
-        img {
-            -moz-transform: scale(0.45);
-            transform: scale(0.45);
-
-            @supports (zoom: 0.45) {
-                -moz-transform: none;
-                transform: none;
-                zoom: 0.45;
-            }
-
-            &.emoji-category--custom {
-                -moz-transform: scale(1);
-                transform: scale(1);
-
-                @supports (zoom: 1) {
-                    -moz-transform: none;
-                    transform: none;
-                    zoom: 1;
-                }
-            }
-        }
     }
 
     &:active {
         background-color: rgba(var(--center-channel-color-rgb), 0.32);
     }
 
-    img {
+    img.emoji-category {
         position: relative;
-        transition: transform 0.2s ease-in-out;
-
-        &.emoji-category--custom {
-            top: auto;
-            left: auto;
-            width: auto;
-            max-width: 22px;
-            height: auto;
-            max-height: 22px;
-        }
+        width: auto;
+        max-width: 22px;
+        height: auto;
+        max-height: 22px;
     }
 }
 
@@ -630,15 +607,11 @@ $emoji-footer-height:  $emoji-footer-border-width + $emoji-half-height + $emoji-
     }
 
     .emoji-picker__preview-image-box {
+        display: inline-block;
+        width: $emoji-half-height;
+        height: $emoji-half-height;
         margin-right: 12px;
         vertical-align: middle;
-
-        &,
-        .sprite-preview {
-            display: inline-block;
-            width: $emoji-half-height;
-            height: $emoji-half-height;
-        }
     }
 
     .emoji-picker__preview-image {


### PR DESCRIPTION
#### Summary
The picker painted every system emoji via a shared ~17MB CSS sprite (apple-sheet.png), so the whole sheet had to download before any emoji displayed correctly, stalling the picker on slow connections. Reactions already rendered on posts don't have this problem because they use small per-emoji PNGs. Switched the picker, its preview panel, and the skin-tone picker to the same getEmojiImageUrl() per-emoji path.

QA steps:
1. Open any channel and click the "Add Reaction" icon on a post.
2. Confirm the emoji picker, category tabs, hover preview, and skin-tone picker all render emoji correctly.
3. Open browser DevTools → Network tab, filter on `/static/emoji/`, and confirm each visible emoji loads as its own small PNG request instead of one large `apple-sheet.png` request.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/37419

#### Release Note
```release-note
Improved emoji picker loading performance on slow network connections by rendering emoji as individually loaded images instead of a single large sprite sheet.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Changes span multiple emoji-picker components and shared styling, and switch rendering from a sprite-based image path to individually resolved PNG URLs via `getEmojiImageUrl()`. Likely UI-only blast radius, but mis-resolved URLs or sizing regressions could cause missing/broken emoji visuals in picker/preview/skin-tone flows.

**QA Recommendation:** Minimal targeted manual QA: verify system emoji rendering across picker categories, hover previews, and skin-tone selection, and confirm DevTools shows separate `/static/emoji/` PNG requests for visible emojis.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->