### PR TITLE
Automated cherry pick of #37658

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
@@ -379,6 +379,51 @@ describe('components/avanced_text_editor/advanced_text_editor', () => {
         });
     });
 
+    it('MM-69928 should not create a synced/visible draft when editing a post and unmounting', async () => {
+        const editStorageKey = StoragePrefixes.EDIT_DRAFT + 'post_id_1';
+        const {unmount} = renderWithContext(
+            <AdvancedTextEditor
+                {...baseProps}
+                postId='post_id_1'
+                isInEditMode={true}
+                storageKey={editStorageKey}
+            />,
+            mergeObjects(initialState, {
+                entities: {
+                    general: {
+                        config: {
+                            AllowSyncedDrafts: 'true',
+                        },
+                    },
+                },
+                storage: {
+                    storage: {
+                        [editStorageKey]: {
+                            value: TestHelper.getPostDraftMock({
+                                message: 'original message',
+                                channelId,
+                            }),
+                        },
+                    },
+                },
+            }),
+        );
+
+        await userEvent.type(screen.getByTestId('edit_textbox'), ' edited');
+
+        expect(mockedUpdateDraft).not.toHaveBeenCalled();
+
+        unmount();
+
+        // The edit content may be persisted locally, but it must never be flagged
+        // as visible (show) or synced to the server (save), which would surface it
+        // as a draft in the drafts UI.
+        mockedUpdateDraft.mock.calls.forEach((call) => {
+            expect(call[1]).not.toMatchObject({show: true});
+            expect(call[3]).toBeFalsy();
+        });
+    });
+
     it('should deleted a deleted draft when changing channels', async () => {
         const {rerender} = renderWithContext(
             <AdvancedTextEditor

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -271,6 +271,14 @@ const AdvancedTextEditor = ({
                 return;
             }
 
+            // Editing an existing post must never create a synced/visible draft. Edit
+            // content is only persisted locally under the edit_draft_* key, so skip the
+            // show + server-upsert paths that would surface it in the drafts UI.
+            if (isInEditMode) {
+                dispatch(updateDraft(key, draftToChange, draftToChange.rootId));
+                return;
+            }
+
             if (options.show) {
                 dispatch(updateDraft(key, {...draftToChange, show: true}, draftToChange.rootId, true));
                 return;
@@ -288,7 +296,7 @@ const AdvancedTextEditor = ({
         }
 
         storedDrafts.current[draftToChange.rootId || draftToChange.channelId] = draftToChange;
-    }, [dispatch]);
+    }, [dispatch, isInEditMode, storageKey]);
 
     const applyWysiwygFormatting = useCallback((editor: Editor, mode: MarkdownMode) => {
         const isInlineMark = mode === 'bold' || mode === 'italic' || mode === 'strike';


### PR DESCRIPTION
Cherry pick of #37658 on release-11.10.

/cc  @isacikgoz

```release-note
NONE
```