### PR TITLE
[MM-68131] Prepackage Calls v1.11.6 (SDP zip-bomb DoS fix) — release-10.11

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -142,7 +142,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.4
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.6
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.7.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.12.3
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.1


### PR DESCRIPTION
#### Summary

Bumps the prepackaged Calls plugin on `release-10.11` from **v1.11.4 → v1.11.6**, which carries the fix for the SDP unbounded zlib-decompression (zip-bomb) DoS.

- Security ticket: MM-68130
- Plugin fix (v1.11.x backport): MM-68131 — published as [mattermost-plugin-calls v1.11.6](https://github.com/mattermost/mattermost-plugin-calls/releases/tag/v1.11.6)

This is the `release-10.11` counterpart to the same bump already landed on the newer lines:
- #37502 — Calls v1.12.2 on `master` / v11.10
- #37672 — cherry-pick to `release-11.9`

Sibling PRs for `release-11.7` and `release-11.8` will follow (both currently on the v1.11.x line).

#### Change

One line in `server/Makefile`:

```diff
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.4
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.6
```

```release-note
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.11.6
```

#### Test / QA

Build the server and confirm the prepackaged Calls plugin bundle is **v1.11.6**.
