### PR TITLE
Fix GM channel header listing the current user and dropping commas between names

### DIFF
--- a/webapp/channels/src/components/channel_header/channel_header_title_group.test.tsx
+++ b/webapp/channels/src/components/channel_header/channel_header_title_group.test.tsx
@@ -29,6 +29,16 @@ describe('components/ChannelHeaderTitleGroup', () => {
         currentChannelId: 'channel_id',
     };
 
+    const channelsWithCurrentUser = {
+        channels: {
+            channel_id: {
+                id: 'channel_id',
+                display_name: 'not_guest_user, regular_user, third_user',
+            },
+        },
+        currentChannelId: 'channel_id',
+    };
+
     const users = {
         profiles: {
             user_id: {
@@ -104,5 +114,53 @@ describe('components/ChannelHeaderTitleGroup', () => {
             state,
         );
         expect(wrapper.queryAllByText('GUEST').length).toBe(0);
+    });
+
+    test('should separate the names with commas and omit the current user when the members have loaded', () => {
+        const state = {
+            entities: {
+                channels: channelsWithCurrentUser,
+                users,
+            },
+        };
+
+        const gmMembers = [
+            TestHelper.getUserMock({
+                id: 'user_id',
+                username: 'regular_user',
+                roles: 'system_user',
+            }),
+            TestHelper.getUserMock({
+                id: 'not_guest_id',
+                username: 'not_guest_user',
+                roles: 'system_user',
+            }),
+            TestHelper.getUserMock({
+                id: 'third_id',
+                username: 'third_user',
+                roles: 'system_user',
+            }),
+        ];
+
+        const wrapper = renderWithContext(
+            <ChannelHeaderTitleGroup gmMembers={gmMembers}/>,
+            state,
+        );
+        expect(wrapper.container).toHaveTextContent('not_guest_user, third_user');
+    });
+
+    test('should separate the names with commas and omit the current user before the members have loaded', () => {
+        const state = {
+            entities: {
+                channels: channelsWithCurrentUser,
+                users,
+            },
+        };
+
+        const wrapper = renderWithContext(
+            <ChannelHeaderTitleGroup/>,
+            state,
+        );
+        expect(wrapper.container).toHaveTextContent('not_guest_user, third_user');
     });
 });

--- a/webapp/channels/src/components/channel_header/channel_header_title_group.tsx
+++ b/webapp/channels/src/components/channel_header/channel_header_title_group.tsx
@@ -45,19 +45,17 @@ const ChannelHeaderTitleGroup = ({
         }
     }
 
-    const displayNames = channel.display_name.split(', ');
+    // The channel's display name is only rebuilt without the current user once every member of the
+    // group message has been loaded, so until then it still contains the current user's username
+    const displayNames = channel.display_name.split(', ').filter((displayName) => displayName !== currentUser?.username);
 
     return (
         <>
             {displayNames.map((displayName, index) => {
-                if (!membersMap[displayName]) {
-                    return displayName;
-                }
-
-                const user = membersMap[displayName].shift();
+                const user = membersMap[displayName]?.shift();
 
                 return (
-                    <React.Fragment key={user?.id}>
+                    <React.Fragment key={user?.id ?? `${displayName}-${index}`}>
                         {index > 0 && ', '}
                         {displayName}
                         {isGuest(user?.roles ?? '') && <GuestTag/>}


### PR DESCRIPTION
#### Summary

The group message channel header renders each name from the channel's display name and tags the ones that match a loaded member as a guest:

```tsx
const displayNames = channel.display_name.split(', ');
...
if (!membersMap[displayName]) {
    return displayName;          // <- skips the ", " separator below
}
```

Two problems come out of that early return:

1. **Missing commas.** The separator is only emitted in the other branch (`{index > 0 && ', '}`), so any name without a matching entry in `membersMap` is rendered run together with the name before it. When `gmMembers` hasn't loaded yet, *no* name matches and the whole header renders as one unseparated string.

2. **The current user is listed.** `membersMap` deliberately skips the current user, but `displayNames` comes from `channel.display_name`, which only gets rebuilt without the current user once every member has been loaded (`completeDirectGroupInfo` bails out and returns the raw channel when it can't resolve all the usernames). Until then the header lists the current user too — and via the early return, without a comma.

Both symptoms are transient, which matches the report that it shows up "briefly" and mostly after a refresh, more often on GMs where the member profiles take a moment to arrive.

Fix: drop the early return so every name goes through the same branch and always gets its separator, and filter the current user's username out of the names before rendering. The guest tagging is unchanged — a name with no loaded member simply gets no tag, as before.

Added two unit tests covering a GM whose display name still contains the current user, with and without `gmMembers` loaded. Both fail on `master` and pass with this change.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/34781

#### Screenshots

n/a — the rendered output is asserted in `channel_header_title_group.test.tsx`. Before, with members not yet loaded, the header for a GM stored as `not_guest_user, regular_user, third_user` (current user `regular_user`) rendered as `not_guest_userregular_userthird_user`; it now renders as `not_guest_user, third_user`.

#### Release Note

```release-note
Fixed the group message channel header briefly listing the current user and rendering member names without separating commas while the members were still loading.
```

---

<sub>Written with assistance from Claude Code; the diagnosis, fix and tests were reviewed and verified locally by me.</sub>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to group channel header rendering, with automated coverage for loaded and loading member states. No shared utilities, APIs, persistence, or critical flows are affected.
**QA Recommendation:** Manual QA can be skipped; automated tests provide sufficient coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->