### PR TITLE
MM-69994: Fix user endpoint request handling

### DIFF
--- a/server/channels/api4/user.go
+++ b/server/channels/api4/user.go
@@ -1926,7 +1926,7 @@ func updateUserMfa(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if appErr := c.App.MFARequired(c.AppContext); !c.AppContext.Session().Local && c.AppContext.Session().UserId != c.Params.UserId && appErr != nil {
+	if appErr := c.App.MFARequired(c.AppContext, r.Method); !c.AppContext.Session().Local && c.AppContext.Session().UserId != c.Params.UserId && appErr != nil {
 		c.Err = appErr
 		return
 	}

--- a/server/channels/api4/user_test.go
+++ b/server/channels/api4/user_test.go
@@ -11351,6 +11351,47 @@ func TestSearchUsersWithMfaEnforced(t *testing.T) {
 	})
 }
 
+func TestMeEndpointsWithMfaEnforced(t *testing.T) {
+	th := Setup(t).InitBasic(t)
+
+	th.App.Srv().SetLicense(model.NewTestLicense("mfa"))
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ServiceSettings.EnableMultifactorAuthentication = true
+		*cfg.ServiceSettings.EnforceMultifactorAuthentication = true
+	})
+
+	userWithoutMFA := th.BasicUser
+	err := th.Server.Store().User().UpdateMfaActive(userWithoutMFA.Id, false)
+	require.NoError(t, err)
+
+	client := th.CreateClient()
+	_, _, loginErr := client.Login(context.Background(), userWithoutMFA.Email, userWithoutMFA.Password)
+	require.NoError(t, loginErr)
+
+	t.Run("GET /users/me remains exempt from MFA enforcement", func(t *testing.T) {
+		me, _, getErr := client.GetMe(context.Background(), "")
+		require.NoError(t, getErr)
+		require.NotNil(t, me)
+	})
+
+	t.Run("PUT /users/me is blocked when MFA is not configured", func(t *testing.T) {
+		update := userWithoutMFA.DeepCopy()
+		update.Id = model.Me
+		update.Nickname = "new nickname"
+
+		_, resp, updateErr := client.UpdateUser(context.Background(), update)
+		CheckErrorID(t, updateErr, "api.context.mfa_required.app_error")
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("DELETE /users/me is blocked when MFA is not configured", func(t *testing.T) {
+		resp, deleteErr := client.DeleteUser(context.Background(), model.Me)
+		CheckErrorID(t, deleteErr, "api.context.mfa_required.app_error")
+		CheckForbiddenStatus(t, resp)
+	})
+}
+
 func TestGetSessionAttributesManifest(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 

--- a/server/channels/app/authentication.go
+++ b/server/channels/app/authentication.go
@@ -375,7 +375,7 @@ func (a *App) CheckUserMfa(rctx request.CTX, user *model.User, token string) *mo
 	return nil
 }
 
-func (a *App) MFARequired(rctx request.CTX) *model.AppError {
+func (a *App) MFARequired(rctx request.CTX, method string) *model.AppError {
 	if license := a.Channels().License(); license == nil || !*license.Features.MFA || !*a.Config().ServiceSettings.EnableMultifactorAuthentication || !*a.Config().ServiceSettings.EnforceMultifactorAuthentication {
 		return nil
 	}
@@ -406,9 +406,9 @@ func (a *App) MFARequired(rctx request.CTX) *model.AppError {
 		return nil
 	}
 
-	// Special case to let user get themself
+	// Special case to let user get (but not modify or delete) themself
 	subpath, _ := utils.GetSubpathFromConfig(a.Config())
-	if rctx.Path() == path.Join(subpath, "/api/v4/users/me") {
+	if method == http.MethodGet && rctx.Path() == path.Join(subpath, "/api/v4/users/me") {
 		return nil
 	}
 

--- a/server/channels/app/platform/helper_test.go
+++ b/server/channels/app/platform/helper_test.go
@@ -68,7 +68,7 @@ func (ms *mockSuite) HasPermissionToFileAction(rctx request.CTX, userID string, 
 	return true
 }
 
-func (ms *mockSuite) MFARequired(rctx request.CTX) *model.AppError {
+func (ms *mockSuite) MFARequired(rctx request.CTX, method string) *model.AppError {
 	return nil
 }
 

--- a/server/channels/app/platform/mocks/SuiteIFace.go
+++ b/server/channels/app/platform/mocks/SuiteIFace.go
@@ -117,17 +117,17 @@ func (_m *SuiteIFace) LogAuditRec(rctx request.CTX, auditRec *model.AuditRecord,
 	_m.Called(rctx, auditRec, err)
 }
 
-// MFARequired provides a mock function with given fields: rctx
-func (_m *SuiteIFace) MFARequired(rctx request.CTX) *model.AppError {
-	ret := _m.Called(rctx)
+// MFARequired provides a mock function with given fields: rctx, method
+func (_m *SuiteIFace) MFARequired(rctx request.CTX, method string) *model.AppError {
+	ret := _m.Called(rctx, method)
 
 	if len(ret) == 0 {
 		panic("no return value specified for MFARequired")
 	}
 
 	var r0 *model.AppError
-	if rf, ok := ret.Get(0).(func(request.CTX) *model.AppError); ok {
-		r0 = rf(rctx)
+	if rf, ok := ret.Get(0).(func(request.CTX, string) *model.AppError); ok {
+		r0 = rf(rctx, method)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*model.AppError)

--- a/server/channels/app/platform/web_conn.go
+++ b/server/channels/app/platform/web_conn.go
@@ -813,7 +813,8 @@ func (wc *WebConn) IsMFAAuthenticated() bool {
 	c := request.EmptyContext(wc.Platform.logger).WithSession(session)
 
 	// Check if MFA is required and user has NOT completed MFA
-	if appErr := wc.Suite.MFARequired(c); appErr != nil {
+	// WebSocket connections are established via an HTTP GET upgrade request.
+	if appErr := wc.Suite.MFARequired(c, http.MethodGet); appErr != nil {
 		return false
 	}
 

--- a/server/channels/app/platform/web_hub.go
+++ b/server/channels/app/platform/web_hub.go
@@ -32,7 +32,7 @@ type SuiteIFace interface {
 	HasPermissionToResolveChannelMention(rctx request.CTX, userID string, channel *model.Channel) bool
 	HasPermissionToFileAction(rctx request.CTX, userID string, roles string, channelID string, action string) bool
 	UserCanSeeOtherUser(rctx request.CTX, userID string, otherUserId string) (bool, *model.AppError)
-	MFARequired(rctx request.CTX) *model.AppError
+	MFARequired(rctx request.CTX, method string) *model.AppError
 	MakeAuditRecord(rctx request.CTX, event string, initialStatus string) *model.AuditRecord
 	LogAuditRec(rctx request.CTX, auditRec *model.AuditRecord, err error)
 }

--- a/server/channels/app/platform/web_hub_test.go
+++ b/server/channels/app/platform/web_hub_test.go
@@ -589,7 +589,7 @@ func TestHubIsRegistered(t *testing.T) {
 
 	mockSuite := &platform_mocks.SuiteIFace{}
 	mockSuite.On("GetSession", session.Token).Return(session, nil)
-	mockSuite.On("MFARequired", mock.Anything).Return(nil)
+	mockSuite.On("MFARequired", mock.Anything, mock.Anything).Return(nil)
 	th.Suite = mockSuite
 
 	s := httptest.NewServer(dummyWebsocketHandler(t))
@@ -624,7 +624,7 @@ func TestHubWebConnCount(t *testing.T) {
 
 	mockSuite := &platform_mocks.SuiteIFace{}
 	mockSuite.On("GetSession", session.Token).Return(session, nil)
-	mockSuite.On("MFARequired", mock.Anything).Return(nil)
+	mockSuite.On("MFARequired", mock.Anything, mock.Anything).Return(nil)
 	th.Suite = mockSuite
 
 	s := httptest.NewServer(dummyWebsocketHandler(t))

--- a/server/channels/app/plugin_requests.go
+++ b/server/channels/app/plugin_requests.go
@@ -252,7 +252,7 @@ func (ch *Channels) servePluginRequest(w http.ResponseWriter, r *http.Request, h
 		WithSession(session)
 
 	// If MFA is required and user has not activated it, treat it as unauthenticated
-	if appErr := app.MFARequired(rctx); appErr != nil {
+	if appErr := app.MFARequired(rctx, r.Method); appErr != nil {
 		if appErr.StatusCode == http.StatusInternalServerError {
 			handleInternalServerError(rctx, "Internal server error during MFA validation", appErr)
 			return

--- a/server/channels/web/context.go
+++ b/server/channels/web/context.go
@@ -155,8 +155,8 @@ func (c *Context) RemoteClusterTokenRequired() {
 	}
 }
 
-func (c *Context) MfaRequired() {
-	if appErr := c.App.MFARequired(c.AppContext); appErr != nil {
+func (c *Context) MfaRequired(method string) {
+	if appErr := c.App.MFARequired(c.AppContext, method); appErr != nil {
 		c.Err = appErr
 	}
 }

--- a/server/channels/web/context_test.go
+++ b/server/channels/web/context_test.go
@@ -83,7 +83,7 @@ func TestMfaRequired(t *testing.T) {
 		AppContext: th.Context,
 	}
 
-	c.MfaRequired()
+	c.MfaRequired(http.MethodGet)
 
 	assert.Equal(t, c.Err.Id, "api.context.get_user.app_error")
 }

--- a/server/channels/web/handlers.go
+++ b/server/channels/web/handlers.go
@@ -336,7 +336,7 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if c.Err == nil && h.RequireMfa {
-		c.MfaRequired()
+		c.MfaRequired(r.Method)
 	}
 
 	if c.Err == nil && h.DisableWhenBusy && c.App.Srv().Platform().Busy.IsBusy() {


### PR DESCRIPTION
## Ticket Link

Fixes MM-69994.

```release-note
Fixed an issue with user profile update handling.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟠 Medium

**Regression Risk:** MFA enforcement behavior changes across shared authentication and request-handling paths, creating moderate risk for method-specific access regressions. Automated coverage includes the primary `/users/me` scenarios.

**QA Recommendation:** Manual QA is recommended for MFA-enforced GET, PUT, DELETE, plugin, and websocket flows.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
