### PR TITLE
Fall back to the filesystem for absolute plugin signature key paths

### DIFF
--- a/server/channels/app/plugin_signature.go
+++ b/server/channels/app/plugin_signature.go
@@ -32,13 +32,8 @@ func (s *Server) getPublicKey(name string) ([]byte, *model.AppError) {
 		return data, nil
 	}
 
-	// The configuration store is the canonical home for these keys, but AddPublicKey is the only
-	// way to populate it, and that requires a running server. A database-backed store never
-	// consults the filesystem, so a deployment that prepackages plugins signed with its own key
-	// has no way to make that key available before startup. Fall back to reading an absolute path
-	// directly, so such a key can be baked into an image or mounted as a secret whichever way the
-	// configuration is stored. Names the store already resolves never reach this point, and
-	// relative names are left to the store alone, having no meaning outside of it.
+	// A database-backed store can't be populated before the server has booted, so fall back to
+	// reading absolute paths directly from disk. Relative names have no meaning outside the store.
 	if !filepath.IsAbs(name) {
 		return nil, model.NewAppError("GetPublicKey", "app.plugin.get_public_key.get_file.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}

--- a/server/channels/app/plugin_signature.go
+++ b/server/channels/app/plugin_signature.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"io"
 	"net/http"
+	"os"
 	"path/filepath"
 	"slices"
 
@@ -27,9 +28,26 @@ func (a *App) GetPublicKey(name string) ([]byte, *model.AppError) {
 
 func (s *Server) getPublicKey(name string) ([]byte, *model.AppError) {
 	data, err := s.platform.GetConfigFile(name)
-	if err != nil {
+	if err == nil {
+		return data, nil
+	}
+
+	// The configuration store is the canonical home for these keys, but AddPublicKey is the only
+	// way to populate it, and that requires a running server. A database-backed store never
+	// consults the filesystem, so a deployment that prepackages plugins signed with its own key
+	// has no way to make that key available before startup. Fall back to reading an absolute path
+	// directly, so such a key can be baked into an image or mounted as a secret whichever way the
+	// configuration is stored. Names the store already resolves never reach this point, and
+	// relative names are left to the store alone, having no meaning outside of it.
+	if !filepath.IsAbs(name) {
 		return nil, model.NewAppError("GetPublicKey", "app.plugin.get_public_key.get_file.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
+
+	data, fsErr := os.ReadFile(name)
+	if fsErr != nil {
+		return nil, model.NewAppError("GetPublicKey", "app.plugin.get_public_key.get_file.app_error", nil, "", http.StatusInternalServerError).Wrap(fsErr)
+	}
+
 	return data, nil
 }
 

--- a/server/channels/app/plugin_signature_test.go
+++ b/server/channels/app/plugin_signature_test.go
@@ -63,6 +63,86 @@ func TestPluginPublicKeys(t *testing.T) {
 	require.NotNil(t, appErr)
 }
 
+func TestGetPublicKeyFilesystemFallback(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t)
+
+	t.Run("reads an absolute path absent from the configuration store", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "key.asc")
+		require.NoError(t, os.WriteFile(keyPath, []byte("from-filesystem"), 0600))
+
+		data, appErr := th.App.GetPublicKey(keyPath)
+		require.Nil(t, appErr)
+		require.Equal(t, []byte("from-filesystem"), data)
+	})
+
+	t.Run("prefers the configuration store over the filesystem", func(t *testing.T) {
+		keyPath := filepath.Join(t.TempDir(), "key.asc")
+		require.NoError(t, os.WriteFile(keyPath, []byte("from-filesystem"), 0600))
+		require.NoError(t, th.App.Srv().platform.SetConfigFile(keyPath, []byte("from-store")))
+		t.Cleanup(func() {
+			require.NoError(t, th.App.Srv().platform.RemoveConfigFile(keyPath))
+		})
+
+		data, appErr := th.App.GetPublicKey(keyPath)
+		require.Nil(t, appErr)
+		require.Equal(t, []byte("from-store"), data)
+	})
+
+	t.Run("errors when an absolute path is in neither", func(t *testing.T) {
+		_, appErr := th.App.GetPublicKey(filepath.Join(t.TempDir(), "missing.asc"))
+		require.NotNil(t, appErr)
+	})
+
+	t.Run("does not fall back for a relative name", func(t *testing.T) {
+		_, appErr := th.App.GetPublicKey("key.asc")
+		require.NotNil(t, appErr)
+	})
+}
+
+func TestVerifyPluginWithKeyFromFilesystem(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t)
+
+	testsPath, _ := fileutils.FindDir("tests")
+	ch := th.App.Channels()
+	logger := th.App.Srv().Log()
+
+	// testplugin.tar.gz is signed with the development key rather than the hard-coded Mattermost
+	// one, so it verifies only once that key is reachable.
+	openPlugin := func(t *testing.T) (*os.File, *os.File) {
+		t.Helper()
+		pluginFile, err := os.Open(filepath.Join(testsPath, "testplugin.tar.gz"))
+		require.NoError(t, err)
+		t.Cleanup(func() { pluginFile.Close() })
+		signatureFile, err := os.Open(filepath.Join(testsPath, "testplugin.tar.gz.sig"))
+		require.NoError(t, err)
+		t.Cleanup(func() { signatureFile.Close() })
+		return pluginFile, signatureFile
+	}
+
+	// Copy the key somewhere absolute and outside the configuration store, standing in for one
+	// baked into an image or mounted as a secret.
+	keyPath := filepath.Join(t.TempDir(), "development-public-key.gpg")
+	keyData, err := os.ReadFile(filepath.Join(testsPath, "development-public-key.gpg"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(keyPath, keyData, 0600))
+
+	t.Run("fails before the key is configured", func(t *testing.T) {
+		pluginFile, signatureFile := openPlugin(t)
+		require.NotNil(t, ch.verifyPlugin(logger, pluginFile, signatureFile))
+	})
+
+	t.Run("verifies with a key referenced by absolute path", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.PluginSettings.SignaturePublicKeyFiles = []string{keyPath}
+		})
+
+		pluginFile, signatureFile := openPlugin(t)
+		require.Nil(t, ch.verifyPlugin(logger, pluginFile, signatureFile))
+	})
+}
+
 func TestVerifySignature(t *testing.T) {
 	mainHelper.Parallel(t)
 	path, _ := fileutils.FindDir("tests")

--- a/server/channels/app/plugin_signature_test.go
+++ b/server/channels/app/plugin_signature_test.go
@@ -95,7 +95,21 @@ func TestGetPublicKeyFilesystemFallback(t *testing.T) {
 	})
 
 	t.Run("does not fall back for a relative name", func(t *testing.T) {
-		_, appErr := th.App.GetPublicKey("key.asc")
+		// Name a key that is genuinely readable at a relative path, so that refusing to fall back
+		// for relative names is the only thing that can fail the lookup.
+		testsPath, _ := fileutils.FindDir("tests")
+		absKeyPath, err := filepath.Abs(filepath.Join(testsPath, "development-public-key.gpg"))
+		require.NoError(t, err)
+		cwd, err := os.Getwd()
+		require.NoError(t, err)
+		relKeyPath, err := filepath.Rel(cwd, absKeyPath)
+		require.NoError(t, err)
+		require.False(t, filepath.IsAbs(relKeyPath))
+
+		_, err = os.ReadFile(relKeyPath)
+		require.NoError(t, err, "fixture must be readable at the relative path for this test to mean anything")
+
+		_, appErr := th.App.GetPublicKey(relKeyPath)
 		require.NotNil(t, appErr)
 	})
 }


### PR DESCRIPTION
#### Summary

**Problem.** An operator running HA with the configuration in the database (`MM_CONFIG` set to a DSN) cannot boot a server with their own prepackaged plugins, signed with their own key.

Three things combine:

1. Prepackaged plugins are always signature-verified. There is no setting to turn that off.
2. To have an extra key trusted, you list it in `SignaturePublicKeyFiles`. That setting holds file *names*  and the bytes behind them are fetched from the `ConfigurationFiles` database table, which is only ever populated by the `AddPublicKey` API.
3. Calling that API needs a running server. With the configuration in the database, a key file sitting on disk is never taken into account, at any path. The table is the only source consulted.

So the key must be trusted before the server boots, and the only way to make it trusted needs the server already booted. Putting the key file on the server does not help, at any path.

**Fix.** `getPublicKey` now falls back to reading the file straight from disk when the entry is an absolute path the configuration store does not resolve. The key only has to exist on the filesystem before startup with `SignaturePublicKeyFiles` holding its absolute path. Setting it through `MM_PLUGINSETTINGS_SIGNATUREPUBLICKEYFILES` is the most convenient way to do that at boot, but any means of setting the field works.

**Compatibility.** The fallback runs last, so it is strictly additive: any name the store resolves today is still served from the store, and only names that currently error get a second chance.

**QA.**

1. Sign a plugin with a non-Mattermost key and put the bundle plus its `.sig` in `prepackaged_plugins/`.
2. Start the server with a database-backed configuration — the plugin fails to verify.
3. Put the public key on disk, set `MM_PLUGINSETTINGS_SIGNATUREPUBLICKEYFILES` to its absolute path, and restart — the plugin verifies and loads.

#### Ticket Link

None.

#### Screenshots

N/A — no UI changes.

#### Release Note
```release-note
Fixed PluginSettings.SignaturePublicKeyFiles being unusable with a database-backed configuration. 
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change affects plugin signature verification and adds filesystem fallback behavior for unresolved absolute paths. Automated tests cover configured, filesystem, missing, and relative-path cases.

**QA Recommendation:** Manual QA can be skipped. Automated coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->