### PR TITLE
MM-68396: Remove deprecated dialog date/datetime fields for v12.0

### DIFF
--- a/docs/develop/integrate/plugins/interactive-dialogs/index.md
+++ b/docs/develop/integrate/plugins/interactive-dialogs/index.md
@@ -436,8 +436,6 @@ The full list of supported fields for `date` elements is included below:
 | `help_text`       | String  | (Optional) Help text displayed below the field. Maximum 150 characters.                                                            |
 | `optional`        | Boolean | (Optional) Set to `true` if this form element is not required. Default is `false`.                                                 |
 | `datetime_config` | Object  | (Optional) Nested date configuration object. See [datetime_config object](#datetime_config-object) for supported properties.       |
-| `min_date`        | String  | (Deprecated — use `datetime_config.min_date`.) Earliest selectable date. Supports ISO date format (YYYY-MM-DD) or relative formats (`today`, `tomorrow`, `+1d`, `-7d`, etc.). Full ISO datetime strings are accepted, but only the date part is parsed; timezone information is ignored. |
-| `max_date`        | String  | (Deprecated — use `datetime_config.max_date`.) Latest selectable date. Supports ISO date format (YYYY-MM-DD) or relative formats (`today`, `+30d`, `+1y`, etc.). Full ISO datetime strings are accepted, but only the date part is parsed; timezone information is ignored. |
 
 #### Date field usage examples
 
@@ -505,9 +503,6 @@ The full list of supported fields for `datetime` elements is included below:
 | `help_text`       | String  | (Optional) Help text displayed below the field. Maximum 150 characters.                                                            |
 | `optional`        | Boolean | (Optional) Set to `true` if this form element is not required. Default is `false`.                                                 |
 | `datetime_config` | Object  | (Optional) Nested datetime configuration object. See [datetime_config object](#datetime_config-object) for supported properties.   |
-| `min_date`        | String  | (Deprecated — use `datetime_config.min_date`.) Earliest selectable date. Supports ISO format or relative formats (`today`, `tomorrow`, `+1d`, `-7d`, etc.). |
-| `max_date`        | String  | (Deprecated — use `datetime_config.max_date`.) Latest selectable date. Supports ISO format or relative formats (`today`, `+30d`, `+1y`, etc.). |
-| `time_interval`   | Integer | (Deprecated — use `datetime_config.time_interval`.) Time selection interval in minutes. Must be between 1 and 1440, and must be a divisor of 1440 to create evenly spaced intervals throughout the day. Common values: 15, 30, 60, 90, 120. Default is 60. |
 
 #### DateTime field usage examples
 
@@ -570,9 +565,8 @@ The `datetime_config` object groups date/datetime configuration into a single ne
 | `time_interval`           | Integer | `datetime`         | 11.6   | (Optional) Time selection interval in minutes. Must be between 1 and 1440, and must be a divisor of 1440. Default is 60.    |
 | `location_timezone`       | String  | `datetime`         | 11.6   | (Optional) IANA timezone used to display and submit the time (e.g. `America/Denver`, `Asia/Tokyo`). When set, all users see the same wall-clock time regardless of their own timezone. Defaults to the viewing user's timezone. |
 | `manual_time_entry`       | Boolean | `datetime`         | 11.8   | (Optional) When `true`, users can type the time directly in addition to using the dropdown. Default is `false`.             |
-| `allow_manual_time_entry` | Boolean | `datetime`         | 11.6 (deprecated in 11.8) | (Deprecated — use `manual_time_entry`.) When both are set, either enabling turns the feature on.         |
 
-**Backward compatibility (new in 11.8):** The top-level `min_date`, `max_date`, and `time_interval` fields on `date` and `datetime` elements are still accepted for existing integrations, but are deprecated in favor of `datetime_config`. When both are provided on the same element, values inside `datetime_config` take precedence over the legacy top-level values.
+> **Breaking change (12.0):** The top-level `min_date`, `max_date`, and `time_interval` fields on `date`/`datetime` elements, and the `datetime_config.allow_manual_time_entry` field, have been removed. Integrations must send these values under `datetime_config` (using `manual_time_entry` instead of `allow_manual_time_entry`) or they will be silently ignored.
 
 #### Date and DateTime field specifications
 

--- a/docs/main/administration-guide/upgrade/important-upgrade-notes.mdx
+++ b/docs/main/administration-guide/upgrade/important-upgrade-notes.mdx
@@ -21,6 +21,10 @@ We recommend reviewing the [additional upgrade notes](#additional-upgrade-notes)
 </thead>
 <tbody>
 <tr>
+<td>v12.0</td>
+<td><p>Mattermost v12.0 removes the deprecated interactive dialog date/datetime fields. Top-level <code>min_date</code>, <code>max_date</code>, and <code>time_interval</code> on dialog elements and app fields, and <code>datetime_config.allow_manual_time_entry</code>, are no longer accepted. Integrations must migrate to <code>datetime_config</code> (using <code>manual_time_entry</code> instead of <code>allow_manual_time_entry</code>) before upgrading to v12.0. Legacy keys are silently ignored, so date constraints and manual time entry will not apply until payloads are updated. See the <a href="https://developers.mattermost.com/integrate/plugins/interactive-dialogs/">interactive dialogs documentation</a> for details.</p></td>
+</tr>
+<tr>
 <td rowspan="13">v11.9</td>
 <td><p>Mattermost v11.9 changes how redirect URI allowlist patterns are matched for OAuth Dynamic Client Registration (DCR). Patterns are now evaluated per URL component (scheme, host, path, and query) rather than as a whole-string glob. As a result, a pattern such as <code>https://\*.example.com/\*\*</code> no longer matches redirect URIs that include a query string (for example, <code>https://app.example.com/callback?tenant=foo</code>); redirect URIs without a query string continue to match as expected.</p><p>Admins using DCR with redirect URIs that include query strings must update their allowlist. To allow redirect URIs both with and without a query string, add two separate entries:</p><ul><li><code>https://\*.example.com/\*\*</code> — matches redirect URIs with no query string.</li><li><code>https://\*.example.com/\*\*?\*\*</code> — matches redirect URIs with any query string.</li></ul><p>A pattern that includes a query component (such as <code>?\*\*</code>) only matches URIs that also carry a query string; it will not match URIs without one. Both entries are required to cover both cases.</p></td>
 </tr>

--- a/e2e-tests/cypress/utils/webhook_utils.js
+++ b/e2e-tests/cypress/utils/webhook_utils.js
@@ -437,7 +437,9 @@ function getBasicDateTimeDialog(triggerId, webhookBaseUrl) {
                     placeholder: 'Select date and time',
                     help_text: 'Select the date and time for your meeting',
                     optional: false,
-                    time_interval: 60,
+                    datetime_config: {
+                        time_interval: 60,
+                    },
                 },
             ],
             submit_label: 'Submit',
@@ -465,7 +467,9 @@ function getMinDateConstraintDialog(triggerId, webhookBaseUrl) {
                     placeholder: 'Select a future date',
                     help_text: 'Must be today or later',
                     optional: true,
-                    min_date: 'today',
+                    datetime_config: {
+                        min_date: 'today',
+                    },
                 },
             ],
             submit_label: 'Submit',
@@ -493,7 +497,9 @@ function getCustomIntervalDialog(triggerId, webhookBaseUrl) {
                     placeholder: 'Select time (30min intervals)',
                     help_text: 'Time picker with 30-minute intervals',
                     optional: true,
-                    time_interval: 30,
+                    datetime_config: {
+                        time_interval: 30,
+                    },
                 },
             ],
             submit_label: 'Submit',

--- a/e2e-tests/playwright/lib/src/containers/assets/webhook/utils/webhook_utils.js
+++ b/e2e-tests/playwright/lib/src/containers/assets/webhook/utils/webhook_utils.js
@@ -567,7 +567,9 @@ function getBasicDateTimeDialog(triggerId, webhookBaseUrl) {
                     placeholder: 'Select date and time',
                     help_text: 'Select the date and time for your meeting',
                     optional: false,
-                    time_interval: 60,
+                    datetime_config: {
+                        time_interval: 60,
+                    },
                 },
             ],
             submit_label: 'Submit',
@@ -595,7 +597,9 @@ function getMinDateConstraintDialog(triggerId, webhookBaseUrl) {
                     placeholder: 'Select a future date',
                     help_text: 'Must be today or later',
                     optional: true,
-                    min_date: 'today',
+                    datetime_config: {
+                        min_date: 'today',
+                    },
                 },
             ],
             submit_label: 'Submit',
@@ -623,7 +627,9 @@ function getCustomIntervalDialog(triggerId, webhookBaseUrl) {
                     placeholder: 'Select time (30min intervals)',
                     help_text: 'Time picker with 30-minute intervals',
                     optional: true,
-                    time_interval: 30,
+                    datetime_config: {
+                        time_interval: 30,
+                    },
                 },
             ],
             submit_label: 'Submit',

--- a/server/public/model/integration_action.go
+++ b/server/public/model/integration_action.go
@@ -467,9 +467,6 @@ type DialogDateTimeConfig struct {
 	LocationTimezone string `json:"location_timezone,omitempty"`
 	// ManualTimeEntry: Allow manual text entry for time instead of dropdown
 	ManualTimeEntry bool `json:"manual_time_entry,omitempty"`
-	// Deprecated: Use ManualTimeEntry instead. Kept for backward compatibility;
-	// when both are provided, either field being true enables manual time entry.
-	AllowManualTimeEntry bool `json:"allow_manual_time_entry,omitempty"`
 }
 
 type DialogElement struct {
@@ -492,46 +489,18 @@ type DialogElement struct {
 
 	// Date/datetime field configuration
 	DateTimeConfig *DialogDateTimeConfig `json:"datetime_config,omitempty"`
-	// Deprecated: Use DateTimeConfig.MinDate instead. Kept for backward compatibility;
-	// if DateTimeConfig is provided, its MinDate takes precedence.
-	MinDate string `json:"min_date,omitempty"`
-	// Deprecated: Use DateTimeConfig.MaxDate instead. Kept for backward compatibility;
-	// if DateTimeConfig is provided, its MaxDate takes precedence.
-	MaxDate string `json:"max_date,omitempty"`
-	// Deprecated: Use DateTimeConfig.TimeInterval instead. Kept for backward compatibility;
-	// if DateTimeConfig is provided, its TimeInterval takes precedence.
-	TimeInterval int `json:"time_interval,omitempty"`
 
 	// Action button configuration (type "action_button")
 	ActionButton *DialogActionButton `json:"action_button,omitempty"`
 }
 
-// EffectiveDateTimeConfig returns the resolved date/datetime configuration by
-// merging DateTimeConfig over the deprecated top-level fields (MinDate, MaxDate,
-// TimeInterval). DateTimeConfig values take precedence when set.
+// EffectiveDateTimeConfig returns the resolved date/datetime configuration,
+// treating a nil DateTimeConfig as the zero value.
 func (e *DialogElement) EffectiveDateTimeConfig() DialogDateTimeConfig {
-	cfg := DialogDateTimeConfig{
-		MinDate:      e.MinDate,
-		MaxDate:      e.MaxDate,
-		TimeInterval: e.TimeInterval,
-	}
 	if e.DateTimeConfig != nil {
-		if e.DateTimeConfig.MinDate != "" {
-			cfg.MinDate = e.DateTimeConfig.MinDate
-		}
-		if e.DateTimeConfig.MaxDate != "" {
-			cfg.MaxDate = e.DateTimeConfig.MaxDate
-		}
-		if e.DateTimeConfig.TimeInterval != 0 {
-			cfg.TimeInterval = e.DateTimeConfig.TimeInterval
-		}
-		cfg.LocationTimezone = e.DateTimeConfig.LocationTimezone
-		// ManualTimeEntry is OR'd with the deprecated AllowManualTimeEntry. Booleans can't
-		// distinguish explicit-false from not-set across JSON (omitempty drops the zero value),
-		// so either field being true must enable the feature during the deprecation window.
-		cfg.ManualTimeEntry = e.DateTimeConfig.ManualTimeEntry || e.DateTimeConfig.AllowManualTimeEntry
+		return *e.DateTimeConfig
 	}
-	return cfg
+	return DialogDateTimeConfig{}
 }
 
 type DialogActionButton struct {

--- a/server/public/model/integration_action_test.go
+++ b/server/public/model/integration_action_test.go
@@ -1391,9 +1391,11 @@ func TestDialogElementDateTimeValidation(t *testing.T) {
 			DisplayName: "Test Date",
 			Name:        "test_date",
 			Type:        "date",
-			MinDate:     "2025-01-01",
-			MaxDate:     "2025-12-31",
-			Optional:    false,
+			DateTimeConfig: &DialogDateTimeConfig{
+				MinDate: "2025-01-01",
+				MaxDate: "2025-12-31",
+			},
+			Optional: false,
 		}
 		err := element.IsValid()
 		assert.NoError(t, err)
@@ -1401,13 +1403,15 @@ func TestDialogElementDateTimeValidation(t *testing.T) {
 
 	t.Run("should validate DialogElement with datetime type and time properties", func(t *testing.T) {
 		element := DialogElement{
-			DisplayName:  "Test DateTime",
-			Name:         "test_datetime",
-			Type:         "datetime",
-			MinDate:      "2025-01-01T00:00:00Z",
-			MaxDate:      "2025-12-31T23:59:59Z",
-			TimeInterval: 30,
-			Optional:     false,
+			DisplayName: "Test DateTime",
+			Name:        "test_datetime",
+			Type:        "datetime",
+			DateTimeConfig: &DialogDateTimeConfig{
+				MinDate:      "2025-01-01T00:00:00Z",
+				MaxDate:      "2025-12-31T23:59:59Z",
+				TimeInterval: 30,
+			},
+			Optional: false,
 		}
 		err := element.IsValid()
 		assert.NoError(t, err)
@@ -1415,13 +1419,15 @@ func TestDialogElementDateTimeValidation(t *testing.T) {
 
 	t.Run("should validate DialogElement with datetime type and relative min/max", func(t *testing.T) {
 		element := DialogElement{
-			DisplayName:  "Test DateTime",
-			Name:         "test_datetime",
-			Type:         "datetime",
-			MinDate:      "+2H",
-			MaxDate:      "+7d",
-			TimeInterval: 30,
-			Optional:     false,
+			DisplayName: "Test DateTime",
+			Name:        "test_datetime",
+			Type:        "datetime",
+			DateTimeConfig: &DialogDateTimeConfig{
+				MinDate:      "+2H",
+				MaxDate:      "+7d",
+				TimeInterval: 30,
+			},
+			Optional: false,
 		}
 		err := element.IsValid()
 		assert.NoError(t, err)
@@ -1429,13 +1435,15 @@ func TestDialogElementDateTimeValidation(t *testing.T) {
 
 	t.Run("should accept datetime DialogElement with date-only min/max for backward compatibility", func(t *testing.T) {
 		element := DialogElement{
-			DisplayName:  "Test DateTime",
-			Name:         "test_datetime",
-			Type:         "datetime",
-			MinDate:      "2025-01-01",
-			MaxDate:      "2025-12-31",
-			TimeInterval: 30,
-			Optional:     false,
+			DisplayName: "Test DateTime",
+			Name:        "test_datetime",
+			Type:        "datetime",
+			DateTimeConfig: &DialogDateTimeConfig{
+				MinDate:      "2025-01-01",
+				MaxDate:      "2025-12-31",
+				TimeInterval: 30,
+			},
+			Optional: false,
 		}
 		err := element.IsValid()
 		assert.NoError(t, err)
@@ -1446,8 +1454,10 @@ func TestDialogElementDateTimeValidation(t *testing.T) {
 			DisplayName: "Test Date",
 			Name:        "test_date",
 			Type:        "date",
-			MinDate:     "invalid-date",
-			Optional:    false,
+			DateTimeConfig: &DialogDateTimeConfig{
+				MinDate: "invalid-date",
+			},
+			Optional: false,
 		}
 		err := element.IsValid()
 		assert.Error(t, err)
@@ -1456,11 +1466,13 @@ func TestDialogElementDateTimeValidation(t *testing.T) {
 
 	t.Run("should reject DialogElement with invalid time_interval", func(t *testing.T) {
 		element := DialogElement{
-			DisplayName:  "Test DateTime",
-			Name:         "test_datetime",
-			Type:         "datetime",
-			TimeInterval: -1, // Invalid
-			Optional:     false,
+			DisplayName: "Test DateTime",
+			Name:        "test_datetime",
+			Type:        "datetime",
+			DateTimeConfig: &DialogDateTimeConfig{
+				TimeInterval: -1, // Invalid
+			},
+			Optional: false,
 		}
 		err := element.IsValid()
 		assert.Error(t, err)
@@ -1469,11 +1481,13 @@ func TestDialogElementDateTimeValidation(t *testing.T) {
 
 	t.Run("should reject DialogElement with time_interval that is not a divisor of 1440", func(t *testing.T) {
 		element := DialogElement{
-			DisplayName:  "Test DateTime",
-			Name:         "test_datetime",
-			Type:         "datetime",
-			TimeInterval: 729, // Invalid - not a divisor of 1440
-			Optional:     false,
+			DisplayName: "Test DateTime",
+			Name:        "test_datetime",
+			Type:        "datetime",
+			DateTimeConfig: &DialogDateTimeConfig{
+				TimeInterval: 729, // Invalid - not a divisor of 1440
+			},
+			Optional: false,
 		}
 		err := element.IsValid()
 		assert.Error(t, err)
@@ -1485,11 +1499,13 @@ func TestDialogElementDateTimeValidation(t *testing.T) {
 
 		for _, interval := range validIntervals {
 			element := DialogElement{
-				DisplayName:  "Test DateTime",
-				Name:         "test_datetime",
-				Type:         "datetime",
-				TimeInterval: interval,
-				Optional:     false,
+				DisplayName: "Test DateTime",
+				Name:        "test_datetime",
+				Type:        "datetime",
+				DateTimeConfig: &DialogDateTimeConfig{
+					TimeInterval: interval,
+				},
+				Optional: false,
 			}
 			err := element.IsValid()
 			assert.NoError(t, err, "time_interval %d should be valid", interval)
@@ -1501,11 +1517,13 @@ func TestDialogElementDateTimeValidation(t *testing.T) {
 
 		for _, interval := range invalidIntervals {
 			element := DialogElement{
-				DisplayName:  "Test DateTime",
-				Name:         "test_datetime",
-				Type:         "datetime",
-				TimeInterval: interval,
-				Optional:     false,
+				DisplayName: "Test DateTime",
+				Name:        "test_datetime",
+				Type:        "datetime",
+				DateTimeConfig: &DialogDateTimeConfig{
+					TimeInterval: interval,
+				},
+				Optional: false,
 			}
 			err := element.IsValid()
 			assert.Error(t, err, "time_interval %d should be invalid", interval)
@@ -1516,22 +1534,26 @@ func TestDialogElementDateTimeValidation(t *testing.T) {
 	t.Run("should use default time_interval of 60 minutes when zero", func(t *testing.T) {
 		// Valid with explicit 60-minute interval
 		element := DialogElement{
-			DisplayName:  "Test DateTime",
-			Name:         "test_datetime",
-			Type:         "datetime",
-			TimeInterval: DefaultTimeIntervalMinutes,
-			Optional:     false,
+			DisplayName: "Test DateTime",
+			Name:        "test_datetime",
+			Type:        "datetime",
+			DateTimeConfig: &DialogDateTimeConfig{
+				TimeInterval: DefaultTimeIntervalMinutes,
+			},
+			Optional: false,
 		}
 		err := element.IsValid()
 		assert.NoError(t, err)
 
 		// time_interval=0 means omitted — treated as default, should pass validation
 		element = DialogElement{
-			DisplayName:  "Test DateTime",
-			Name:         "test_datetime",
-			Type:         "datetime",
-			TimeInterval: 0,
-			Optional:     false,
+			DisplayName: "Test DateTime",
+			Name:        "test_datetime",
+			Type:        "datetime",
+			DateTimeConfig: &DialogDateTimeConfig{
+				TimeInterval: 0,
+			},
+			Optional: false,
 		}
 		err = element.IsValid()
 		assert.NoError(t, err)
@@ -1594,64 +1616,6 @@ func TestDialogElementDateTimeValidation(t *testing.T) {
 		assert.Contains(t, err.Error(), "divisor of 1440")
 	})
 
-	t.Run("DateTimeConfig should take precedence over legacy fields", func(t *testing.T) {
-		element := DialogElement{
-			DisplayName: "Test Date",
-			Name:        "test_date",
-			Type:        "date",
-			MinDate:     "invalid-date",
-			DateTimeConfig: &DialogDateTimeConfig{
-				MinDate: "2025-01-01",
-			},
-		}
-		cfg := element.EffectiveDateTimeConfig()
-		assert.Equal(t, "2025-01-01", cfg.MinDate)
-	})
-
-	t.Run("legacy fields used when DateTimeConfig not provided", func(t *testing.T) {
-		element := DialogElement{
-			DisplayName:  "Test DateTime",
-			Name:         "test_datetime",
-			Type:         "datetime",
-			MinDate:      "2025-01-01T00:00:00Z",
-			MaxDate:      "2025-12-31T23:59:59Z",
-			TimeInterval: 30,
-		}
-		cfg := element.EffectiveDateTimeConfig()
-		assert.Equal(t, "2025-01-01T00:00:00Z", cfg.MinDate)
-		assert.Equal(t, "2025-12-31T23:59:59Z", cfg.MaxDate)
-		assert.Equal(t, 30, cfg.TimeInterval)
-	})
-
-	t.Run("ManualTimeEntry resolves via OR across new and deprecated fields", func(t *testing.T) {
-		cases := []struct {
-			name     string
-			newField bool
-			oldField bool
-			expected bool
-		}{
-			{"both false", false, false, false},
-			{"only new true", true, false, true},
-			{"only deprecated true", false, true, true},
-			{"both true", true, true, true},
-		}
-		for _, tc := range cases {
-			t.Run(tc.name, func(t *testing.T) {
-				element := DialogElement{
-					DisplayName: "Test DateTime",
-					Name:        "test_datetime",
-					Type:        "datetime",
-					DateTimeConfig: &DialogDateTimeConfig{
-						ManualTimeEntry:      tc.newField,
-						AllowManualTimeEntry: tc.oldField,
-					},
-				}
-				cfg := element.EffectiveDateTimeConfig()
-				assert.Equal(t, tc.expected, cfg.ManualTimeEntry)
-			})
-		}
-	})
-
 	t.Run("ManualTimeEntry marshals under manual_time_entry JSON key", func(t *testing.T) {
 		cfg := DialogDateTimeConfig{ManualTimeEntry: true}
 		b, err := json.Marshal(cfg)
@@ -1659,22 +1623,31 @@ func TestDialogElementDateTimeValidation(t *testing.T) {
 		assert.Contains(t, string(b), `"manual_time_entry":true`)
 	})
 
-	t.Run("deprecated allow_manual_time_entry payload still enables manual entry end-to-end", func(t *testing.T) {
-		// Simulate a legacy integrator sending only the deprecated field.
-		payload := []byte(`{"allow_manual_time_entry":true}`)
+	t.Run("removed legacy top-level fields are silently ignored on unmarshal", func(t *testing.T) {
+		// MM-68396: min_date, max_date, and time_interval are no longer DialogElement
+		// fields (moved to DateTimeConfig). This documents the intended breaking-change
+		// behavior for integrations still sending them at the top level: encoding/json
+		// drops unrecognized keys, so the element ends up with no date/datetime config
+		// and IsValid() no longer applies constraints derived from them.
+		payload := []byte(`{
+			"display_name": "Test Date",
+			"name": "test_date",
+			"type": "date",
+			"min_date": "invalid-date",
+			"max_date": "2025-12-31"
+		}`)
+		var element DialogElement
+		require.NoError(t, json.Unmarshal(payload, &element))
+
+		assert.Nil(t, element.DateTimeConfig, "legacy top-level fields must not populate DateTimeConfig")
+		assert.NoError(t, element.IsValid(), "an invalid legacy min_date must no longer fail validation since the field is unrecognized")
+	})
+
+	t.Run("removed deprecated AllowManualTimeEntry is silently ignored on unmarshal", func(t *testing.T) {
+		payload := []byte(`{"allow_manual_time_entry": true}`)
 		var cfg DialogDateTimeConfig
 		require.NoError(t, json.Unmarshal(payload, &cfg))
-		require.False(t, cfg.ManualTimeEntry, "new field should remain zero-value after unmarshal")
-		require.True(t, cfg.AllowManualTimeEntry, "deprecated field should unmarshal under its legacy tag")
-
-		element := DialogElement{
-			DisplayName:    "Test",
-			Name:           "t",
-			Type:           "datetime",
-			DateTimeConfig: &cfg,
-		}
-		effective := element.EffectiveDateTimeConfig()
-		assert.True(t, effective.ManualTimeEntry, "deprecated field alone should enable manual entry after EffectiveDateTimeConfig")
+		assert.False(t, cfg.ManualTimeEntry, "the deprecated key must no longer populate ManualTimeEntry")
 	})
 }
 

--- a/webapp/channels/src/components/apps_form/apps_form_component.test.tsx
+++ b/webapp/channels/src/components/apps_form/apps_form_component.test.tsx
@@ -1348,9 +1348,11 @@ describe('AppsFormComponent', () => {
                         type: 'datetime',
                         is_required: true,
                         label: 'Meeting Time',
-                        time_interval: 30,
-                        min_date: 'today',
-                        max_date: '+30d',
+                        datetime_config: {
+                            time_interval: 30,
+                            min_date: 'today',
+                            max_date: '+30d',
+                        },
                     },
                 ],
             };
@@ -1374,8 +1376,10 @@ describe('AppsFormComponent', () => {
                     {
                         name: 'invalid_field',
                         type: 'datetime',
-                        time_interval: -1, // Invalid interval
-                        min_date: 'invalid-date', // Invalid date format
+                        datetime_config: {
+                            time_interval: -1, // Invalid interval
+                            min_date: 'invalid-date', // Invalid date format
+                        },
                         label: 'Invalid Field',
                     },
                 ],
@@ -1429,7 +1433,7 @@ describe('AppsFormComponent', () => {
                         {
                             name: 'valid_datetime',
                             type: 'datetime',
-                            time_interval: interval,
+                            datetime_config: {time_interval: interval},
                             label: `DateTime with ${interval}min interval`,
                         },
                     ],
@@ -1456,7 +1460,7 @@ describe('AppsFormComponent', () => {
                         {
                             name: 'invalid_datetime',
                             type: 'datetime',
-                            time_interval: interval,
+                            datetime_config: {time_interval: interval},
                             label: `DateTime with ${interval}min interval`,
                         },
                     ],
@@ -1494,7 +1498,7 @@ describe('AppsFormComponent', () => {
                         {
                             name: 'out_of_range_datetime',
                             type: 'datetime',
-                            time_interval: interval,
+                            datetime_config: {time_interval: interval},
                             label: `DateTime with ${interval}min interval`,
                         },
                     ],
@@ -1532,7 +1536,7 @@ describe('AppsFormComponent', () => {
                         {
                             name: 'non_numeric_datetime',
                             type: 'datetime',
-                            time_interval: interval as any,
+                            datetime_config: {time_interval: interval as any},
                             label: `DateTime with ${interval} interval`,
                         },
                     ],
@@ -1570,13 +1574,13 @@ describe('AppsFormComponent', () => {
                     {
                         name: 'text_with_interval',
                         type: 'text',
-                        time_interval: 729, // Invalid but should be ignored for text fields
+                        datetime_config: {time_interval: 729}, // Invalid but should be ignored for text fields
                         label: 'Text Field',
                     },
                     {
                         name: 'date_with_interval',
                         type: 'date',
-                        time_interval: 729, // Invalid but should be ignored for date fields
+                        datetime_config: {time_interval: 729}, // Invalid but should be ignored for date fields
                         label: 'Date Field',
                     },
                 ],
@@ -1594,78 +1598,9 @@ describe('AppsFormComponent', () => {
 
             consoleSpy.mockRestore();
         });
-
-        it('should validate min_date and max_date formats for date and datetime fields', () => {
-            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-            const formWithInvalidDates = {
-                ...baseProps.form,
-                fields: [
-                    {
-                        name: 'invalid_dates',
-                        type: 'datetime',
-                        min_date: 'invalid-date-format',
-                        max_date: '2025/01/01', // Wrong format
-                        label: 'DateTime with Invalid Dates',
-                    },
-                ],
-            };
-
-            const props = {
-                ...baseProps,
-                form: formWithInvalidDates,
-            };
-
-            renderWithContext(<AppsForm {...props}/>);
-
-            // Should log warnings for invalid date formats
-            expect(consoleSpy).toHaveBeenCalledWith(
-                'AppForm field validation errors:',
-                expect.arrayContaining([
-                    expect.stringContaining('min_date "invalid-date-format" is not a valid date format'),
-                    expect.stringContaining('max_date "2025/01/01" is not a valid date format'),
-                ]),
-            );
-
-            consoleSpy.mockRestore();
-        });
-
-        it('should validate date range when min_date is after max_date', () => {
-            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-            const formWithInvalidDateRange = {
-                ...baseProps.form,
-                fields: [
-                    {
-                        name: 'invalid_range',
-                        type: 'date',
-                        min_date: '2025-12-31',
-                        max_date: '2025-01-01', // Before min_date
-                        label: 'Date with Invalid Range',
-                    },
-                ],
-            };
-
-            const props = {
-                ...baseProps,
-                form: formWithInvalidDateRange,
-            };
-
-            renderWithContext(<AppsForm {...props}/>);
-
-            // Should log warning for invalid date range
-            expect(consoleSpy).toHaveBeenCalledWith(
-                'AppForm field validation errors:',
-                expect.arrayContaining([
-                    expect.stringContaining('min_date cannot be after max_date'),
-                ]),
-            );
-
-            consoleSpy.mockRestore();
-        });
     });
 
-    describe('DateTime Field Validation - datetime_config precedence', () => {
+    describe('DateTime Field Validation - datetime_config', () => {
         it('should validate invalid datetime_config.time_interval', () => {
             const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
@@ -1748,76 +1683,6 @@ describe('AppsFormComponent', () => {
                 'AppForm field validation errors:',
                 expect.arrayContaining([
                     expect.stringContaining('min_date cannot be after max_date'),
-                ]),
-            );
-
-            consoleSpy.mockRestore();
-        });
-
-        it('should use datetime_config values over legacy fields for validation', () => {
-            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-            // Legacy values are valid, datetime_config values are invalid.
-            // If precedence works, validation should flag the datetime_config values.
-            const form = {
-                ...baseProps.form,
-                fields: [
-                    {
-                        name: 'precedence_test',
-                        type: 'datetime',
-                        time_interval: 30, // Valid legacy
-                        min_date: '2025-01-01', // Valid legacy
-                        max_date: '2025-12-31', // Valid legacy
-                        datetime_config: {
-                            time_interval: 729, // Invalid
-                            min_date: 'not-a-date', // Invalid
-                            max_date: '2025/13/45', // Invalid
-                        },
-                        label: 'Precedence Test',
-                    },
-                ],
-            };
-
-            renderWithContext(<AppsForm {...{...baseProps, form}}/>);
-
-            expect(consoleSpy).toHaveBeenCalledWith(
-                'AppForm field validation errors:',
-                expect.arrayContaining([
-                    expect.stringContaining('time_interval must be a divisor of 1440 (24 hours * 60 minutes) to create valid time intervals, got 729'),
-                    expect.stringContaining('min_date "not-a-date" is not a valid date format'),
-                ]),
-            );
-
-            // Legacy values are valid, so they should NOT appear in error messages.
-            const errorCalls = consoleSpy.mock.calls.flat().flat();
-            const errorStr = JSON.stringify(errorCalls);
-            expect(errorStr).not.toContain('got 30');
-            expect(errorStr).not.toContain('"2025-01-01"');
-
-            consoleSpy.mockRestore();
-        });
-
-        it('should fall back to legacy fields when datetime_config is absent', () => {
-            const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
-
-            const form = {
-                ...baseProps.form,
-                fields: [
-                    {
-                        name: 'legacy_only',
-                        type: 'datetime',
-                        time_interval: 729, // Invalid legacy
-                        label: 'Legacy Only',
-                    },
-                ],
-            };
-
-            renderWithContext(<AppsForm {...{...baseProps, form}}/>);
-
-            expect(consoleSpy).toHaveBeenCalledWith(
-                'AppForm field validation errors:',
-                expect.arrayContaining([
-                    expect.stringContaining('time_interval must be a divisor of 1440 (24 hours * 60 minutes) to create valid time intervals, got 729'),
                 ]),
             );
 

--- a/webapp/channels/src/components/apps_form/apps_form_component.tsx
+++ b/webapp/channels/src/components/apps_form/apps_form_component.tsx
@@ -93,10 +93,10 @@ const validateDateFieldValue = (fieldName: string, valueType: string, value: str
 const validateAppField = (field: AppField): string[] => {
     const errors: string[] = [];
 
-    // Resolve effective datetime values (datetime_config takes precedence over deprecated top-level fields)
-    const effectiveTimeInterval = field.datetime_config?.time_interval ?? field.time_interval;
-    const effectiveMinDate = field.datetime_config?.min_date ?? field.min_date;
-    const effectiveMaxDate = field.datetime_config?.max_date ?? field.max_date;
+    // Resolve effective datetime values
+    const effectiveTimeInterval = field.datetime_config?.time_interval;
+    const effectiveMinDate = field.datetime_config?.min_date;
+    const effectiveMaxDate = field.datetime_config?.max_date;
 
     // Validate time_interval for datetime fields (no mutation)
     if (field.type === AppFieldTypes.DATETIME && effectiveTimeInterval !== undefined) {
@@ -167,10 +167,10 @@ const getSafeDateValue = (dateString: string): string => {
 const createSanitizedField = (field: AppField): AppField => {
     const sanitized = {...field};
 
-    // Resolve effective datetime values (datetime_config takes precedence over deprecated top-level fields)
-    const effectiveInterval = field.datetime_config?.time_interval ?? field.time_interval;
-    const effectiveMin = field.datetime_config?.min_date ?? field.min_date;
-    const effectiveMax = field.datetime_config?.max_date ?? field.max_date;
+    // Resolve effective datetime values
+    const effectiveInterval = field.datetime_config?.time_interval;
+    const effectiveMin = field.datetime_config?.min_date;
+    const effectiveMax = field.datetime_config?.max_date;
 
     // Sanitize time_interval for datetime fields
     if (field.type === AppFieldTypes.DATETIME && effectiveInterval !== undefined) {
@@ -179,7 +179,6 @@ const createSanitizedField = (field: AppField): AppField => {
         if (sanitized.datetime_config) {
             sanitized.datetime_config = {...sanitized.datetime_config, time_interval: sanitizedInterval};
         }
-        sanitized.time_interval = sanitizedInterval;
     }
 
     // Sanitize date values for date fields only — datetime fields need the full pattern preserved
@@ -189,14 +188,12 @@ const createSanitizedField = (field: AppField): AppField => {
             if (sanitized.datetime_config) {
                 sanitized.datetime_config = {...sanitized.datetime_config, min_date: safeMin};
             }
-            sanitized.min_date = safeMin;
         }
         if (effectiveMax) {
             const safeMax = getSafeDateValue(effectiveMax);
             if (sanitized.datetime_config) {
                 sanitized.datetime_config = {...sanitized.datetime_config, max_date: safeMax};
             }
-            sanitized.max_date = safeMax;
         }
         if (field.type === AppFieldTypes.DATE && field.value && typeof field.value === 'string') {
             sanitized.value = getSafeDateValue(field.value);
@@ -236,8 +233,8 @@ const initFormValues = (form: AppForm, timezone?: string): AppFormValues => {
                 // Set default to current time for required datetime fields
                 const currentTime = timezone ? moment.tz(timezone) : moment();
 
-                // Use sanitized time_interval (guaranteed to be valid; datetime_config takes precedence)
-                const timePickerInterval = field.datetime_config?.time_interval ?? field.time_interval ?? DEFAULT_TIME_INTERVAL_MINUTES;
+                // Use sanitized time_interval (guaranteed to be valid)
+                const timePickerInterval = field.datetime_config?.time_interval ?? DEFAULT_TIME_INTERVAL_MINUTES;
 
                 // Round up to next time interval
                 const minutesMod = currentTime.minutes() % timePickerInterval;
@@ -245,9 +242,9 @@ const initFormValues = (form: AppForm, timezone?: string): AppFormValues => {
                     currentTime.clone().seconds(0).milliseconds(0) :
                     currentTime.clone().add(timePickerInterval - minutesMod, 'minutes').seconds(0).milliseconds(0);
 
-                // Clamp default to min_date/max_date bounds (datetime_config takes precedence)
-                const effectiveMin = field.datetime_config?.min_date ?? field.min_date;
-                const effectiveMax = field.datetime_config?.max_date ?? field.max_date;
+                // Clamp default to min_date/max_date bounds
+                const effectiveMin = field.datetime_config?.min_date;
+                const effectiveMax = field.datetime_config?.max_date;
                 const minMoment = effectiveMin ? stringToMoment(effectiveMin, timezone) : null;
                 const maxMoment = effectiveMax ? stringToMoment(effectiveMax, timezone) : null;
                 if (minMoment && defaultMoment.isBefore(minMoment)) {
@@ -857,9 +854,6 @@ function fieldsAsElements(fields?: AppField[]): DialogElement[] {
         subtype: f.subtype,
         optional: !f.is_required,
         datetime_config: f.datetime_config,
-        min_date: f.datetime_config?.min_date ?? f.min_date,
-        max_date: f.datetime_config?.max_date ?? f.max_date,
-        time_interval: f.datetime_config?.time_interval ?? f.time_interval,
     })) as DialogElement[];
 }
 

--- a/webapp/channels/src/components/apps_form/apps_form_date_field/apps_form_date_field.test.tsx
+++ b/webapp/channels/src/components/apps_form/apps_form_date_field/apps_form_date_field.test.tsx
@@ -114,8 +114,10 @@ describe('AppsFormDateField', () => {
     it('should render without errors even when date is outside range (validation is centralized)', () => {
         const fieldWithRange = {
             ...defaultField,
-            min_date: '2025-01-10',
-            max_date: '2025-01-20',
+            datetime_config: {
+                min_date: '2025-01-10',
+                max_date: '2025-01-20',
+            },
         };
         renderComponent({field: fieldWithRange, value: '2025-01-01'});
 
@@ -126,8 +128,10 @@ describe('AppsFormDateField', () => {
     it('should not show error for valid date within range', () => {
         const fieldWithRange = {
             ...defaultField,
-            min_date: '2025-01-01',
-            max_date: '2025-01-31',
+            datetime_config: {
+                min_date: '2025-01-01',
+                max_date: '2025-01-31',
+            },
         };
         renderComponent({field: fieldWithRange, value: '2025-01-15'});
         expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
@@ -145,8 +149,10 @@ describe('AppsFormDateField', () => {
     it('should handle date range constraints', () => {
         const fieldWithRange = {
             ...defaultField,
-            min_date: '2025-01-01',
-            max_date: '2025-01-31',
+            datetime_config: {
+                min_date: '2025-01-01',
+                max_date: '2025-01-31',
+            },
         };
 
         renderComponent({field: fieldWithRange, value: '2025-01-15'});

--- a/webapp/channels/src/components/apps_form/apps_form_date_field/apps_form_date_field.tsx
+++ b/webapp/channels/src/components/apps_form/apps_form_date_field/apps_form_date_field.tsx
@@ -58,9 +58,9 @@ const AppsFormDateField: React.FC<Props> = ({
         setIsInteracting?.(isOpen);
     }, [setIsInteracting]);
 
-    // Resolve effective min/max dates (datetime_config takes precedence over deprecated top-level fields)
-    const effectiveMinDate = field.datetime_config?.min_date ?? field.min_date;
-    const effectiveMaxDate = field.datetime_config?.max_date ?? field.max_date;
+    // Resolve effective min/max dates
+    const effectiveMinDate = field.datetime_config?.min_date;
+    const effectiveMaxDate = field.datetime_config?.max_date;
 
     const disabledDays = useMemo(() => {
         const disabled = [];

--- a/webapp/channels/src/components/apps_form/apps_form_datetime_field/apps_form_datetime_field.test.tsx
+++ b/webapp/channels/src/components/apps_form/apps_form_datetime_field/apps_form_datetime_field.test.tsx
@@ -119,7 +119,7 @@ describe('AppsFormDateTimeField', () => {
     });
 
     it('should use custom time_interval', () => {
-        const fieldWithInterval = {...defaultField, time_interval: 30};
+        const fieldWithInterval = {...defaultField, datetime_config: {time_interval: 30}};
         renderComponent({field: fieldWithInterval, value: '2025-01-15T14:30:00Z'});
 
         // The time_interval is passed to DateTimeInput component
@@ -138,8 +138,10 @@ describe('AppsFormDateTimeField', () => {
     it('should render without errors even when datetime is outside range (validation is centralized)', () => {
         const fieldWithRange = {
             ...defaultField,
-            min_date: '2025-01-10',
-            max_date: '2025-01-20',
+            datetime_config: {
+                min_date: '2025-01-10',
+                max_date: '2025-01-20',
+            },
         };
         renderComponent({field: fieldWithRange, value: '2025-01-01T14:30:00Z'});
 
@@ -150,8 +152,10 @@ describe('AppsFormDateTimeField', () => {
     it('should not show error for valid datetime within range', () => {
         const fieldWithRange = {
             ...defaultField,
-            min_date: '2025-01-01',
-            max_date: '2025-01-31',
+            datetime_config: {
+                min_date: '2025-01-01',
+                max_date: '2025-01-31',
+            },
         };
         renderComponent({field: fieldWithRange, value: '2025-01-15T14:30:00Z'});
         expect(screen.queryByText(/error/i)).not.toBeInTheDocument();
@@ -160,8 +164,10 @@ describe('AppsFormDateTimeField', () => {
     it('should handle datetime range constraints', () => {
         const fieldWithRange = {
             ...defaultField,
-            min_date: '2025-01-01',
-            max_date: '2025-01-31',
+            datetime_config: {
+                min_date: '2025-01-01',
+                max_date: '2025-01-31',
+            },
         };
 
         renderComponent({field: fieldWithRange, value: '2025-01-15T14:30:00Z'});
@@ -190,7 +196,7 @@ describe('AppsFormDateTimeField', () => {
         });
 
         it('should restrict past dates when min_date is today or future', () => {
-            const fieldWithMinDate = {...defaultField, min_date: 'today'};
+            const fieldWithMinDate = {...defaultField, datetime_config: {min_date: 'today'}};
             renderComponent({field: fieldWithMinDate, value: '2025-01-15T14:30:00Z'});
 
             // DateTimeInput should receive allowPastDates=false
@@ -198,7 +204,7 @@ describe('AppsFormDateTimeField', () => {
         });
 
         it('should allow past dates when min_date is in the past', () => {
-            const fieldWithMinDate = {...defaultField, min_date: '-5d'};
+            const fieldWithMinDate = {...defaultField, datetime_config: {min_date: '-5d'}};
             renderComponent({field: fieldWithMinDate, value: '2025-01-15T14:30:00Z'});
 
             // DateTimeInput should receive allowPastDates=true
@@ -206,26 +212,14 @@ describe('AppsFormDateTimeField', () => {
         });
     });
 
-    describe('manualTimeEntry resolution (OR precedence)', () => {
-        it('is false when neither field is set', () => {
+    describe('manualTimeEntry resolution', () => {
+        it('is false when not set', () => {
             renderComponent();
             expect(screen.getByTestId('datetime-input')).toHaveAttribute('data-manual-time-entry', 'false');
         });
 
-        it('is true when only the new manual_time_entry is set', () => {
+        it('is true when manual_time_entry is set', () => {
             const field = {...defaultField, datetime_config: {manual_time_entry: true}};
-            renderComponent({field});
-            expect(screen.getByTestId('datetime-input')).toHaveAttribute('data-manual-time-entry', 'true');
-        });
-
-        it('is true when only the deprecated allow_manual_time_entry is set', () => {
-            const field = {...defaultField, datetime_config: {allow_manual_time_entry: true}};
-            renderComponent({field});
-            expect(screen.getByTestId('datetime-input')).toHaveAttribute('data-manual-time-entry', 'true');
-        });
-
-        it('is true when either field is true (OR semantics)', () => {
-            const field = {...defaultField, datetime_config: {manual_time_entry: false, allow_manual_time_entry: true}};
             renderComponent({field});
             expect(screen.getByTestId('datetime-input')).toHaveAttribute('data-manual-time-entry', 'true');
         });

--- a/webapp/channels/src/components/apps_form/apps_form_datetime_field/apps_form_datetime_field.tsx
+++ b/webapp/channels/src/components/apps_form/apps_form_datetime_field/apps_form_datetime_field.tsx
@@ -49,15 +49,11 @@ const AppsFormDateTimeField: React.FC<Props> = ({
 }) => {
     const userTimezone = useSelector(getCurrentTimezone);
 
-    // Resolve datetime config (datetime_config takes precedence over deprecated top-level fields)
+    // Resolve datetime config
     const locationTimezone = field.datetime_config?.location_timezone;
-    const timePickerInterval = field.datetime_config?.time_interval ?? field.time_interval ?? DEFAULT_TIME_INTERVAL_MINUTES;
+    const timePickerInterval = field.datetime_config?.time_interval ?? DEFAULT_TIME_INTERVAL_MINUTES;
 
-    // manual_time_entry supersedes the deprecated allow_manual_time_entry. Either enabling
-    // it turns it on (booleans can't distinguish explicit-false from not-set across the wire).
-    // The OR covers direct Apps Framework bindings that may still carry the deprecated key;
-    // dialog-sourced AppFields are pre-normalized by dialog_conversion and only carry manual_time_entry.
-    const manualTimeEntry = Boolean(field.datetime_config?.manual_time_entry) || Boolean(field.datetime_config?.allow_manual_time_entry);
+    const manualTimeEntry = Boolean(field.datetime_config?.manual_time_entry);
 
     // Use location_timezone if specified, otherwise fall back to user's timezone
     const timezone = locationTimezone || userTimezone;
@@ -87,9 +83,9 @@ const AppsFormDateTimeField: React.FC<Props> = ({
         onChange(field.name, newValue);
     }, [field.name, onChange]);
 
-    // Resolve effective min/max dates (datetime_config takes precedence over deprecated top-level fields)
-    const effectiveMinDate = field.datetime_config?.min_date ?? field.min_date;
-    const effectiveMaxDate = field.datetime_config?.max_date ?? field.max_date;
+    // Resolve effective min/max dates
+    const effectiveMinDate = field.datetime_config?.min_date;
+    const effectiveMaxDate = field.datetime_config?.max_date;
 
     const {minDateTime, allowPastDates} = useMemo(() => {
         if (!effectiveMinDate) {

--- a/webapp/channels/src/packages/mattermost-redux/src/utils/integration_utils.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/utils/integration_utils.test.ts
@@ -149,7 +149,9 @@ describe('integration utils', () => {
         it('should return error when datetime is before min_date', () => {
             const element = TestHelper.getDialogElementMock({
                 type: 'datetime',
-                min_date: '2025-06-01T00:00:00Z',
+                datetime_config: {
+                    min_date: '2025-06-01T00:00:00Z',
+                },
             });
 
             const error = checkDialogElementForError(element, '2025-05-15T12:00:00Z');
@@ -159,7 +161,9 @@ describe('integration utils', () => {
         it('should return error when datetime is after max_date', () => {
             const element = TestHelper.getDialogElementMock({
                 type: 'datetime',
-                max_date: '2025-06-01T00:00:00Z',
+                datetime_config: {
+                    max_date: '2025-06-01T00:00:00Z',
+                },
             });
 
             const error = checkDialogElementForError(element, '2025-06-15T12:00:00Z');
@@ -169,8 +173,10 @@ describe('integration utils', () => {
         it('should return null when datetime is within min_date and max_date bounds', () => {
             const element = TestHelper.getDialogElementMock({
                 type: 'datetime',
-                min_date: '2025-01-01T00:00:00Z',
-                max_date: '2025-12-31T23:59:59Z',
+                datetime_config: {
+                    min_date: '2025-01-01T00:00:00Z',
+                    max_date: '2025-12-31T23:59:59Z',
+                },
             });
 
             expect(checkDialogElementForError(element, '2025-06-15T12:00:00Z')).toBeNull();
@@ -184,51 +190,14 @@ describe('integration utils', () => {
         it('should handle unresolvable min_date/max_date gracefully', () => {
             const element = TestHelper.getDialogElementMock({
                 type: 'datetime',
-                min_date: 'not-a-valid-format',
-                max_date: 'also-invalid',
+                datetime_config: {
+                    min_date: 'not-a-valid-format',
+                    max_date: 'also-invalid',
+                },
             });
 
             // Should skip range check (resolveBoundToDate returns null) and pass
             expect(checkDialogElementForError(element, '2025-06-15T12:00:00Z')).toBeNull();
-        });
-
-        it('should use datetime_config.min_date over legacy min_date', () => {
-            const element = TestHelper.getDialogElementMock({
-                type: 'datetime',
-                min_date: '2020-01-01T00:00:00Z',
-                datetime_config: {
-                    min_date: '2025-06-01T00:00:00Z',
-                },
-            });
-
-            // datetime_config.min_date (2025-06-01) takes precedence over legacy (2020-01-01)
-            const error = checkDialogElementForError(element, '2025-05-15T12:00:00Z');
-            expect(error?.id).toBe('interactive_dialog.error.before_min_date');
-        });
-
-        it('should use datetime_config.max_date over legacy max_date', () => {
-            const element = TestHelper.getDialogElementMock({
-                type: 'datetime',
-                max_date: '2030-12-31T23:59:59Z',
-                datetime_config: {
-                    max_date: '2025-06-01T00:00:00Z',
-                },
-            });
-
-            // datetime_config.max_date (2025-06-01) takes precedence over legacy (2030-12-31)
-            const error = checkDialogElementForError(element, '2025-06-15T12:00:00Z');
-            expect(error?.id).toBe('interactive_dialog.error.after_max_date');
-        });
-
-        it('should fall back to legacy fields when datetime_config not set', () => {
-            const element = TestHelper.getDialogElementMock({
-                type: 'datetime',
-                min_date: '2025-06-01T00:00:00Z',
-                max_date: '2025-12-31T23:59:59Z',
-            });
-
-            expect(checkDialogElementForError(element, '2025-06-15T12:00:00Z')).toBeNull();
-            expect(checkDialogElementForError(element, '2025-05-01T12:00:00Z')?.id).toBe('interactive_dialog.error.before_min_date');
         });
     });
 });

--- a/webapp/channels/src/packages/mattermost-redux/src/utils/integration_utils.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/utils/integration_utils.ts
@@ -83,9 +83,9 @@ function validateDateTimeValue(value: string, elem: DialogElement): DialogError 
         });
     }
 
-    // Range validation against min_date / max_date (datetime_config takes precedence over legacy fields)
-    const effectiveMinDate = elem.datetime_config?.min_date ?? elem.min_date;
-    const effectiveMaxDate = elem.datetime_config?.max_date ?? elem.max_date;
+    // Range validation against min_date / max_date
+    const effectiveMinDate = elem.datetime_config?.min_date;
+    const effectiveMaxDate = elem.datetime_config?.max_date;
     if (effectiveMinDate) {
         const minDate = resolveBoundToDate(effectiveMinDate);
         if (minDate && parsedDate < minDate) {

--- a/webapp/channels/src/utils/apps_type_guard.test.ts
+++ b/webapp/channels/src/utils/apps_type_guard.test.ts
@@ -158,35 +158,6 @@ describe('isAppBinding — isAppField datetime_config validation', () => {
         });
     });
 
-    describe('datetime_config.allow_manual_time_entry (deprecated)', () => {
-        test('accepts boolean', () => {
-            const binding = bindingWithField({
-                ...baseField,
-                datetime_config: {allow_manual_time_entry: true},
-            });
-            expect(isAppBinding(binding)).toBe(true);
-        });
-
-        test('rejects non-boolean value', () => {
-            const binding = bindingWithField({
-                ...baseField,
-                datetime_config: {allow_manual_time_entry: 1},
-            });
-            expect(isAppBinding(binding)).toBe(false);
-        });
-
-        test('accepts both new and deprecated fields set simultaneously', () => {
-            const binding = bindingWithField({
-                ...baseField,
-                datetime_config: {
-                    manual_time_entry: true,
-                    allow_manual_time_entry: false,
-                },
-            });
-            expect(isAppBinding(binding)).toBe(true);
-        });
-    });
-
     describe('datetime_config shape', () => {
         test('accepts empty object', () => {
             const binding = bindingWithField({
@@ -208,26 +179,6 @@ describe('isAppBinding — isAppField datetime_config validation', () => {
             const binding = bindingWithField({
                 ...baseField,
                 datetime_config: 'not-an-object',
-            });
-            expect(isAppBinding(binding)).toBe(false);
-        });
-    });
-
-    describe('interaction with deprecated top-level fields', () => {
-        test('accepts both datetime_config and legacy top-level min_date when valid', () => {
-            const binding = bindingWithField({
-                ...baseField,
-                min_date: '2024-01-01',
-                datetime_config: {min_date: '2025-01-15'},
-            });
-            expect(isAppBinding(binding)).toBe(true);
-        });
-
-        test('rejects when datetime_config.min_date is invalid even if legacy min_date is valid', () => {
-            const binding = bindingWithField({
-                ...baseField,
-                min_date: '2025-01-15',
-                datetime_config: {min_date: 'not-a-date'},
             });
             expect(isAppBinding(binding)).toBe(false);
         });

--- a/webapp/channels/src/utils/dialog_conversion.test.ts
+++ b/webapp/channels/src/utils/dialog_conversion.test.ts
@@ -1755,81 +1755,17 @@ describe('dialog_conversion', () => {
         });
 
         describe('convertDialogToAppForm with date/datetime fields', () => {
-            it('should convert date field with min_date and max_date', () => {
-                const elements: DialogElement[] = [
-                    {
-                        name: 'event_date',
-                        type: 'date',
-                        display_name: 'Event Date',
-                        min_date: '2025-01-01',
-                        max_date: '2025-12-31',
-                        optional: false,
-                    } as DialogElement,
-                ];
-
-                const {form} = convertDialogToAppForm(
-                    elements,
-                    'Test Form',
-                    undefined,
-                    undefined,
-                    undefined,
-                    '',
-                    '',
-                    legacyOptions,
-                );
-
-                expect(form.fields).toHaveLength(1);
-                expect(form.fields?.[0]).toMatchObject({
-                    name: 'event_date',
-                    type: 'date',
-                    label: 'Event Date',
-                    min_date: '2025-01-01',
-                    max_date: '2025-12-31',
-                    is_required: true,
-                });
-            });
-
-            it('should convert datetime field with time_interval', () => {
-                const elements: DialogElement[] = [
-                    {
-                        name: 'meeting_time',
-                        type: 'datetime',
-                        display_name: 'Meeting Time',
-                        time_interval: 30,
-                        optional: true,
-                    } as DialogElement,
-                ];
-
-                const {form} = convertDialogToAppForm(
-                    elements,
-                    'Test Form',
-                    undefined,
-                    undefined,
-                    undefined,
-                    '',
-                    '',
-                    legacyOptions,
-                );
-
-                expect(form.fields).toHaveLength(1);
-                expect(form.fields?.[0]).toMatchObject({
-                    name: 'meeting_time',
-                    type: 'datetime',
-                    label: 'Meeting Time',
-                    time_interval: 30,
-                    is_required: false,
-                });
-            });
-
-            it('should convert datetime field with all date properties', () => {
+            it('should convert datetime field with all datetime_config properties', () => {
                 const elements: DialogElement[] = [
                     {
                         name: 'full_datetime',
                         type: 'datetime',
                         display_name: 'Full DateTime',
-                        min_date: 'today',
-                        max_date: '+30d',
-                        time_interval: 15,
+                        datetime_config: {
+                            min_date: 'today',
+                            max_date: '+30d',
+                            time_interval: 15,
+                        },
                         optional: false,
                     } as DialogElement,
                 ];
@@ -1850,10 +1786,12 @@ describe('dialog_conversion', () => {
                     name: 'full_datetime',
                     type: 'datetime',
                     label: 'Full DateTime',
+                    is_required: true,
+                });
+                expect(form.fields?.[0]?.datetime_config).toMatchObject({
                     min_date: 'today',
                     max_date: '+30d',
                     time_interval: 15,
-                    is_required: true,
                 });
             });
 
@@ -1887,8 +1825,6 @@ describe('dialog_conversion', () => {
                     name: 'event_date',
                     type: 'date',
                     label: 'Event Date',
-                    min_date: '2025-01-01',
-                    max_date: '2025-12-31',
                     is_required: true,
                 });
                 expect(form.fields?.[0]?.datetime_config).toMatchObject({
@@ -1926,41 +1862,12 @@ describe('dialog_conversion', () => {
                     name: 'meeting_time',
                     type: 'datetime',
                     label: 'Meeting Time',
-                    time_interval: 30,
                     is_required: false,
                 });
                 expect(form.fields?.[0]?.datetime_config?.time_interval).toBe(30);
             });
 
-            it('normalizes deprecated allow_manual_time_entry into manual_time_entry', () => {
-                const elements: DialogElement[] = [
-                    {
-                        name: 'meeting_time',
-                        type: 'datetime',
-                        display_name: 'Meeting Time',
-                        datetime_config: {
-                            allow_manual_time_entry: true,
-                        },
-                        optional: false,
-                    } as DialogElement,
-                ];
-
-                const {form} = convertDialogToAppForm(
-                    elements,
-                    'Test Form',
-                    undefined,
-                    undefined,
-                    undefined,
-                    '',
-                    '',
-                    legacyOptions,
-                );
-
-                expect(form.fields?.[0]?.datetime_config?.manual_time_entry).toBe(true);
-                expect(form.fields?.[0]?.datetime_config?.allow_manual_time_entry).toBeUndefined();
-            });
-
-            it('preserves manual_time_entry when set directly', () => {
+            it('preserves manual_time_entry when set', () => {
                 const elements: DialogElement[] = [
                     {
                         name: 'meeting_time',
@@ -1985,10 +1892,9 @@ describe('dialog_conversion', () => {
                 );
 
                 expect(form.fields?.[0]?.datetime_config?.manual_time_entry).toBe(true);
-                expect(form.fields?.[0]?.datetime_config?.allow_manual_time_entry).toBeUndefined();
             });
 
-            it('omits manual_time_entry when neither source is true', () => {
+            it('omits manual_time_entry when not set', () => {
                 const elements: DialogElement[] = [
                     {
                         name: 'meeting_time',
@@ -2013,20 +1919,16 @@ describe('dialog_conversion', () => {
                 );
 
                 expect(form.fields?.[0]?.datetime_config?.manual_time_entry).toBeUndefined();
-                expect(form.fields?.[0]?.datetime_config?.allow_manual_time_entry).toBeUndefined();
             });
 
-            it('datetime_config should take precedence over legacy fields', () => {
+            it('should not add datetime-specific properties to date fields', () => {
                 const elements: DialogElement[] = [
                     {
-                        name: 'event_date',
+                        name: 'simple_date',
                         type: 'date',
-                        display_name: 'Event Date',
-                        min_date: '2024-01-01',
-                        max_date: '2024-12-31',
+                        display_name: 'Simple Date',
                         datetime_config: {
-                            min_date: '2025-06-01',
-                            max_date: '2025-12-31',
+                            time_interval: 30, // Should be ignored for date fields
                         },
                         optional: false,
                     } as DialogElement,
@@ -2043,37 +1945,7 @@ describe('dialog_conversion', () => {
                     legacyOptions,
                 );
 
-                expect(form.fields?.[0]?.min_date).toBe('2025-06-01');
-                expect(form.fields?.[0]?.max_date).toBe('2025-12-31');
-                expect(form.fields?.[0]?.datetime_config?.min_date).toBe('2025-06-01');
-                expect(form.fields?.[0]?.datetime_config?.max_date).toBe('2025-12-31');
-            });
-
-            it('should not add datetime-specific properties to date fields', () => {
-                const elements: DialogElement[] = [
-                    {
-                        name: 'simple_date',
-                        type: 'date',
-                        display_name: 'Simple Date',
-                        time_interval: 30, // Should be ignored for date fields
-                        optional: false,
-                    } as DialogElement,
-                ];
-
-                const {form} = convertDialogToAppForm(
-                    elements,
-                    'Test Form',
-                    undefined,
-                    undefined,
-                    undefined,
-                    '',
-                    '',
-                    legacyOptions,
-                );
-
-                expect(form.fields?.[0]).not.toHaveProperty('time_interval');
-                expect(form.fields?.[0]).not.toHaveProperty('min_date');
-                expect(form.fields?.[0]).not.toHaveProperty('max_date');
+                expect(form.fields?.[0]?.datetime_config?.time_interval).toBeUndefined();
             });
         });
 

--- a/webapp/channels/src/utils/dialog_conversion.ts
+++ b/webapp/channels/src/utils/dialog_conversion.ts
@@ -479,20 +479,16 @@ export function convertElement(element: DialogElement, options: ConversionOption
 
     // Add date/datetime specific properties
     if (element.type === DialogElementTypes.DATE || element.type === DialogElementTypes.DATETIME) {
-        // Merge datetime_config over deprecated top-level fields (datetime_config takes precedence)
-        const minDate = element.datetime_config?.min_date ?? element.min_date;
-        const maxDate = element.datetime_config?.max_date ?? element.max_date;
-        const timeInterval = element.datetime_config?.time_interval ?? element.time_interval;
+        const minDate = element.datetime_config?.min_date;
+        const maxDate = element.datetime_config?.max_date;
+        const timeInterval = element.datetime_config?.time_interval;
 
         const mergedConfig: DateTimeConfig = {};
         if (element.datetime_config?.location_timezone) {
             mergedConfig.location_timezone = element.datetime_config.location_timezone;
         }
 
-        // manual_time_entry supersedes the deprecated allow_manual_time_entry. OR-merge
-        // the two sources into a single normalized key so downstream consumers don't
-        // need to repeat the precedence logic.
-        if (element.datetime_config?.manual_time_entry || element.datetime_config?.allow_manual_time_entry) {
+        if (element.datetime_config?.manual_time_entry) {
             mergedConfig.manual_time_entry = true;
         }
         if (minDate !== undefined) {
@@ -507,17 +503,6 @@ export function convertElement(element: DialogElement, options: ConversionOption
 
         if (Object.keys(mergedConfig).length > 0) {
             appField.datetime_config = mergedConfig;
-        }
-
-        // Also set deprecated top-level fields for backward compatibility with consumers
-        if (minDate !== undefined) {
-            appField.min_date = String(minDate);
-        }
-        if (maxDate !== undefined) {
-            appField.max_date = String(maxDate);
-        }
-        if (timeInterval !== undefined && element.type === DialogElementTypes.DATETIME) {
-            appField.time_interval = Number(timeInterval);
         }
 
         if (element.refresh !== undefined) {

--- a/webapp/platform/types/src/apps.ts
+++ b/webapp/platform/types/src/apps.ts
@@ -445,9 +445,6 @@ export type DateTimeConfig = {
     time_interval?: number; // Minutes between time options (default: 60)
     location_timezone?: string; // IANA timezone for display (e.g., "America/Denver", "Asia/Tokyo")
     manual_time_entry?: boolean; // Allow text entry for time
-
-    /** @deprecated Use manual_time_entry instead. Kept for backward compatibility. */
-    allow_manual_time_entry?: boolean;
 };
 
 // This should go in mattermost-redux
@@ -486,15 +483,6 @@ export type AppField = {
 
     // Date/datetime configuration
     datetime_config?: DateTimeConfig;
-
-    /** @deprecated Use datetime_config.min_date instead. Kept for backward compatibility. */
-    min_date?: string;
-
-    /** @deprecated Use datetime_config.max_date instead. Kept for backward compatibility. */
-    max_date?: string;
-
-    /** @deprecated Use datetime_config.time_interval instead. Kept for backward compatibility. */
-    time_interval?: number;
 
     // Action button props
     action_button_url?: string;
@@ -619,34 +607,6 @@ function isAppField(v: unknown): v is AppField {
         if (field.datetime_config.manual_time_entry !== undefined && typeof field.datetime_config.manual_time_entry !== 'boolean') {
             return false;
         }
-        if (field.datetime_config.allow_manual_time_entry !== undefined && typeof field.datetime_config.allow_manual_time_entry !== 'boolean') {
-            return false;
-        }
-    }
-
-    // Validate deprecated top-level fields (kept for backward compatibility)
-    if (field.min_date !== undefined) {
-        if (typeof field.min_date !== 'string') {
-            return false;
-        }
-
-        if (!isValidDateString(field.min_date)) {
-            return false;
-        }
-    }
-
-    if (field.max_date !== undefined) {
-        if (typeof field.max_date !== 'string') {
-            return false;
-        }
-
-        if (!isValidDateString(field.max_date)) {
-            return false;
-        }
-    }
-
-    if (field.time_interval !== undefined && typeof field.time_interval !== 'number') {
-        return false;
     }
 
     // Validate action button fields

--- a/webapp/platform/types/src/integrations.ts
+++ b/webapp/platform/types/src/integrations.ts
@@ -207,19 +207,7 @@ export type DialogElement = {
         time_interval?: number;
         location_timezone?: string;
         manual_time_entry?: boolean;
-
-        /** @deprecated Use manual_time_entry instead. Kept for backward compatibility. */
-        allow_manual_time_entry?: boolean;
     };
-
-    /** @deprecated Use datetime_config.min_date instead. Kept for backward compatibility. */
-    min_date?: string;
-
-    /** @deprecated Use datetime_config.max_date instead. Kept for backward compatibility. */
-    max_date?: string;
-
-    /** @deprecated Use datetime_config.time_interval instead. Kept for backward compatibility. */
-    time_interval?: number;
 
     // Action button configuration (type "action_button")
     action_button?: {


### PR DESCRIPTION
#### Summary

Removes the deprecated interactive dialog date/datetime fields for the v12.0 major cut:
- Drop top-level `min_date`, `max_date`, and `time_interval` on dialog elements / app fields
- Drop `datetime_config.allow_manual_time_entry` in favor of `manual_time_entry`
- Update server model, webapp consumers, types, e2e webhook fixtures, and docs to use `datetime_config` only
- Add tests documenting that legacy JSON keys are silently ignored post-removal
Legacy payloads still open, but old keys no longer apply constraints or enable manual time entry.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-68396

#### Documentation Update
https://github.com/mattermost/mattermost-developer-documentation/pull/1519

#### Release Note
```release-note
Breaking Change: Removed deprecated interactive dialog date/datetime fields. Top-level min_date, max_date, and time_interval, and datetime_config.allow_manual_time_entry, are no longer accepted; use datetime_config (with manual_time_entry) instead. Legacy keys are silently ignored.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Changes touch the end-to-end date/datetime dialog contract across server models, webapp validation/conversion, and shared TypeScript types, so consumers relying on deprecated keys may see different runtime behavior. Deprecated fields are intentionally ignored (silently), but this is still a user-facing behavioral contract shift and requires correct mapping of `datetime_config`/`manual_time_entry`.  
**QA Recommendation:** Skip broad manual QA; do a quick spot-check of interactive dialog date/datetime constraints and manual time entry behavior using the v12+ `datetime_config` payload shape.
  
*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->