### PR TITLE
MM-69980 Fix edited posts being slightly taller than unedited ones

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/post_list/post_height.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/post_list/post_height.spec.ts
@@ -468,10 +468,9 @@ test.describe('Post height', () => {
         await postComponent.toContainText('edited post');
 
         // * Verify that the post height didn't change
-        // MM-69980 The post height shouldn't increase when it's edited, but it increases by 1px
-        expect(await sizeWatcher.getObservations()).toHaveLength(2);
+        expect(await sizeWatcher.getObservations()).toHaveLength(1);
 
-        // # Edit the post to be multiple linesfrom another client
+        // # Edit the post to be multiple lines from another client
         await userClient.updatePost({
             ...post,
             message: 'edited post\nwith multiple lines',
@@ -480,8 +479,8 @@ test.describe('Post height', () => {
         // * Verify that the post text has changed
         await postComponent.toContainText('edited post\nwith multiple lines');
 
-        // * Verify that the post height didn't change
-        expect(await sizeWatcher.getObservations()).toHaveLength(3);
+        // * Verify that the post height changed since it now takes up an extra line
+        expect(await sizeWatcher.getObservations()).toHaveLength(2);
     });
 
     // Helpers specific to these tests

--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -913,6 +913,8 @@
         color: rgba(var(--center-channel-color-rgb), 0.75);
         font-size: 11px;
         font-style: italic;
+        line-height: normal;
+
         -webkit-user-select: none; /* Chrome all / Safari all */
         -moz-user-select: none; /* Firefox all */
         -ms-user-select: none; /* IE 10+ */


### PR DESCRIPTION
#### Summary
The "Edited" indicator on a post has a taller line height than the surrounding text, causing edited posts to be 1 pixel taller currently. Setting an explicit line-height instead of using the inherited one fixes that.

#### Ticket Link
MM-69980

#### Release Note
```release-note
Fixed edited posts being slightly taller than unedited ones
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes are isolated to post styling and related height assertions. They do not affect shared utilities, data, APIs, or high-risk flows.  
**QA Recommendation:** Manual QA is not required. Automated coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->