### PR TITLE
fix(e2e): remove obsolete CRT modal dismiss and sync Playwright baseURL

### DIFF
--- a/e2e-tests/cypress/tests/support/ui/sidebar_left.ts
+++ b/e2e-tests/cypress/tests/support/ui/sidebar_left.ts
@@ -132,11 +132,7 @@ Cypress.Commands.add('uiClickSidebarItem', (name) => {
     cy.uiGetSidebarItem(name).click({force: true});
 
     if (name === 'threads') {
-        cy.get('body').then((body) => {
-            if (body.find('#genericModalLabel').length > 0) {
-                cy.uiCloseModal('A new way to view and follow threads');
-            }
-        });
+        // CRT intro modal was removed in MM-66470; only wait for the threads view to settle.
         cy.get('#tutorial-threads-mobile-header span.Button_label').contains('Followed threads');
     } else {
         cy.findAllByTestId('postView').last().scrollIntoView().should('be.visible');

--- a/e2e-tests/playwright/lib/src/browser_context.ts
+++ b/e2e-tests/playwright/lib/src/browser_context.ts
@@ -5,7 +5,7 @@ import {writeFile} from 'node:fs/promises';
 import path from 'node:path';
 import fs from 'node:fs';
 
-import type {Browser, BrowserContext} from '@playwright/test';
+import type {Browser, BrowserContext, Page} from '@playwright/test';
 import {request} from '@playwright/test';
 import type {UserProfile} from '@mattermost/types/users';
 
@@ -14,7 +14,7 @@ import {pages} from './ui/pages';
 import {resolvePlaywrightPath} from './util';
 
 /** Keep page.goto pointed at testConfig.baseURL after testcontainers remaps the host port. */
-export function bindPageToLiveBaseURL(page: import('@playwright/test').Page): void {
+export function bindPageToLiveBaseURL(page: Page): void {
     const originalGoto = page.goto.bind(page);
     page.goto = ((url, options) => {
         if (typeof url === 'string') {

--- a/e2e-tests/playwright/lib/src/browser_context.ts
+++ b/e2e-tests/playwright/lib/src/browser_context.ts
@@ -9,9 +9,20 @@ import type {Browser, BrowserContext} from '@playwright/test';
 import {request} from '@playwright/test';
 import type {UserProfile} from '@mattermost/types/users';
 
-import {testConfig} from './test_config';
+import {resolveAppUrl, testConfig} from './test_config';
 import {pages} from './ui/pages';
 import {resolvePlaywrightPath} from './util';
+
+/** Keep page.goto pointed at testConfig.baseURL after testcontainers remaps the host port. */
+export function bindPageToLiveBaseURL(page: import('@playwright/test').Page): void {
+    const originalGoto = page.goto.bind(page);
+    page.goto = ((url, options) => {
+        if (typeof url === 'string') {
+            return originalGoto(resolveAppUrl(url), options);
+        }
+        return originalGoto(url, options);
+    }) as typeof page.goto;
+}
 
 export class TestBrowser {
     readonly browser: Browser;
@@ -22,7 +33,11 @@ export class TestBrowser {
     }
 
     async login(user: UserProfile) {
-        const options = {storageState: ''};
+        const options: {storageState: string; baseURL: string} = {
+            storageState: '',
+            // Capture the current mapped URL at context creation (updated after server restarts).
+            baseURL: testConfig.baseURL,
+        };
         if (user) {
             // Log in via API request and save user storage
             const storagePath = await loginByAPI(user.username, user.password);
@@ -32,6 +47,7 @@ export class TestBrowser {
         // Sign in a user in new browser context
         const context = await this.browser.newContext(options);
         const page = await context.newPage();
+        bindPageToLiveBaseURL(page);
 
         const channelsPage = new pages.ChannelsPage(page);
         const systemConsolePage = new pages.SystemConsolePage(page);

--- a/e2e-tests/playwright/lib/src/index.ts
+++ b/e2e-tests/playwright/lib/src/index.ts
@@ -3,10 +3,10 @@
 
 export {test, expect, PlaywrightExtended} from './test_fixture';
 export type {ExtendedFixtures} from './test_fixture';
-export {testConfig, TESTCONTAINERS_SERVICE_NAMES} from './test_config';
+export {testConfig, resolveAppUrl, TESTCONTAINERS_SERVICE_NAMES} from './test_config';
 export type {TestContainersServiceName} from './test_config';
 export {baseGlobalSetup} from './global_setup';
-export {TestBrowser} from './browser_context';
+export {bindPageToLiveBaseURL, TestBrowser} from './browser_context';
 export {getBlobFromAsset, getFileFromAsset} from './file';
 export {setupFileServer} from './file_server';
 export {decomposeKorean, koreanTestPhrase, typeHangulCharacterWithIme, typeHangulWithIme} from './ime';

--- a/e2e-tests/playwright/lib/src/test_config.ts
+++ b/e2e-tests/playwright/lib/src/test_config.ts
@@ -193,6 +193,18 @@ export class TestConfig {
 // Create a singleton instance
 export const testConfig = new TestConfig();
 
+/**
+ * Resolve a path against the live server URL. Playwright's config `baseURL` is fixed when the
+ * worker starts; after `restartMattermostContainer()` remaps the host port, relative `page.goto`
+ * calls would still hit the stale port unless they go through this helper (or an absolute URL).
+ */
+export function resolveAppUrl(pathOrUrl: string): string {
+    if (/^[a-z][a-z0-9+.-]*:/i.test(pathOrUrl)) {
+        return pathOrUrl;
+    }
+    return new URL(pathOrUrl, testConfig.baseURL).href;
+}
+
 function parseBool(actualValue: string | undefined, defaultValue: boolean) {
     return actualValue ? actualValue === 'true' : defaultValue;
 }

--- a/e2e-tests/playwright/lib/src/test_fixture.ts
+++ b/e2e-tests/playwright/lib/src/test_fixture.ts
@@ -6,7 +6,7 @@ import {test as base} from '@playwright/test';
 import type {AxeResults} from 'axe-core';
 import {AxeBuilder} from '@axe-core/playwright';
 
-import {TestBrowser} from './browser_context';
+import {bindPageToLiveBaseURL, TestBrowser} from './browser_context';
 import {
     ensureLicense,
     ensurePluginsLoaded,
@@ -102,6 +102,9 @@ export const test = base.extend<ExtendedFixtures>({
         await use(ab);
     },
     pw: async ({browser, page, isMobile}, use) => {
+        // Playwright's project baseURL is fixed at worker start; rebind so navigations follow
+        // testConfig.baseURL after testcontainers restarts remap the host port.
+        bindPageToLiveBaseURL(page);
         const pw = new PlaywrightExtended(browser, page, isMobile);
         await use(pw);
         await pw.testBrowser.close();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Fixes two E2E flakiness/footgun issues found while cherry-picking testcontainers to `release-11.10` (#37729):

1. **Cypress `MM-T4261_3` flake** — `uiClickSidebarItem('threads')` still tried to dismiss the CRT intro modal removed in MM-66470 (#34433). When `#genericModalLabel` briefly existed (often empty), `uiCloseModal('A new way to view and follow threads')` raced and timed out. Seen on the prior cherry-pick retest ([pr-37698 cypress report](https://test-io.test.mattermost.com/reports/mattermost/pr-37698/acf2d07/cypress-full-enterprise?gh_run_id=30346289698)). Note: #37729's Cypress run passed 100% without this fix; the flake is intermittent.

2. **Playwright stale `baseURL` after testcontainers restart** — Playwright's project `baseURL` is fixed when the worker starts. After `restartMattermostContainer()` remaps the host port, relative `page.goto('/')` still hit the old port (`ERR_CONNECTION_REFUSED`). Bind navigations to the live `testConfig.baseURL` and pass it into `TestBrowser` contexts.

**Verify:**
- Cypress: open Threads via `cy.uiClickSidebarItem('threads')` (no CRT modal expected).
- Playwright (testcontainers): run a restarting spec then a login/navigation spec in one process, e.g.
  `PW_USE_TESTCONTAINERS=true PW_TESTCONTAINERS_REUSE=true npx playwright test --project=chrome specs/functional/system_console/file_storage/minio_file_storage.spec.ts specs/functional/system_console/ldap/ldap_login.spec.ts`
  (verified locally: minio → ldap both passed after this change)

#### Release Note
```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6fd54d08-a357-4059-af68-5e11459d7408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6fd54d08-a357-4059-af68-5e11459d7408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Playwright navigation utilities and browser context setup are shared across e2e tests, so stale or incorrectly resolved URLs could affect multiple test flows. The Cypress change is isolated and low risk.
**QA Recommendation:** Manual QA can be skipped; rely on the full automated test suite, with attention to container-restart scenarios.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->