### PR TITLE
Gate ci-report and ci-artifacts on relevant-changed in server-ci.yml

### DIFF
--- a/.github/workflows/server-ci.yml
+++ b/.github/workflows/server-ci.yml
@@ -391,7 +391,9 @@ jobs:
 
   ci-report:
     name: Server CI Report
-    if: always()
+    # Skip cleanly (rather than fail) when no relevant Server CI paths
+    # changed, since none of the test jobs it reports on will have run.
+    if: always() && needs.go.outputs.relevant-changed == 'true'
     permissions:
       contents: read
       actions: read
@@ -399,6 +401,7 @@ jobs:
       pull-requests: write
       issues: write
     needs:
+      - go
       - ci-complete
     uses: ./.github/workflows/server-ci-report.yml
     secrets:
@@ -414,8 +417,11 @@ jobs:
 
   ci-artifacts:
     name: Server CI Artifacts
+    # Skip when no relevant Server CI paths changed, since build-mattermost-server
+    # (and thus server-dist-artifact) will not have run.
     if: >-
       success('ci-complete') &&
+      needs.go.outputs.relevant-changed == 'true' &&
       github.repository_owner == 'mattermost' &&
       github.event_name == 'pull_request' &&
       github.event.pull_request.head.repo.full_name == github.repository
@@ -424,6 +430,7 @@ jobs:
       actions: read
       statuses: write
     needs:
+      - go
       - ci-complete
     uses: ./.github/workflows/server-ci-artifacts.yml
     secrets:


### PR DESCRIPTION
#### Summary
`server-ci.yml` (#37557) moved path-based skipping from a top-level `pull_request.paths` trigger filter into a job-level `if: needs.go.outputs.relevant-changed == 'true'` on each job, so the workflow always triggers and required checks never get stuck pending. However, the `ci-report` and `ci-artifacts` reusable-workflow calls were not gated on `relevant-changed`, so they still ran unconditionally.

On PRs that don't touch server-relevant paths, `build-mattermost-server` and the test jobs are skipped, so:
* `ci-artifacts` fails downloading `server-dist-artifact`, since `build-mattermost-server` never uploaded it.
* `ci-report` fails validating test logs, since no test jobs produced any `*-test-logs` artifacts.

This adds the same `needs.go.outputs.relevant-changed == 'true'` gate to both jobs so they skip cleanly instead of failing. Neither job's check is currently part of the repo's required status checks, so skipping them cleanly does not reintroduce the "stuck pending" problem #37557 fixed.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Isolated workflow-condition changes affect only CI reporting and artifact jobs; no production code or critical user flows are involved.  
**QA Recommendation:** No manual QA recommended; validate the workflow for relevant and irrelevant path changes.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->