### PR TITLE
MM-70024: Improve atomicity in desktop SSO token validation (CI fixes)

### DIFF
--- a/server/channels/app/desktop_login.go
+++ b/server/channels/app/desktop_login.go
@@ -25,29 +25,21 @@ func (a *App) GenerateAndSaveDesktopToken(createAt int64, user *model.User) (*st
 }
 
 func (a *App) ValidateDesktopToken(token string, expiryTime int64) (*model.User, *model.AppError) {
-	// Check if token is valid
-	userId, err := a.Srv().Store().DesktopTokens().GetUserId(token, expiryTime)
+	// Atomically consume the token: delete it and return its UserId in one operation.
+	// This prevents duplicate sessions from concurrent requests racing on the same token.
+	userId, err := a.Srv().Store().DesktopTokens().ConsumeToken(token, expiryTime)
 	if err != nil {
-		// Delete the token if it is expired or invalid
-		if deleteErr := a.Srv().Store().DesktopTokens().Delete(token); deleteErr != nil {
-			a.Log().Error("Unable to delete desktop token", mlog.Err(deleteErr))
-		}
 		return nil, model.NewAppError("ValidateDesktopToken", "app.desktop_token.validate.invalid", nil, "", http.StatusUnauthorized).Wrap(err)
+	}
+	if userId == nil {
+		// Token was not found or already consumed.
+		return nil, model.NewAppError("ValidateDesktopToken", "app.desktop_token.validate.invalid", nil, "", http.StatusUnauthorized)
 	}
 
 	// Get the user profile
 	user, userErr := a.GetUser(*userId)
 	if userErr != nil {
-		// Delete the token if the user is invalid somehow
-		if deleteErr := a.Srv().Store().DesktopTokens().Delete(token); deleteErr != nil {
-			a.Log().Error("Unable to delete desktop token", mlog.Err(deleteErr))
-		}
 		return nil, model.NewAppError("ValidateDesktopToken", "app.desktop_token.validate.no_user", nil, "", http.StatusInternalServerError).Wrap(userErr)
-	}
-
-	// Clean up other tokens if they exist
-	if deleteErr := a.Srv().Store().DesktopTokens().DeleteByUserId(*userId); deleteErr != nil {
-		a.Log().Error("Unable to delete desktop token", mlog.Err(deleteErr))
 	}
 
 	return user, nil

--- a/server/channels/app/desktop_login.go
+++ b/server/channels/app/desktop_login.go
@@ -42,5 +42,10 @@ func (a *App) ValidateDesktopToken(token string, expiryTime int64) (*model.User,
 		return nil, model.NewAppError("ValidateDesktopToken", "app.desktop_token.validate.no_user", nil, "", http.StatusInternalServerError).Wrap(userErr)
 	}
 
+	// Clean up any remaining tokens for this user (e.g. from multiple concurrent login attempts).
+	if deleteErr := a.Srv().Store().DesktopTokens().DeleteByUserId(*userId); deleteErr != nil {
+		a.Log().Error("Unable to delete desktop token", mlog.Err(deleteErr))
+	}
+
 	return user, nil
 }

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -5065,6 +5065,11 @@ func (s *RetryLayerContentFlaggingStore) SaveReviewerSettings(reviewerSettings m
 
 }
 
+func (s *RetryLayerDesktopTokensStore) ConsumeToken(token string, minCreateAt int64) (*string, error) {
+	// ConsumeToken must not be retried: a partial failure must not create a second consume attempt.
+	return s.DesktopTokensStore.ConsumeToken(token, minCreateAt)
+}
+
 func (s *RetryLayerDesktopTokensStore) Delete(token string) error {
 
 	tries := 0

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -5066,8 +5066,24 @@ func (s *RetryLayerContentFlaggingStore) SaveReviewerSettings(reviewerSettings m
 }
 
 func (s *RetryLayerDesktopTokensStore) ConsumeToken(token string, minCreateAt int64) (*string, error) {
-	// ConsumeToken must not be retried: a partial failure must not create a second consume attempt.
-	return s.DesktopTokensStore.ConsumeToken(token, minCreateAt)
+
+	tries := 0
+	for {
+		result, err := s.DesktopTokensStore.ConsumeToken(token, minCreateAt)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
 }
 
 func (s *RetryLayerDesktopTokensStore) Delete(token string) error {

--- a/server/channels/store/sqlstore/desktop_tokens_store.go
+++ b/server/channels/store/sqlstore/desktop_tokens_store.go
@@ -46,6 +46,22 @@ func (s *SqlDesktopTokensStore) GetUserId(token string, minCreateAt int64) (*str
 	return &dt.UserId, nil
 }
 
+func (s *SqlDesktopTokensStore) ConsumeToken(token string, minCreateAt int64) (*string, error) {
+	dt := struct{ UserId string }{}
+
+	query := `DELETE FROM DesktopTokens WHERE Token = ? AND CreateAt >= ? RETURNING UserId`
+
+	err := s.GetMaster().Get(&dt, query, token, minCreateAt)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return nil, nil
+		}
+		return nil, errors.Wrapf(err, "failed to consume desktop token %s", token)
+	}
+
+	return &dt.UserId, nil
+}
+
 func (s *SqlDesktopTokensStore) Insert(token string, createAt int64, userId string) error {
 	builder := s.getQueryBuilder().
 		Insert("DesktopTokens").

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -742,6 +742,7 @@ type TokenStore interface {
 
 type DesktopTokensStore interface {
 	GetUserId(token string, minCreatedAt int64) (*string, error)
+	ConsumeToken(token string, minCreateAt int64) (*string, error)
 	Insert(token string, createAt int64, userID string) error
 	Delete(token string) error
 	DeleteByUserId(userID string) error

--- a/server/channels/store/storetest/desktop_tokens_store.go
+++ b/server/channels/store/storetest/desktop_tokens_store.go
@@ -4,6 +4,7 @@
 package storetest
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/mattermost/mattermost/server/public/shared/request"
@@ -18,6 +19,9 @@ func TestDesktopTokensStore(t *testing.T, rctx request.CTX, ss store.Store, s Sq
 	t.Run("Delete", func(t *testing.T) { testDeleteToken(t, rctx, ss) })
 	t.Run("DeleteByUserId", func(t *testing.T) { testDeleteByUserID(t, rctx, ss) })
 	t.Run("DeleteOlderThan", func(t *testing.T) { testDeleteOlderThan(t, rctx, ss) })
+	t.Run("ConsumeToken", func(t *testing.T) { testConsumeToken(t, rctx, ss) })
+	t.Run("ConsumeToken/idempotent", func(t *testing.T) { testConsumeTokenIdempotent(t, rctx, ss) })
+	t.Run("ConsumeToken/concurrent", func(t *testing.T) { testConsumeTokenConcurrent(t, rctx, ss) })
 }
 
 func testGetUserID(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -86,6 +90,75 @@ func testDeleteByUserID(t *testing.T, rctx request.CTX, ss store.Store) {
 		_, err = ss.DesktopTokens().GetUserId("deleteable_token_2", 3000)
 		assert.Error(t, err)
 	})
+}
+
+func testConsumeToken(t *testing.T, rctx request.CTX, ss store.Store) {
+	const tok = "consume_token_valid"
+	err := ss.DesktopTokens().Insert(tok, 1000, "consume_user_id")
+	require.NoError(t, err)
+
+	// Consuming a valid, unexpired token returns the userId and removes the row.
+	userID, err := ss.DesktopTokens().ConsumeToken(tok, 1000)
+	assert.NoError(t, err)
+	require.NotNil(t, userID)
+	assert.Equal(t, "consume_user_id", *userID)
+
+	// Row must be gone after consume.
+	_, err = ss.DesktopTokens().GetUserId(tok, 1000)
+	assert.Error(t, err)
+	assert.IsType(t, &store.ErrNotFound{}, err)
+}
+
+func testConsumeTokenIdempotent(t *testing.T, rctx request.CTX, ss store.Store) {
+	const tok = "consume_token_idempotent"
+	err := ss.DesktopTokens().Insert(tok, 1000, "consume_user_id_2")
+	require.NoError(t, err)
+
+	// First consume succeeds.
+	userID, err := ss.DesktopTokens().ConsumeToken(tok, 1000)
+	assert.NoError(t, err)
+	require.NotNil(t, userID)
+
+	// Second consume on the same token returns nil, nil (not an error).
+	userID2, err := ss.DesktopTokens().ConsumeToken(tok, 1000)
+	assert.NoError(t, err)
+	assert.Nil(t, userID2)
+}
+
+func testConsumeTokenConcurrent(t *testing.T, rctx request.CTX, ss store.Store) {
+	const tok = "consume_token_concurrent"
+	const goroutines = 10
+	err := ss.DesktopTokens().Insert(tok, 1000, "consume_user_id_concurrent")
+	require.NoError(t, err)
+
+	var (
+		mu      sync.Mutex
+		winners []string
+	)
+
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	start := make(chan struct{})
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			<-start
+			userID, err := ss.DesktopTokens().ConsumeToken(tok, 1000)
+			assert.NoError(t, err)
+			if userID != nil {
+				mu.Lock()
+				winners = append(winners, *userID)
+				mu.Unlock()
+			}
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+
+	// Exactly one goroutine must have consumed the token.
+	assert.Len(t, winners, 1, "exactly one goroutine should have consumed the token")
 }
 
 func testDeleteOlderThan(t *testing.T, rctx request.CTX, ss store.Store) {

--- a/server/channels/store/storetest/desktop_tokens_store.go
+++ b/server/channels/store/storetest/desktop_tokens_store.go
@@ -140,7 +140,7 @@ func testConsumeTokenConcurrent(t *testing.T, rctx request.CTX, ss store.Store) 
 	wg.Add(goroutines)
 	start := make(chan struct{})
 
-	for i := 0; i < goroutines; i++ {
+	for range goroutines {
 		go func() {
 			defer wg.Done()
 			<-start

--- a/server/channels/store/storetest/mocks/DesktopTokensStore.go
+++ b/server/channels/store/storetest/mocks/DesktopTokensStore.go
@@ -11,6 +11,36 @@ type DesktopTokensStore struct {
 	mock.Mock
 }
 
+// ConsumeToken provides a mock function with given fields: token, minCreateAt
+func (_m *DesktopTokensStore) ConsumeToken(token string, minCreateAt int64) (*string, error) {
+	ret := _m.Called(token, minCreateAt)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConsumeToken")
+	}
+
+	var r0 *string
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, int64) (*string, error)); ok {
+		return rf(token, minCreateAt)
+	}
+	if rf, ok := ret.Get(0).(func(string, int64) *string); ok {
+		r0 = rf(token, minCreateAt)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*string)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, int64) error); ok {
+		r1 = rf(token, minCreateAt)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Delete provides a mock function with given fields: token
 func (_m *DesktopTokensStore) Delete(token string) error {
 	ret := _m.Called(token)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -4168,6 +4168,22 @@ func (s *TimerLayerContentFlaggingStore) SaveReviewerSettings(reviewerSettings m
 	return err
 }
 
+func (s *TimerLayerDesktopTokensStore) ConsumeToken(token string, minCreateAt int64) (*string, error) {
+	start := time.Now()
+
+	result, err := s.DesktopTokensStore.ConsumeToken(token, minCreateAt)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("DesktopTokensStore.ConsumeToken", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerDesktopTokensStore) Delete(token string) error {
 	start := time.Now()
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Babysit follow-up for #37748. Includes the original desktop SSO token atomicity changes plus CI fixes:

- Regenerate `retrylayer.go` via `make store-layers` so generated files match the generator output (fixes "Check generated files" CI failure).
- Modernize the concurrent `ConsumeToken` store test loop to satisfy the `rangeint` linter (fixes `check-style` CI failure).

The original PR's CodeRabbit review comment about per-user token cleanup is already addressed in commit `c1eeef8`.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-70024

#### Release Note

```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-51d48d19-b282-4ad1-8229-a91138e8730a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-51d48d19-b282-4ad1-8229-a91138e8730a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

