### PR TITLE
Preserve relative redirect_to on root SiteURL

### DIFF
--- a/server/channels/web/oauth.go
+++ b/server/channels/web/oauth.go
@@ -580,6 +580,12 @@ func fullyQualifiedRedirectURL(siteURLPrefix, targetURL string, otherValidScheme
 	if err != nil {
 		return siteURLPrefix
 	}
+	// path.Clean("") is ".", which no real path has as a prefix, so a root
+	// SiteURL (empty path) would reject every same-origin relative redirect.
+	prefixPath := path.Clean(prefixParsed.Path)
+	if prefixPath == "." {
+		prefixPath = "/"
+	}
 	// mobile access
 	if slices.Contains(otherValidSchemes, fmt.Sprintf("%v://", parsed.Scheme)) &&
 		parsed.Host == callbackHost &&
@@ -591,7 +597,7 @@ func fullyQualifiedRedirectURL(siteURLPrefix, targetURL string, otherValidScheme
 	// Check if the targetURL is valid and within the siteURLPrefix, excluding native app schemes like mmauth://
 	sameScheme := parsed.Scheme == prefixParsed.Scheme
 	sameHost := parsed.Host == prefixParsed.Host
-	safePath := strings.HasPrefix(path.Clean(parsed.Path), path.Clean(prefixParsed.Path))
+	safePath := strings.HasPrefix(path.Clean(parsed.Path), prefixPath)
 
 	if sameScheme && sameHost && safePath {
 		return targetURL
@@ -618,7 +624,7 @@ func fullyQualifiedRedirectURL(siteURLPrefix, targetURL string, otherValidScheme
 		return siteURLPrefix
 	}
 
-	if !strings.HasPrefix(path.Clean(parsed.Path), path.Clean(prefixParsed.Path)) {
+	if !strings.HasPrefix(path.Clean(parsed.Path), prefixPath) {
 		return siteURLPrefix
 	}
 

--- a/server/channels/web/oauth.go
+++ b/server/channels/web/oauth.go
@@ -571,6 +571,18 @@ func signupWithOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	http.Redirect(w, r, authURL, http.StatusFound)
 }
 
+// pathWithinPrefix reports whether target is at or under prefix, comparing on
+// path segments so /mmfoo is not treated as under /mm. An empty or "/" prefix
+// (root SiteURL) matches the root and any absolute path.
+func pathWithinPrefix(target, prefix string) bool {
+	target = path.Clean(target)
+	prefix = path.Clean(prefix)
+	if prefix == "." || prefix == "/" {
+		return target == "." || strings.HasPrefix(target, "/")
+	}
+	return target == prefix || strings.HasPrefix(target, prefix+"/")
+}
+
 func fullyQualifiedRedirectURL(siteURLPrefix, targetURL string, otherValidSchemes []string) string {
 	parsed, err := url.Parse(targetURL)
 	if err != nil {
@@ -579,12 +591,6 @@ func fullyQualifiedRedirectURL(siteURLPrefix, targetURL string, otherValidScheme
 	prefixParsed, err := url.Parse(siteURLPrefix)
 	if err != nil {
 		return siteURLPrefix
-	}
-	// path.Clean("") is ".", which no real path has as a prefix, so a root
-	// SiteURL (empty path) would reject every same-origin relative redirect.
-	prefixPath := path.Clean(prefixParsed.Path)
-	if prefixPath == "." {
-		prefixPath = "/"
 	}
 	// mobile access
 	if slices.Contains(otherValidSchemes, fmt.Sprintf("%v://", parsed.Scheme)) &&
@@ -597,7 +603,7 @@ func fullyQualifiedRedirectURL(siteURLPrefix, targetURL string, otherValidScheme
 	// Check if the targetURL is valid and within the siteURLPrefix, excluding native app schemes like mmauth://
 	sameScheme := parsed.Scheme == prefixParsed.Scheme
 	sameHost := parsed.Host == prefixParsed.Host
-	safePath := strings.HasPrefix(path.Clean(parsed.Path), prefixPath)
+	safePath := pathWithinPrefix(parsed.Path, prefixParsed.Path)
 
 	if sameScheme && sameHost && safePath {
 		return targetURL
@@ -624,7 +630,7 @@ func fullyQualifiedRedirectURL(siteURLPrefix, targetURL string, otherValidScheme
 		return siteURLPrefix
 	}
 
-	if !strings.HasPrefix(path.Clean(parsed.Path), prefixPath) {
+	if !pathWithinPrefix(parsed.Path, prefixParsed.Path) {
 		return siteURLPrefix
 	}
 

--- a/server/channels/web/oauth_test.go
+++ b/server/channels/web/oauth_test.go
@@ -977,6 +977,7 @@ func TestFullyQualifiedRedirectURL(t *testing.T) {
 		"https://xxx.yyy/mm/some-path?foo=bar": siteURL + "/some-path?foo=bar",
 		"https://xxx.yyy/mm/some-path#section": siteURL + "/some-path#section",
 		"https://xxx.yyy/mm/../malicious-path": siteURL,
+		"https://xxx.yyy/mmfoo":                siteURL, // segment boundary: /mmfoo is not under /mm
 		":foo":                                 siteURL,
 		"mmauth://callback":                    "mmauth://callback",
 		"mmauth://xxx.yyy/mm":                  siteURL, // invalid mobile URL (wrong host)

--- a/server/channels/web/oauth_test.go
+++ b/server/channels/web/oauth_test.go
@@ -1000,6 +1000,8 @@ func TestFullyQualifiedRedirectURL(t *testing.T) {
 		"//evil.com":                rootSiteURL,
 		"https://yyy.zzz/some-path": rootSiteURL,
 		"https://xxx.yyy/some-path": rootSiteURL + "/some-path",
+		"https://xxx.yyy?foo=bar":   rootSiteURL + "?foo=bar",
+		"https://xxx.yyy#section":   rootSiteURL + "#section",
 	} {
 		t.Run("root/"+target, func(t *testing.T) {
 			require.Equal(t, expected, fullyQualifiedRedirectURL(rootSiteURL, target, []string{"mmauth://"}))

--- a/server/channels/web/oauth_test.go
+++ b/server/channels/web/oauth_test.go
@@ -985,6 +985,26 @@ func TestFullyQualifiedRedirectURL(t *testing.T) {
 			require.Equal(t, expected, fullyQualifiedRedirectURL(siteURL, target, []string{"mmauth://"}))
 		})
 	}
+
+	// Root SiteURL (empty path). SetSiteURLHeader strips the trailing slash, so
+	// the site path is "" and path.Clean gives ".". Same-origin relative targets
+	// (e.g. the /oauth/authorize resume after SSO login) must be preserved, while
+	// cross-origin targets must still collapse to the site root.
+	const rootSiteURL = "https://xxx.yyy"
+
+	for target, expected := range map[string]string{
+		"":                         rootSiteURL,
+		"/":                        rootSiteURL + "/",
+		"/oauth/authorize?foo=bar": rootSiteURL + "/oauth/authorize?foo=bar",
+		"/oauth/authorize?response_type=code&client_id=abc&state=x": rootSiteURL + "/oauth/authorize?response_type=code&client_id=abc&state=x",
+		"//evil.com":                rootSiteURL,
+		"https://yyy.zzz/some-path": rootSiteURL,
+		"https://xxx.yyy/some-path": rootSiteURL + "/some-path",
+	} {
+		t.Run("root/"+target, func(t *testing.T) {
+			require.Equal(t, expected, fullyQualifiedRedirectURL(rootSiteURL, target, []string{"mmauth://"}))
+		})
+	}
 }
 
 func TestAuthorizeOAuthPage(t *testing.T) {


### PR DESCRIPTION
#### Summary
  On a root `SiteURL` (empty path), `fullyQualifiedRedirectURL` cleaned the empty prefix path to `"."`
  and required the redirect target to have that as a prefix. No real path (e.g. `/oauth/authorize`) is
  `HasPrefix(".")`, so every same-origin relative `redirect_to` was discarded and only the site origin
  returned. After SSO (SAML/OIDC) login on a root-SiteURL install, the
  `redirect_to=/oauth/authorize?...` resume was dropped, the user landed on the default team channel,
  no authorization code was issued, and OAuth flows (including the Agents/MCP OAuth flow) never
  completed.

  Fix: normalize an empty cleaned prefix path (`"."`) to `"/"` before the `HasPrefix` checks. Subpath
  SiteURL installs were unaffected because `path.Clean("/mm")` is a real prefix — which is why the
  existing test table (subpath only) missed this.

  QA:
  1. Set SiteURL to a root URL (no path), enable an SSO method (e.g. SAML).
  2. From a logged-out browser, start an OAuth authorize request (`/oauth/authorize?...`).
  3. Before: after login the browser lands on `/<team>/channels/town-square`; the callback never
  receives a code.
  4. After: the browser returns to `/oauth/authorize?...` and completes to the registered callback.

  #### Ticket Link
  N/A

  #### Screenshots
  N/A — backend change.

  #### Release Note
  ```release-note
  Fixed OAuth and SSO logins on a root SiteURL dropping the redirect_to parameter, which prevented the
  login from returning to the OAuth authorize/callback (e.g. the Agents/MCP OAuth flow).
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change directly affects OAuth/SSO redirect URL handling (authentication-critical) and therefore could impact redirect validation behavior, but it is localized to redirect URL computation and extended with targeted root `SiteURL` test cases.  
**QA Recommendation:** Automated coverage should be sufficient; perform a brief manual verification of OAuth/SSO login redirects for a root-`SiteURL` installation and one subpath installation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->