### PR TITLE
Automated cherry pick of #36555

### DIFF
--- a/webapp/channels/src/components/markdown/index.ts
+++ b/webapp/channels/src/components/markdown/index.ts
@@ -57,7 +57,6 @@ function makeMapStateToProps() {
             mentionKeys: ownProps.mentionKeys || getAllUserMentionKeys(state),
             siteURL: getSiteURL(),
             team: getCurrentTeam(state),
-            hasImageProxy: config.HasImageProxy === 'true',
             minimumHashtagLength: parseInt(config.MinimumHashtagLength || '', 10),
             emojiMap: getEmojiMap(state),
             channelId,

--- a/webapp/channels/src/components/markdown/markdown.test.tsx
+++ b/webapp/channels/src/components/markdown/markdown.test.tsx
@@ -7,7 +7,7 @@ import type {TeamType} from '@mattermost/types/teams';
 
 import Markdown from 'components/markdown';
 
-import {renderWithContext} from 'tests/react_testing_utils';
+import {renderWithContext, screen} from 'tests/react_testing_utils';
 import EmojiMap from 'utils/emoji_map';
 import {TestHelper} from 'utils/test_helper';
 
@@ -54,5 +54,64 @@ describe('components/Markdown', () => {
 
         const {container} = renderWithContext(<Markdown {...props}/>);
         expect(container).toMatchSnapshot();
+    });
+
+    describe('image proxy', () => {
+        const imageUrl = 'https://example.com/image.png';
+
+        test('when the proxy is enabled, images should be requested through the server', () => {
+            const props = {...baseProps, message: `![alt](${imageUrl})`};
+
+            renderWithContext(<Markdown {...props}/>, {
+                entities: {
+                    general: {
+                        config: {
+                            HasImageProxy: 'true',
+                        },
+                    },
+                },
+            });
+
+            const img = screen.getByRole('img');
+            expect(img).toBeInTheDocument();
+            expect(img).toHaveAttribute('src', expect.stringMatching(`/image\\?url=${encodeURIComponent(imageUrl)}$`));
+        });
+
+        test('when the proxy is disabled, images should not be requested through the server', () => {
+            const props = {...baseProps, message: `![alt](${imageUrl})`};
+
+            renderWithContext(<Markdown {...props}/>, {
+                entities: {
+                    general: {
+                        config: {
+                            HasImageProxy: 'false',
+                        },
+                    },
+                },
+            });
+
+            const img = screen.getByRole('img');
+            expect(img).toBeInTheDocument();
+            expect(img).toHaveAttribute('src', imageUrl);
+        });
+
+        test('when the proxy is enabled, image URLs containing query parameters should be correctly encoded', () => {
+            const urlWithParams = 'https://example.com/image.png?width=100&height=200';
+            const props = {...baseProps, message: `![alt](${urlWithParams})`};
+
+            renderWithContext(<Markdown {...props}/>, {
+                entities: {
+                    general: {
+                        config: {
+                            HasImageProxy: 'true',
+                        },
+                    },
+                },
+            });
+
+            const img = screen.getByRole('img');
+            expect(img).toBeInTheDocument();
+            expect(img).toHaveAttribute('src', expect.stringMatching(`/image\\?url=${encodeURIComponent(urlWithParams)}$`));
+        });
     });
 });

--- a/webapp/channels/src/components/markdown/markdown.tsx
+++ b/webapp/channels/src/components/markdown/markdown.tsx
@@ -26,11 +26,6 @@ export type OwnProps = {
     options?: Partial<TextFormattingOptions>;
 
     /**
-     * Whether or not to proxy image URLs
-     */
-    proxyImages?: boolean;
-
-    /**
      * prop for passed down to image component for dimensions
      */
     imagesMetadata?: Record<string, PostImage>;
@@ -88,7 +83,6 @@ export type OwnProps = {
 
 function Markdown({
     options = {},
-    proxyImages = true,
     imagesMetadata = {},
     postId = '', // Needed to avoid proptypes console errors for cases like channel header, which doesn't have a proper value
     editedAt = 0,
@@ -105,7 +99,6 @@ function Markdown({
     messageMetadata,
     enableFormatting,
     siteURL,
-    hasImageProxy,
     team,
     minimumHashtagLength,
     managedResourcePaths,
@@ -128,7 +121,6 @@ function Markdown({
         highlightKeys,
         atMentions: true,
         channelNamesMap,
-        proxyImages: hasImageProxy && proxyImages,
         team,
         minimumHashtagLength,
         managedResourcePaths,

--- a/webapp/channels/src/components/post_markdown/post_markdown.tsx
+++ b/webapp/channels/src/components/post_markdown/post_markdown.tsx
@@ -111,8 +111,6 @@ export default class PostMarkdown extends React.PureComponent<Props> {
             );
         }
 
-        // Proxy images if we have an image proxy and the server hasn't already rewritten the this.props.post's image URLs.
-        const proxyImages = !this.props.post || !this.props.post.message_source || this.props.post.message === this.props.post.message_source;
         const channelNamesMap = isChannelNamesMap(this.props.post?.props?.channel_mentions) ? this.props.post?.props?.channel_mentions : undefined;
 
         this.props.pluginHooks?.forEach((o) => {
@@ -143,7 +141,6 @@ export default class PostMarkdown extends React.PureComponent<Props> {
             <Markdown
                 imageProps={this.props.imageProps}
                 message={message}
-                proxyImages={proxyImages}
                 mentionKeys={this.props.mentionKeys}
                 highlightKeys={highlightKeys}
                 options={options}

--- a/webapp/channels/src/utils/markdown/renderer.tsx
+++ b/webapp/channels/src/utils/markdown/renderer.tsx
@@ -5,7 +5,6 @@ import marked from 'marked';
 import type {MarkedOptions} from 'marked';
 
 import EmojiMap from 'utils/emoji_map';
-import * as PostUtils from 'utils/post_utils';
 import * as TextFormatting from 'utils/text_formatting';
 import {mightTriggerExternalRequest, getScheme, isUrlSafe, shouldOpenInNewTab} from 'utils/url';
 
@@ -111,8 +110,8 @@ export default class Renderer extends marked.Renderer {
     public image(href: string, title: string, text: string) {
         const dimensions = parseImageDimensions(href);
 
-        let src = dimensions.href;
-        src = PostUtils.getImageSrc(src, this.formattingOptions.proxyImages);
+        // Don't pass the image through the proxy yet because that's handled by MarkdownImage
+        const src = dimensions.href;
 
         let out = `<img src="${src}" alt="${text}"`;
         if (title) {

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -168,13 +168,6 @@ export interface TextFormattingOptionsBase {
     team: Team;
 
     /**
-     * If specified, images are proxied.
-     *
-     * Defaults to `false`.
-     */
-    proxyImages: boolean;
-
-    /**
      * An array of paths on the server that are managed by another server. Any path provided will be treated as an
      * external link that will not by handled by react-router.
      *
@@ -251,7 +244,6 @@ const DEFAULT_OPTIONS: TextFormattingOptions = {
     atSumOfMembersMentions: false,
     atPlanMentions: false,
     minimumHashtagLength: 3,
-    proxyImages: false,
     editedAt: 0,
     postId: '',
     unsafeLinks: false,


### PR DESCRIPTION
Cherry pick of #36555 on release-11.7.

/cc  @hmhealey

```release-note
NONE
```