### PR TITLE
Prepackage mattermost-plugin-agents v2.5.1

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -163,7 +163,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.1
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.11.1
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.0-rc2
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.0
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.1
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.7.0
@@ -177,7 +177,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.11.1%2B329b65c-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.0-rc2%2B2119bcf-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.0%2B48a6b5e-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.1%2B29b4688-fips
 endif
 

--- a/server/Makefile
+++ b/server/Makefile
@@ -163,7 +163,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.1
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.11.1
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.0
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.1
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.1
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.7.0
@@ -177,7 +177,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.11.1%2B329b65c-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.0%2B48a6b5e-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.1%2B276cb86-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.1%2B29b4688-fips
 endif
 


### PR DESCRIPTION
#### Summary

Updates the default prepackaged [mattermost-plugin-agents](https://github.com/mattermost/mattermost-plugin-agents) artifact from **2.5.0** to **2.5.1** ([release v2.5.1](https://github.com/mattermost/mattermost-plugin-agents/releases/tag/v2.5.1)) for the `master` branch.

Both prepackaged plugin lists are updated:
- non-FIPS: `mattermost-plugin-agents-v2.5.1`
- FIPS: `mattermost-plugin-agents-v2.5.1%2B276cb86-fips` (`276cb86` is the tagged release commit)

Bundles verified on `plugins.releases.mattermost.com`.

#### Release Note

```release-note
Prepackaged the Mattermost Agents plugin at version 2.5.1 instead of 2.5.0.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are limited to prepackaged plugin artifact references in `server/Makefile` for both non-FIPS and FIPS plugin lists, with no application logic, contracts, or data-path behavior affected. Any failure would most likely surface as missing/incorrect plugin bundle downloads rather than runtime regressions.  
**QA Recommendation:** Manual QA can be skipped; rely on existing automated checks plus verification that the updated plugin bundles are available and download correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->