### PR TITLE
Fix low-contrast mobile nav sidebar text in light mode

### DIFF
--- a/docs/site/src/css/custom.css
+++ b/docs/site/src/css/custom.css
@@ -99,6 +99,21 @@
   --ifm-color-content-secondary: var(--mm-text-secondary);
 }
 
+/* The mobile nav slide-out (.navbar-sidebar) always has a dark denim
+ * background, but its menu inherits the light-mode --ifm-menu-color*
+ * vars tuned for the light desktop sidebar — force the dark-mode values
+ * unconditionally so mobile text stays readable in light mode too. */
+.navbar-sidebar {
+  --ifm-menu-color:                   rgba(255,255,255,0.78);
+  --ifm-menu-color-active:            var(--mm-color-white);
+  --ifm-menu-color-background-active: var(--mm-denim-700);
+  --ifm-menu-color-background-hover:  var(--mm-denim-700);
+}
+/* "Back to main menu" text color isn't covered by the vars above. */
+.navbar-sidebar__back {
+  color: var(--ifm-menu-color-active);
+}
+
 /* === Type rhythm === */
 
 html {
@@ -337,6 +352,13 @@ h2, h3, h4 {
   color: var(--mm-text-secondary);
   padding-top: 0.55rem;
   padding-bottom: 0.4rem;
+}
+
+/* Category headers hardcode --mm-text-secondary above, so they don't
+ * pick up the .navbar-sidebar menu-color override — fix separately. */
+.navbar-sidebar .menu .menu__list-item-collapsible > .menu__link,
+.navbar-sidebar .menu > .menu__list > .menu__list-item > .menu__link {
+  color: var(--ifm-menu-color);
 }
 
 /* Endpoint leaves keep their natural case (e.g. "Login to Mattermost server"). */


### PR DESCRIPTION
#### Summary
On narrow screens, opening the docs site's mobile hamburger menu shows the sidebar (`.navbar-sidebar`) on a dark denim background, matching the always-dark top navbar. Its menu links, however, inherited the light-mode `--ifm-menu-color*` values tuned for the desktop sidebar's light background, rendering dark navy text on a dark navy panel — nearly unreadable in light mode.

This scopes the "readable on dark" menu color values (already used in dark mode) to `.navbar-sidebar` unconditionally, and fixes the "Back to main menu" button's text color, which wasn't covered by those variables.

QA: On the docs site in light mode, resize to a narrow/mobile viewport and open the hamburger menu — sidebar text, active item, and "Back to main menu" button should now all be clearly readable against the dark denim panel, matching how it already looked in dark mode.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Scoped to `docs/site/src/css/custom.css` mobile-only sidebar styling (`.navbar-sidebar` and `.navbar-sidebar__back`), with no runtime logic changes. The risk is limited to visual contrast/hover-state differences in the docs navigation.
**QA Recommendation:** Manual spot-check on mobile in light mode for the slide-out sidebar (menu items, active/hover states) and the “Back to main menu” label; dark mode can be sanity-checked quickly.
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->