### PR TITLE
MM-69996: Fix session cache invalidation not fully propagating to websocket connections

### DIFF
--- a/server/channels/app/platform/cluster_handlers.go
+++ b/server/channels/app/platform/cluster_handlers.go
@@ -125,11 +125,32 @@ func (ps *PlatformService) invalidateWebConnSessionCacheForUserSkipClusterSend(u
 
 // invalidateWebConnSessionCacheForAllUsersSkipClusterSend signals
 // every hub on this node to invalidate the cached session state of
-// all of its WebConns. Companion to ClearAllUsersSessionCacheLocal.
+// all of its WebConns, and clears their session tokens so they cannot
+// re-authenticate on this connection again. This is intentionally
+// destructive and is only appropriate when every session on the server
+// is actually being revoked (e.g. "revoke all sessions for all users").
+// Companion to ClearAllUsersSessionCacheLocal.
 func (ps *PlatformService) invalidateWebConnSessionCacheForAllUsersSkipClusterSend() {
 	for _, hub := range ps.hubs {
 		if hub != nil {
 			hub.InvalidateAll()
+		}
+	}
+}
+
+// softInvalidateWebConnSessionCacheForAllUsersSkipClusterSend signals every
+// hub on this node to reset the cached session state of all of its
+// WebConns, without clearing their session tokens. This forces each WebConn
+// to re-validate its session against the store on next use: sessions that
+// are still valid transparently re-authenticate, while sessions that were
+// actually revoked correctly stop being treated as authenticated. Unlike
+// invalidateWebConnSessionCacheForAllUsersSkipClusterSend, this is safe to
+// use for routine, non-revocation cache purges since it never permanently
+// breaks unrelated, still-valid connections.
+func (ps *PlatformService) softInvalidateWebConnSessionCacheForAllUsersSkipClusterSend() {
+	for _, hub := range ps.hubs {
+		if hub != nil {
+			hub.InvalidateAllCache()
 		}
 	}
 }
@@ -139,6 +160,7 @@ func (ps *PlatformService) InvalidateAllCachesSkipSend() *model.AppError {
 	if err := ps.ClearAllUsersSessionCacheLocal(); err != nil {
 		ps.logger.Error("Failed to purge session cache", mlog.Err(err))
 	}
+	ps.softInvalidateWebConnSessionCacheForAllUsersSkipClusterSend()
 	if err := ps.statusCache.Purge(); err != nil {
 		ps.logger.Warn("Failed to clear the status cache", mlog.Err(err))
 	}

--- a/server/channels/app/platform/cluster_handlers_test.go
+++ b/server/channels/app/platform/cluster_handlers_test.go
@@ -62,6 +62,12 @@ func TestClearSessionCacheInvalidatesWebConnSession(t *testing.T) {
 				_ = ps.ClearSessionCacheForAllUsersSkipClusterSend()
 			},
 		},
+		{
+			name: "InvalidateAllCachesInvalidatesWebConnSession",
+			revoke: func(ps *PlatformService, _ string) {
+				_ = ps.InvalidateAllCachesSkipSend()
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -108,4 +114,67 @@ func TestClearSessionCacheInvalidatesWebConnSession(t *testing.T) {
 			)
 		})
 	}
+}
+
+// TestInvalidateAllCachesDoesNotPermanentlyBreakUnrelatedSessions asserts
+// that InvalidateAllCachesSkipSend (used e.g. by routine, non-revocation
+// admin actions such as OAuth app deletion or license changes) forces
+// WebConns to re-validate their cached session against the store, but
+// preserves the underlying session token. As a result, a WebConn whose
+// session is still valid in the store must be able to successfully
+// re-authenticate afterwards, unlike a genuine "revoke all sessions for all
+// users" call which intentionally and permanently deauthenticates every
+// WebConn by clearing its session token too.
+func TestInvalidateAllCachesDoesNotPermanentlyBreakUnrelatedSessions(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	th := Setup(t).InitBasic(t)
+
+	s := httptest.NewServer(dummyWebsocketHandler(t))
+	defer s.Close()
+
+	session, err := th.Service.CreateSession(th.Context, &model.Session{
+		UserId: th.BasicUser.Id,
+	})
+	require.NoError(t, err)
+
+	// Pin a future expiry so IsBasicAuthenticated trusts the cached
+	// session and doesn't re-validate against the store yet.
+	session.ExpiresAt = model.GetMillis() + time.Hour.Milliseconds()
+
+	preWarmStatusOnline(th, th.BasicUser.Id)
+
+	wc := registerDummyWebConn(t, th, s.Listener.Addr(), session)
+	defer wc.Close()
+
+	waitForWebConnRegistered(t, th, session)
+
+	require.NotNil(t, wc.GetSession(),
+		"precondition: webconn must have a cached session before invalidation")
+	require.NotEmpty(t, wc.GetSessionToken(),
+		"precondition: webconn must have a session token before invalidation")
+
+	_ = th.Service.InvalidateAllCachesSkipSend()
+
+	// Hub invalidation is async, so poll for the cached session to be
+	// reset, forcing the next IsBasicAuthenticated call to re-validate
+	// against the store.
+	require.Eventually(t, func() bool {
+		return wc.GetSession() == nil && wc.GetSessionExpiresAt() == 0
+	}, 2*time.Second, 25*time.Millisecond,
+		"webconn cached session was not invalidated after InvalidateAllCachesSkipSend")
+
+	// Unlike a genuine mass session revocation, the underlying session
+	// token must be preserved, since this session was never actually
+	// revoked in the store.
+	require.Equal(t, session.Token, wc.GetSessionToken(),
+		"InvalidateAllCachesSkipSend must not clear the session token of unrelated, still-valid sessions")
+
+	// Because the token survived, the WebConn must be able to
+	// successfully re-validate against the store and resume being
+	// treated as authenticated.
+	require.True(t, wc.IsBasicAuthenticated(),
+		"webconn with a still-valid session must re-authenticate after InvalidateAllCachesSkipSend")
+	require.NotNil(t, wc.GetSession(),
+		"webconn must have repopulated its cached session after re-authenticating")
 }

--- a/server/channels/app/platform/web_hub.go
+++ b/server/channels/app/platform/web_hub.go
@@ -78,23 +78,24 @@ var hubSemaphoreCount = runtime.NumCPU() * 4
 type Hub struct {
 	// connectionCount should be kept first.
 	// See https://github.com/mattermost/mattermost-server/pull/7281
-	connectionCount int64
-	platform        *PlatformService
-	connectionIndex int
-	register        chan *webConnRegisterMessage
-	unregister      chan *WebConn
-	broadcast       chan *model.WebSocketEvent
-	stop            chan struct{}
-	didStop         chan struct{}
-	invalidateUser  chan string
-	invalidateAll   chan struct{}
-	activity        chan *webConnActivityMessage
-	directMsg       chan *webConnDirectMessage
-	explicitStop    bool
-	checkRegistered chan *webConnSessionMessage
-	checkConn       chan *webConnCheckMessage
-	connCount       chan *webConnCountMessage
-	broadcastHooks  map[string]BroadcastHook
+	connectionCount    int64
+	platform           *PlatformService
+	connectionIndex    int
+	register           chan *webConnRegisterMessage
+	unregister         chan *WebConn
+	broadcast          chan *model.WebSocketEvent
+	stop               chan struct{}
+	didStop            chan struct{}
+	invalidateUser     chan string
+	invalidateAll      chan struct{}
+	invalidateAllCache chan struct{}
+	activity           chan *webConnActivityMessage
+	directMsg          chan *webConnDirectMessage
+	explicitStop       bool
+	checkRegistered    chan *webConnSessionMessage
+	checkConn          chan *webConnCheckMessage
+	connCount          chan *webConnCountMessage
+	broadcastHooks     map[string]BroadcastHook
 
 	// Hub-specific semaphore for limiting concurrent goroutines
 	hubSemaphore chan struct{}
@@ -103,20 +104,21 @@ type Hub struct {
 // newWebHub creates a new Hub.
 func newWebHub(ps *PlatformService) *Hub {
 	return &Hub{
-		platform:        ps,
-		register:        make(chan *webConnRegisterMessage),
-		unregister:      make(chan *WebConn),
-		broadcast:       make(chan *model.WebSocketEvent, broadcastQueueSize),
-		stop:            make(chan struct{}),
-		didStop:         make(chan struct{}),
-		invalidateUser:  make(chan string),
-		invalidateAll:   make(chan struct{}),
-		activity:        make(chan *webConnActivityMessage),
-		directMsg:       make(chan *webConnDirectMessage),
-		checkRegistered: make(chan *webConnSessionMessage),
-		checkConn:       make(chan *webConnCheckMessage),
-		connCount:       make(chan *webConnCountMessage),
-		hubSemaphore:    make(chan struct{}, hubSemaphoreCount),
+		platform:           ps,
+		register:           make(chan *webConnRegisterMessage),
+		unregister:         make(chan *WebConn),
+		broadcast:          make(chan *model.WebSocketEvent, broadcastQueueSize),
+		stop:               make(chan struct{}),
+		didStop:            make(chan struct{}),
+		invalidateUser:     make(chan string),
+		invalidateAll:      make(chan struct{}),
+		invalidateAllCache: make(chan struct{}),
+		activity:           make(chan *webConnActivityMessage),
+		directMsg:          make(chan *webConnDirectMessage),
+		checkRegistered:    make(chan *webConnSessionMessage),
+		checkConn:          make(chan *webConnCheckMessage),
+		connCount:          make(chan *webConnCountMessage),
+		hubSemaphore:       make(chan struct{}, hubSemaphoreCount),
 	}
 }
 
@@ -467,10 +469,30 @@ func (h *Hub) InvalidateUser(userID string) {
 }
 
 // InvalidateAll invalidates the cached session state of every WebConn
-// registered with this hub. Global counterpart of InvalidateUser.
+// registered with this hub, and clears their session tokens so they can
+// never re-authenticate on this connection again. This is intentionally
+// destructive and should only be used when every session on the server is
+// actually being revoked (e.g. "revoke all sessions for all users"), since
+// clearing the token permanently prevents the WebConn from re-validating
+// against the store. Global counterpart of InvalidateUser.
 func (h *Hub) InvalidateAll() {
 	select {
 	case h.invalidateAll <- struct{}{}:
+	case <-h.stop:
+	}
+}
+
+// InvalidateAllCache resets the cached session state (but not the session
+// token) of every WebConn registered with this hub. Unlike InvalidateAll,
+// this does not clear the session token, so on next use each WebConn
+// re-validates its session against the store: unaffected/valid sessions
+// transparently re-authenticate, while sessions that were actually revoked
+// in the store correctly stop being treated as authenticated. Suitable for
+// routine, non-revocation cache purges that must not permanently break
+// unrelated connections.
+func (h *Hub) InvalidateAllCache() {
+	select {
+	case h.invalidateAllCache <- struct{}{}:
 	case <-h.stop:
 	}
 }
@@ -684,6 +706,18 @@ func (h *Hub) Start() {
 				for webConn := range connIndex.All() {
 					webConn.InvalidateCache()
 					webConn.SetSessionToken("")
+				}
+				if *h.platform.Config().ServiceSettings.EnableWebHubChannelIteration {
+					connIndex.clearChannels()
+				}
+			case <-h.invalidateAllCache:
+				// Like invalidateAll, but leaves the session token intact
+				// so the next IsBasicAuthenticated check re-fetches the
+				// session from the store instead of permanently failing.
+				// Used for routine cache purges that aren't an actual
+				// mass session revocation.
+				for webConn := range connIndex.All() {
+					webConn.InvalidateCache()
 				}
 				if *h.platform.Config().ServiceSettings.EnableWebHubChannelIteration {
 					connIndex.clearChannels()


### PR DESCRIPTION
## Ticket Link

Fixes MM-69998.

```release-note
Fixed an issue where invalidating cached sessions did not propagate to already-open websocket connections in some cases.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** The changes affect shared WebSocket session invalidation and authentication state across hub and cluster paths. The OAuth deletion test covers the primary flow, but other hub and cluster paths may still regress.

**QA Recommendation:** Perform targeted manual tests for OAuth deletion, session invalidation, and existing WebSocket connections.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
