### PR TITLE
Update merge-definitions.js

### DIFF
--- a/api/playbooks/merge-definitions.js
+++ b/api/playbooks/merge-definitions.js
@@ -11,19 +11,28 @@ class MergeDefinitions {
      * @param data {Record<String, any>}
      */
     writeFile(filename, data) {
-        fs.writeFileSync(filename, YAML.stringify(data, { lineWidth: 0 }).trimEnd());
-        console.log("wrote file " + filename);
+        try {
+            fs.writeFileSync(filename, YAML.stringify(data, { lineWidth: 0 }).trimEnd());
+            console.log("Wrote file " + filename);
+        } catch (error) {
+            console.error("Error writing file " + filename + ":", error.message);
+        }
     }
 
     /**
      * Read a YAML file, parse it, and return the resulting object
      * @param filename {String} The YAML file to read
-     * @returns {Record<String,any>} The parsed object
+     * @returns {Record<String,any>|null} The parsed object
      */
     readFile(filename) {
-        const rawYaml = fs.readFileSync(filename);
-        console.log("read file " + filename);
-        return YAML.parse(rawYaml.toString());
+        try {
+            const rawYaml = fs.readFileSync(filename, 'utf8');
+            console.log("Read file " + filename);
+            return YAML.parse(rawYaml) || {};
+        } catch (error) {
+            console.error("Error reading file " + filename + ":", error.message);
+            return null;
+        }
     }
 
     /**
@@ -31,29 +40,32 @@ class MergeDefinitions {
      * @param args {Array<String>} Program arguments
      */
     run(args) {
-        if (args.length < 3) {
-            console.error("please specify an input file");
+        if (args.length < 3 || !args[2]) {
+            console.error("Please specify an input file");
             return;
         }
-        if (args[2] === "") {
-            console.error("input file not specified");
-            return;
-        }
-        // read definitions.yaml
+
+        // Read definitions.yaml
         const parsed = this.readFile(args[2]);
-        // read schemas.yaml
-        const schemas = this.readFile("schemas.yaml");
-        // read responses.yaml
-        const responses = this.readFile("responses.yaml");
-        // read securitySchemes.yaml
-        const securitySchemes = this.readFile("securitySchemes.yaml");
-        // merge schemas with definitions.yaml
-        parsed["components"]["schemas"] = Object.assign(parsed["components"]["schemas"], schemas);
-        // merge responses with definitions.yaml
-        parsed["components"]["responses"] = Object.assign(parsed["components"]["responses"], responses);
-        // merge securitySchemes with definitions.yaml
-        parsed["components"]["securitySchemes"] = Object.assign(parsed["components"]["securitySchemes"], securitySchemes);
-        // write merged definitions to a new file
+        if (!parsed) return;
+
+        // Ensure 'components' structure exists safely
+        parsed.components = parsed.components || {};
+        parsed.components.schemas = parsed.components.schemas || {};
+        parsed.components.responses = parsed.components.responses || {};
+        parsed.components.securitySchemes = parsed.components.securitySchemes || {};
+
+        // Read other files safely (defaults to empty object if file fails/missing)
+        const schemas = this.readFile("schemas.yaml") || {};
+        const responses = this.readFile("responses.yaml") || {};
+        const securitySchemes = this.readFile("securitySchemes.yaml") || {};
+
+        // Merge components
+        Object.assign(parsed.components.schemas, schemas);
+        Object.assign(parsed.components.responses, responses);
+        Object.assign(parsed.components.securitySchemes, securitySchemes);
+
+        // Write merged definitions to a new file
         this.writeFile("merged-definitions.yaml", parsed);
     }
 }


### PR DESCRIPTION
## Summary

Improved the `MergeDefinitions` class with better error handling and robustness.

## Changes

- Added `try/catch` error handling in `readFile()` and `writeFile()` methods
- Added `'utf8'` encoding explicitly in `fs.readFileSync()`
- Added safe fallback for missing `components` structure
- Improved input validation — handles null/undefined args
- Cleaner console log messages

## Type of Change
- Bug fix / improvement
- Chore / refactor

## Testing
- Tested with valid YAML input files
- Tested with missing/invalid files — graceful error handling confirmed.

<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
<!-- What does this PR do? Include QA steps if not covered in the ticket. -->

#### Ticket Link
<!--
Fixes: https://github.com/mattermost/mattermost/issues/XXX
Fixes: https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!-- Include screenshots or GIFs for UI changes. -->

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are isolated to YAML file I/O and definition merging, with limited risk confined to malformed or missing inputs.  
**QA Recommendation:** Manual QA can be skipped given full automated test coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->