### PR TITLE
Use COUNT(*) for per-team channel limit pre-check

### DIFF
--- a/server/channels/app/channel.go
+++ b/server/channels/app/channel.go
@@ -173,7 +173,7 @@ func (a *App) CreateChannelWithUser(rctx request.CTX, channel *model.Channel, us
 		return nil, model.NewAppError("CreateChannelWithUser", "app.channel.create_channel.no_team_id.app_error", nil, "", http.StatusBadRequest)
 	}
 
-	// Get total number of channels on current team
+	// Count the channels that count toward MaxChannelsPerTeam (open/private, non-deleted).
 	count, err := a.GetNumberOfChannelsOnTeam(rctx, channel.TeamId)
 	if err != nil {
 		return nil, err
@@ -3138,18 +3138,15 @@ func (a *App) RemoveUserFromChannel(rctx request.CTX, userIDToRemove string, rem
 }
 
 func (a *App) GetNumberOfChannelsOnTeam(rctx request.CTX, teamID string) (int, *model.AppError) {
-	// Get total number of channels on current team
-	list, err := a.Srv().Store().Channel().GetTeamChannels(teamID)
+	// Count the channels that count toward MaxChannelsPerTeam on the current team. This
+	// mirrors the limit check in SqlChannelStore.saveChannelT (open/private, non-deleted) so
+	// the app-layer pre-check and the store-layer final check agree, and it avoids loading
+	// every channel row into memory just to take len() of the slice.
+	count, err := a.Srv().Store().Channel().GetTeamChannelsCount(teamID)
 	if err != nil {
-		var nfErr *store.ErrNotFound
-		switch {
-		case errors.As(err, &nfErr):
-			return 0, model.NewAppError("GetNumberOfChannelsOnTeam", "app.channel.get_channels.not_found.app_error", nil, "", http.StatusNotFound).Wrap(err)
-		default:
-			return 0, model.NewAppError("GetNumberOfChannelsOnTeam", "app.channel.get_channels.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
-		}
+		return 0, model.NewAppError("GetNumberOfChannelsOnTeam", "app.channel.get_channels.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
-	return len(list), nil
+	return int(count), nil
 }
 
 func (a *App) SetActiveChannel(rctx request.CTX, userID string, channelID string) *model.AppError {

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -2953,6 +2953,27 @@ func (s *RetryLayerChannelStore) GetTeamChannels(teamID string) (model.ChannelLi
 
 }
 
+func (s *RetryLayerChannelStore) GetTeamChannelsCount(teamID string) (int64, error) {
+
+	tries := 0
+	for {
+		result, err := s.ChannelStore.GetTeamChannelsCount(teamID)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerChannelStore) GetTeamChannelsWithUnreadAndMentions(rctx request.CTX, teamID string, userID string, userNotifyProps model.StringMap) ([]string, []string, map[string]int64, error) {
 
 	tries := 0

--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -1584,6 +1584,34 @@ func (s SqlChannelStore) GetTeamChannels(teamId string) (model.ChannelList, erro
 	return data, nil
 }
 
+// GetTeamChannelsCount returns the number of non-deleted open (O) and private (P) channels
+// for a team. The Type and DeleteAt filters intentionally mirror the per-team channel limit
+// check in saveChannelT, so the app-layer pre-check (GetNumberOfChannelsOnTeam) and the
+// store-layer final check agree on what counts toward MaxChannelsPerTeam. Unlike
+// GetTeamChannels it performs a COUNT(*) instead of loading every channel row.
+func (s SqlChannelStore) GetTeamChannelsCount(teamID string) (int64, error) {
+	query := s.getQueryBuilder().
+		Select("COUNT(*) AS Value").
+		From("Channels").
+		Where(sq.And{
+			sq.Eq{"TeamId": teamID},
+			sq.Eq{"DeleteAt": 0},
+			sq.Eq{"Type": []model.ChannelType{model.ChannelTypeOpen, model.ChannelTypePrivate}},
+		})
+
+	sqlStr, args, err := query.ToSql()
+	if err != nil {
+		return 0, errors.Wrap(err, "GetTeamChannelsCount_ToSql")
+	}
+
+	var count int64
+	if err := s.GetReplica().Get(&count, sqlStr, args...); err != nil {
+		return 0, errors.Wrapf(err, "failed to count Channels with teamId=%s", teamID)
+	}
+
+	return count, nil
+}
+
 // GetTeamSpaceChannels returns all space (S) channels for a team, including archived ones, so
 // team teardown can remove them. GetTeamChannels/GetAll exclude spaces, hence this dedicated
 // enumerator. Returns an empty list (not ErrNotFound) when the team has no spaces. It reads from

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -232,6 +232,7 @@ type ChannelStore interface {
 	GetPublicChannelsForTeam(teamID string, offset int, limit int) (model.ChannelList, error)
 	GetPublicChannelsByIdsForTeam(teamID string, channelIds []string) (model.ChannelList, error)
 	GetTeamChannels(teamID string) (model.ChannelList, error)
+	GetTeamChannelsCount(teamID string) (int64, error)
 	GetTeamSpaceChannels(teamID string) (model.ChannelList, error)
 	GetTeamSpaceChannelsForUser(teamID string, userID string) (model.ChannelList, error)
 	GetAll(teamID string) ([]*model.Channel, error)

--- a/server/channels/store/storetest/channel_store.go
+++ b/server/channels/store/storetest/channel_store.go
@@ -147,6 +147,7 @@ func TestChannelStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore
 	t.Run("GetPinnedPosts", func(t *testing.T) { testChannelStoreGetPinnedPosts(t, rctx, ss) })
 	t.Run("GetPinnedPostCount", func(t *testing.T) { testChannelStoreGetPinnedPostCount(t, rctx, ss) })
 	t.Run("MaxChannelsPerTeam", func(t *testing.T) { testChannelStoreMaxChannelsPerTeam(t, rctx, ss) })
+	t.Run("GetTeamChannelsCount", func(t *testing.T) { testChannelStoreGetTeamChannelsCount(t, rctx, ss) })
 	t.Run("GetChannelsByScheme", func(t *testing.T) { testChannelStoreGetChannelsByScheme(t, rctx, ss) })
 	t.Run("MigrateChannelMembers", func(t *testing.T) { testChannelStoreMigrateChannelMembers(t, rctx, ss) })
 	t.Run("ResetAllChannelSchemes", func(t *testing.T) { testResetAllChannelSchemes(t, rctx, ss) })
@@ -7803,6 +7804,45 @@ func testChannelStoreMaxChannelsPerTeam(t *testing.T, rctx request.CTX, ss store
 	channel.Id = ""
 	_, nErr = ss.Channel().Save(rctx, channel, 1)
 	assert.NoError(t, nErr)
+}
+
+func testChannelStoreGetTeamChannelsCount(t *testing.T, rctx request.CTX, ss store.Store) {
+	teamID := model.NewId()
+
+	saveChannel := func(channelType model.ChannelType) *model.Channel {
+		c, err := ss.Channel().Save(rctx, &model.Channel{
+			TeamId:      teamID,
+			DisplayName: "Name",
+			Name:        NewTestID(),
+			Type:        channelType,
+		}, -1)
+		require.NoError(t, err)
+		return c
+	}
+
+	// Two open + one private channel count toward the per-team limit.
+	saveChannel(model.ChannelTypeOpen)
+	saveChannel(model.ChannelTypeOpen)
+	saveChannel(model.ChannelTypePrivate)
+
+	// Group channels must NOT count toward the limit. saveChannelT exempts Group entirely
+	// (its guard skips Group/Direct/Space), so GetTeamChannelsCount's Type IN (O,P) filter
+	// must exclude them too. Seed a group channel on the same team and assert it is ignored.
+	saveChannel(model.ChannelTypeGroup)
+
+	// Deleted channels must also be excluded, mirroring the DeleteAt = 0 filter in saveChannelT.
+	deleted := saveChannel(model.ChannelTypeOpen)
+	require.NoError(t, ss.Channel().Delete(deleted.Id, model.GetMillis()))
+
+	count, err := ss.Channel().GetTeamChannelsCount(teamID)
+	require.NoError(t, err)
+	require.EqualValues(t, 3, count, "expected 2 open + 1 private; group and deleted channels must be excluded")
+
+	// A team with no matching channels reports 0. Unlike GetTeamChannels, a COUNT(*) never
+	// returns ErrNotFound — it returns a single row with value 0.
+	emptyCount, err := ss.Channel().GetTeamChannelsCount(model.NewId())
+	require.NoError(t, err)
+	require.EqualValues(t, 0, emptyCount)
 }
 
 func testChannelStoreGetChannelsByScheme(t *testing.T, rctx request.CTX, ss store.Store) {

--- a/server/channels/store/storetest/mocks/ChannelStore.go
+++ b/server/channels/store/storetest/mocks/ChannelStore.go
@@ -2222,6 +2222,34 @@ func (_m *ChannelStore) GetTeamChannels(teamID string) (model.ChannelList, error
 	return r0, r1
 }
 
+// GetTeamChannelsCount provides a mock function with given fields: teamID
+func (_m *ChannelStore) GetTeamChannelsCount(teamID string) (int64, error) {
+	ret := _m.Called(teamID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTeamChannelsCount")
+	}
+
+	var r0 int64
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) (int64, error)); ok {
+		return rf(teamID)
+	}
+	if rf, ok := ret.Get(0).(func(string) int64); ok {
+		r0 = rf(teamID)
+	} else {
+		r0 = ret.Get(0).(int64)
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(teamID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetTeamChannelsWithUnreadAndMentions provides a mock function with given fields: rctx, teamID, userID, userNotifyProps
 func (_m *ChannelStore) GetTeamChannelsWithUnreadAndMentions(rctx request.CTX, teamID string, userID string, userNotifyProps model.StringMap) ([]string, []string, map[string]int64, error) {
 	ret := _m.Called(rctx, teamID, userID, userNotifyProps)

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -2465,6 +2465,22 @@ func (s *TimerLayerChannelStore) GetTeamChannels(teamID string) (model.ChannelLi
 	return result, err
 }
 
+func (s *TimerLayerChannelStore) GetTeamChannelsCount(teamID string) (int64, error) {
+	start := time.Now()
+
+	result, err := s.ChannelStore.GetTeamChannelsCount(teamID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("ChannelStore.GetTeamChannelsCount", success, elapsed)
+	}
+	return result, err
+}
+
 func (s *TimerLayerChannelStore) GetTeamChannelsWithUnreadAndMentions(rctx request.CTX, teamID string, userID string, userNotifyProps model.StringMap) ([]string, []string, map[string]int64, error) {
 	start := time.Now()
 


### PR DESCRIPTION
GetNumberOfChannelsOnTeam loaded every open/private/group channel for a team via GetTeamChannels and returned len(list), only to compare it against MaxChannelsPerTeam when creating a channel. This read every channel row into memory on each create just to count them.

Add SqlChannelStore.GetTeamChannelsCount, a COUNT(*) query whose Type and DeleteAt filters mirror the store-layer limit check in saveChannelT (open/private, non-deleted), and use it from GetNumberOfChannelsOnTeam. This keeps the app-layer pre-check and the store-layer final check in agreement on what counts toward the limit, and avoids the full-row load.

<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
<!-- What does this PR do? Include QA steps if not covered in the ticket. -->

#### Ticket Link
<!--
Fixes: https://github.com/mattermost/mattermost/issues/XXX
Fixes: https://mattermost.atlassian.net/browse/MM-XXX
-->

#### Screenshots
<!-- Include screenshots or GIFs for UI changes. -->

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note

```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes span multiple store layers (SQL, retry, timer) to add a new `GetTeamChannelsCount` method that uses `COUNT(*)` instead of loading full channel rows. While the method is only called by `GetNumberOfChannelsOnTeam`, this function controls a critical pre-check for the per-team channel limit during channel creation. Filter discrepancies between the pre-check and store-layer enforcement (Type IN (O,P), DeleteAt = 0) could silently break or bypass the MaxChannelsPerTeam limit.

**QA Recommendation:** Full regression testing of channel creation workflows is recommended, particularly boundary conditions at MaxChannelsPerTeam limits, group/direct channel behavior, and deleted channel filtering. Automated test coverage exists and is comprehensive, but manual QA should verify the pre-check and store-layer enforcement remain synchronized under load.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->