### PR TITLE
Gate E2E Cypress/Playwright on image availability, with pre-warmed caching

### DIFF
--- a/.github/workflows/e2e-tests-check-images.yml
+++ b/.github/workflows/e2e-tests-check-images.yml
@@ -1,0 +1,208 @@
+---
+name: E2E Tests - Check Images
+
+# Server images are built and pushed by a separate pipeline, sometimes
+# concurrently with the E2E workflow being dispatched, so a tag can be
+# requested before it's actually published. Runs as its own reusable
+# workflow, called before the Cypress/Playwright template, so a
+# not-yet-published or rate-limited image fails clearly as its own status
+# check instead of surfacing as a mysterious Cypress/Playwright failure once
+# workers start.
+#
+# Also pre-warms every image into the GitHub Actions cache so the Cypress /
+# Playwright workers below load them locally instead of each separately
+# pulling from Docker Hub. The server image (rebuilt every run, sometimes
+# under a mutable tag like `master` that gets overwritten on every build) is
+# cached under its immutable digest rather than its tag, so a stale image can
+# never be silently reused once the tag moves. The fixed service images
+# rarely change, so they're cached under a hash of the pinned list below and
+# persist across runs until a version is bumped.
+
+on:
+  workflow_call:
+    inputs:
+      commit_sha:
+        type: string
+        required: true
+      framework:
+        description: "cypress or playwright - selects which image set to verify"
+        type: string
+        required: true
+      server_image_tag:
+        type: string
+        required: true
+      server_edition:
+        type: string
+        required: false
+        description: "Server edition: enterprise (default), fips, or team"
+      server_image_repo:
+        type: string
+        required: false
+        default: mattermostdevelopment
+        description: "Docker registry: mattermostdevelopment (default) or mattermost"
+      enabled_docker_services:
+        description: "Space-separated docker-compose services (cypress only)"
+        type: string
+        required: false
+        default: "postgres inbucket"
+    outputs:
+      fixed_images_cache_key:
+        description: "Cache key the pre-warmed fixed-service-images tarball was saved under"
+        value: ${{ jobs.cache-fixed-images.outputs.cache_key }}
+
+permissions: {}
+
+env:
+  SERVER_IMAGE: "${{ inputs.server_image_repo }}/${{ inputs.server_edition == 'fips' && 'mattermost-enterprise-fips-edition' || inputs.server_edition == 'team' && 'mattermost-team-edition' || 'mattermost-enterprise-edition' }}:${{ inputs.server_image_tag }}"
+  # Fixed/pinned service images (excludes the server image above, which is
+  # unique per run). Keep in sync by hand with:
+  #   e2e-tests/.ci/server.generate.sh (Cypress docker-compose images)
+  #   e2e-tests/playwright/lib/src/containers/default_images.ts (Playwright)
+  #   server/build/Dockerfile.elasticsearch, server/build/Dockerfile.opensearch
+  PINNED_IMAGES: |
+    mattermostdevelopment/mirrored-postgres:14
+    postgres:14
+    inbucket/inbucket:3.1.1
+    minio/minio:RELEASE.2024-06-22T05-26-45Z
+    osixia/openldap:1.4.0
+    quay.io/keycloak/keycloak:23.0.7
+    docker.elastic.co/elasticsearch/elasticsearch:9.0.0
+    opensearchproject/opensearch:3.0.0
+    mcr.microsoft.com/azure-storage/azurite:3.34.0
+    cypress/browsers:node-24.14.0-chrome-145.0.7632.116-1-ff-148.0-edge-145.0.3800.70-1
+
+jobs:
+  check-images:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: ci/checkout-repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ inputs.commit_sha }}
+          fetch-depth: 1
+
+      - name: ci/check-images-available-cypress
+        if: inputs.framework == 'cypress'
+        working-directory: e2e-tests/.ci
+        env:
+          SERVER: onprem
+          TEST: cypress
+          ENABLED_DOCKER_SERVICES: ${{ inputs.enabled_docker_services }}
+          BRANCH: image-check
+          BUILD_ID: image-check
+          CI_BASE_URL: image-check
+        run: |
+          bash ./server.generate.sh
+          # NODE_VERSION_REQUIRED is exported inside server.generate.sh's own
+          # subshell, so it doesn't survive here - re-derive it the same way
+          # (.e2erc) before resolving the webhook-interactions image tag.
+          export NODE_VERSION_REQUIRED=$(cat ../../.nvmrc)
+
+          # elasticsearch/opensearch are `build:` services (Dockerfile on top
+          # of a base image), so `config --images` prints a synthetic local
+          # name (e.g. mmserver-opensearch) instead of a real registry ref.
+          # Swap those for the actual upstream base image from the Dockerfile.
+          ES_VERSION=$(sed -nE "s/^ARG ELASTICSEARCH_VERSION=(.+)/\1/p" ../../server/build/Dockerfile.elasticsearch)
+          OS_VERSION=$(sed -nE "s/^ARG OPENSEARCH_VERSION=(.+)/\1/p" ../../server/build/Dockerfile.opensearch)
+
+          mapfile -t IMAGES < <(docker compose -p mmserver -f server.yml config --images | sort -u)
+          for i in "${!IMAGES[@]}"; do
+            case "${IMAGES[$i]}" in
+              mmserver-elasticsearch) IMAGES[$i]="docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}" ;;
+              mmserver-opensearch) IMAGES[$i]="opensearchproject/opensearch:${OS_VERSION}" ;;
+            esac
+          done
+
+          ./check_images.sh "${IMAGES[@]}"
+
+      - name: ci/check-images-available-playwright
+        if: inputs.framework == 'playwright'
+        working-directory: e2e-tests/playwright/lib/src/containers
+        run: |
+          # default_images.ts is "the single place to check and bump every
+          # image" (see its header comment) for the fixed testcontainers
+          # images, so read the list from there rather than duplicating it -
+          # MATTERMOST_SERVER_IMAGE is excluded since $SERVER_IMAGE (this
+          # run's actual tag) already covers it.
+          mapfile -t FIXED_IMAGES < <(
+            grep -E "^export const [A-Z_]+_IMAGE = '" default_images.ts \
+              | grep -v MATTERMOST_SERVER_IMAGE \
+              | sed -E "s/.*= '([^']+)';?/\1/"
+          )
+          ES_VERSION=$(sed -nE "s/^export const ELASTICSEARCH_VERSION = '([^']+)';?/\1/p" default_images.ts)
+          OS_VERSION=$(sed -nE "s/^export const OPENSEARCH_VERSION = '([^']+)';?/\1/p" default_images.ts)
+
+          ../../../.ci/check_images.sh \
+            "$SERVER_IMAGE" \
+            "${FIXED_IMAGES[@]}" \
+            "docker.elastic.co/elasticsearch/elasticsearch:${ES_VERSION}" \
+            "opensearchproject/opensearch:${OS_VERSION}"
+
+  # Pre-warms the server image into the cache so workers load it locally
+  # instead of each pulling it from Docker Hub. Cached by immutable digest
+  # (resolved via a manifest inspect, no download) rather than by tag, since
+  # some callers pass a mutable tag like `master`.
+  cache-server-image:
+    needs: check-images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    steps:
+      - name: ci/resolve-server-image-digest
+        id: resolve
+        run: |
+          DIGEST=$(docker manifest inspect -v "$SERVER_IMAGE" | jq -r '
+            if type=="array"
+            then (.[] | select(.Descriptor.platform.architecture=="amd64" and .Descriptor.platform.os=="linux") | .Descriptor.digest)
+            else .Descriptor.digest
+            end' | head -1)
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+      - name: ci/cache-server-image
+        id: cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: /tmp/docker-image-cache/server-image.tar.gz
+          key: docker-image-server-${{ steps.resolve.outputs.digest }}
+      - name: ci/populate-server-image-cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/docker-image-cache
+          docker pull --platform linux/amd64 "$SERVER_IMAGE"
+          docker save "$SERVER_IMAGE" | gzip > /tmp/docker-image-cache/server-image.tar.gz
+
+  # Pre-warms the fixed/pinned service images into the cache, keyed on
+  # PINNED_IMAGES' content so the same cache entry is reused by every future
+  # run until a pin changes - unlike the server image above, these rarely
+  # change so this cache is meant to live for a long time.
+  cache-fixed-images:
+    needs: check-images
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
+    permissions:
+      contents: read
+    outputs:
+      cache_key: ${{ steps.hash.outputs.key }}
+    steps:
+      - name: ci/hash-pinned-images
+        id: hash
+        run: echo "key=docker-images-fixed-$(sha256sum <<<"$PINNED_IMAGES" | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+      - name: ci/cache-fixed-images
+        id: cache
+        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: /tmp/docker-image-cache/fixed-images.tar.gz
+          key: ${{ steps.hash.outputs.key }}
+      - name: ci/populate-fixed-images-cache
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: |
+          mkdir -p /tmp/docker-image-cache
+          mapfile -t IMAGES <<<"$PINNED_IMAGES"
+          for IMAGE in "${IMAGES[@]}"; do
+            docker pull "$IMAGE"
+          done
+          docker save "${IMAGES[@]}" | gzip > /tmp/docker-image-cache/fixed-images.tar.gz

--- a/.github/workflows/e2e-tests-cypress-template.yml
+++ b/.github/workflows/e2e-tests-cypress-template.yml
@@ -54,6 +54,10 @@ on:
         description: "Comma-separated alias tags for description"
         type: string
         required: false
+      fixed_images_cache_key:
+        description: "Cache key of the pre-warmed fixed-service-images tarball (see e2e-tests-check-images.yml); empty skips restore"
+        type: string
+        required: false
 
       enable_reporting:
         type: boolean
@@ -325,6 +329,37 @@ jobs:
             ~/.cache/Cypress
           key: e2e-cypress-deps-${{ runner.os }}-${{ hashFiles('e2e-tests/cypress/package-lock.json') }}
           fail-on-cache-miss: true
+      # Loads images pre-warmed by e2e-tests-check-images.yml so the pulls
+      # below (inside `make start-server`) hit local content instead of
+      # Docker Hub. A cache miss here just means a normal pull happens -
+      # never fails the job.
+      - name: ci/restore-fixed-images-cache
+        if: inputs.fixed_images_cache_key != ''
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: /tmp/docker-image-cache/fixed-images.tar.gz
+          key: ${{ inputs.fixed_images_cache_key }}
+      - name: ci/resolve-server-image-digest
+        id: resolve-server-digest
+        run: |
+          DIGEST=$(docker manifest inspect -v "$SERVER_IMAGE" | jq -r '
+            if type=="array"
+            then (.[] | select(.Descriptor.platform.architecture=="amd64" and .Descriptor.platform.os=="linux") | .Descriptor.digest)
+            else .Descriptor.digest
+            end' | head -1)
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+      - name: ci/restore-server-image-cache
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: /tmp/docker-image-cache/server-image.tar.gz
+          key: docker-image-server-${{ steps.resolve-server-digest.outputs.digest }}
+      - name: ci/load-cached-images
+        run: |
+          shopt -s nullglob
+          for f in /tmp/docker-image-cache/*.tar.gz; do
+            echo "Loading cached images from $f"
+            gunzip -c "$f" | docker load
+          done
       - name: ci/cloud-init
         working-directory: e2e-tests
         run: make cloud-init

--- a/.github/workflows/e2e-tests-cypress.yml
+++ b/.github/workflows/e2e-tests-cypress.yml
@@ -176,9 +176,25 @@ jobs:
             -f target_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           echo "Posted success for ${CONTEXT_NAME}"
 
+  check-images:
+    needs:
+      - generate-build-variables
+    if: inputs.should_run != 'false'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/e2e-tests-check-images.yml
+    with:
+      framework: cypress
+      commit_sha: ${{ inputs.commit_sha }}
+      server_image_tag: ${{ needs.generate-build-variables.outputs.server_image_tag }}
+      server_edition: ${{ inputs.server_edition }}
+      server_image_repo: ${{ inputs.server_image_repo }}
+      enabled_docker_services: "postgres inbucket minio openldap elasticsearch keycloak"
+
   cypress-full:
     needs:
       - generate-build-variables
+      - check-images
     if: inputs.should_run != 'false'
     permissions:
       contents: read
@@ -197,6 +213,7 @@ jobs:
       server_edition: ${{ inputs.server_edition }}
       server_image_repo: ${{ inputs.server_image_repo }}
       server_image_aliases: ${{ inputs.server_image_aliases }}
+      fixed_images_cache_key: ${{ needs.check-images.outputs.fixed_images_cache_key }}
       server: ${{ inputs.server }}
       enable_reporting: ${{ inputs.enable_reporting }}
       report_type: ${{ inputs.report_type }}

--- a/.github/workflows/e2e-tests-playwright-template.yml
+++ b/.github/workflows/e2e-tests-playwright-template.yml
@@ -50,6 +50,10 @@ on:
         description: "Comma-separated alias tags for description"
         type: string
         required: false
+      fixed_images_cache_key:
+        description: "Cache key of the pre-warmed fixed-service-images tarball (see e2e-tests-check-images.yml); empty skips restore"
+        type: string
+        required: false
 
       enable_reporting:
         type: boolean
@@ -313,6 +317,37 @@ jobs:
           path: ~/.cache/ms-playwright
           key: playwright-browsers-${{ runner.os }}-${{ hashFiles('e2e-tests/playwright/package-lock.json') }}
           fail-on-cache-miss: true
+      # Loads images pre-warmed by e2e-tests-check-images.yml so the
+      # Testcontainers pulls below (inside ci/prepare-playwright) hit local
+      # content instead of Docker Hub. A cache miss here just means a normal
+      # pull happens - never fails the job.
+      - name: ci/restore-fixed-images-cache
+        if: inputs.fixed_images_cache_key != ''
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: /tmp/docker-image-cache/fixed-images.tar.gz
+          key: ${{ inputs.fixed_images_cache_key }}
+      - name: ci/resolve-server-image-digest
+        id: resolve-server-digest
+        run: |
+          DIGEST=$(docker manifest inspect -v "$SERVER_IMAGE" | jq -r '
+            if type=="array"
+            then (.[] | select(.Descriptor.platform.architecture=="amd64" and .Descriptor.platform.os=="linux") | .Descriptor.digest)
+            else .Descriptor.digest
+            end' | head -1)
+          echo "digest=${DIGEST}" >> "$GITHUB_OUTPUT"
+      - name: ci/restore-server-image-cache
+        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: /tmp/docker-image-cache/server-image.tar.gz
+          key: docker-image-server-${{ steps.resolve-server-digest.outputs.digest }}
+      - name: ci/load-cached-images
+        run: |
+          shopt -s nullglob
+          for f in /tmp/docker-image-cache/*.tar.gz; do
+            echo "Loading cached images from $f"
+            gunzip -c "$f" | docker load
+          done
       # Brings up the stack via Testcontainers in `testcontainers` mode (global setup). Also runs the
       # `setup` project so per-spec dispatches can pass --no-deps and skip plugin-load +
       # server-deployment checks. node_modules, lib/dist, and chromium are all restored from cache.

--- a/.github/workflows/e2e-tests-playwright.yml
+++ b/.github/workflows/e2e-tests-playwright.yml
@@ -166,9 +166,24 @@ jobs:
             -f target_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
           echo "Posted success for ${CONTEXT_NAME}"
 
+  check-images:
+    needs:
+      - generate-build-variables
+    if: inputs.should_run != 'false'
+    permissions:
+      contents: read
+    uses: ./.github/workflows/e2e-tests-check-images.yml
+    with:
+      framework: playwright
+      commit_sha: ${{ inputs.commit_sha }}
+      server_image_tag: ${{ needs.generate-build-variables.outputs.server_image_tag }}
+      server_edition: ${{ inputs.server_edition }}
+      server_image_repo: ${{ inputs.server_image_repo }}
+
   playwright-full:
     needs:
       - generate-build-variables
+      - check-images
     if: inputs.should_run != 'false'
     permissions:
       contents: read
@@ -186,6 +201,7 @@ jobs:
       server_edition: ${{ inputs.server_edition }}
       server_image_repo: ${{ inputs.server_image_repo }}
       server_image_aliases: ${{ inputs.server_image_aliases }}
+      fixed_images_cache_key: ${{ needs.check-images.outputs.fixed_images_cache_key }}
       server: ${{ inputs.server }}
       enable_reporting: ${{ inputs.enable_reporting }}
       report_type: ${{ inputs.report_type }}

--- a/e2e-tests/.ci/check_images.sh
+++ b/e2e-tests/.ci/check_images.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+# Checks that each image argument is pullable (via `docker manifest inspect`),
+# retrying with backoff on transient errors. Checks every image before
+# failing, and prints a per-image pass/fail summary so it's obvious at a
+# glance which image(s) are the actual problem.
+set -e -u -o pipefail
+cd "$(dirname "$0")"
+. .e2erc
+
+RETRIES="${CHECK_IMAGES_RETRIES:-30}"
+INTERVAL="${CHECK_IMAGES_INTERVAL:-30}"
+
+classify_error() {
+  local OUTPUT="$1"
+  if grep -qiE 'toomanyrequests|429' <<<"$OUTPUT"; then
+    echo "rate-limited by registry (429/toomanyrequests)"
+  elif grep -qiE 'manifest unknown|no such manifest|not found' <<<"$OUTPUT"; then
+    echo "image/tag not published yet (manifest unknown)"
+  elif grep -qiE 'timeout|connection reset|i/o timeout|no such host|EOF|TLS handshake' <<<"$OUTPUT"; then
+    echo "transient network/connection error"
+  else
+    echo "unrecognized error"
+  fi
+}
+
+# Sets LAST_REASON on failure, for the final summary table.
+check_image_available() {
+  local IMAGE="$1" ATTEMPT=0 OUTPUT
+  echo "::group::Checking image: $IMAGE"
+  until OUTPUT=$(docker manifest inspect "$IMAGE" 2>&1); do
+    ATTEMPT=$((ATTEMPT + 1))
+    LAST_REASON=$(classify_error "$OUTPUT")
+    if [ "$ATTEMPT" -ge "$RETRIES" ]; then
+      mme2e_log "[$IMAGE] FAILED after $ATTEMPT attempts: $LAST_REASON"
+      echo "$OUTPUT"
+      echo "::endgroup::"
+      return 1
+    fi
+    mme2e_log "[$IMAGE] not available yet ($LAST_REASON); retry $ATTEMPT/$RETRIES in ${INTERVAL}s"
+    sleep "$INTERVAL"
+  done
+  mme2e_log "[$IMAGE] OK"
+  echo "::endgroup::"
+}
+
+if [ "$#" -eq 0 ]; then
+  mme2e_log "No images given to check" >&2
+  exit 2
+fi
+
+mme2e_log "Checking availability of ${#} image(s): $*"
+
+declare -a RESULT_LINES=()
+FAILED_COUNT=0
+for IMAGE in "$@"; do
+  LAST_REASON=""
+  if check_image_available "$IMAGE"; then
+    RESULT_LINES+=("  PASS  $IMAGE")
+  else
+    RESULT_LINES+=("  FAIL  $IMAGE  (${LAST_REASON})")
+    FAILED_COUNT=$((FAILED_COUNT + 1))
+    echo "::error::Image not available: $IMAGE (${LAST_REASON})"
+  fi
+done
+
+mme2e_log "Image availability summary:"
+printf '%s\n' "${RESULT_LINES[@]}"
+
+if [ "$FAILED_COUNT" -gt 0 ]; then
+  echo "::error::${FAILED_COUNT}/$# image(s) never became available"
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- CI has failed with `manifest unknown` when the E2E job starts before the server image build pipeline finishes publishing its tag (seen on `cypress-full-fips-release`), which surfaces as a confusing Cypress failure instead of an image-availability problem.
- Adds a standalone `e2e-tests-check-images.yml` reusable workflow, called before Cypress/Playwright workers start, that verifies every image the run needs (server image + all Cypress docker-compose / Playwright testcontainers service images, including the real upstream base images behind the Dockerfile-built elasticsearch/opensearch services) via `docker manifest inspect` with retry/backoff, classifying failures (rate-limited/429, not-yet-published, network) so a failure is unambiguous about which image and why.
- Also pre-warms those images into the GitHub Actions cache so workers `docker load` locally instead of each separately pulling from Docker Hub: the server image is cached by its immutable digest (not its tag, since some callers pass a mutable `master` tag), while the fixed service images are cached under a hash of a pinned list and persist across future runs.

## Test plan
- [ ] Manually trigger against this branch and against `master` via the `test-public-project` dispatch workflow to confirm the check-images gate and cache populate/restore round-trip both work end-to-end
- [ ] Confirm a real Cypress/Playwright run still passes with the gate + cache wired in
- [ ] Confirm the gate correctly fails (with a clear per-image reason) when pointed at a bogus/unpublished image tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes span shared E2E workflows and image-caching logic, creating some risk of CI failures across Cypress and Playwright jobs, particularly in cache misses and image availability edge cases. No production runtime or critical business logic is affected.

**QA Recommendation:** Manual QA can be skipped; rely on automated E2E workflow coverage and targeted CI validation.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->