### PR TITLE
Automated cherry pick of #37388

### DIFF
--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 	"strconv"
 	"time"
+	"unicode/utf8"
 
 	"github.com/gorilla/mux"
 
@@ -54,6 +55,20 @@ func (api *API) InitPost() {
 	api.BaseRoutes.Posts.Handle("/rewrite", api.APISessionRequired(rewriteMessage)).Methods(http.MethodPost)
 	api.BaseRoutes.Post.Handle("/reveal", api.APISessionRequired(revealPost)).Methods(http.MethodGet)
 	api.BaseRoutes.Post.Handle("/burn", api.APISessionRequired(burnPost)).Methods(http.MethodDelete)
+}
+
+// rejectOversizedMessage sets c.Err and returns true if message is longer than the configured
+// MaxPostSize. It mirrors the check in model.Post.IsValid, but runs before any markdown processing
+// (e.g. PostWithProxyRemovedFromImageURLs) is applied to the raw message, so that oversized
+// messages are rejected before that processing pays for them.
+func rejectOversizedMessage(c *Context, where string, message string) bool {
+	maxPostSize := c.App.MaxPostSize()
+	if length := utf8.RuneCountInString(message); length > maxPostSize {
+		c.Err = model.NewAppError(where, "model.post.is_valid.message_length.app_error",
+			map[string]any{"Length": length, "MaxLength": maxPostSize}, "", http.StatusBadRequest)
+		return true
+	}
+	return false
 }
 
 func createPostChecks(where string, c *Context, post *model.Post) {
@@ -113,6 +128,10 @@ func createPost(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	createPostChecks("Api4.createPost", c, &post)
 	if c.Err != nil {
+		return
+	}
+
+	if rejectOversizedMessage(c, "Api4.createPost", post.Message) {
 		return
 	}
 
@@ -1110,6 +1129,10 @@ func updatePost(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	if rejectOversizedMessage(c, "Api4.updatePost", post.Message) {
+		return
+	}
+
 	if originalPost.Type == model.PostTypeCard && c.App.Config().FeatureFlags.IntegratedBoards {
 		// Cards: collaborative model — skip ownership check
 		// PermissionEditPost already checked above
@@ -1173,6 +1196,10 @@ func patchPost(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	isMember := postPatchChecks(c, auditRec, &post)
 	if c.Err != nil {
+		return
+	}
+
+	if post.Message != nil && rejectOversizedMessage(c, "Api4.patchPost", *post.Message) {
 		return
 	}
 

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -353,6 +353,19 @@ func TestCreatePost(t *testing.T) {
 		require.Nil(t, appErr)
 		require.Zero(t, *createdPost.RemoteId)
 	})
+
+	t.Run("message longer than max post size is rejected", func(t *testing.T) {
+		longPost := &model.Post{
+			ChannelId: th.BasicChannel.Id,
+			Message:   strings.Repeat("a", th.App.MaxPostSize()+1),
+		}
+
+		rpost, resp, err := client.CreatePost(context.Background(), longPost)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+		assert.Nil(t, rpost)
+	})
+
 	t.Run("not logged in", func(t *testing.T) {
 		resp, err := client.Logout(context.Background())
 		require.NoError(t, err)
@@ -2141,6 +2154,25 @@ func TestUpdatePost(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("message longer than max post size is rejected", func(t *testing.T) {
+		post, _, appErr := th.App.CreatePost(th.Context, &model.Post{
+			UserId:    th.BasicUser.Id,
+			ChannelId: channel.Id,
+			Message:   "zz" + model.NewId() + "a",
+		}, channel, model.CreatePostFlags{SetOnline: true})
+		require.Nil(t, appErr)
+
+		longPost := &model.Post{
+			Id:        post.Id,
+			ChannelId: channel.Id,
+			Message:   strings.Repeat("a", th.App.MaxPostSize()+1),
+		}
+		updatedPost, resp, err := client.UpdatePost(context.Background(), post.Id, longPost)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+		assert.Nil(t, updatedPost)
+	})
 }
 
 func TestUpdateOthersPostInDirectMessageChannel(t *testing.T) {
@@ -2741,6 +2773,22 @@ func TestPatchPost(t *testing.T) {
 		require.Equal(t, 2, len(patchedPost.FileIds))
 		require.Contains(t, patchedPost.FileIds, fileInfo1.Id)
 		require.Contains(t, patchedPost.FileIds, fileInfo2.Id)
+	})
+
+	t.Run("message longer than max post size is rejected", func(t *testing.T) {
+		post, _, err := client.CreatePost(context.Background(), &model.Post{
+			ChannelId: channel.Id,
+			Message:   "#hashtag a message",
+		})
+		require.NoError(t, err)
+
+		patch := &model.PostPatch{
+			Message: new(strings.Repeat("a", th.App.MaxPostSize()+1)),
+		}
+		patchedPost, resp, err := client.PatchPost(context.Background(), post.Id, patch)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+		assert.Nil(t, patchedPost)
 	})
 }
 

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -2782,8 +2782,9 @@ func TestPatchPost(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		oversizedMessage := strings.Repeat("a", th.App.MaxPostSize()+1)
 		patch := &model.PostPatch{
-			Message: new(strings.Repeat("a", th.App.MaxPostSize()+1)),
+			Message: &oversizedMessage,
 		}
 		patchedPost, resp, err := client.PatchPost(context.Background(), post.Id, patch)
 		require.Error(t, err)

--- a/server/channels/app/platform/service.go
+++ b/server/channels/app/platform/service.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
+	"github.com/mattermost/mattermost/server/public/shared/markdown"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/v8/channels/app/featureflag"
 	"github.com/mattermost/mattermost/server/v8/channels/jobs"
@@ -327,6 +328,10 @@ func New(sc ServiceConfig, options ...Option) (*PlatformService, error) {
 	if err != nil {
 		return nil, fmt.Errorf("cannot create store: %w", err)
 	}
+
+	// The markdown package needs to know what the maximum post size is, so we
+	// let it know once the store is created.
+	markdown.SetMaxPostRunes(ps.MaxPostSize())
 
 	// Step 7: initialize status and session cache.
 	// We need to do this because ps.LoadLicense() called in step 8, could

--- a/server/channels/app/platform/service_test.go
+++ b/server/channels/app/platform/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/markdown"
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest"
 	"github.com/mattermost/mattermost/server/v8/config"
 	"github.com/mattermost/mattermost/server/v8/einterfaces/mocks"
@@ -248,4 +249,12 @@ func TestDatabaseTypeAndMattermostVersion(t *testing.T) {
 	// It's hard to check whether the schema version is correct or not.
 	// So, we just check if it's greater than 1.
 	assert.GreaterOrEqual(t, schemaVersion, strconv.Itoa(1))
+}
+
+func TestNewSyncsMarkdownMaxLenWithMaxPostSize(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t)
+
+	maxPostSize := th.Service.MaxPostSize()
+	assert.Equal(t, 4*maxPostSize, markdown.MaxLen())
 }

--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -2663,7 +2663,6 @@ func (s *SqlPostStore) determineMaxPostSize() int {
 }
 
 // GetMaxPostSize returns the maximum number of runes that may be stored in a post.
-// For any changes, accordingly update the markdown maxLen here - markdown/inspect.go.
 func (s *SqlPostStore) GetMaxPostSize() int {
 	s.maxPostSizeOnce.Do(func() {
 		s.maxPostSizeCached = s.determineMaxPostSize()

--- a/server/public/shared/markdown/block_quote.go
+++ b/server/public/shared/markdown/block_quote.go
@@ -34,8 +34,11 @@ func (b *BlockQuote) AddChild(openBlocks []Block) []Block {
 	return openBlocks
 }
 
-func blockQuoteStart(markdown string, indent int, r Range) []Block {
+func blockQuoteStart(markdown string, indent int, r Range, depth int) []Block {
 	if indent > 3 {
+		return nil
+	}
+	if depth >= maxNestingDepth {
 		return nil
 	}
 	s := markdown[r.Position:r.End]
@@ -54,7 +57,7 @@ func blockQuoteStart(markdown string, indent int, r Range) []Block {
 	indent, bytes := countIndentation(markdown, r)
 
 	ret := []Block{block}
-	if descendants := blockStartOrParagraph(markdown, indent, Range{r.Position + bytes, r.End}, nil, nil); descendants != nil {
+	if descendants := blockStartOrParagraph(markdown, indent, Range{r.Position + bytes, r.End}, nil, nil, depth+1); descendants != nil {
 		block.Children = append(block.Children, descendants[0])
 		ret = append(ret, descendants...)
 	}

--- a/server/public/shared/markdown/block_quote_test.go
+++ b/server/public/shared/markdown/block_quote_test.go
@@ -1,0 +1,42 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package markdown
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBlockQuoteStart(t *testing.T) {
+	t.Run("depth at the nesting limit is rejected even for a well-formed block quote", func(t *testing.T) {
+		markdown := "> foo"
+		blocks := blockQuoteStart(markdown, 0, Range{0, len(markdown)}, maxNestingDepth)
+		assert.Nil(t, blocks)
+	})
+
+	t.Run("nesting from a single line is capped at maxNestingDepth", func(t *testing.T) {
+		n := maxNestingDepth + 8
+		markdown := strings.Repeat("> ", n) + "x"
+		blocks := blockQuoteStart(markdown, 0, Range{0, len(markdown)}, 0)
+		require.NotEmpty(t, blocks)
+
+		counts := countBlocksByType(blocks)
+		assert.Equal(t, maxNestingDepth, counts["*markdown.BlockQuote"])
+		assert.Equal(t, 1, counts["*markdown.Paragraph"])
+		assert.IsType(t, &Paragraph{}, blocks[len(blocks)-1])
+	})
+
+	t.Run("nesting is capped relative to the depth already accrued by open ancestor blocks", func(t *testing.T) {
+		markdown := "> > > x"
+		blocks := blockQuoteStart(markdown, 0, Range{0, len(markdown)}, maxNestingDepth-2)
+		require.NotEmpty(t, blocks)
+
+		counts := countBlocksByType(blocks)
+		assert.Equal(t, 2, counts["*markdown.BlockQuote"])
+		assert.Equal(t, 1, counts["*markdown.Paragraph"])
+	})
+}

--- a/server/public/shared/markdown/blocks.go
+++ b/server/public/shared/markdown/blocks.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 )
 
+// See MM-69445
+const maxNestingDepth = 32
+
 type continuation struct {
 	Indentation int
 	Remaining   Range
@@ -74,7 +77,7 @@ func ParseBlocks(markdown string, lines []Line) (*Document, []*ReferenceDefiniti
 		}
 
 		if openBlocks[lastMatchIndex].AllowsBlockStarts() {
-			if newBlocks := blockStart(markdown, indentation, r, openBlocks[:lastMatchIndex+1], openBlocks[lastMatchIndex+1:]); newBlocks != nil {
+			if newBlocks := blockStart(markdown, indentation, r, openBlocks[:lastMatchIndex+1], openBlocks[lastMatchIndex+1:], lastMatchIndex+1); newBlocks != nil {
 				didAdd := false
 				for i := lastMatchIndex; i >= 0; i-- {
 					if container, ok := openBlocks[i].(ContainerBlock); ok {
@@ -125,14 +128,14 @@ func ParseBlocks(markdown string, lines []Line) (*Document, []*ReferenceDefiniti
 	return document, referenceDefinitions
 }
 
-func blockStart(markdown string, indentation int, r Range, matchedBlocks, unmatchedBlocks []Block) []Block {
+func blockStart(markdown string, indentation int, r Range, matchedBlocks, unmatchedBlocks []Block, depth int) []Block {
 	if r.Position >= r.End {
 		return nil
 	}
 
-	if start := blockQuoteStart(markdown, indentation, r); start != nil {
+	if start := blockQuoteStart(markdown, indentation, r, depth); start != nil {
 		return start
-	} else if start := listStart(markdown, indentation, r, matchedBlocks, unmatchedBlocks); start != nil {
+	} else if start := listStart(markdown, indentation, r, matchedBlocks, unmatchedBlocks, depth); start != nil {
 		return start
 	} else if start := indentedCodeStart(markdown, indentation, r, matchedBlocks, unmatchedBlocks); start != nil {
 		return start
@@ -143,8 +146,8 @@ func blockStart(markdown string, indentation int, r Range, matchedBlocks, unmatc
 	return nil
 }
 
-func blockStartOrParagraph(markdown string, indentation int, r Range, matchedBlocks, unmatchedBlocks []Block) []Block {
-	if start := blockStart(markdown, indentation, r, matchedBlocks, unmatchedBlocks); start != nil {
+func blockStartOrParagraph(markdown string, indentation int, r Range, matchedBlocks, unmatchedBlocks []Block, depth int) []Block {
+	if start := blockStart(markdown, indentation, r, matchedBlocks, unmatchedBlocks, depth); start != nil {
 		return start
 	}
 	if paragraph := newParagraph(markdown, r); paragraph != nil {

--- a/server/public/shared/markdown/blocks_test.go
+++ b/server/public/shared/markdown/blocks_test.go
@@ -1,0 +1,80 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package markdown
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// countBlocksByType tallies the concrete type of each block in a flat block chain, such as the one
+// returned by blockQuoteStart/listStart/blockStart, which append each nesting level's block(s)
+// directly onto the same slice as its descendants.
+func countBlocksByType(blocks []Block) map[string]int {
+	counts := map[string]int{}
+	for _, block := range blocks {
+		counts[fmt.Sprintf("%T", block)]++
+	}
+	return counts
+}
+
+func TestBlockStart(t *testing.T) {
+	t.Run("block quote nesting is capped at maxNestingDepth", func(t *testing.T) {
+		markdown := "> foo"
+		blocks := blockStart(markdown, 0, Range{0, len(markdown)}, nil, nil, maxNestingDepth)
+		assert.Nil(t, blocks)
+	})
+
+	t.Run("list nesting is capped at maxNestingDepth", func(t *testing.T) {
+		markdown := "- foo"
+		blocks := blockStart(markdown, 0, Range{0, len(markdown)}, nil, nil, maxNestingDepth)
+		assert.Nil(t, blocks)
+	})
+
+	t.Run("a single line cannot recurse past maxNestingDepth nested block quotes", func(t *testing.T) {
+		n := maxNestingDepth + 8
+		markdown := strings.Repeat("> ", n) + "x"
+		blocks := blockStart(markdown, 0, Range{0, len(markdown)}, nil, nil, 0)
+		require.NotEmpty(t, blocks)
+
+		counts := countBlocksByType(blocks)
+		assert.Equal(t, maxNestingDepth, counts["*markdown.BlockQuote"])
+		assert.Equal(t, 1, counts["*markdown.Paragraph"])
+	})
+
+	t.Run("a single line cannot recurse past maxNestingDepth nested list items", func(t *testing.T) {
+		n := maxNestingDepth + 8
+		markdown := strings.Repeat("- ", n) + "x"
+		blocks := blockStart(markdown, 0, Range{0, len(markdown)}, nil, nil, 0)
+		require.NotEmpty(t, blocks)
+
+		counts := countBlocksByType(blocks)
+		assert.Equal(t, maxNestingDepth, counts["*markdown.List"])
+		assert.Equal(t, maxNestingDepth, counts["*markdown.ListItem"])
+		assert.Equal(t, 1, counts["*markdown.Paragraph"])
+	})
+
+	t.Run("nesting already accrued by open ancestor blocks counts toward the cap", func(t *testing.T) {
+		markdown := "> > > x"
+		blocks := blockStart(markdown, 0, Range{0, len(markdown)}, nil, nil, maxNestingDepth-2)
+		require.NotEmpty(t, blocks)
+
+		counts := countBlocksByType(blocks)
+		assert.Equal(t, 2, counts["*markdown.BlockQuote"])
+		assert.Equal(t, 1, counts["*markdown.Paragraph"])
+	})
+}
+
+func TestBlockStartOrParagraph(t *testing.T) {
+	t.Run("falls back to a paragraph once the nesting depth is exhausted", func(t *testing.T) {
+		markdown := "> foo"
+		blocks := blockStartOrParagraph(markdown, 0, Range{0, len(markdown)}, nil, nil, maxNestingDepth)
+		require.Len(t, blocks, 1)
+		assert.IsType(t, &Paragraph{}, blocks[0])
+	})
+}

--- a/server/public/shared/markdown/inspect.go
+++ b/server/public/shared/markdown/inspect.go
@@ -3,16 +3,40 @@
 
 package markdown
 
-const (
-	// Assuming 64k maxSize of a post which can be stored in DB.
-	// Allow scanning upto twice(arbitrary value) the post size.
-	maxLen = 1024 * 64 * 2
-)
+import "sync/atomic"
+
+// defaultMaxPostRunes is used only if no value has been registered via
+// SetMaxPostRunes, which should not happen in practice. It assumes a post is at
+// most 64KiB in DB. Assuming four bytes per rune, it gives us 16*1024 runes.
+// If we allow scanning up to twice (arbitrary value) that value, we get:
+const defaultMaxPostRunes = 2 * 16 * 1024
+
+var maxPostRunes atomic.Int64
+
+func init() {
+	maxPostRunes.Store(defaultMaxPostRunes)
+}
+
+// SetMaxPostRunes registers the real configured maximum post size, in runes, that MaxLen uses to
+// compute the maximum markdown input length. This lets MaxLen reflect the real limit regardless
+// of which code path first parses markdown, rather than depending on that path having already
+// pushed the value in. Safe to call concurrently with MaxLen.
+func SetMaxPostRunes(size int) {
+	maxPostRunes.Store(int64(size))
+}
+
+// MaxLen returns the current maximum markdown input length, in bytes, enforced by Parse and
+// Inspect: four times the maximum post size, in runes, registered via SetMaxPostRunes (or
+// defaultMaxPostRunes if it hasn't been called yet), assuming a worst case of four bytes per
+// rune.
+func MaxLen() int {
+	return 4 * int(maxPostRunes.Load())
+}
 
 // Inspect traverses the markdown tree in depth-first order. If f returns true, Inspect invokes f
 // recursively for each child of the block or inline, followed by a call of f(nil).
 func Inspect(markdown string, f func(any) bool) {
-	if len(markdown) > maxLen {
+	if len(markdown) > MaxLen() {
 		return
 	}
 	document, referenceDefinitions := Parse(markdown)

--- a/server/public/shared/markdown/inspect_test.go
+++ b/server/public/shared/markdown/inspect_test.go
@@ -55,7 +55,7 @@ func TestInspect(t *testing.T) {
 	})
 
 	t.Run("visit nodes when len is smaller than maxLen", func(t *testing.T) {
-		n := maxLen / 5
+		n := MaxLen() / 5
 		markdown := strings.Repeat(`![`, n) + strings.Repeat(`]()`, n)
 
 		visited := []string{}
@@ -74,7 +74,7 @@ func TestInspect(t *testing.T) {
 	})
 
 	t.Run("do not visit any nodes when len is greater than maxLen", func(t *testing.T) {
-		n := (maxLen / 5) + 1
+		n := (MaxLen() / 5) + 1
 		markdown := strings.Repeat(`![`, n) + strings.Repeat(`]()`, n)
 
 		visited := []string{}
@@ -90,6 +90,36 @@ func TestInspect(t *testing.T) {
 		})
 
 		assert.Empty(t, visited)
+	})
+
+	t.Run("a deeply nested single-line block quote is bounded rather than fully descended", func(t *testing.T) {
+		n := 20000
+		markdown := strings.Repeat("> ", n) + "x"
+
+		blockQuoteCount := 0
+		Inspect(markdown, func(blockOrInline any) bool {
+			if _, ok := blockOrInline.(*BlockQuote); ok {
+				blockQuoteCount++
+			}
+			return true
+		})
+
+		assert.Equal(t, maxNestingDepth-1, blockQuoteCount)
+	})
+
+	t.Run("a deeply nested single-line list is bounded rather than fully descended", func(t *testing.T) {
+		n := 20000
+		markdown := strings.Repeat("- ", n) + "x"
+
+		listCount := 0
+		Inspect(markdown, func(blockOrInline any) bool {
+			if _, ok := blockOrInline.(*List); ok {
+				listCount++
+			}
+			return true
+		})
+
+		assert.Equal(t, maxNestingDepth-1, listCount)
 	})
 }
 
@@ -110,6 +140,38 @@ At the end, some more lines`
 		Inspect(text, func(_ any) bool {
 			counterSink++
 			return true
+		})
+	}
+}
+
+// BenchmarkInspectNestedBlockQuote and BenchmarkInspectNestedList measure the cost of parsing a
+// single line made up of repeated block-quote/list markers. These benchmarks should scale roughly
+// linearly with input size (i.e. per-op time should stay flat as the marker count grows), since the
+// number of nested blocks actually created is capped at maxNestingDepth regardless of input size.
+func BenchmarkInspectNestedBlockQuote(b *testing.B) {
+	for _, n := range []int{1_000, 10_000, 60_000} {
+		markdown := strings.Repeat("> ", n) + "x"
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				Inspect(markdown, func(_ any) bool {
+					counterSink++
+					return true
+				})
+			}
+		})
+	}
+}
+
+func BenchmarkInspectNestedList(b *testing.B) {
+	for _, n := range []int{1_000, 10_000, 60_000} {
+		markdown := strings.Repeat("- ", n) + "x"
+		b.Run(fmt.Sprintf("n=%d", n), func(b *testing.B) {
+			for b.Loop() {
+				Inspect(markdown, func(_ any) bool {
+					counterSink++
+					return true
+				})
+			}
 		})
 	}
 }

--- a/server/public/shared/markdown/list.go
+++ b/server/public/shared/markdown/list.go
@@ -166,12 +166,15 @@ func parseListMarker(markdown string, r Range) (success, isOrdered bool, ordered
 	return true, false, 0, next, 1, Range{r.Position + 1, r.End}
 }
 
-func listStart(markdown string, indent int, r Range, matchedBlocks, unmatchedBlocks []Block) []Block {
+func listStart(markdown string, indent int, r Range, matchedBlocks, unmatchedBlocks []Block, depth int) []Block {
 	afterList := false
 	if len(matchedBlocks) > 0 {
 		_, afterList = matchedBlocks[len(matchedBlocks)-1].(*List)
 	}
 	if !afterList && indent > 3 {
+		return nil
+	}
+	if depth >= maxNestingDepth {
 		return nil
 	}
 
@@ -212,7 +215,7 @@ func listStart(markdown string, indent int, r Range, matchedBlocks, unmatchedBlo
 		Children:          []*ListItem{listItem},
 	}
 	ret := []Block{list, listItem}
-	if descendants := blockStartOrParagraph(markdown, indentAfterMarker-consumedIndentAfterMarker, remaining, nil, nil); descendants != nil {
+	if descendants := blockStartOrParagraph(markdown, indentAfterMarker-consumedIndentAfterMarker, remaining, nil, nil, depth+1); descendants != nil {
 		listItem.Children = append(listItem.Children, descendants[0])
 		ret = append(ret, descendants...)
 	}

--- a/server/public/shared/markdown/list_test.go
+++ b/server/public/shared/markdown/list_test.go
@@ -1,0 +1,44 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package markdown
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestListStart(t *testing.T) {
+	t.Run("depth at the nesting limit is rejected even for a well-formed list item", func(t *testing.T) {
+		markdown := "- foo"
+		blocks := listStart(markdown, 0, Range{0, len(markdown)}, nil, nil, maxNestingDepth)
+		assert.Nil(t, blocks)
+	})
+
+	t.Run("nesting from a single line is capped at maxNestingDepth", func(t *testing.T) {
+		n := maxNestingDepth + 8
+		markdown := strings.Repeat("- ", n) + "x"
+		blocks := listStart(markdown, 0, Range{0, len(markdown)}, nil, nil, 0)
+		require.NotEmpty(t, blocks)
+
+		counts := countBlocksByType(blocks)
+		assert.Equal(t, maxNestingDepth, counts["*markdown.List"])
+		assert.Equal(t, maxNestingDepth, counts["*markdown.ListItem"])
+		assert.Equal(t, 1, counts["*markdown.Paragraph"])
+		assert.IsType(t, &Paragraph{}, blocks[len(blocks)-1])
+	})
+
+	t.Run("nesting is capped relative to the depth already accrued by open ancestor blocks", func(t *testing.T) {
+		markdown := "- - - x"
+		blocks := listStart(markdown, 0, Range{0, len(markdown)}, nil, nil, maxNestingDepth-2)
+		require.NotEmpty(t, blocks)
+
+		counts := countBlocksByType(blocks)
+		assert.Equal(t, 2, counts["*markdown.List"])
+		assert.Equal(t, 2, counts["*markdown.ListItem"])
+		assert.Equal(t, 1, counts["*markdown.Paragraph"])
+	})
+}

--- a/server/public/shared/markdown/markdown.go
+++ b/server/public/shared/markdown/markdown.go
@@ -151,6 +151,9 @@ func trimBytesFromRanges(ranges []Range, bytes int) (result []Range) {
 }
 
 func Parse(markdown string) (*Document, []*ReferenceDefinition) {
+	if len(markdown) > MaxLen() {
+		return &Document{}, nil
+	}
 	lines := ParseLines(markdown)
 	return ParseBlocks(markdown, lines)
 }

--- a/server/public/shared/markdown/markdown_test.go
+++ b/server/public/shared/markdown/markdown_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package markdown
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParse(t *testing.T) {
+	t.Run("rejects input longer than maxLen bytes without parsing it", func(t *testing.T) {
+		markdown := strings.Repeat("a", MaxLen()+1)
+		document, referenceDefinitions := Parse(markdown)
+		assert.Empty(t, document.Children)
+		assert.Empty(t, referenceDefinitions)
+	})
+
+	t.Run("SetMaxPostSize raises the cap so a previously rejected input is parsed", func(t *testing.T) {
+		defer SetMaxPostRunes(defaultMaxPostRunes)
+
+		SetMaxPostRunes(defaultMaxPostRunes)
+		markdown := strings.Repeat("a", MaxLen()+1)
+
+		document, _ := Parse(markdown)
+		assert.Empty(t, document.Children)
+
+		SetMaxPostRunes(defaultMaxPostRunes + 1)
+
+		document, _ = Parse(markdown)
+		assert.NotEmpty(t, document.Children)
+	})
+
+	t.Run("nesting depth is bounded regardless of how deeply a single line nests", func(t *testing.T) {
+		// Without the depth cap in blockStart/blockQuoteStart/listStart, this would force parse
+		// work that grows with the nesting depth rather than staying bounded.
+		n := 20000
+		markdown := strings.Repeat("> ", n) + "x"
+
+		document, _ := Parse(markdown)
+		require.Len(t, document.Children, 1)
+
+		depth := 0
+		block := document.Children[0]
+		for {
+			blockQuote, ok := block.(*BlockQuote)
+			if !ok {
+				break
+			}
+			depth++
+			require.NotEmpty(t, blockQuote.Children)
+			block = blockQuote.Children[0]
+		}
+		// ParseBlocks counts the Document itself as the first ancestor, so a full parse tops out
+		// one level below the maxNestingDepth threshold used by the block-start functions directly.
+		assert.Equal(t, maxNestingDepth-1, depth)
+	})
+}


### PR DESCRIPTION
#### Summary
Cherry pick of #37388 on release-11.7.

#### Conflict Resolution Changes
- server/public/shared/markdown/inspect.go: Combined dynamic markdown length limit with release-branch reverse traversal implementation.

#### Release Note
```release-note
NONE
```