### PR TITLE
ci: remove testcontainers teardown step

### DIFF
--- a/.github/workflows/e2e-tests-playwright-template.yml
+++ b/.github/workflows/e2e-tests-playwright-template.yml
@@ -331,14 +331,6 @@ jobs:
           gh-job-name: dispatch-run-${{ matrix.worker_index }}
           playwright-retries: ${{ inputs.playwright_retries }}
           playwright-project: ${{ inputs.playwright_project }}
-      # The only step that actually tears down the stack: PW_TESTCONTAINERS_REUSE means every
-      # earlier step (including ci/prepare-playwright's own global-teardown call) just adopts the
-      # already-running server instead of stopping it. Also collects container logs and archives
-      # the boot-env drift history (.env.testcontainers) before removing containers.
-      - name: ci/testcontainers-teardown
-        if: always()
-        working-directory: e2e-tests/playwright
-        run: npm run testcontainers:down
       - name: ci/upload-debug-artifacts
         if: always()
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0


### PR DESCRIPTION
#### Summary
Removes the `ci/testcontainers-teardown` step from the playwright e2e workflow.

#### Ticket Link


#### Screenshots


#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The isolated workflow change only removes per-worker Testcontainers teardown and does not affect application code or critical user-facing paths.  
**QA Recommendation:** Automated coverage is sufficient; manual QA can be skipped.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->