### PR TITLE
Mm 70056 missing info banner team abac team admin

### DIFF
--- a/e2e-tests/playwright/specs/functional/channels/team_settings/team_settings_team_admin_membership.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/team_settings/team_settings_team_admin_membership.spec.ts
@@ -388,6 +388,62 @@ test.describe('Team Settings Modal - Team Membership as Team Admin', {tag: ['@ab
         await teamSettings.close();
     });
 
+    test('MM-70057_1 team admin sees the last-synced timestamp in the sync footer', async ({pw}) => {
+        await pw.skipIfNoLicense();
+        const {adminClient} = await pw.getAdminClient();
+        const suffix = pw.random.id();
+        await enableTeamMembershipABACConfig(adminClient);
+        await ensureDepartmentAttribute(adminClient);
+
+        const team = await createPublicTeam(adminClient, suffix);
+        createdTeamIds.push(team.id);
+        const teamAdmin = await createTeamAdmin(adminClient, team.id);
+        createdUserIds.push(teamAdmin.id);
+        await setUserAttribute(adminClient, teamAdmin.id, 'Department', 'Engineering');
+
+        // # A policy must exist for the sync footer to render at all
+        await createTeamMembershipPolicy(adminClient, team.id, 'user.attributes.Department == "Engineering"', false);
+        await waitForAttributeViewToInclude(adminClient, 'user.attributes.Department == "Engineering"', [teamAdmin.id]);
+
+        // # Run a sync and wait for it to complete, so there is a timestamp to show
+        await (adminClient as any).doFetch(`${adminClient.getBaseRoute()}/jobs`, {
+            method: 'POST',
+            body: JSON.stringify({type: 'access_control_team_sync', data: {policy_id: team.id}}),
+        });
+
+        await expect
+            .poll(
+                async () => {
+                    const jobs: any[] = await (adminClient as any).doFetch(
+                        `${adminClient.getBaseRoute()}/jobs/type/access_control_team_sync`,
+                        {method: 'GET'},
+                    );
+                    return jobs.some((j: any) => j.data?.policy_id === team.id && j.status === 'success');
+                },
+                {
+                    timeout: 30000,
+                    intervals: [500, 1000, 2000, 3000],
+                    message: 'the team sync job should complete before checking the footer',
+                },
+            )
+            .toBe(true);
+
+        const {page} = await pw.testBrowser.login(teamAdmin);
+        const channelsPage = new ChannelsPage(page);
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        const {teamSettings, tab} = await openTeamMembershipTab(page, channelsPage);
+
+        // * The footer reports the completed sync. Reading the job list used to be
+        // system-admin only, so a team admin always saw "Never synced" (MM-70057).
+        const syncFooterText = tab.locator('.SyncStatusFooter .SyncStatusFooter__text');
+        await expect(syncFooterText).toContainText(/Last synced/i, {timeout: 15000});
+        await expect(syncFooterText).not.toContainText(/Never synced/i);
+
+        await teamSettings.close();
+    });
+
     test('MM-69100_29 team admin existing policy and auto-add state load correctly on tab open', async ({pw}) => {
         await pw.skipIfNoLicense();
         const {adminClient, team} = await pw.initSetup();

--- a/e2e-tests/playwright/specs/functional/channels/team_settings/team_settings_team_admin_membership.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/team_settings/team_settings_team_admin_membership.spec.ts
@@ -21,6 +21,8 @@ import {
     waitForAttributeViewToExclude,
     addAttributeRule,
     getTeamAccessControlPolicy,
+    createParentMembershipPolicy,
+    assignTeamToParentPolicy,
 } from './helpers';
 
 async function openTeamMembershipTab(page: Page, channelsPage: ChannelsPage) {
@@ -34,9 +36,15 @@ async function openTeamMembershipTab(page: Page, channelsPage: ChannelsPage) {
 test.describe('Team Settings Modal - Team Membership as Team Admin', {tag: ['@abac', '@team_membership']}, () => {
     const createdTeamIds: string[] = [];
     const createdUserIds: string[] = [];
+    const createdPolicyIds: string[] = [];
 
     test.afterEach(async ({pw}) => {
         const {adminClient} = await pw.getAdminClient();
+        const base = adminClient.getBaseRoute();
+        const headers = {Authorization: `Bearer ${adminClient.getToken()}`};
+        for (const id of createdPolicyIds.splice(0)) {
+            await fetch(`${base}/access_control_policies/${id}`, {method: 'DELETE', headers}).catch(() => {});
+        }
         for (const id of createdTeamIds.splice(0)) {
             await adminClient.deleteTeam(id).catch(() => {});
         }
@@ -314,6 +322,68 @@ test.describe('Team Settings Modal - Team Membership as Team Admin', {tag: ['@ab
         );
         const recentJobs = jobs.filter((j: any) => j.create_at >= testStartTime);
         expect(recentJobs.length).toBeGreaterThan(0);
+
+        await teamSettings.close();
+    });
+
+    test('MM-70055_1 team admin mode-flip modal resolves the member count on a parent-governed team', async ({pw}) => {
+        await pw.skipIfNoLicense();
+        const {adminClient} = await pw.getAdminClient();
+        const suffix = pw.random.id();
+        await enableTeamMembershipABACConfig(adminClient);
+        await ensureDepartmentAttribute(adminClient);
+
+        const team = await createPublicTeam(adminClient, suffix);
+        createdTeamIds.push(team.id);
+        const teamAdmin = await createTeamAdmin(adminClient, team.id);
+        createdUserIds.push(teamAdmin.id);
+
+        // # The team admin must match the rule, otherwise self-exclusion blocks the flip
+        await setUserAttribute(adminClient, teamAdmin.id, 'Department', 'Engineering');
+
+        // # A non-qualifying member so the count is non-zero
+        const outsider = await adminClient.createUser(
+            {
+                email: `outsider${suffix}@sample.mattermost.com`,
+                username: `outsider${suffix}`,
+                password: newTestPassword(),
+            } as any,
+            '',
+            '',
+        );
+        createdUserIds.push(outsider.id);
+        await adminClient.addToTeam(team.id, outsider.id);
+        await setUserAttribute(adminClient, outsider.id, 'Department', 'Marketing');
+
+        // # Govern the team by a parent policy only — no custom rules in Team Settings
+        const parent = await createParentMembershipPolicy(
+            adminClient,
+            `Parent Policy ${suffix}`,
+            'user.attributes.Department == "Engineering"',
+        );
+        createdPolicyIds.push(parent.id);
+        await assignTeamToParentPolicy(adminClient, parent.id, team.id);
+
+        await waitForAttributeViewToInclude(adminClient, 'user.attributes.Department == "Engineering"', [teamAdmin.id]);
+
+        const {page} = await pw.testBrowser.login(teamAdmin);
+        const channelsPage = new ChannelsPage(page);
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        const teamSettings = await channelsPage.openTeamSettings();
+        await teamSettings.openAccessTab();
+
+        // # Click the Private card
+        await teamSettings.container.locator('#public-private-selector-button-P').click();
+
+        const modeFlipModal = page.locator('.ConfirmModal').filter({hasText: 'Switch to Private Team?'});
+        await expect(modeFlipModal).toBeVisible({timeout: 30000});
+
+        // * The count resolves from the parent policy instead of falling back to the
+        // generic copy, which is all a team admin used to get (MM-70055).
+        await expect(modeFlipModal.getByText(/not meet criteria and will be removed/i)).toBeVisible({timeout: 15000});
+        await expect(modeFlipModal.getByText(/Some members may not meet/i)).toHaveCount(0);
 
         await teamSettings.close();
     });

--- a/e2e-tests/playwright/specs/functional/channels/team_settings/team_settings_team_membership_tab.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/team_settings/team_settings_team_membership_tab.spec.ts
@@ -155,6 +155,40 @@ test.describe('Team Settings Modal - Team Membership Tab', {tag: ['@abac', '@tea
         await teamSettings.close();
     });
 
+    test('MM-70056_1 System policy InfoBanner visible to a TEAM ADMIN when the team is assigned to a parent policy', async ({
+        pw,
+    }) => {
+        await pw.skipIfNoLicense();
+        const {adminClient, team} = await pw.initSetup();
+        await enableTeamMembershipABACConfig(adminClient);
+        await ensureDepartmentAttribute(adminClient);
+
+        // # Create a parent policy and assign the team to it
+        const policyName = `Global Team Policy ${pw.random.id()}`;
+        const policy = await createParentPolicy(adminClient, policyName);
+        createdPolicyIds.push(policy.id);
+        await assignTeamToParentPolicy(adminClient, policy.id, team.id);
+
+        // # Log in as a TEAM ADMIN (only ManageTeamAccessRules, not ManageSystem)
+        const teamAdmin = await createTeamAdmin(adminClient, team.id);
+        createdUserIds.push(teamAdmin.id);
+
+        const {page} = await pw.testBrowser.login(teamAdmin);
+        const channelsPage = new ChannelsPage(page);
+        await channelsPage.goto(team.name, 'town-square');
+        await channelsPage.toBeVisible();
+
+        const {teamSettings, tab} = await openTeamMembershipTab(page, channelsPage);
+
+        // * Banner is visible to the team admin, not just the system admin (MM-70056),
+        // and names the resolved parent policy.
+        const banner = tab.locator('.TeamMembershipTab__systemPolicies');
+        await expect(banner).toBeVisible({timeout: 10000});
+        await expect(banner.getByText(policyName)).toBeVisible();
+
+        await teamSettings.close();
+    });
+
     test('MM-69100_12 Auto-add disabled with no expression, enabled after adding a rule', async ({pw}) => {
         await pw.skipIfNoLicense();
         const {adminUser, adminClient, team} = await pw.initSetup();

--- a/server/channels/api4/job.go
+++ b/server/channels/api4/job.go
@@ -293,14 +293,23 @@ func getJobsByType(c *Context, w http.ResponseWriter, r *http.Request) {
 		hasTeamFilter &&
 		c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), teamID, model.PermissionManageTeamAccessRules)
 
-	if !hasPermission && !isTeamScopedSyncRequest {
+	// A team-type policy's ID is its team ID, so filtering team sync jobs by
+	// policy_id keeps a team admin scoped to their own team. Requires the absence
+	// of team_id so this grant can never authorize an unvetted team filter.
+	policyID := r.URL.Query().Get("policy_id")
+	isTeamPolicyScopedSyncRequest := !hasPermission &&
+		c.Params.JobType == model.JobTypeAccessControlTeamSync &&
+		!hasTeamFilter &&
+		policyID != "" && model.IsValidId(policyID) &&
+		c.App.SessionHasPermissionToTeam(*c.AppContext.Session(), policyID, model.PermissionManageTeamAccessRules)
+
+	if !hasPermission && !isTeamScopedSyncRequest && !isTeamPolicyScopedSyncRequest {
 		c.SetPermissionError(permissionRequired)
 		return
 	}
 
 	var jobs []*model.Job
 
-	policyID := r.URL.Query().Get("policy_id")
 	if hasTeamFilter {
 		// When team_id is provided, return only jobs scoped to that team.
 		// Sorted by CreateAt DESC; limited to the requested page size.
@@ -320,8 +329,9 @@ func getJobsByType(c *Context, w http.ResponseWriter, r *http.Request) {
 			jobs = teamJobs[start:end]
 		}
 	} else if policyID != "" && (c.Params.JobType == model.JobTypeAccessControlSync || c.Params.JobType == model.JobTypeAccessControlTeamSync) {
-		// Only system admins may filter by policy_id to prevent job enumeration across policies.
-		if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem) {
+		// Otherwise only system admins may filter by policy_id, to prevent job
+		// enumeration across policies.
+		if !isTeamPolicyScopedSyncRequest && !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionManageSystem) {
 			c.SetPermissionError(model.PermissionManageSystem)
 			return
 		}

--- a/server/channels/api4/job_test.go
+++ b/server/channels/api4/job_test.go
@@ -6,6 +6,7 @@ package api4
 import (
 	"context"
 	"encoding/json"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -583,6 +584,116 @@ func TestGetJobsByType_TeamAdminAccessControlSync(t *testing.T) {
 		_, resp, err := th.SystemAdminClient.GetJobsByTypeForTeam(context.Background(), model.JobTypeAccessControlSync, 0, 60, "not-a-valid-id")
 		require.Error(t, err)
 		CheckBadRequestStatus(t, resp)
+	})
+}
+
+func TestGetJobsByType_TeamAdminAccessControlTeamSync(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	th.AddPermissionToRole(t, model.PermissionManageTeamAccessRules.Id, model.TeamAdminRoleId)
+
+	otherTeamID := model.NewId()
+	parentPolicyID := model.NewId()
+
+	// A team-type policy's ID is its team ID, so policy_id is the team scope here.
+	ownTeamJob := &model.Job{
+		Id:       model.NewId(),
+		Type:     model.JobTypeAccessControlTeamSync,
+		Status:   model.JobStatusSuccess,
+		CreateAt: model.GetMillis(),
+		Data:     map[string]string{"policy_id": th.BasicTeam.Id},
+	}
+	otherTeamJob := &model.Job{
+		Id:       model.NewId(),
+		Type:     model.JobTypeAccessControlTeamSync,
+		Status:   model.JobStatusSuccess,
+		CreateAt: model.GetMillis(),
+		Data:     map[string]string{"policy_id": otherTeamID},
+	}
+	channelSyncJob := &model.Job{
+		Id:       model.NewId(),
+		Type:     model.JobTypeAccessControlSync,
+		Status:   model.JobStatusSuccess,
+		CreateAt: model.GetMillis(),
+		Data:     map[string]string{"policy_id": parentPolicyID},
+	}
+
+	for _, job := range []*model.Job{ownTeamJob, otherTeamJob, channelSyncJob} {
+		_, err := th.App.Srv().Store().Job().Save(job)
+		require.NoError(t, err)
+		defer func(id string) {
+			_, _ = th.App.Srv().Store().Job().Delete(id)
+		}(job.Id)
+	}
+
+	getJobs := func(t *testing.T, client *model.Client4, jobType, extraQuery string) *http.Response {
+		t.Helper()
+		resp, _ := client.DoAPIGet(context.Background(), "/jobs/type/"+jobType+"?page=0&per_page=60"+extraQuery, "")
+		require.NotNil(t, resp)
+		return resp
+	}
+
+	t.Run("team admin reads team sync jobs for their own team", func(t *testing.T) {
+		th.LoginTeamAdmin(t)
+		defer th.LoginBasic(t)
+
+		resp := getJobs(t, th.Client, model.JobTypeAccessControlTeamSync, "&policy_id="+th.BasicTeam.Id)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var received []*model.Job
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&received))
+		require.Len(t, received, 1)
+		require.Equal(t, ownTeamJob.Id, received[0].Id)
+	})
+
+	t.Run("team admin cannot read another team's team sync jobs", func(t *testing.T) {
+		th.LoginTeamAdmin(t)
+		defer th.LoginBasic(t)
+
+		resp := getJobs(t, th.Client, model.JobTypeAccessControlTeamSync, "&policy_id="+otherTeamID)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("team admin still cannot enumerate channel sync jobs by policy_id", func(t *testing.T) {
+		th.LoginTeamAdmin(t)
+		defer th.LoginBasic(t)
+
+		resp := getJobs(t, th.Client, model.JobTypeAccessControlSync, "&policy_id="+parentPolicyID)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("team admin cannot read team sync jobs without a policy_id", func(t *testing.T) {
+		th.LoginTeamAdmin(t)
+		defer th.LoginBasic(t)
+
+		resp := getJobs(t, th.Client, model.JobTypeAccessControlTeamSync, "")
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("team admin cannot pair an unvetted team_id with their own policy_id", func(t *testing.T) {
+		th.LoginTeamAdmin(t)
+		defer th.LoginBasic(t)
+
+		resp := getJobs(t, th.Client, model.JobTypeAccessControlTeamSync,
+			"&policy_id="+th.BasicTeam.Id+"&team_id="+otherTeamID)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("system admin reads team sync jobs by policy_id", func(t *testing.T) {
+		resp := getJobs(t, th.SystemAdminClient, model.JobTypeAccessControlTeamSync, "&policy_id="+otherTeamID)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var received []*model.Job
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&received))
+		require.Len(t, received, 1)
+		require.Equal(t, otherTeamJob.Id, received[0].Id)
 	})
 }
 

--- a/server/channels/api4/team.go
+++ b/server/channels/api4/team.go
@@ -227,12 +227,39 @@ func getTeamAccessControlPolicy(c *Context, w http.ResponseWriter, r *http.Reque
 		}
 	}
 
+	// Team admins can read this route but cannot fetch a parent policy directly.
+	// Resolve the parents this team imports so the tab can name them in the
+	// system-policy banner and AND their rules into its member counts. Project to
+	// id/name/rules only: the parents' assignment metadata (scope, child_ids) spans
+	// other teams and must not leak. Expressions are masked as elsewhere.
+	var parentPolicies []*model.AccessControlPolicy
+	if policy != nil {
+		redact := shouldRedactExpressions(c)
+		for _, importID := range policy.Imports {
+			parent, parentErr := c.App.GetAccessControlPolicy(c.AppContext, importID)
+			if parentErr != nil {
+				c.Logger.Warn("Skipping unresolved imported parent policy", mlog.String("policy_id", importID), mlog.Err(parentErr))
+				continue
+			}
+			if redact {
+				c.App.MaskPolicyExpressions(c.AppContext, parent, c.AppContext.Session().UserId)
+			}
+			parentPolicies = append(parentPolicies, &model.AccessControlPolicy{
+				ID:    parent.ID,
+				Name:  parent.Name,
+				Rules: parent.Rules,
+			})
+		}
+	}
+
 	resp := struct {
-		Policy   *model.AccessControlPolicy `json:"policy"`
-		Enforced bool                       `json:"enforced"`
+		Policy         *model.AccessControlPolicy   `json:"policy"`
+		Enforced       bool                         `json:"enforced"`
+		ParentPolicies []*model.AccessControlPolicy `json:"parent_policies,omitempty"`
 	}{
-		Policy:   policy,
-		Enforced: enforced,
+		Policy:         policy,
+		Enforced:       enforced,
+		ParentPolicies: parentPolicies,
 	}
 
 	js, err := json.Marshal(resp)

--- a/server/channels/api4/team_abac_api_test.go
+++ b/server/channels/api4/team_abac_api_test.go
@@ -253,6 +253,86 @@ func TestGetTeamAccessControlPolicy(t *testing.T) {
 		require.Equal(t, http.StatusOK, resp.StatusCode)
 	})
 
+	t.Run("resolves imported parent policies into parent_policies for the banner", func(t *testing.T) {
+		m := enableTeamABAC(t, th)
+
+		// Team child policy that imports a system-level parent policy.
+		parentID := model.NewId()
+		teamPolicy := saveTeamMembershipPolicy(t, th, th.BasicTeam.Id)
+		teamPolicy.Imports = []string{parentID}
+		_, err := th.App.Srv().Store().AccessControlPolicy().Save(th.Context, teamPolicy)
+		require.NoError(t, err)
+
+		// The stored parent carries assignment metadata (scope, child_ids) that spans
+		// other teams — the response must not leak any of it.
+		parentPolicy := &model.AccessControlPolicy{
+			ID:       parentID,
+			Type:     model.AccessControlPolicyTypeParent,
+			Name:     "Engineering",
+			Active:   true,
+			Revision: 1,
+			Version:  model.AccessControlPolicyVersionV0_3,
+			Scope:    model.AccessControlPolicyScopeTeam,
+			ScopeID:  model.NewId(),
+			Props:    map[string]any{"child_ids": []string{model.NewId(), model.NewId()}},
+			Rules: []model.AccessControlPolicyRule{
+				{Actions: []string{model.AccessControlPolicyActionMembership}, Expression: `user.attributes.Department == "Engineering"`},
+			},
+		}
+
+		m.On("GetPolicy", mock.AnythingOfType("*request.Context"), th.BasicTeam.Id).Return(teamPolicy, nil)
+		m.On("GetPolicy", mock.AnythingOfType("*request.Context"), parentID).Return(parentPolicy, nil)
+
+		// AttributeValueMasking is on by default, so the handler masks parent
+		// expressions through the PDP. Pass them through unchanged here.
+		m.On("MaskExpressionForCaller", mock.Anything, mock.Anything, mock.Anything).
+			Return(`user.attributes.Department == "Engineering"`, false, (*model.AppError)(nil))
+
+		assertBanner := func(t *testing.T, client *model.Client4) {
+			t.Helper()
+			resp, err := getPolicy(t, client, th.BasicTeam.Id)
+			require.NoError(t, err)
+			defer resp.Body.Close()
+			require.Equal(t, http.StatusOK, resp.StatusCode)
+
+			var body struct {
+				Policy         *model.AccessControlPolicy   `json:"policy"`
+				Enforced       bool                         `json:"enforced"`
+				ParentPolicies []*model.AccessControlPolicy `json:"parent_policies"`
+			}
+			require.NoError(t, json.NewDecoder(resp.Body).Decode(&body))
+			require.Len(t, body.ParentPolicies, 1)
+			got := body.ParentPolicies[0]
+			require.Equal(t, parentID, got.ID)
+			require.Equal(t, "Engineering", got.Name)
+			require.Len(t, got.Rules, 1)
+			require.Equal(t, `user.attributes.Department == "Engineering"`, got.Rules[0].Expression)
+
+			// Assignment metadata must be stripped.
+			require.Empty(t, got.Scope)
+			require.Empty(t, got.ScopeID)
+			require.Nil(t, got.Props)
+		}
+
+		// System admin gets the resolved parent — the pre-existing behavior.
+		t.Run("system admin", func(t *testing.T) {
+			assertBanner(t, th.SystemAdminClient)
+		})
+
+		// Team admin gets the SAME banner data, without needing to fetch the parent
+		// policy directly (which requires ManageSystem). This is the MM-70056 fix.
+		t.Run("team admin", func(t *testing.T) {
+			th.AddPermissionToRole(t, model.PermissionManageTeamAccessRules.Id, model.TeamAdminRoleId)
+			defer th.RemovePermissionFromRole(t, model.PermissionManageTeamAccessRules.Id, model.TeamAdminRoleId)
+			th.LinkUserToTeam(t, th.TeamAdminUser, th.BasicTeam)
+			th.UpdateUserToTeamAdmin(t, th.TeamAdminUser, th.BasicTeam)
+			th.LoginTeamAdmin(t)
+			defer th.LoginBasic(t)
+
+			assertBanner(t, th.Client)
+		})
+	})
+
 	t.Run("disabled flag hides a policy row created while dark", func(t *testing.T) {
 		enableTeamABAC(t, th)
 		// A child policy persisted while the feature was on must not leak through

--- a/webapp/channels/src/components/team_settings/team_access_tab/index.ts
+++ b/webapp/channels/src/components/team_settings/team_access_tab/index.ts
@@ -10,7 +10,6 @@ import type {Team} from '@mattermost/types/teams';
 
 import {
     createAccessControlTeamSyncJob,
-    getAccessControlPolicy,
     getTeamAccessControlPolicy,
     searchUsersForExpression,
     validateExpressionAgainstRequester,
@@ -44,7 +43,6 @@ function mapDispatchToProps(dispatch: Dispatch) {
             regenerateTeamInviteId,
             getTeamStats,
             getTeamAccessControlPolicy,
-            getAccessControlPolicy,
             searchUsersForExpression,
             validateExpressionAgainstRequester,
             createAccessControlTeamSyncJob,

--- a/webapp/channels/src/components/team_settings/team_access_tab/team_access_tab.test.tsx
+++ b/webapp/channels/src/components/team_settings/team_access_tab/team_access_tab.test.tsx
@@ -16,7 +16,6 @@ describe('components/TeamSettings', () => {
     const regenerateTeamInviteId = jest.fn().mockReturnValue({data: true});
     const getTeamStats = jest.fn().mockResolvedValue({data: {total_member_count: 10, active_member_count: 10}});
     const getTeamAccessControlPolicy = jest.fn().mockResolvedValue({data: {policy: null, enforced: false}});
-    const getAccessControlPolicy = jest.fn().mockResolvedValue({data: undefined});
     const searchUsersForExpression = jest.fn().mockResolvedValue({data: {users: [], total: 0}});
     const createAccessControlTeamSyncJob = jest.fn().mockResolvedValue({data: {}});
     const validateExpressionAgainstRequester = jest.fn().mockResolvedValue({data: {requester_matches: true}});
@@ -25,7 +24,6 @@ describe('components/TeamSettings', () => {
         regenerateTeamInviteId,
         getTeamStats,
         getTeamAccessControlPolicy,
-        getAccessControlPolicy,
         searchUsersForExpression,
         validateExpressionAgainstRequester,
         createAccessControlTeamSyncJob,
@@ -228,12 +226,13 @@ describe('components/TeamSettings', () => {
 
     test('parent-policy governed team: mode-flip modal shows the resolved member count', async () => {
         getTeamAccessControlPolicy.mockResolvedValueOnce({
-            data: {policy: {id: 'team_id', rules: [], imports: ['parent1']}, enforced: true},
-        });
-        getAccessControlPolicy.mockResolvedValueOnce({
             data: {
-                id: 'parent1',
-                rules: [{actions: ['membership'], expression: 'user.attributes.Department == "Engineering"'}],
+                policy: {id: 'team_id', rules: [], imports: ['parent1']},
+                enforced: true,
+                parent_policies: [{
+                    id: 'parent1',
+                    rules: [{actions: ['membership'], expression: 'user.attributes.Department == "Engineering"'}],
+                }],
             },
         });
         searchUsersForExpression.mockResolvedValueOnce({data: {users: [], total: 9}});
@@ -248,17 +247,41 @@ describe('components/TeamSettings', () => {
         await userEvent.click(screen.getByText('Private Team'));
 
         expect(await screen.findByText(/1 current member does not meet criteria/i)).toBeInTheDocument();
-        expect(getAccessControlPolicy).toHaveBeenCalledWith('parent1');
         expect(searchUsersForExpression).toHaveBeenCalledWith(
             'user.attributes.Department == "Engineering"', '', '', 1, undefined, 'team_id',
         );
     });
 
-    test('parent-policy fetch failure: modal falls back to the generic message', async () => {
+    test('parent-policy governed team: self-exclusion still blocks the switch', async () => {
+        getTeamAccessControlPolicy.mockResolvedValueOnce({
+            data: {
+                policy: {id: 'team_id', rules: [], imports: ['parent1']},
+                enforced: true,
+                parent_policies: [{
+                    id: 'parent1',
+                    rules: [{actions: ['membership'], expression: 'user.attributes.Department == "Engineering"'}],
+                }],
+            },
+        });
+        validateExpressionAgainstRequester.mockResolvedValueOnce({data: {requester_matches: false}});
+
+        const props = {
+            ...defaultProps,
+            team: TestHelper.getTeamMock({id: 'team_id', type: 'O', allow_open_invite: true, policy_enforced: true}),
+            teamMembershipAccessControlEnabled: true,
+        };
+        renderWithContext(<AccessTab {...props}/>);
+        await userEvent.click(screen.getByText('Private Team'));
+
+        expect(await screen.findByText('Cannot switch to Private Team')).toBeInTheDocument();
+        expect(screen.queryByText('Switch to Private Team?')).not.toBeInTheDocument();
+        expect(patchTeam).not.toHaveBeenCalled();
+    });
+
+    test('unresolved parent import: modal falls back to the generic message', async () => {
         getTeamAccessControlPolicy.mockResolvedValueOnce({
             data: {policy: {id: 'team_id', rules: [], imports: ['parent1']}, enforced: true},
         });
-        getAccessControlPolicy.mockResolvedValueOnce({error: {message: 'boom'}});
 
         const props = {
             ...defaultProps,
@@ -295,7 +318,6 @@ describe('components/TeamSettings', () => {
         await userEvent.click(screen.getByText('Private Team'));
 
         expect(await screen.findByText(/2 current members do not meet criteria/i)).toBeInTheDocument();
-        expect(getAccessControlPolicy).not.toHaveBeenCalled();
     });
 
     test('self-exclusion: blocks the switch to Private when the admin does not meet the rules', async () => {

--- a/webapp/channels/src/components/team_settings/team_access_tab/team_access_tab.tsx
+++ b/webapp/channels/src/components/team_settings/team_access_tab/team_access_tab.tsx
@@ -107,19 +107,15 @@ const AccessTab = ({showTabSwitchError, areThereUnsavedChanges, setShowTabSwitch
         const policyData = policyResult?.data;
         const teamExpression = getMembershipRule(policyData?.policy?.rules)?.expression;
 
-        // Parent-governed teams keep the rules in the imported policy, not here.
-        const parentIds = policyData?.policy?.imports ?? [];
-        const parentPolicies = await Promise.all(
-            parentIds.map((id) => actions.getAccessControlPolicy(id)),
-        );
+        // Resolved server-side: team admins can't fetch parent policies directly.
+        const parentIds: string[] = policyData?.policy?.imports ?? [];
+        const parentPolicies: AccessControlPolicy[] = policyData?.parent_policies ?? [];
 
         // A dropped import would understate the rule set; treat as unresolved.
-        if (parentPolicies.some((result) => result?.error || !result?.data)) {
+        if (parentPolicies.length !== parentIds.length) {
             return null;
         }
-        const parentExpressions = parentPolicies.map((result) =>
-            getMembershipRule((result.data as AccessControlPolicy).rules)?.expression,
-        );
+        const parentExpressions = parentPolicies.map((policy) => getMembershipRule(policy.rules)?.expression);
 
         return combineMembershipExpressions([teamExpression, ...parentExpressions]) || null;
     }, [actions, team.id]);

--- a/webapp/channels/src/components/team_settings/team_membership_tab/team_membership_tab.test.tsx
+++ b/webapp/channels/src/components/team_settings/team_membership_tab/team_membership_tab.test.tsx
@@ -198,11 +198,11 @@ describe('components/team_settings/TeamMembershipTab', () => {
         expect(screen.queryByText(/who no longer match will be removed/i)).not.toBeInTheDocument();
     });
 
-    it('shows system policy indicator when parent policies are applied', async () => {
+    it('shows system policy indicator from parent_policies returned by the team policy endpoint', async () => {
         const parentPolicy = {
             id: 'parent_policy_id',
             name: 'Global Policy',
-            type: 'team',
+            type: 'parent',
             active: true,
             rules: [{actions: ['membership'], expression: 'user.attributes.location in ["US"]'}],
             imports: [],
@@ -218,18 +218,23 @@ describe('components/team_settings/TeamMembershipTab', () => {
                     imports: ['parent_policy_id'],
                 },
                 enforced: true,
+
+                // The server resolves imported parent policies so team admins — who cannot
+                // fetch a parent policy directly — can still render the banner.
+                parent_policies: [parentPolicy],
             },
         }));
-        mockActions.getChannelPolicy.mockResolvedValue({data: parentPolicy});
 
         renderWithContext(
             <TeamMembershipTab {...baseProps}/>,
             initialState,
         );
 
+        // The banner renders the resolved parent policy name without any getChannelPolicy call.
         await waitFor(() => {
-            expect(mockActions.getChannelPolicy).toHaveBeenCalledWith('parent_policy_id');
+            expect(screen.getByText('Global Policy')).toBeInTheDocument();
         });
+        expect(mockActions.getChannelPolicy).not.toHaveBeenCalled();
     });
 
     it('triggers createAccessControlTeamSyncJob on a rule change even with auto-add off', async () => {
@@ -651,9 +656,9 @@ describe('components/team_settings/TeamMembershipTab', () => {
                     imports: ['parent_policy_id'],
                 },
                 enforced: true,
+                parent_policies: [parentPolicy],
             },
         }));
-        mockActions.getChannelPolicy.mockResolvedValue({data: parentPolicy});
         mockActions.searchUsers.mockResolvedValue({data: {users: [], total: 3}});
 
         const privateTeam = TestHelper.getTeamMock({
@@ -668,8 +673,8 @@ describe('components/team_settings/TeamMembershipTab', () => {
             initialState,
         );
 
-        // Wait until the parent/system policy has been loaded into state.
-        await waitFor(() => expect(mockActions.getChannelPolicy).toHaveBeenCalledWith('parent_policy_id'));
+        // Wait until the parent/system policy has been loaded into state (banner renders its name).
+        await waitFor(() => expect(screen.getByText('Global Policy')).toBeInTheDocument());
 
         // Add a custom rule via the editor, then save to open the confirm modal.
         await userEvent.click(screen.getByTestId('table-editor-change'));

--- a/webapp/channels/src/components/team_settings/team_membership_tab/team_membership_tab.tsx
+++ b/webapp/channels/src/components/team_settings/team_membership_tab/team_membership_tab.tsx
@@ -198,7 +198,7 @@ function TeamMembershipTab({
         let cancelled = false;
         const loadTeamPolicy = async () => {
             try {
-                const result = await dispatch(getTeamAccessControlPolicy(team.id)) as {data?: {policy: AccessControlPolicy | null; enforced: boolean} | null; error?: unknown};
+                const result = await dispatch(getTeamAccessControlPolicy(team.id)) as {data?: {policy: AccessControlPolicy | null; enforced: boolean; parent_policies?: AccessControlPolicy[]} | null; error?: unknown};
                 if (cancelled) {
                     return;
                 }
@@ -215,18 +215,8 @@ function TeamMembershipTab({
                     setAutoAddMembers(existingAutoAdd);
                     setOriginalAutoAddMembers(existingAutoAdd);
 
-                    if (imports.length > 0) {
-                        const fetchedPolicies = await Promise.all(
-                            imports.map(async (policyId) => {
-                                const pr = await actions.getChannelPolicy(policyId);
-                                return pr.data ?? null;
-                            }),
-                        );
-                        if (cancelled) {
-                            return;
-                        }
-                        setSystemPolicies(fetchedPolicies.filter((p): p is AccessControlPolicy => p !== null));
-                    }
+                    // Resolved server-side: team admins can't fetch parent policies directly.
+                    setSystemPolicies(result.data?.parent_policies ?? []);
                 }
             } catch {
                 if (!cancelled) {

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -5157,7 +5157,7 @@ export default class Client4 {
     };
 
     getTeamAccessControlPolicy = (teamId: string) => {
-        return this.doFetch<{policy: AccessControlPolicy | null; enforced: boolean}>(
+        return this.doFetch<{policy: AccessControlPolicy | null; enforced: boolean; parent_policies?: AccessControlPolicy[]}>(
             `${this.getTeamRoute(teamId)}/access_control/policy`,
             {method: 'get'},
         );


### PR DESCRIPTION
#### Summary

Team admins were missing key information in the Team Settings → Team Membership tab: no system policy banner, no member count. On the mode-flip modal, and a sync footer stuck on "Never synced". All three came from the same thing, a permission extra unnecessary validation on the Team admin role.
Fixed by giving team admins the data through endpoints they're already authorized on, rather than loosening any existing valid permission check. BTW, No write path or ownership gate was touched.

  ---
  MM-70056 — Team Admin System policy banner missing

  Validate:
  1. Assign a parent policy to a team, make a user team admin of it.
  2. As that team admin: Team Settings → Team Membership.
  3. Banner appears naming the policy — same as system admin sees.

  MM-70055 — Mode-flip modal showed generic text instead of a member count

  Validate:
  1. Public team governed only by a parent policy, plus one member who doesn't match it.
  2. As team admin: Team Settings → Access → click Private Team.
  3. Modal shows "N current member(s) do not meet criteria", not "Some members may not meet".


MM-70057 — Sync footer stuck on "Never synced"

  Validate:
  2. Run a sync on a team with a policy. 
  3. As team admin: Team Settings → Team Membership → footer shows "Last synced …", matching the system admin.


#### Ticket Link

[MM-70055](https://mattermost.atlassian.net/browse/MM-70055)
[MM-70056](https://mattermost.atlassian.net/browse/MM-70056)
[MM-70057](https://mattermost.atlassian.net/browse/MM-70057)

#### Screenshots

https://github.com/user-attachments/assets/ba515f42-bdae-485f-b79b-4f7f43d7f0bc




#### Release Note
```release-note
NONE
```


[MM-70055]: https://mattermost.atlassian.net/browse/MM-70055?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes affect authorization logic, API responses, and Team Settings flows. Automated tests cover the affected Team Admin and system-admin paths.

**QA Recommendation:** Manual QA can be skipped. Automated coverage validates the policy banner, member count, and sync timestamp.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->