### PR TITLE
docs(developers): fix broken Integrate & Extend link on developers landing page

### DIFF
--- a/docs/develop/index.mdx
+++ b/docs/develop/index.mdx
@@ -23,7 +23,7 @@ Build with, on, and for Mattermost. Contribute to the platform, build plugins an
   {
     title: 'Integrate & Extend',
     icon: 'channels',
-    to: '/developers/integrate',
+    to: '/developers/integrate/getting-started',
     description: 'Bots, slash commands, webhooks, OAuth apps, plugins, mobile clients. Build with the platform.',
     meta: 'Plugins · Apps · SDK'
   },
@@ -39,7 +39,7 @@ Build with, on, and for Mattermost. Contribute to the platform, build plugins an
 ## What's covered here
 
 - **[Contribute](/developers/contribute)** — onboarding, expectations, finding good first issues, the contribution workflow.
-- **[Integrate & Extend](/developers/integrate)** — apps, plugins, slash commands, incoming + outgoing webhooks, OAuth, customization, the marketplace.
+- **[Integrate & Extend](/developers/integrate/getting-started)** — apps, plugins, slash commands, incoming + outgoing webhooks, OAuth, customization, the marketplace.
 - **[Internal](/developers/internal)** — Mattermost-engineering team docs (build process, infrastructure, QA).
 
 ## Looking for something else?


### PR DESCRIPTION
#### Summary
The "Integrate & Extend" card and its matching inline link on the "Mattermost for Developers" landing page (`/developers`) pointed to `/developers/integrate`, which 404s because that category has no index page — only its "Get started" subcategory (`/developers/integrate/getting-started`) resolves to an actual doc. Updated both links to point to `/developers/integrate/getting-started`, matching the working "Contribute" card's pattern of linking to a real page.

QA: Visit `/developers`, click the "Integrate & Extend" card in the "Start here" section (or the matching link under "What's covered here") — it should now load the "Get started" page instead of 404ing.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Isolated documentation-link updates with no shared code, critical flows, or public API changes.  
**QA Recommendation:** Manual QA can be skipped; optionally verify both links resolve correctly.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->