### PR TITLE
Show the close button on menu popups in mobile view

### DIFF
--- a/webapp/channels/src/components/menu/menu.scss
+++ b/webapp/channels/src/components/menu/menu.scss
@@ -22,7 +22,15 @@
 
 .menuModal {
     & .modal-header {
-        display: none;
+        display: block;
+        height: 0;
+        min-height: 0;
+        padding: 0;
+        border-bottom: none;
+
+        & .close {
+            z-index: 1;
+        }
     }
 
     & .GenericModal__body {


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
<!-- What does this PR do? Include QA steps if not covered in the ticket. -->
In mobile view a menu is not rendered as a popover but as a modal, via `MenuModal` → `GenericModal`. `GenericModal` already renders a working close button, but it sits inside `.modal-header` — and `.menuModal` hid that header outright with `display: none`. The close button was therefore present in the DOM but invisible, leaving these menus with no visible way to be dismissed. The schedule message popup could only be closed by picking one of its options.

This collapses the header to zero height instead of hiding it. `.close` is positioned against `.modal-content` rather than against the header, so it keeps the same top right placement it has on every other modal, and no empty title bar is added above the menu items.

This is not specific to the schedule message popup. `MenuModal` always applies the `menuModal` class, so every menu shown in mobile view was affected — the channel header menu had the same problem. All of them now get a close button.

QA steps:

1. Open Mattermost in a mobile or tablet browser, or narrow a desktop browser until the mobile layout kicks in.
2. Go to any channel and write a message so the send button becomes active.
3. Click the arrow to the right of the send button to open the schedule message popup.
4. A close button is shown in the top right corner, aligned with the "Schedule message" title, and closes the popup.
5. Repeat with other menus, for example the channel name menu in the header, and confirm they also show a close button in the same position.
6. In desktop view, confirm menus are unchanged and still open as popovers that close when clicking outside.

#### Ticket Link
<!--
Fixes: https://github.com/mattermost/mattermost/issues/37745
-->
Fixes: https://github.com/mattermost/mattermost/issues/37745

#### Screenshots
<!-- Include screenshots or GIFs for UI changes. -->

https://github.com/user-attachments/assets/fa38e67d-3393-4cab-a09b-7aed8590dc7c



#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Isolated modal styling change limited to mobile menu dialogs; desktop popovers and application logic are unaffected.  
**QA Recommendation:** Manual QA can be skipped given full automated coverage; optionally smoke-test mobile menu dismissal.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->