### PR TITLE
Spike: WebSocket permessage-deflate compression with wire-size measurements

### DIFF
--- a/server/channels/api4/websocket.go
+++ b/server/channels/api4/websocket.go
@@ -56,9 +56,10 @@ func (api *API) InitWebSocket() {
 
 func connectWebSocket(c *Context, w http.ResponseWriter, r *http.Request) {
 	upgrader := websocket.Upgrader{
-		ReadBufferSize:  model.SocketMaxMessageSizeKb,
-		WriteBufferSize: model.SocketMaxMessageSizeKb,
-		CheckOrigin:     c.App.OriginChecker(),
+		ReadBufferSize:    model.SocketMaxMessageSizeKb,
+		WriteBufferSize:   model.SocketMaxMessageSizeKb,
+		CheckOrigin:       c.App.OriginChecker(),
+		EnableCompression: *c.App.Config().ServiceSettings.EnableWebSocketCompression,
 	}
 
 	ws, err := upgrader.Upgrade(w, r, nil)

--- a/server/channels/app/platform/wsdeflate_spike/measure_test.go
+++ b/server/channels/app/platform/wsdeflate_spike/measure_test.go
@@ -1,0 +1,351 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package wsdeflate_spike
+
+import (
+	"bytes"
+	"compress/flate"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/stretchr/testify/require"
+)
+
+const measureIterations = 100
+
+// countingConn counts bytes read from the underlying connection (client side =
+// server→client wire bytes including WebSocket framing).
+type countingConn struct {
+	net.Conn
+	n atomic.Int64
+}
+
+func (c *countingConn) Read(p []byte) (int, error) {
+	n, err := c.Conn.Read(p)
+	if n > 0 {
+		c.n.Add(int64(n))
+	}
+	return n, err
+}
+
+func (c *countingConn) Bytes() int64 { return c.n.Load() }
+
+type wsPair struct {
+	server *websocket.Conn
+	client *websocket.Conn
+	count  *countingConn
+	close  func()
+}
+
+func dialPair(t testing.TB, compress bool, level int) *wsPair {
+	t.Helper()
+
+	upgrader := websocket.Upgrader{
+		CheckOrigin:       func(r *http.Request) bool { return true },
+		EnableCompression: compress,
+	}
+
+	var serverConn atomic.Pointer[websocket.Conn]
+	ready := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			t.Errorf("upgrade: %v", err)
+			return
+		}
+		if compress && level != 0 {
+			if err := c.SetCompressionLevel(level); err != nil {
+				t.Errorf("SetCompressionLevel(%d): %v", level, err)
+				c.Close()
+				return
+			}
+		}
+		serverConn.Store(c)
+		close(ready)
+		// Keep handler alive until the test closes the server conn.
+		select {
+		case <-r.Context().Done():
+		case <-time.After(2 * time.Minute):
+		}
+	}))
+
+	var counted *countingConn
+	dialer := websocket.Dialer{
+		EnableCompression: compress,
+		NetDial: func(network, addr string) (net.Conn, error) {
+			c, err := net.Dial(network, addr)
+			if err != nil {
+				return nil, err
+			}
+			counted = &countingConn{Conn: c}
+			return counted, nil
+		},
+	}
+
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client, _, err := dialer.Dial(wsURL, nil)
+	require.NoError(t, err)
+
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for server websocket upgrade")
+	}
+
+	sc := serverConn.Load()
+	require.NotNil(t, sc)
+	require.NotNil(t, counted)
+
+	return &wsPair{
+		server: sc,
+		client: client,
+		count:  counted,
+		close: func() {
+			_ = client.Close()
+			_ = sc.Close()
+			srv.Close()
+		},
+	}
+}
+
+func measureWireAvg(t *testing.T, pair *wsPair, kind PayloadKind, n int) (rawAvg, wireAvg float64) {
+	t.Helper()
+	var rawTotal, wireTotal int64
+	for i := 0; i < n; i++ {
+		payload, err := GeneratePayloadJSON(kind, i, int64(i+1))
+		require.NoError(t, err)
+		rawTotal += int64(len(payload))
+
+		before := pair.count.Bytes()
+		require.NoError(t, pair.server.WriteMessage(websocket.TextMessage, payload))
+		_, msg, err := pair.client.ReadMessage()
+		require.NoError(t, err)
+		require.Equal(t, payload, msg, "client should receive identical payload bytes")
+		wireTotal += pair.count.Bytes() - before
+	}
+	return float64(rawTotal) / float64(n), float64(wireTotal) / float64(n)
+}
+
+// measureContextTakeoverAvg compresses varied payloads with a single reused
+// flate.Writer (level 6), simulating permessage-deflate *with* context takeover.
+// Returns average compressed payload bytes after a short warmup (no WS framing).
+func measureContextTakeoverAvg(t *testing.T, kind PayloadKind, n int) float64 {
+	t.Helper()
+
+	var buf bytes.Buffer
+	fw, err := flate.NewWriter(&buf, flate.DefaultCompression) // level 6
+	require.NoError(t, err)
+
+	warmup := 10
+	var total int64
+	var counted int
+	for i := 0; i < n+warmup; i++ {
+		payload, err := GeneratePayloadJSON(kind, i, int64(i+1))
+		require.NoError(t, err)
+
+		buf.Reset()
+		_, err = fw.Write(payload)
+		require.NoError(t, err)
+		require.NoError(t, fw.Flush())
+
+		// Match permessage-deflate: strip trailing 0x00 0x00 0xff 0xff sync marker.
+		comp := buf.Bytes()
+		if len(comp) >= 4 && bytes.Equal(comp[len(comp)-4:], []byte{0x00, 0x00, 0xff, 0xff}) {
+			comp = comp[:len(comp)-4]
+		}
+		if i >= warmup {
+			total += int64(len(comp))
+			counted++
+		}
+	}
+	require.NoError(t, fw.Close())
+	require.Positive(t, counted)
+	return float64(total) / float64(counted)
+}
+
+type row struct {
+	name        string
+	raw         float64
+	uncomp      float64
+	deflateL1   float64
+	deflateL6   float64
+	ctxTakeover float64
+}
+
+func TestMeasureDeflateSavings(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping deflate wire measurement in short mode")
+	}
+
+	rows := make([]row, 0, len(AllKinds))
+	for _, kind := range AllKinds {
+		kind := kind
+		t.Run(string(kind), func(t *testing.T) {
+			uncompPair := dialPair(t, false, 0)
+			defer uncompPair.close()
+			rawAvg, uncompWire := measureWireAvg(t, uncompPair, kind, measureIterations)
+
+			l1Pair := dialPair(t, true, 1)
+			defer l1Pair.close()
+			_, l1Wire := measureWireAvg(t, l1Pair, kind, measureIterations)
+
+			l6Pair := dialPair(t, true, 6)
+			defer l6Pair.close()
+			_, l6Wire := measureWireAvg(t, l6Pair, kind, measureIterations)
+
+			ctxAvg := measureContextTakeoverAvg(t, kind, measureIterations)
+
+			rows = append(rows, row{
+				name:        string(kind),
+				raw:         rawAvg,
+				uncomp:      uncompWire,
+				deflateL1:   l1Wire,
+				deflateL6:   l6Wire,
+				ctxTakeover: ctxAvg,
+			})
+		})
+	}
+
+	// Print after subtests so the table is contiguous in -v output.
+	t.Log("\n" + formatResultsTable(rows))
+}
+
+func formatResultsTable(rows []row) string {
+	var b strings.Builder
+	b.WriteString("WebSocket permessage-deflate wire-size measurement (avg over 100 varied messages)\n")
+	b.WriteString("gorilla/websocket v1.5.3 negotiates no-context-takeover only.\n")
+	b.WriteString("Wire columns include WebSocket framing; ctx-takeover is compressed payload only (no framing).\n\n")
+
+	fmt.Fprintf(&b, "%-26s %8s %10s %10s %10s %10s %8s %8s %8s\n",
+		"payload", "rawJSON", "uncomp", "deflL1", "deflL6", "ctxTO", "saveL1%", "saveL6%", "saveCT%")
+	b.WriteString(strings.Repeat("-", 110) + "\n")
+
+	for _, r := range rows {
+		fmt.Fprintf(&b, "%-26s %8.0f %10.1f %10.1f %10.1f %10.1f %7.1f%% %7.1f%% %7.1f%%\n",
+			r.name,
+			r.raw,
+			r.uncomp,
+			r.deflateL1,
+			r.deflateL6,
+			r.ctxTakeover,
+			pctSaved(r.uncomp, r.deflateL1),
+			pctSaved(r.uncomp, r.deflateL6),
+			pctSaved(r.raw, r.ctxTakeover), // vs raw JSON; framing-free reference
+		)
+	}
+	return b.String()
+}
+
+func pctSaved(baseline, compressed float64) float64 {
+	if baseline <= 0 {
+		return 0
+	}
+	return (baseline - compressed) / baseline * 100
+}
+
+// BenchmarkDeflateWrite compares WriteMessage CPU cost for a representative
+// posted_long event over compressed vs uncompressed connections.
+func BenchmarkDeflateWrite(b *testing.B) {
+	payload, err := GeneratePayloadJSON(KindPostedLong, 0, 1)
+	require.NoError(b, err)
+
+	b.Run("uncompressed", func(b *testing.B) {
+		benchWrite(b, false, 0, payload)
+	})
+	b.Run("compressed_level1", func(b *testing.B) {
+		benchWrite(b, true, 1, payload)
+	})
+	b.Run("compressed_level6", func(b *testing.B) {
+		benchWrite(b, true, 6, payload)
+	})
+}
+
+func benchWrite(b *testing.B, compress bool, level int, payload []byte) {
+	b.Helper()
+
+	upgrader := websocket.Upgrader{
+		CheckOrigin:       func(r *http.Request) bool { return true },
+		EnableCompression: compress,
+	}
+
+	var serverConn atomic.Pointer[websocket.Conn]
+	ready := make(chan struct{})
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c, err := upgrader.Upgrade(w, r, nil)
+		if err != nil {
+			b.Errorf("upgrade: %v", err)
+			return
+		}
+		if compress {
+			if err := c.SetCompressionLevel(level); err != nil {
+				b.Errorf("SetCompressionLevel: %v", err)
+				c.Close()
+				return
+			}
+		}
+		serverConn.Store(c)
+		close(ready)
+		select {
+		case <-r.Context().Done():
+		case <-time.After(5 * time.Minute):
+		}
+	}))
+	defer srv.Close()
+
+	dialer := websocket.Dialer{EnableCompression: compress}
+	wsURL := "ws" + strings.TrimPrefix(srv.URL, "http")
+	client, _, err := dialer.Dial(wsURL, nil)
+	require.NoError(b, err)
+	defer client.Close()
+
+	select {
+	case <-ready:
+	case <-time.After(5 * time.Second):
+		b.Fatal("timed out waiting for upgrade")
+	}
+	sc := serverConn.Load()
+	require.NotNil(b, sc)
+	defer sc.Close()
+
+	// Drain client reads so the writer is not blocked on TCP window.
+	var wg sync.WaitGroup
+	wg.Add(1)
+	done := make(chan struct{})
+	go func() {
+		defer wg.Done()
+		for {
+			if _, _, err := client.ReadMessage(); err != nil {
+				return
+			}
+			select {
+			case <-done:
+				return
+			default:
+			}
+		}
+	}()
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(payload)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := sc.WriteMessage(websocket.TextMessage, payload); err != nil {
+			b.Fatal(err)
+		}
+	}
+	b.StopTimer()
+	close(done)
+	_ = client.Close()
+	wg.Wait()
+}

--- a/server/channels/app/platform/wsdeflate_spike/payloads.go
+++ b/server/channels/app/platform/wsdeflate_spike/payloads.go
@@ -1,0 +1,354 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// Package wsdeflate_spike is a standalone harness that measures wire-size
+// savings from WebSocket permessage-deflate (gorilla/websocket no-context-takeover)
+// on realistic Mattermost WebSocket event payloads.
+package wsdeflate_spike
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// PayloadKind identifies a representative Mattermost WebSocket event class.
+type PayloadKind string
+
+const (
+	KindTyping                 PayloadKind = "typing"
+	KindStatusChange           PayloadKind = "status_change"
+	KindReactionAdded          PayloadKind = "reaction_added"
+	KindPostedShort            PayloadKind = "posted_short"
+	KindPostedLong             PayloadKind = "posted_long"
+	KindPostedAttachments      PayloadKind = "posted_attachments"
+	KindUserUpdated            PayloadKind = "user_updated"
+	KindMultipleChannelsViewed PayloadKind = "multiple_channels_viewed"
+)
+
+// AllKinds is the measurement matrix order.
+var AllKinds = []PayloadKind{
+	KindTyping,
+	KindStatusChange,
+	KindReactionAdded,
+	KindPostedShort,
+	KindPostedLong,
+	KindPostedAttachments,
+	KindUserUpdated,
+	KindMultipleChannelsViewed,
+}
+
+// fixedIDs keeps structure stable across a single generated event while still
+// allowing per-iteration variation via varyIndex.
+type fixedIDs struct {
+	teamID    string
+	channelID string
+	userID    string
+	userID2   string
+	postID    string
+	fileID    string
+	emojiID   string
+}
+
+func newFixedIDs() fixedIDs {
+	// Fresh IDs each call so consecutive same-kind payloads differ
+	// (avoids identical-message compression artifacts).
+	return fixedIDs{
+		teamID:    model.NewId(),
+		channelID: model.NewId(),
+		userID:    model.NewId(),
+		userID2:   model.NewId(),
+		postID:    model.NewId(),
+		fileID:    model.NewId(),
+		emojiID:   model.NewId(),
+	}
+}
+
+// GenerateEvent builds a realistic WebSocket event for kind, varied by index.
+func GenerateEvent(kind PayloadKind, varyIndex int) *model.WebSocketEvent {
+	ids := newFixedIDs()
+	now := model.GetMillis() + int64(varyIndex)
+
+	switch kind {
+	case KindTyping:
+		return makeTyping(ids, varyIndex)
+	case KindStatusChange:
+		return makeStatusChange(ids, varyIndex)
+	case KindReactionAdded:
+		return makeReactionAdded(ids, now, varyIndex)
+	case KindPostedShort:
+		return makePosted(ids, now, shortMessage(varyIndex), nil, varyIndex)
+	case KindPostedLong:
+		return makePosted(ids, now, longMessage(varyIndex), nil, varyIndex)
+	case KindPostedAttachments:
+		return makePosted(ids, now, attachmentMessage(varyIndex), makePostMetadata(ids, now, varyIndex), varyIndex)
+	case KindUserUpdated:
+		return makeUserUpdated(ids, now, varyIndex)
+	case KindMultipleChannelsViewed:
+		return makeMultipleChannelsViewed(ids, now, varyIndex)
+	default:
+		panic(fmt.Sprintf("unknown payload kind %q", kind))
+	}
+}
+
+// MarshalEventJSON returns the wire JSON bytes (ToJSON with sequence), matching
+// what writePump sends after SetSequence.
+func MarshalEventJSON(ev *model.WebSocketEvent, seq int64) ([]byte, error) {
+	return ev.SetSequence(seq).ToJSON()
+}
+
+// GeneratePayloadJSON is a convenience for GenerateEvent + MarshalEventJSON.
+func GeneratePayloadJSON(kind PayloadKind, varyIndex int, seq int64) ([]byte, error) {
+	return MarshalEventJSON(GenerateEvent(kind, varyIndex), seq)
+}
+
+func makeTyping(ids fixedIDs, varyIndex int) *model.WebSocketEvent {
+	omit := map[string]bool{ids.userID: true}
+	ev := model.NewWebSocketEvent(model.WebsocketEventTyping, "", ids.channelID, "", omit, "")
+	ev.Add("user_id", ids.userID)
+	// parent_id is empty for channel-level typing; occasionally a thread root.
+	parentID := ""
+	if varyIndex%3 == 0 {
+		parentID = ids.postID
+	}
+	ev.Add("parent_id", parentID)
+	return ev
+}
+
+func makeStatusChange(ids fixedIDs, varyIndex int) *model.WebSocketEvent {
+	statuses := []string{model.StatusOnline, model.StatusAway, model.StatusDnd, model.StatusOffline}
+	ev := model.NewWebSocketEvent(model.WebsocketEventStatusChange, "", "", ids.userID, nil, "")
+	ev.Add("status", statuses[varyIndex%len(statuses)])
+	ev.Add("user_id", ids.userID)
+	return ev
+}
+
+func makeReactionAdded(ids fixedIDs, now int64, varyIndex int) *model.WebSocketEvent {
+	emojis := []string{"thumbsup", "heart", "tada", "eyes", "rocket"}
+	reaction := &model.Reaction{
+		UserId:    ids.userID,
+		PostId:    ids.postID,
+		EmojiName: emojis[varyIndex%len(emojis)],
+		CreateAt:  now,
+		UpdateAt:  now,
+		ChannelId: ids.channelID,
+	}
+	reactionJSON, err := json.Marshal(reaction)
+	if err != nil {
+		panic(err)
+	}
+	// Mirrors app.sendReactionEvent: reaction is embedded as a JSON string.
+	ev := model.NewWebSocketEvent(model.WebsocketEventReactionAdded, "", ids.channelID, "", nil, "")
+	ev.Add("reaction", string(reactionJSON))
+	return ev
+}
+
+func makePosted(ids fixedIDs, now int64, message string, metadata *model.PostMetadata, varyIndex int) *model.WebSocketEvent {
+	post := &model.Post{
+		Id:        ids.postID,
+		CreateAt:  now,
+		UpdateAt:  now,
+		UserId:    ids.userID,
+		ChannelId: ids.channelID,
+		Message:   message,
+		Type:      model.PostTypeDefault,
+		Hashtags:  "#standup #engineering",
+		Props:     model.StringInterface{},
+		Metadata:  metadata,
+	}
+	if metadata != nil && len(metadata.Files) > 0 {
+		post.FileIds = model.StringArray{ids.fileID}
+	}
+
+	postJSON, err := post.ToJSON()
+	if err != nil {
+		panic(err)
+	}
+
+	// Mirrors notification.go websocket posted construction + publishWebsocketEventForPost.
+	// post is embedded as a JSON string (same as publishWebsocketEventForPost).
+	ev := model.NewWebSocketEvent(model.WebsocketEventPosted, "", ids.channelID, "", nil, "")
+	ev.Add("post", postJSON)
+	ev.Add("channel_display_name", "Engineering")
+	ev.Add("channel_name", "engineering")
+	ev.Add("channel_type", string(model.ChannelTypeOpen))
+	ev.Add("sender_name", fmt.Sprintf("jane.doe%d", varyIndex%10))
+	ev.Add("set_online", true)
+	ev.Add("team_id", ids.teamID)
+	// Per-recipient mentions hook result as seen on the wire for a mentioned user.
+	mentions, _ := json.Marshal(model.StringArray{ids.userID2})
+	ev.Add("mentions", string(mentions))
+	if metadata != nil && len(metadata.Files) > 0 {
+		ev.Add("otherFile", "true")
+		ev.Add("image", "true")
+	}
+	return ev
+}
+
+func makePostMetadata(ids fixedIDs, now int64, varyIndex int) *model.PostMetadata {
+	remoteID := ""
+	file := &model.FileInfo{
+		Id:              ids.fileID,
+		CreatorId:       ids.userID,
+		PostId:          ids.postID,
+		ChannelId:       ids.channelID,
+		CreateAt:        now,
+		UpdateAt:        now,
+		Name:            fmt.Sprintf("architecture-diagram-%d.png", varyIndex%7),
+		Extension:       "png",
+		Size:            248_576 + int64(varyIndex%1000),
+		MimeType:        "image/png",
+		Width:           1600,
+		Height:          900,
+		HasPreviewImage: true,
+		RemoteId:        &remoteID,
+	}
+
+	emoji := &model.Emoji{
+		Id:        ids.emojiID,
+		CreateAt:  now - 1_000_000,
+		UpdateAt:  now - 1_000_000,
+		CreatorId: ids.userID,
+		Name:      fmt.Sprintf("party_blob_%d", varyIndex%5),
+	}
+
+	attachment := &model.MessageAttachment{
+		Id:         int64(varyIndex + 1),
+		Fallback:   "Deploy finished for api-gateway",
+		Color:      "#00A3E0",
+		Pretext:    "CI notification",
+		AuthorName: "BuildBot",
+		AuthorLink: "https://ci.example.com/bots/buildbot",
+		Title:      fmt.Sprintf("Build #%d succeeded", 1200+varyIndex),
+		TitleLink:  fmt.Sprintf("https://ci.example.com/builds/%d", 1200+varyIndex),
+		Text:       "All integration tests passed. Artifact uploaded to the release bucket.",
+		Fields: []*model.MessageAttachmentField{
+			{Title: "Service", Value: "api-gateway", Short: true},
+			{Title: "Duration", Value: "4m 12s", Short: true},
+			{Title: "Commit", Value: fmt.Sprintf("abc%ddef", varyIndex%97), Short: false},
+		},
+		Footer: "Mattermost CI",
+	}
+
+	return &model.PostMetadata{
+		Embeds: []*model.PostEmbed{
+			{Type: model.PostEmbedMessageAttachment, Data: attachment},
+		},
+		Emojis: []*model.Emoji{emoji},
+		Files:  []*model.FileInfo{file},
+		Images: map[string]*model.PostImage{
+			"https://cdn.example.com/charts/latency.png": {Width: 640, Height: 320},
+		},
+		Reactions: []*model.Reaction{
+			{
+				UserId:    ids.userID2,
+				PostId:    ids.postID,
+				EmojiName: "tada",
+				CreateAt:  now - 500,
+				UpdateAt:  now - 500,
+				ChannelId: ids.channelID,
+			},
+		},
+	}
+}
+
+func makeUserUpdated(ids fixedIDs, now int64, varyIndex int) *model.WebSocketEvent {
+	user := &model.User{
+		Id:            ids.userID,
+		CreateAt:      now - 86_400_000,
+		UpdateAt:      now,
+		Username:      fmt.Sprintf("jane.doe%d", varyIndex%10),
+		Email:         fmt.Sprintf("jane.doe%d@example.com", varyIndex%10),
+		EmailVerified: true,
+		Nickname:      "JD",
+		FirstName:     "Jane",
+		LastName:      "Doe",
+		Position:      "Staff Software Engineer",
+		Roles:         model.SystemUserRoleId,
+		Locale:        "en",
+		Timezone: model.StringMap{
+			"useAutomaticTimezone": "true",
+			"automaticTimezone":    "America/Los_Angeles",
+			"manualTimezone":       "",
+		},
+	}
+	user.SetDefaultNotifications()
+	user.SanitizeProfile(map[string]bool{
+		"email":          true,
+		"fullname":       true,
+		"passwordupdate": false,
+		"authservice":    true,
+	}, false)
+
+	ev := model.NewWebSocketEvent(model.WebsocketEventUserUpdated, "", "", "", nil, "")
+	ev.Add("user", user)
+	return ev
+}
+
+func makeMultipleChannelsViewed(ids fixedIDs, now int64, varyIndex int) *model.WebSocketEvent {
+	// Real server publishes WebsocketEventMultipleChannelsViewed with channel_times.
+	times := map[string]int64{
+		ids.channelID: now,
+		model.NewId(): now - int64(varyIndex*1000),
+		model.NewId(): now - int64(varyIndex*2000),
+	}
+	ev := model.NewWebSocketEvent(model.WebsocketEventMultipleChannelsViewed, "", "", ids.userID, nil, "")
+	ev.Add("channel_times", times)
+	return ev
+}
+
+func shortMessage(varyIndex int) string {
+	// ~50 characters of realistic chat text, with a small varying suffix.
+	base := "Quick sync at 3pm works for me — see you then"
+	return fmt.Sprintf("%s (%d)", base, varyIndex%100)
+}
+
+func attachmentMessage(varyIndex int) string {
+	return fmt.Sprintf("Deploy notes for api-gateway build %d :tada: see attachment", 1200+varyIndex)
+}
+
+func longMessage(varyIndex int) string {
+	// ~2000 chars of varied English/markdown — not repeated single characters.
+	paragraphs := []string{
+		"## Incident follow-up",
+		"",
+		"Yesterday's latency spike on the notifications path was traced to a hot shard in the",
+		"status cache. After the deploy, p99 dropped from ~850ms back to the 120–160ms band.",
+		"",
+		"### What changed",
+		"1. Split the status fan-out so offline transitions no longer block online writes.",
+		"2. Added a short-circuit when the web hub channel iterator is enabled for large teams.",
+		"3. Tightened the retry backoff on the push proxy client (was amplifying thundering herds).",
+		"",
+		"### Remaining work",
+		"- [ ] Confirm CRT follower fan-out stays under the new budget during Monday standup peaks.",
+		"- [ ] Double-check that ephemeral posts still omit permalink metadata on the wire.",
+		"- [ ] Capture a before/after flamegraph for `writePump` under compression once the spike lands.",
+		"",
+		"Sample markdown table for the on-call handoff:",
+		"",
+		"| Service        | Owner     | Notes                                      |",
+		"|----------------|-----------|--------------------------------------------|",
+		"| api-gateway    | platform  | rolled forward; watch error budget         |",
+		"| push-proxy     | mobile    | backoff tuned; no customer-visible impact  |",
+		"| jobs           | server    | queue depth normal after rebalance         |",
+		"",
+		"If you see typing indicators stalling again, check hub occupancy before paging.",
+		"Link to the runbook: https://docs.example.com/runbooks/websocket-backpressure",
+		"",
+		"cc @channel — please thumbs-up once you've skimmed the checklist. Thanks!",
+	}
+	body := strings.Join(paragraphs, "\n")
+	// Pad with an extra varied sentence so length stays near ~2000 and differs per index.
+	pad := fmt.Sprintf("\n\n_Revision %d captured at iteration %d for compression measurement._\n", varyIndex+1, varyIndex)
+	for len(body)+len(pad) < 2000 {
+		pad += fmt.Sprintf(" Additional context block %d discusses retry semantics and hub fairness under load.", varyIndex%17)
+	}
+	out := body + pad
+	if len(out) > 2200 {
+		out = out[:2200]
+	}
+	return out
+}

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -492,6 +492,7 @@ type ServiceSettings struct {
 	MaximumURLLength                                  *int    `access:"environment_file_storage,write_restrictable,cloud_restrictable"`
 	ScheduledPosts                                    *bool   `access:"site_posts"`
 	EnableWebHubChannelIteration                      *bool   `access:"write_restrictable,cloud_restrictable"` // telemetry: none
+	EnableWebSocketCompression                        *bool   `access:"write_restrictable,cloud_restrictable"` // telemetry: none
 	FrameAncestors                                    *string `access:"write_restrictable,cloud_restrictable"` // telemetry: none
 	DeleteAccountLink                                 *string `access:"site_users_and_teams,write_restrictable,cloud_restrictable"`
 }
@@ -1060,6 +1061,10 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.EnableWebHubChannelIteration == nil {
 		s.EnableWebHubChannelIteration = new(false)
+	}
+
+	if s.EnableWebSocketCompression == nil {
+		s.EnableWebSocketCompression = new(false)
 	}
 
 	if s.FrameAncestors == nil {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Spike investigating whether WebSocket permessage-deflate compression is worthwhile for Mattermost, with real wire-level measurements.

Changes:
- New config setting `ServiceSettings.EnableWebSocketCompression` (default `false`) that sets `EnableCompression` on the gorilla/websocket upgrader in `connectWebSocket`. When enabled, the server offers permessage-deflate during the handshake; browsers negotiate it automatically.
- Measurement harness in `server/channels/app/platform/wsdeflate_spike/` that builds realistic websocket event payloads via real model types (`typing`, `status_change`, `reaction_added`, `posted` short/long/with-attachments, `user_updated`, `multiple_channels_viewed`), sends them over real compressed vs uncompressed gorilla connections, and counts actual TCP bytes including framing. Also simulates context-takeover deflate (which gorilla v1.5.3 does not support) as a reference, and benchmarks write CPU cost.

Measured savings (avg over 100 varied messages, wire bytes including WS framing):

| payload | raw JSON | uncompressed wire | deflate L6 wire | savings (no-ctx L6) | savings if ctx-takeover |
|---|---|---|---|---|---|
| typing | 273 | 277 | 169 | 39% | 72% |
| status_change | 242 | 246 | 143 | 42% | 84% |
| reaction_added | 450 | 454 | 255 | 44% | 77% |
| posted (short) | 913 | 917 | 506 | 45% | 84% |
| posted (long) | 2992 | 2996 | 1339 | 55% | 94% |
| posted (attachments) | 2818 | 2822 | 1119 | 60% | 90% |
| user_updated | 618 | 622 | 353 | 43% | 93% |
| multiple_channels_viewed | 344 | 348 | 227 | 35% | 63% |

CPU cost per write (`posted_long`, ~3KB): uncompressed 2.6µs; deflate level 1 27µs (~10x); level 6 46µs (~18x). Compression runs per connection on broadcast fan-out, so hubs pay this per recipient.

Conclusions:
- Real-world savings with gorilla's no-context-takeover implementation are ~35-60%, not the ~80% headline figure, which requires context takeover (confirmed by the simulated column: 63-94%).
- The feature is off by default and opt-in; the main trade-off is write CPU on broadcast fan-out.

Run the measurements:

```
cd server
go test ./channels/app/platform/wsdeflate_spike/ -run TestMeasureDeflateSavings -v
go test ./channels/app/platform/wsdeflate_spike/ -bench BenchmarkDeflateWrite -benchtime 2s -run '^$'
```

#### Release Note

```release-note
Added ServiceSettings.EnableWebSocketCompression (default false) to enable permessage-deflate compression on WebSocket connections.
Added ``ServiceSettings.EnableWebSocketCompression`` configuration setting.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2188b0c8-aceb-4016-9e99-acdb34efc071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2188b0c8-aceb-4016-9e99-acdb34efc071"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>