### PR TITLE
Add wait_for_cluster option to plugin upload API, mmctl, and system console

### DIFF
--- a/api/v4/source/plugins.yaml
+++ b/api/v4/source/plugins.yaml
@@ -30,11 +30,25 @@
                   description: Set to 'true' to overwrite a previously installed plugin
                     with the same ID, if any
                   type: string
+                wait_for_cluster:
+                  description: Set to 'true' to block the request until the plugin is
+                    deployed to all nodes in the cluster, subject to a 30 second
+                    timeout. If the timeout elapses first, the server responds with
+                    `202` instead of `201`.
+                  type: string
               required:
                 - plugin
       responses:
         "201":
           description: Plugin upload successful
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StatusOK"
+        "202":
+          description: Plugin upload successful, but deployment to all nodes in the
+            cluster wasn't confirmed before the timeout while `wait_for_cluster`
+            was set
           content:
             application/json:
               schema:

--- a/server/channels/api4/plugin.go
+++ b/server/channels/api4/plugin.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
 
@@ -23,6 +24,11 @@ const (
 	// MaxPluginMemory is the maximum number of bytes to hold in memory when reading a plugin bundle.
 	MaxPluginMemory = 50 * 1024 * 1024
 )
+
+// pluginClusterDeploymentTimeout is the maximum time an upload request blocks waiting for the
+// plugin to be deployed to all nodes in the cluster. It's a variable to allow tests to shorten
+// the wait.
+var pluginClusterDeploymentTimeout = 30 * time.Second
 
 func (api *API) InitPlugin() {
 	api.BaseRoutes.Plugins.Handle("", api.APISessionRequired(uploadPlugin, handlerParamFileAPI)).Methods(http.MethodPost)
@@ -93,7 +99,12 @@ func uploadPlugin(c *Context, w http.ResponseWriter, r *http.Request) {
 		force = true
 	}
 
-	installPlugin(c, w, file, force)
+	waitForCluster := false
+	if len(m.Value["wait_for_cluster"]) > 0 && m.Value["wait_for_cluster"][0] == "true" {
+		waitForCluster = true
+	}
+
+	installPlugin(c, w, file, force, waitForCluster)
 	auditRec.Success()
 }
 
@@ -123,7 +134,7 @@ func installPluginFromURL(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	installPlugin(c, w, bytes.NewReader(pluginFileBytes), force)
+	installPlugin(c, w, bytes.NewReader(pluginFileBytes), force, false)
 	auditRec.Success()
 }
 
@@ -409,7 +420,7 @@ func parseMarketplacePluginFilter(u *url.URL) (*model.MarketplacePluginFilter, e
 	}, nil
 }
 
-func installPlugin(c *Context, w http.ResponseWriter, plugin io.ReadSeeker, force bool) {
+func installPlugin(c *Context, w http.ResponseWriter, plugin io.ReadSeeker, force, waitForCluster bool) {
 	conflict, err := fileutils.CheckDirectoryConflict(*c.App.Config().PluginSettings.Directory, *c.App.Config().ImportSettings.Directory)
 	if err != nil {
 		c.Err = model.NewAppError("installPlugin", "api.plugin.install.check_directory.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
@@ -425,7 +436,15 @@ func installPlugin(c *Context, w http.ResponseWriter, plugin io.ReadSeeker, forc
 		c.Err = appErr
 		return
 	}
-	w.WriteHeader(http.StatusCreated)
+
+	// 201 Created signals a fully deployed plugin, while 202 Accepted signals a successful
+	// install that couldn't be confirmed as deployed to all cluster nodes before the timeout.
+	statusCode := http.StatusCreated
+	if waitForCluster && !c.App.WaitForPluginDeployment(c.AppContext, manifest, pluginClusterDeploymentTimeout) {
+		statusCode = http.StatusAccepted
+	}
+
+	w.WriteHeader(statusCode)
 	if err := json.NewEncoder(w).Encode(manifest); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}

--- a/server/channels/api4/plugin_test.go
+++ b/server/channels/api4/plugin_test.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -477,6 +478,123 @@ func TestNotifyClusterPluginEvent(t *testing.T) {
 	pluginStored, appErr = th.App.FileExists(expectedPath)
 	require.Nil(t, appErr)
 	require.False(t, pluginStored)
+}
+
+// pluginDeploymentClusterMock extends the fake cluster with configurable cluster infos and
+// plugin statuses to exercise waiting on plugin deployment across the cluster.
+type pluginDeploymentClusterMock struct {
+	*testlib.FakeClusterInterface
+
+	mut            sync.RWMutex
+	clusterInfos   []*model.ClusterInfo
+	pluginStatuses model.PluginStatuses
+}
+
+func (c *pluginDeploymentClusterMock) GetClusterId() string {
+	return "node-1"
+}
+
+func (c *pluginDeploymentClusterMock) GetClusterInfos() ([]*model.ClusterInfo, error) {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	return c.clusterInfos, nil
+}
+
+func (c *pluginDeploymentClusterMock) GetPluginStatuses() (model.PluginStatuses, *model.AppError) {
+	c.mut.RLock()
+	defer c.mut.RUnlock()
+	return c.pluginStatuses, nil
+}
+
+func (c *pluginDeploymentClusterMock) setPluginStatuses(statuses model.PluginStatuses) {
+	c.mut.Lock()
+	defer c.mut.Unlock()
+	c.pluginStatuses = statuses
+}
+
+func TestUploadPluginWaitForCluster(t *testing.T) {
+	th := Setup(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.PluginSettings.Enable = true
+		*cfg.PluginSettings.EnableUploads = true
+	})
+
+	path, _ := fileutils.FindDir("tests")
+	tarData, err := os.ReadFile(filepath.Join(path, "testplugin.tar.gz"))
+	require.NoError(t, err)
+
+	uploadWithWait := func(force bool) (*model.Manifest, *model.Response, error) {
+		return th.SystemAdminClient.UploadPluginWithOptions(context.Background(), bytes.NewReader(tarData), model.PluginUploadOptions{
+			Force:          force,
+			WaitForCluster: true,
+		})
+	}
+
+	t.Run("without a cluster, the plugin is deployed as soon as it's installed", func(t *testing.T) {
+		manifest, resp, err := uploadWithWait(false)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		require.Equal(t, "testplugin", manifest.Id)
+	})
+
+	// Shorten the deployment timeout to keep the timeout test fast.
+	originalTimeout := pluginClusterDeploymentTimeout
+	pluginClusterDeploymentTimeout = 2 * time.Second
+	defer func() { pluginClusterDeploymentTimeout = originalTimeout }()
+
+	testCluster := &pluginDeploymentClusterMock{
+		FakeClusterInterface: &testlib.FakeClusterInterface{},
+		clusterInfos: []*model.ClusterInfo{
+			{Hostname: "node-1"},
+			{Hostname: "node-2"},
+		},
+	}
+	th.Server.Platform().SetCluster(testCluster)
+	defer th.Server.Platform().SetCluster(nil)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ClusterSettings.Enable = true
+	})
+	defer th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.ClusterSettings.Enable = false
+	})
+
+	t.Run("202 when deployment to all cluster nodes isn't confirmed before the timeout", func(t *testing.T) {
+		manifest, resp, err := uploadWithWait(true)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, resp.StatusCode)
+		require.Equal(t, "testplugin", manifest.Id)
+	})
+
+	t.Run("201 when all cluster nodes report the plugin at the same version", func(t *testing.T) {
+		testCluster.setPluginStatuses(model.PluginStatuses{{
+			ClusterId: "node-2",
+			PluginId:  "testplugin",
+			Version:   "0.0.1",
+		}})
+
+		manifest, resp, err := uploadWithWait(true)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusCreated, resp.StatusCode)
+		require.Equal(t, "testplugin", manifest.Id)
+	})
+
+	t.Run("202 when a cluster node reports a different version of the plugin", func(t *testing.T) {
+		testCluster.setPluginStatuses(model.PluginStatuses{{
+			ClusterId: "node-2",
+			PluginId:  "testplugin",
+			Version:   "0.0.2",
+		}})
+
+		manifest, resp, err := uploadWithWait(true)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusAccepted, resp.StatusCode)
+		require.Equal(t, "testplugin", manifest.Id)
+	})
+
+	_, err = th.SystemAdminClient.RemovePlugin(context.Background(), "testplugin")
+	require.NoError(t, err)
 }
 
 func TestDisableOnRemove(t *testing.T) {

--- a/server/channels/app/plugin_install.go
+++ b/server/channels/app/plugin_install.go
@@ -80,11 +80,14 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/pkg/errors"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 	"github.com/mattermost/mattermost/server/public/utils"
 	"github.com/mattermost/mattermost/server/v8/platform/shared/filestore"
 )
@@ -176,6 +179,75 @@ func (a *App) InstallPlugin(pluginFile io.ReadSeeker, replace bool) (*model.Mani
 	}
 
 	return a.ch.installPlugin(pluginFile, nil, installationStrategy)
+}
+
+// pluginDeploymentPollInterval is how often to check cluster peers when waiting for a plugin to
+// be deployed to all nodes in the cluster.
+const pluginDeploymentPollInterval = 500 * time.Millisecond
+
+// WaitForPluginDeployment blocks until the given plugin version is installed on every node in
+// the cluster, the given timeout elapses, or the request is cancelled, returning true only if
+// full deployment was observed.
+//
+// Servers without clustering are considered fully deployed as soon as the plugin is installed
+// locally, so this returns true immediately.
+func (a *App) WaitForPluginDeployment(rctx request.CTX, manifest *model.Manifest, timeout time.Duration) bool {
+	return a.ch.waitForPluginDeployment(rctx, manifest, timeout)
+}
+
+func (ch *Channels) waitForPluginDeployment(rctx request.CTX, manifest *model.Manifest, timeout time.Duration) bool {
+	if ch.srv.platform.Cluster() == nil || !*ch.cfgSvc.Config().ClusterSettings.Enable {
+		return true
+	}
+
+	logger := rctx.Logger().With(mlog.String("plugin_id", manifest.Id), mlog.String("version", manifest.Version))
+
+	deadline := time.After(timeout)
+	ticker := time.NewTicker(pluginDeploymentPollInterval)
+	defer ticker.Stop()
+
+	for {
+		deployed, err := ch.pluginDeployedOnAllNodes(manifest)
+		if err != nil {
+			logger.Warn("Failed to check plugin deployment status across the cluster", mlog.Err(err))
+		} else if deployed {
+			return true
+		}
+
+		select {
+		case <-rctx.Context().Done():
+			return false
+		case <-deadline:
+			logger.Warn("Timed out waiting for the plugin to be deployed to all nodes in the cluster")
+			return false
+		case <-ticker.C:
+		}
+	}
+}
+
+// pluginDeployedOnAllNodes reports whether every node in the cluster reports the given plugin at
+// the given version. Plugin statuses identify nodes by cluster id, which isn't guaranteed to
+// match the id reported by GetClusterInfos, so compare the number of nodes reporting the
+// expected version against the total number of nodes in the cluster.
+func (ch *Channels) pluginDeployedOnAllNodes(manifest *model.Manifest) (bool, error) {
+	clusterInfos, err := ch.srv.platform.Cluster().GetClusterInfos()
+	if err != nil {
+		return false, errors.Wrap(err, "failed to get cluster infos")
+	}
+
+	statuses, appErr := ch.getClusterPluginStatuses()
+	if appErr != nil {
+		return false, appErr
+	}
+
+	nodesWithPlugin := make(map[string]bool)
+	for _, status := range statuses {
+		if status.PluginId == manifest.Id && status.Version == manifest.Version {
+			nodesWithPlugin[status.ClusterId] = true
+		}
+	}
+
+	return len(nodesWithPlugin) >= len(clusterInfos), nil
 }
 
 // installPlugin extracts and installs the given plugin bundle (optionally signed) for the

--- a/server/cmd/mmctl/client/client.go
+++ b/server/cmd/mmctl/client/client.go
@@ -62,6 +62,7 @@ type Client interface {
 	PatchRole(ctx context.Context, roleID string, patch *model.RolePatch) (*model.Role, *model.Response, error)
 	UploadPlugin(ctx context.Context, file io.Reader) (*model.Manifest, *model.Response, error)
 	UploadPluginForced(ctx context.Context, file io.Reader) (*model.Manifest, *model.Response, error)
+	UploadPluginWithOptions(ctx context.Context, file io.Reader, options model.PluginUploadOptions) (*model.Manifest, *model.Response, error)
 	RemovePlugin(ctx context.Context, id string) (*model.Response, error)
 	EnablePlugin(ctx context.Context, id string) (*model.Response, error)
 	DisablePlugin(ctx context.Context, id string) (*model.Response, error)

--- a/server/cmd/mmctl/commands/plugin.go
+++ b/server/cmd/mmctl/commands/plugin.go
@@ -6,8 +6,10 @@ package commands
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 
+	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/client"
 	"github.com/mattermost/mattermost/server/v8/cmd/mmctl/printer"
 
@@ -80,6 +82,7 @@ var PluginListCmd = &cobra.Command{
 
 func init() {
 	PluginAddCmd.Flags().BoolP("force", "f", false, "overwrite a previously installed plugin with the same ID, if any")
+	PluginAddCmd.Flags().BoolP("wait-for-cluster", "w", false, "wait up to 30 seconds for the plugin to be deployed to all nodes in the cluster")
 	PluginInstallURLCmd.Flags().BoolP("force", "f", false, "overwrite a previously installed plugin with the same ID, if any")
 
 	PluginCmd.AddCommand(
@@ -95,6 +98,7 @@ func init() {
 
 func pluginAddCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 	force, _ := cmd.Flags().GetBool("force")
+	waitForCluster, _ := cmd.Flags().GetBool("wait-for-cluster")
 	var multiErr *multierror.Error
 
 	for i, plugin := range args {
@@ -103,14 +107,18 @@ func pluginAddCmdF(c client.Client, cmd *cobra.Command, args []string) error {
 			return err
 		}
 
-		if force {
-			_, _, err = c.UploadPluginForced(context.TODO(), fileReader)
-		} else {
-			_, _, err = c.UploadPlugin(context.TODO(), fileReader)
+		options := model.PluginUploadOptions{
+			Force:          force,
+			WaitForCluster: waitForCluster,
 		}
+		_, resp, err := c.UploadPluginWithOptions(context.TODO(), fileReader, options)
 
 		if err != nil {
 			printer.PrintError("Unable to add plugin: " + args[i] + ". Error: " + err.Error())
+			multiErr = multierror.Append(multiErr, err)
+		} else if resp.StatusCode == http.StatusAccepted {
+			err = errors.New("plugin was uploaded, but deployment to all nodes in the cluster wasn't confirmed within 30 seconds: " + plugin)
+			printer.PrintError(err.Error())
 			multiErr = multierror.Append(multiErr, err)
 		} else {
 			printer.Print("Added plugin: " + plugin)

--- a/server/cmd/mmctl/commands/plugin_test.go
+++ b/server/cmd/mmctl/commands/plugin_test.go
@@ -29,8 +29,8 @@ func (s *MmctlUnitTestSuite) TestPluginAddCmd() {
 
 		s.client.
 			EXPECT().
-			UploadPlugin(context.TODO(), gomock.AssignableToTypeOf(tmpFile)).
-			Return(&model.Manifest{}, &model.Response{}, nil).
+			UploadPluginWithOptions(context.TODO(), gomock.AssignableToTypeOf(tmpFile), model.PluginUploadOptions{}).
+			Return(&model.Manifest{}, &model.Response{StatusCode: http.StatusCreated}, nil).
 			Times(1)
 
 		err = pluginAddCmdF(s.client, &cobra.Command{}, []string{pluginName})
@@ -49,8 +49,8 @@ func (s *MmctlUnitTestSuite) TestPluginAddCmd() {
 
 		s.client.
 			EXPECT().
-			UploadPluginForced(context.TODO(), gomock.AssignableToTypeOf(tmpFile)).
-			Return(&model.Manifest{}, &model.Response{}, nil).
+			UploadPluginWithOptions(context.TODO(), gomock.AssignableToTypeOf(tmpFile), model.PluginUploadOptions{Force: true}).
+			Return(&model.Manifest{}, &model.Response{StatusCode: http.StatusCreated}, nil).
 			Times(1)
 
 		cmd := &cobra.Command{}
@@ -60,6 +60,53 @@ func (s *MmctlUnitTestSuite) TestPluginAddCmd() {
 		s.Require().NoError(err)
 		s.Require().Len(printer.GetLines(), 1)
 		s.Require().Equal(printer.GetLines()[0], "Added plugin: "+pluginName)
+	})
+
+	s.Run("Add 1 plugin, waiting for cluster deployment", func() {
+		printer.Clean()
+		tmpFile, err := os.CreateTemp("", "tmpPlugin")
+		s.Require().Nil(err)
+		defer os.Remove(tmpFile.Name())
+
+		pluginName := tmpFile.Name()
+
+		s.client.
+			EXPECT().
+			UploadPluginWithOptions(context.TODO(), gomock.AssignableToTypeOf(tmpFile), model.PluginUploadOptions{WaitForCluster: true}).
+			Return(&model.Manifest{}, &model.Response{StatusCode: http.StatusCreated}, nil).
+			Times(1)
+
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("wait-for-cluster", true, "")
+
+		err = pluginAddCmdF(s.client, cmd, []string{pluginName})
+		s.Require().NoError(err)
+		s.Require().Len(printer.GetLines(), 1)
+		s.Require().Equal(printer.GetLines()[0], "Added plugin: "+pluginName)
+	})
+
+	s.Run("Add 1 plugin, timing out waiting for cluster deployment", func() {
+		printer.Clean()
+		tmpFile, err := os.CreateTemp("", "tmpPlugin")
+		s.Require().Nil(err)
+		defer os.Remove(tmpFile.Name())
+
+		pluginName := tmpFile.Name()
+
+		s.client.
+			EXPECT().
+			UploadPluginWithOptions(context.TODO(), gomock.AssignableToTypeOf(tmpFile), model.PluginUploadOptions{WaitForCluster: true}).
+			Return(&model.Manifest{}, &model.Response{StatusCode: http.StatusAccepted}, nil).
+			Times(1)
+
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("wait-for-cluster", true, "")
+
+		err = pluginAddCmdF(s.client, cmd, []string{pluginName})
+		s.Require().ErrorContains(err, "deployment to all nodes in the cluster wasn't confirmed")
+		s.Require().Len(printer.GetLines(), 0)
+		s.Require().Len(printer.GetErrorLines(), 1)
+		s.Require().Equal(printer.GetErrorLines()[0], "plugin was uploaded, but deployment to all nodes in the cluster wasn't confirmed within 30 seconds: "+pluginName)
 	})
 
 	s.Run("Add 1 plugin no file", func() {
@@ -80,7 +127,7 @@ func (s *MmctlUnitTestSuite) TestPluginAddCmd() {
 
 		s.client.
 			EXPECT().
-			UploadPlugin(context.TODO(), gomock.AssignableToTypeOf(tmpFile)).
+			UploadPluginWithOptions(context.TODO(), gomock.AssignableToTypeOf(tmpFile), model.PluginUploadOptions{}).
 			Return(&model.Manifest{}, &model.Response{}, mockError).
 			Times(1)
 
@@ -102,14 +149,14 @@ func (s *MmctlUnitTestSuite) TestPluginAddCmd() {
 			if arg == "fail" {
 				s.client.
 					EXPECT().
-					UploadPlugin(context.TODO(), gomock.AssignableToTypeOf(tmpFile)).
+					UploadPluginWithOptions(context.TODO(), gomock.AssignableToTypeOf(tmpFile), model.PluginUploadOptions{}).
 					Return(nil, &model.Response{}, mockError).
 					Times(1)
 			} else {
 				s.client.
 					EXPECT().
-					UploadPlugin(context.TODO(), gomock.AssignableToTypeOf(tmpFile)).
-					Return(&model.Manifest{}, &model.Response{}, nil).
+					UploadPluginWithOptions(context.TODO(), gomock.AssignableToTypeOf(tmpFile), model.PluginUploadOptions{}).
+					Return(&model.Manifest{}, &model.Response{StatusCode: http.StatusCreated}, nil).
 					Times(1)
 			}
 			args[idx] = tmpFile.Name()

--- a/server/cmd/mmctl/docs/mmctl_plugin_add.rst
+++ b/server/cmd/mmctl/docs/mmctl_plugin_add.rst
@@ -27,8 +27,9 @@ Options
 
 ::
 
-  -f, --force   overwrite a previously installed plugin with the same ID, if any
-  -h, --help    help for add
+  -f, --force              overwrite a previously installed plugin with the same ID, if any
+  -h, --help               help for add
+  -w, --wait-for-cluster   wait up to 30 seconds for the plugin to be deployed to all nodes in the cluster
 
 Options inherited from parent commands
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/server/cmd/mmctl/mocks/client_mock.go
+++ b/server/cmd/mmctl/mocks/client_mock.go
@@ -2718,6 +2718,22 @@ func (mr *MockClientMockRecorder) UploadPluginForced(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadPluginForced", reflect.TypeOf((*MockClient)(nil).UploadPluginForced), arg0, arg1)
 }
 
+// UploadPluginWithOptions mocks base method.
+func (m *MockClient) UploadPluginWithOptions(arg0 context.Context, arg1 io.Reader, arg2 model.PluginUploadOptions) (*model.Manifest, *model.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadPluginWithOptions", arg0, arg1, arg2)
+	ret0, _ := ret[0].(*model.Manifest)
+	ret1, _ := ret[1].(*model.Response)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// UploadPluginWithOptions indicates an expected call of UploadPluginWithOptions.
+func (mr *MockClientMockRecorder) UploadPluginWithOptions(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadPluginWithOptions", reflect.TypeOf((*MockClient)(nil).UploadPluginWithOptions), arg0, arg1, arg2)
+}
+
 // VerifyUserEmailWithoutToken mocks base method.
 func (m *MockClient) VerifyUserEmailWithoutToken(arg0 context.Context, arg1 string) (*model.User, *model.Response, error) {
 	m.ctrl.T.Helper()

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -6607,21 +6607,44 @@ func (c *Client4) GetChannelsForScheme(ctx context.Context, schemeId string, pag
 
 // Plugin Section
 
+// PluginUploadOptions alters the behavior of uploading a plugin.
+type PluginUploadOptions struct {
+	// Force overwrites a previously installed plugin with the same id, if any.
+	Force bool
+
+	// WaitForCluster blocks the request until the plugin is deployed to all nodes in the
+	// cluster, subject to a 30 second timeout. If the timeout elapses first, the server
+	// responds with 202 Accepted instead of 201 Created, but the upload itself succeeds.
+	WaitForCluster bool
+}
+
 // UploadPlugin takes an io.Reader stream pointing to the contents of a .tar.gz plugin.
 func (c *Client4) UploadPlugin(ctx context.Context, file io.Reader) (*Manifest, *Response, error) {
-	return c.uploadPlugin(ctx, file, false)
+	return c.UploadPluginWithOptions(ctx, file, PluginUploadOptions{})
 }
 
 func (c *Client4) UploadPluginForced(ctx context.Context, file io.Reader) (*Manifest, *Response, error) {
-	return c.uploadPlugin(ctx, file, true)
+	return c.UploadPluginWithOptions(ctx, file, PluginUploadOptions{Force: true})
 }
 
-func (c *Client4) uploadPlugin(ctx context.Context, file io.Reader, force bool) (*Manifest, *Response, error) {
+// UploadPluginWithOptions takes an io.Reader stream pointing to the contents of a .tar.gz
+// plugin, along with options altering the upload behavior. Callers passing
+// PluginUploadOptions.WaitForCluster should check the Response's StatusCode for 202 Accepted,
+// indicating a successful upload that couldn't be confirmed as deployed to all nodes in the
+// cluster before the timeout.
+func (c *Client4) UploadPluginWithOptions(ctx context.Context, file io.Reader, options PluginUploadOptions) (*Manifest, *Response, error) {
 	body := new(bytes.Buffer)
 	writer := multipart.NewWriter(body)
 
-	if force {
+	if options.Force {
 		err := writer.WriteField("force", c.boolString(true))
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	if options.WaitForCluster {
+		err := writer.WriteField("wait_for_cluster", c.boolString(true))
 		if err != nil {
 			return nil, nil, err
 		}

--- a/webapp/channels/src/components/admin_console/plugin_management/plugin_management.test.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_management/plugin_management.test.tsx
@@ -576,4 +576,92 @@ describe('components/PluginManagement', () => {
         });
         expect(container).toMatchSnapshot();
     });
+
+    describe('helpSubmitUpload', () => {
+        const file = new File(['test'], 'plugin.tar.gz');
+        let scrollIntoView: jest.Mock;
+
+        beforeEach(() => {
+            jest.spyOn(window, 'requestAnimationFrame').mockImplementation((cb) => {
+                cb(0);
+                return 0;
+            });
+
+            scrollIntoView = jest.fn();
+            Element.prototype.scrollIntoView = scrollIntoView;
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        const renderComponent = (uploadPlugin: jest.Mock) => {
+            const props = {
+                ...defaultProps,
+                actions: {
+                    ...defaultProps.actions,
+                    uploadPlugin,
+                },
+            };
+            const ref = React.createRef<InstanceType<typeof PluginManagement>>();
+            renderWithContext(
+                <PluginManagement
+                    {...props}
+                    ref={ref}
+                />,
+            );
+            act(() => {
+                ref.current!.setState({loading: false} as any);
+            });
+            return ref;
+        };
+
+        test('waits for cluster deployment and scrolls to the plugin on success', async () => {
+            const uploadPlugin = jest.fn().mockResolvedValue({
+                data: {manifest: {id: 'plugin_0'}, deployedToAllNodes: true},
+            });
+            const ref = renderComponent(uploadPlugin);
+
+            await act(async () => {
+                await ref.current!.helpSubmitUpload(file, false);
+            });
+
+            expect(uploadPlugin).toHaveBeenCalledWith(file, false, true);
+            expect(ref.current!.state.lastMessage).toBe('Successfully uploaded plugin from plugin.tar.gz');
+            expect(ref.current!.state.serverError).toBeNull();
+            expect(scrollIntoView).toHaveBeenCalledTimes(1);
+            expect((scrollIntoView.mock.instances[0] as HTMLElement).getAttribute('data-testid')).toBe('plugin_0');
+        });
+
+        test('shows an error but still scrolls to the plugin when cluster deployment times out', async () => {
+            const uploadPlugin = jest.fn().mockResolvedValue({
+                data: {manifest: {id: 'plugin_0'}, deployedToAllNodes: false},
+            });
+            const ref = renderComponent(uploadPlugin);
+
+            await act(async () => {
+                await ref.current!.helpSubmitUpload(file, false);
+            });
+
+            expect(uploadPlugin).toHaveBeenCalledWith(file, false, true);
+            expect(ref.current!.state.lastMessage).toBeNull();
+            expect(ref.current!.state.serverError).toContain('wasn\'t confirmed within 30 seconds');
+            expect(scrollIntoView).toHaveBeenCalledTimes(1);
+            expect((scrollIntoView.mock.instances[0] as HTMLElement).getAttribute('data-testid')).toBe('plugin_0');
+        });
+
+        test('does not scroll when the upload fails', async () => {
+            const uploadPlugin = jest.fn().mockResolvedValue({
+                error: {server_error_id: 'some.error', message: 'upload failed'},
+            });
+            const ref = renderComponent(uploadPlugin);
+
+            await act(async () => {
+                await ref.current!.helpSubmitUpload(file, false);
+            });
+
+            expect(ref.current!.state.serverError).toBe('upload failed');
+            expect(scrollIntoView).not.toHaveBeenCalled();
+        });
+    });
 });

--- a/webapp/channels/src/components/admin_console/plugin_management/plugin_management.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_management/plugin_management.tsx
@@ -8,6 +8,7 @@ import {Link} from 'react-router-dom';
 
 import {Button} from '@mattermost/shared/components/button';
 import type {AdminConfig} from '@mattermost/types/config';
+import type {PluginUploadResponse} from '@mattermost/types/plugins';
 import type {DeepPartial} from '@mattermost/types/utilities';
 
 import PluginState from 'mattermost-redux/constants/plugins';
@@ -466,7 +467,7 @@ type Props = BaseProps & {
     plugins: any;
     appsFeatureFlagEnabled: boolean;
     actions: {
-        uploadPlugin: (fileData: File, force: boolean) => Promise<ActionResult>;
+        uploadPlugin: (fileData: File, force: boolean, waitForCluster: boolean) => Promise<ActionResult<PluginUploadResponse>>;
         removePlugin: (pluginId: string) => Promise<ActionResult>;
         getPlugins: () => Promise<ActionResult>;
         getPluginStatuses: () => Promise<ActionResult>;
@@ -576,7 +577,10 @@ export class PluginManagement extends OLDAdminSettings<Props, State> {
 
     helpSubmitUpload = async (file: File, force: boolean) => {
         this.setState({uploading: true});
-        const {error} = await this.props.actions.uploadPlugin(file, force);
+
+        // Block until the plugin is deployed to all nodes in the cluster, subject to a
+        // server-side timeout, so the plugin list reflects the upload when it finishes.
+        const {data, error} = await this.props.actions.uploadPlugin(file, force, true);
 
         if (error) {
             if (error.server_error_id === 'app.plugin.install_id.app_error' && !force) {
@@ -600,21 +604,40 @@ export class PluginManagement extends OLDAdminSettings<Props, State> {
         }
 
         this.setState({loading: true});
-        await this.props.actions.getPlugins();
+        await Promise.all([
+            this.props.actions.getPlugins(),
+            this.props.actions.getPluginStatuses(),
+        ]);
 
-        let msg = `Successfully uploaded plugin from ${file?.name}`;
-        if (this.state.overwritingUpload) {
-            msg = `Successfully updated plugin from ${file?.name}`;
+        let serverError: string | null = null;
+        let lastMessage: string | null = null;
+        if (data && !data.deployedToAllNodes) {
+            serverError = this.props.intl.formatMessage({id: 'admin.plugin.error.cluster_deployment_timeout', defaultMessage: 'The plugin was uploaded, but its deployment to all servers in the cluster wasn\'t confirmed within 30 seconds. Check the plugin status below.'});
+        } else if (this.state.overwritingUpload) {
+            lastMessage = `Successfully updated plugin from ${file?.name}`;
+        } else {
+            lastMessage = `Successfully uploaded plugin from ${file?.name}`;
         }
 
         this.setState({
             file: null,
             fileSelected: false,
-            serverError: null,
-            lastMessage: msg,
+            serverError,
+            lastMessage,
             overwritingUpload: false,
             uploading: false,
             loading: false,
+        }, () => {
+            if (data) {
+                this.scrollToPlugin(data.manifest.id);
+            }
+        });
+    };
+
+    scrollToPlugin = (pluginId: string) => {
+        window.requestAnimationFrame(() => {
+            const element = document.querySelector(`div[data-testid="${CSS.escape(pluginId)}"]`);
+            element?.scrollIntoView({behavior: 'smooth', block: 'center'});
         });
     };
 

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -2683,6 +2683,7 @@
   "admin.plugin.enable_plugin.help": "When true, this plugin is enabled.",
   "admin.plugin.enabling": "Enabling...",
   "admin.plugin.error.activate": "Unable to upload the plugin. It may conflict with another plugin on your server.",
+  "admin.plugin.error.cluster_deployment_timeout": "The plugin was uploaded, but its deployment to all servers in the cluster wasn't confirmed within 30 seconds. Check the plugin status below.",
   "admin.plugin.error.extract": "Encountered an error when extracting the plugin. Review your plugin file content and try again.",
   "admin.plugin.installedDesc": "Installed plugins on your Mattermost server.",
   "admin.plugin.installedTitle": "Installed Plugins: ",

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/admin.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/admin.test.ts
@@ -711,10 +711,26 @@ describe('Actions.Admin', () => {
 
         nock(Client4.getBaseRoute()).
             post('/plugins').
-            reply(200, testPlugin);
-        await store.dispatch(Actions.uploadPlugin(testFileData as any, false));
+            reply(201, testPlugin);
+        const {data} = await store.dispatch(Actions.uploadPlugin(testFileData as any, false));
 
         expect(nock.isDone()).toBe(true);
+        expect(data!.manifest.id).toBe(testPlugin.id);
+        expect(data!.deployedToAllNodes).toBe(true);
+    });
+
+    it('uploadPlugin, timing out waiting for cluster deployment', async () => {
+        const testFileData = fs.createReadStream('src/packages/mattermost-redux/test/assets/images/test.png');
+        const testPlugin = {id: 'testplugin', webapp: {bundle_path: '/static/somebundle.js'}};
+
+        nock(Client4.getBaseRoute()).
+            post('/plugins').
+            reply(202, testPlugin);
+        const {data} = await store.dispatch(Actions.uploadPlugin(testFileData as any, false, true));
+
+        expect(nock.isDone()).toBe(true);
+        expect(data!.manifest.id).toBe(testPlugin.id);
+        expect(data!.deployedToAllNodes).toBe(false);
     });
 
     it('overwriteInstallPlugin', async () => {

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/admin.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/admin.ts
@@ -18,6 +18,7 @@ import type {
 } from '@mattermost/types/data_retention';
 import type {ServerError} from '@mattermost/types/errors';
 import type {GroupSearchOpts} from '@mattermost/types/groups';
+import type {PluginUploadResponse} from '@mattermost/types/plugins';
 import type {CompleteOnboardingRequest} from '@mattermost/types/setup';
 import type {
     Team,
@@ -522,11 +523,11 @@ export function getUsersPerDayAnalytics(teamId = '') {
     return getAnalytics('user_counts_with_posts_day', teamId);
 }
 
-export function uploadPlugin(fileData: File, force = false): ActionFuncAsync {
+export function uploadPlugin(fileData: File, force = false, waitForCluster = false): ActionFuncAsync<PluginUploadResponse> {
     return async (dispatch, getState) => {
         let data;
         try {
-            data = await Client4.uploadPlugin(fileData, force);
+            data = await Client4.uploadPlugin(fileData, force, waitForCluster);
         } catch (error) {
             forceLogoutIfNecessary(error as ServerError, dispatch, getState);
             dispatch(logError(error as ServerError));

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -113,6 +113,7 @@ import type {
     PluginManifest,
     PluginsResponse,
     PluginStatus,
+    PluginUploadResponse,
 } from '@mattermost/types/plugins';
 import type {Post, PostList, PostSearchResults, PostsUsageResponse, TeamsUsageResponse, PaginatedPostList, FilesUsageResponse, PostAcknowledgement, PostAnalytics, PostInfo} from '@mattermost/types/posts';
 import type {PreferenceType} from '@mattermost/types/preferences';
@@ -4265,10 +4266,13 @@ export default class Client4 {
 
     // Plugin Routes
 
-    uploadPlugin = async (fileData: File, force = false) => {
+    uploadPlugin = async (fileData: File, force = false, waitForCluster = false): Promise<PluginUploadResponse> => {
         const formData = new FormData();
         if (force) {
             formData.append('force', 'true');
+        }
+        if (waitForCluster) {
+            formData.append('wait_for_cluster', 'true');
         }
         formData.append('plugin', fileData);
 
@@ -4277,10 +4281,18 @@ export default class Client4 {
             body: formData,
         };
 
-        return this.doFetch<PluginManifest>(
+        const {response, data} = await this.doFetchWithResponse<PluginManifest>(
             this.getPluginsRoute(),
             request,
         );
+
+        return {
+            manifest: data,
+
+            // A 202 Accepted response indicates a successful upload that couldn't be confirmed
+            // as deployed to all nodes in the cluster before the timeout.
+            deployedToAllNodes: response.status !== 202,
+        };
     };
 
     installPluginFromUrl = (pluginDownloadUrl: string, force = false) => {

--- a/webapp/platform/types/src/plugins.ts
+++ b/webapp/platform/types/src/plugins.ts
@@ -82,6 +82,16 @@ export type PluginsResponse = {
     inactive: PluginManifest[];
 };
 
+export type PluginUploadResponse = {
+    manifest: PluginManifest;
+
+    /**
+     * false when the upload succeeded but the server couldn't confirm the plugin was deployed
+     * to all nodes in the cluster before the timeout.
+     */
+    deployedToAllNodes: boolean;
+};
+
 export type PluginStatus = {
     plugin_id: string;
     cluster_id: string;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Extends the plugin upload REST API (`POST /api/v4/plugins`) with a `wait_for_cluster` multipart form field. When set to `true`, the request blocks up to 30 seconds until the plugin is deployed to all nodes in the cluster, polling the cluster's plugin statuses every 500ms. If full deployment is confirmed, the server responds with `201 Created` as before; if the timeout elapses first, the server responds with `202 Accepted` (the upload itself still succeeded). Servers without clustering are fully deployed as soon as the plugin is installed locally, so they always respond with `201`.

- Server: new `App.WaitForPluginDeployment` polls `GetClusterInfos` and cluster plugin statuses until every node reports the uploaded plugin at the expected version.
- Go client: new `Client4.UploadPluginWithOptions` accepting `model.PluginUploadOptions{Force, WaitForCluster}`.
- mmctl: `mmctl plugin add` gains a `--wait-for-cluster` (`-w`) flag, reporting an error when deployment isn't confirmed within 30 seconds.
- System console: plugin uploads now wait for cluster deployment by default, and the page scrolls to the plugin in the list of installed plugins once the upload returns — both on success and when deployment times out (in which case an error message is also shown).

QA steps:
1. Upload a plugin in **System Console > Plugins > Plugin Management**: the page scrolls to the plugin in the installed plugins list and shows the success message.
2. `mmctl plugin add my-plugin.tar.gz --wait-for-cluster` succeeds on a single-node server.
3. In an HA cluster, uploads confirm deployment on all nodes before returning `201`; a node failing to deploy results in `202` (API), an error from mmctl, and an error message in the system console.

#### Screenshots
Demo of the system console upload waiting for deployment and scrolling to the installed plugin:

[system_console_plugin_upload_wait_and_scroll.mp4](https://cursor.com/agents/bc-4202c41e-d9e0-4cb3-9381-e0252e4626e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fsystem_console_plugin_upload_wait_and_scroll.mp4)

[Upload success with auto-scroll to the plugin](https://cursor.com/agents/bc-4202c41e-d9e0-4cb3-9381-e0252e4626e3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshot_upload_success_scrolled_to_plugin.webp)

#### Release Note
```release-note
Added a wait_for_cluster option to the plugin upload API (POST /api/v4/plugins) that blocks up to 30 seconds until the plugin is deployed to all nodes in the cluster, responding with 202 Accepted if the timeout elapses first. Added a --wait-for-cluster flag to mmctl plugin add. The System Console now waits for cluster deployment when uploading a plugin and scrolls to the plugin in the installed plugins list once the upload finishes.
```

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4202c41e-d9e0-4cb3-9381-e0252e4626e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4202c41e-d9e0-4cb3-9381-e0252e4626e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

