### PR TITLE
fix: fix UI broken in message edit buttons in non-US locale

### DIFF
--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -405,7 +405,7 @@
     > button {
         @include mixins.button-small;
 
-        padding: 10px 16px;
+        flex-shrink: 0;
         border-width: 0;
         border-radius: 4px;
         box-shadow: none;


### PR DESCRIPTION
#### Summary

This pull request makes a minor style adjustment to the post component's button.

The `padding` property is removed due to duplication with mixin and `flex-shrink: 0` is added to improve layout behavior and prevent the button from shrinking within a flex container.

#### Ticket Link

Fixes: #37778

#### Screenshots

| locale | before | after |
|-|-|-|
| ja | <img width="525" height="572" alt="Image" src="https://github.com/user-attachments/assets/ddc7fc7d-81d9-44e2-ac60-6b9b8486e03e" /> | <img width="525" height="572" alt="Image" src="https://github.com/user-attachments/assets/ddaef372-97fe-46cb-bf39-68d3052df0bc" /> |
| en (no changes, no regression) | <img width="525" height="572" alt="Image" src="https://github.com/user-attachments/assets/ea660063-adde-40ab-ac1a-f5750f2e8f7b" /> | <img width="525" height="572" alt="Image" src="https://github.com/user-attachments/assets/ea660063-adde-40ab-ac1a-f5750f2e8f7b" /> |

### Observed behavior

Texts in any buttons were unintentionally wrapped in CJK locale (at least ja-jp).

#### Release Note

```release-note
Adjust UI style to the post component's button for non-US environment.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The isolated CSS change affects a single post component and has a low likelihood of impacting unrelated behavior. No shared utilities, critical flows, or public contracts are involved.
**QA Recommendation:** Manual QA can be skipped; automated testing coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->