### PR TITLE
Prepackage mattermost-plugin-agents v2.5.0-rc2

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -163,7 +163,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.1
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.11.1
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.0-rc1
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.0-rc2
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.1
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.7.0
@@ -177,7 +177,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.11.1%2B329b65c-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.0-rc1%2B666ae7a-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.0-rc2%2B2119bcf-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.1%2B29b4688-fips
 endif
 


### PR DESCRIPTION
#### Summary

Updates the default prepackaged [mattermost-plugin-agents](https://github.com/mattermost/mattermost-plugin-agents) artifact from **2.5.0-rc1** to **2.5.0-rc2** ([release v2.5.0-rc2](https://github.com/mattermost/mattermost-plugin-agents/releases/tag/v2.5.0-rc2)) for the `master` branch.

Both prepackaged plugin lists are updated:
- non-FIPS: `mattermost-plugin-agents-v2.5.0-rc2`
- FIPS: `mattermost-plugin-agents-v2.5.0-rc2%2B2119bcf-fips` (`2119bcf` is the tagged release commit)

Bundles verified on `plugins.releases.mattermost.com`.

#### Release Note
```release-note
Prepackaged the Mattermost Agents plugin at version 2.5.0-rc2 instead of 2.5.0-rc1.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: Low 🟢

**Regression Risk:** Changes are isolated to prepackaged plugin version references in `server/Makefile`; no application logic or critical flows are affected.  
**QA Recommendation:** Manual QA can be skipped; automated validation and artifact verification are sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->