### PR TITLE
Support inline PGP public keys for plugin signature verification

### DIFF
--- a/server/channels/app/plugin_signature.go
+++ b/server/channels/app/plugin_signature.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"slices"
+	"strings"
 
 	"github.com/pkg/errors"
 	"golang.org/x/crypto/openpgp"       //nolint:staticcheck
@@ -75,9 +76,23 @@ func (a *App) DeletePublicKey(name string) *model.AppError {
 
 func (ch *Channels) verifyPlugin(logger *mlog.Logger, plugin, signature io.ReadSeeker) *model.AppError {
 	// First try verifying using the hard-coded public key.
-	if err := verifySignature(bytes.NewReader(mattermostPluginPublicKey), plugin, signature); err == nil {
-		logger.Debug("Plugin signature verified using hard-coded public key")
+	if signer, err := verifySignature(bytes.NewReader(mattermostPluginPublicKey), plugin, signature); err == nil {
+		logger.Debug("Plugin signature verified using hard-coded public key", mlog.String("signing_key", describeSigner(signer)))
 		return nil
+	}
+
+	// Then try any inline public keys.
+	if inlineKeys := ch.srv.Config().PluginSettings.SignaturePublicKeys; inlineKeys != nil && *inlineKeys != "" {
+		if _, err := plugin.Seek(0, io.SeekStart); err != nil {
+			logger.Warn("Unable to seek in plugin reader for inline signature public keys", mlog.Err(err))
+		} else if _, err := signature.Seek(0, io.SeekStart); err != nil {
+			logger.Warn("Unable to seek in signature reader for inline signature public keys", mlog.Err(err))
+		} else if signer, err := verifyWithArmoredKeyRing(*inlineKeys, plugin, signature); err == nil {
+			logger.Debug("Plugin signature verified using inline public key", mlog.String("signing_key", describeSigner(signer)))
+			return nil
+		} else {
+			logger.Warn("Unable to verify plugin signature using inline public keys", mlog.Err(err))
+		}
 	}
 
 	// If that fails, try any of the admin-configured public keys.
@@ -97,8 +112,8 @@ func (ch *Channels) verifyPlugin(logger *mlog.Logger, plugin, signature io.ReadS
 			logger.Warn("Unable to seek in signature for public key ", mlog.String("public_key_path", pk))
 			continue
 		}
-		if err := verifySignature(publicKey, plugin, signature); err == nil {
-			logger.Debug("Plugin signature verified using configured public key", mlog.String("public_key_path", pk))
+		if signer, err := verifySignature(publicKey, plugin, signature); err == nil {
+			logger.Debug("Plugin signature verified using configured public key", mlog.String("public_key_path", pk), mlog.String("signing_key", describeSigner(signer)))
 			return nil
 		}
 	}
@@ -106,27 +121,88 @@ func (ch *Channels) verifyPlugin(logger *mlog.Logger, plugin, signature io.ReadS
 	return model.NewAppError("VerifyPlugin", "api.plugin.verify_plugin.app_error", nil, "", http.StatusInternalServerError)
 }
 
-func verifySignature(publicKey, message, signature io.Reader) error {
+// describeSigner formats an entity for logging: its key ID, and any identities (name/email) it
+// claims.
+func describeSigner(entity *openpgp.Entity) string {
+	if entity == nil {
+		return "unknown"
+	}
+	names := make([]string, 0, len(entity.Identities))
+	for _, identity := range entity.Identities {
+		names = append(names, identity.Name)
+	}
+	if len(names) == 0 {
+		return entity.PrimaryKey.KeyIdString()
+	}
+	return entity.PrimaryKey.KeyIdString() + " (" + strings.Join(names, ", ") + ")"
+}
+
+func verifySignature(publicKey, message, signature io.Reader) (*openpgp.Entity, error) {
 	pk, err := decodeIfArmored(publicKey)
 	if err != nil {
-		return errors.Wrap(err, "can't decode public key")
+		return nil, errors.Wrap(err, "can't decode public key")
 	}
 	s, err := decodeIfArmored(signature)
 	if err != nil {
-		return errors.Wrap(err, "can't decode signature")
+		return nil, errors.Wrap(err, "can't decode signature")
 	}
 	return verifyBinarySignature(pk, message, s)
 }
 
-func verifyBinarySignature(publicKey, signedFile, signature io.Reader) error {
+// pgpPublicKeyBlockEnd marks the end of one ASCII-armored PGP public key block. Unlike
+// openpgp.ReadArmoredKeyRing, which decodes a single armor envelope whose body may itself pack
+// several keys, verifyWithArmoredKeyRing accepts several such envelopes concatenated as plain
+// text, splitting on this marker to decode and merge them independently.
+const pgpPublicKeyBlockEnd = "-----END PGP PUBLIC KEY BLOCK-----"
+
+// verifyWithArmoredKeyRing verifies a signature against one or more concatenated ASCII-armored
+// PGP public keys, unlike verifySignature which reads a single key.
+func verifyWithArmoredKeyRing(armoredKeys string, message, signature io.Reader) (*openpgp.Entity, error) {
+	var keyring openpgp.EntityList
+	for remaining := armoredKeys; strings.TrimSpace(remaining) != ""; {
+		end := strings.Index(remaining, pgpPublicKeyBlockEnd)
+		if end == -1 {
+			return nil, errors.New("armored public key ring has a block missing its closing marker")
+		}
+		end += len(pgpPublicKeyBlockEnd)
+
+		block, err := armor.Decode(strings.NewReader(remaining[:end]))
+		if err != nil {
+			return nil, errors.Wrap(err, "can't decode armored public key block")
+		}
+		entities, err := openpgp.ReadKeyRing(block.Body)
+		if err != nil {
+			return nil, errors.Wrap(err, "can't read public key block")
+		}
+		keyring = append(keyring, entities...)
+
+		remaining = remaining[end:]
+	}
+	if len(keyring) == 0 {
+		return nil, errors.New("no public keys found in configured key ring")
+	}
+
+	s, err := decodeIfArmored(signature)
+	if err != nil {
+		return nil, errors.Wrap(err, "can't decode signature")
+	}
+	signer, err := openpgp.CheckDetachedSignature(keyring, message, s)
+	if err != nil {
+		return nil, errors.Wrap(err, "error while checking the signature")
+	}
+	return signer, nil
+}
+
+func verifyBinarySignature(publicKey, signedFile, signature io.Reader) (*openpgp.Entity, error) {
 	keyring, err := openpgp.ReadKeyRing(publicKey)
 	if err != nil {
-		return errors.Wrap(err, "can't read public key")
+		return nil, errors.Wrap(err, "can't read public key")
 	}
-	if _, err = openpgp.CheckDetachedSignature(keyring, signedFile, signature); err != nil {
-		return errors.Wrap(err, "error while checking the signature")
+	signer, err := openpgp.CheckDetachedSignature(keyring, signedFile, signature)
+	if err != nil {
+		return nil, errors.Wrap(err, "error while checking the signature")
 	}
-	return nil
+	return signer, nil
 }
 
 func decodeIfArmored(reader io.Reader) (io.Reader, error) {

--- a/server/channels/app/plugin_signature_test.go
+++ b/server/channels/app/plugin_signature_test.go
@@ -4,12 +4,17 @@
 package app
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/crypto/openpgp"        //nolint:staticcheck
+	"golang.org/x/crypto/openpgp/armor"  //nolint:staticcheck
+	"golang.org/x/crypto/openpgp/packet" //nolint:staticcheck
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
@@ -63,6 +68,218 @@ func TestPluginPublicKeys(t *testing.T) {
 	require.NotNil(t, appErr)
 }
 
+// generateArmoredPublicKey returns a freshly generated, well-formed but unrelated ASCII-armored
+// public key, standing in for a second administrator-configured key that doesn't match the
+// signature under test.
+func generateArmoredPublicKey(t *testing.T) string {
+	t.Helper()
+	entity, err := openpgp.NewEntity("decoy", "", "decoy@example.com", &packet.Config{RSABits: 1024})
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	armorWriter, err := armor.Encode(&buf, openpgp.PublicKeyType, nil)
+	require.NoError(t, err)
+	require.NoError(t, entity.Serialize(armorWriter))
+	require.NoError(t, armorWriter.Close())
+
+	return buf.String()
+}
+
+// combineIntoSingleArmorEnvelope re-packs several armored public keys into one armor envelope
+// whose body carries all of their binary packets, matching what `gpg --export --armor key1 key2`
+// produces -- as opposed to simply concatenating each key's own separate envelope as text.
+func combineIntoSingleArmorEnvelope(t *testing.T, armoredKeys ...string) string {
+	t.Helper()
+	var buf bytes.Buffer
+	armorWriter, err := armor.Encode(&buf, openpgp.PublicKeyType, nil)
+	require.NoError(t, err)
+
+	for _, armoredKey := range armoredKeys {
+		block, err := armor.Decode(strings.NewReader(armoredKey))
+		require.NoError(t, err)
+		entities, err := openpgp.ReadKeyRing(block.Body)
+		require.NoError(t, err)
+		for _, entity := range entities {
+			require.NoError(t, entity.Serialize(armorWriter))
+		}
+	}
+	require.NoError(t, armorWriter.Close())
+
+	return buf.String()
+}
+
+func TestVerifyWithArmoredKeyRing(t *testing.T) {
+	mainHelper.Parallel(t)
+	path, _ := fileutils.FindDir("tests")
+
+	developmentKey, err := os.ReadFile(filepath.Join(path, "development-public-key.asc"))
+	require.NoError(t, err)
+	decoyKey := generateArmoredPublicKey(t)
+
+	openPlugin := func(t *testing.T) (*os.File, *os.File) {
+		t.Helper()
+		pluginFile, err := os.Open(filepath.Join(path, "testplugin.tar.gz"))
+		require.NoError(t, err)
+		t.Cleanup(func() { pluginFile.Close() })
+		signatureFile, err := os.Open(filepath.Join(path, "testplugin.tar.gz.sig"))
+		require.NoError(t, err)
+		t.Cleanup(func() { signatureFile.Close() })
+		return pluginFile, signatureFile
+	}
+
+	t.Run("verifies against a single inline key", func(t *testing.T) {
+		pluginFile, signatureFile := openPlugin(t)
+		signer, err := verifyWithArmoredKeyRing(string(developmentKey), pluginFile, signatureFile)
+		require.NoError(t, err)
+		require.NotNil(t, signer)
+	})
+
+	t.Run("verifies against the matching key in a multi-key ring", func(t *testing.T) {
+		pluginFile, signatureFile := openPlugin(t)
+		keyRing := decoyKey + string(developmentKey)
+		signer, err := verifyWithArmoredKeyRing(keyRing, pluginFile, signatureFile)
+		require.NoError(t, err)
+		require.NotNil(t, signer)
+	})
+
+	t.Run("verifies against a key packed alongside others in a single armor envelope", func(t *testing.T) {
+		// Unlike the concatenated-envelopes case above, gpg's own `--export key1 key2` produces
+		// one envelope whose body packs every key's binary data together.
+		keyRing := combineIntoSingleArmorEnvelope(t, decoyKey, string(developmentKey))
+		require.Equal(t, 1, strings.Count(keyRing, "-----BEGIN PGP PUBLIC KEY BLOCK-----"),
+			"the combined export should be a single envelope, not several concatenated ones")
+
+		pluginFile, signatureFile := openPlugin(t)
+		signer, err := verifyWithArmoredKeyRing(keyRing, pluginFile, signatureFile)
+		require.NoError(t, err)
+		require.NotNil(t, signer)
+	})
+
+	t.Run("fails when no key in the ring matches", func(t *testing.T) {
+		pluginFile, signatureFile := openPlugin(t)
+		_, err := verifyWithArmoredKeyRing(decoyKey, pluginFile, signatureFile)
+		require.Error(t, err)
+	})
+
+	t.Run("fails on malformed key material", func(t *testing.T) {
+		pluginFile, signatureFile := openPlugin(t)
+		_, err := verifyWithArmoredKeyRing("not a key", pluginFile, signatureFile)
+		require.Error(t, err)
+	})
+}
+
+func TestVerifyPluginWithInlineSignaturePublicKeys(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t)
+
+	path, _ := fileutils.FindDir("tests")
+	ch := th.App.Channels()
+	logger := th.App.Srv().Log()
+
+	developmentKey, err := os.ReadFile(filepath.Join(path, "development-public-key.asc"))
+	require.NoError(t, err)
+
+	// testplugin.tar.gz is signed with the development key rather than the hard-coded Mattermost
+	// one, so it verifies only once that key is reachable.
+	openPlugin := func(t *testing.T) (*os.File, *os.File) {
+		t.Helper()
+		pluginFile, err := os.Open(filepath.Join(path, "testplugin.tar.gz"))
+		require.NoError(t, err)
+		t.Cleanup(func() { pluginFile.Close() })
+		signatureFile, err := os.Open(filepath.Join(path, "testplugin.tar.gz.sig"))
+		require.NoError(t, err)
+		t.Cleanup(func() { signatureFile.Close() })
+		return pluginFile, signatureFile
+	}
+
+	t.Run("fails before the key is configured", func(t *testing.T) {
+		pluginFile, signatureFile := openPlugin(t)
+		require.NotNil(t, ch.verifyPlugin(logger, pluginFile, signatureFile))
+	})
+
+	t.Run("verifies with a key supplied inline", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			keys := string(developmentKey)
+			cfg.PluginSettings.SignaturePublicKeys = &keys
+		})
+		t.Cleanup(func() {
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				empty := ""
+				cfg.PluginSettings.SignaturePublicKeys = &empty
+			})
+		})
+
+		pluginFile, signatureFile := openPlugin(t)
+		require.Nil(t, ch.verifyPlugin(logger, pluginFile, signatureFile))
+	})
+}
+
+// TestVerifyPluginWithSignaturePublicKeysFromEnvironment proves the key material can be supplied
+// by a genuine environment variable rather than patched directly into the in-memory config, and
+// that its newlines survive that round trip intact for both a single key and several concatenated
+// keys.
+func TestVerifyPluginWithSignaturePublicKeysFromEnvironment(t *testing.T) {
+	// t.Setenv prevents t.Parallel — env var has no config equivalent
+	th := Setup(t)
+
+	path, _ := fileutils.FindDir("tests")
+	ch := th.App.Channels()
+	logger := th.App.Srv().Log()
+
+	developmentKey, err := os.ReadFile(filepath.Join(path, "development-public-key.asc"))
+	require.NoError(t, err)
+	decoyKey := generateArmoredPublicKey(t)
+
+	// testplugin.tar.gz is signed with the development key rather than the hard-coded Mattermost
+	// one, so it verifies only once that key is reachable.
+	openPlugin := func(t *testing.T) (*os.File, *os.File) {
+		t.Helper()
+		pluginFile, err := os.Open(filepath.Join(path, "testplugin.tar.gz"))
+		require.NoError(t, err)
+		t.Cleanup(func() { pluginFile.Close() })
+		signatureFile, err := os.Open(filepath.Join(path, "testplugin.tar.gz.sig"))
+		require.NoError(t, err)
+		t.Cleanup(func() { signatureFile.Close() })
+		return pluginFile, signatureFile
+	}
+
+	t.Run("fails before any environment variable is set", func(t *testing.T) {
+		pluginFile, signatureFile := openPlugin(t)
+		require.NotNil(t, ch.verifyPlugin(logger, pluginFile, signatureFile))
+	})
+
+	t.Run("verifies with a single key set via environment variable", func(t *testing.T) {
+		t.Setenv("MM_PLUGINSETTINGS_SIGNATUREPUBLICKEYS", string(developmentKey))
+		require.NoError(t, th.App.ReloadConfig())
+
+		require.Equal(t, string(developmentKey), *th.App.Config().PluginSettings.SignaturePublicKeys,
+			"the key must reach config with its newlines intact")
+
+		pluginFile, signatureFile := openPlugin(t)
+		require.Nil(t, ch.verifyPlugin(logger, pluginFile, signatureFile))
+	})
+
+	t.Run("verifies with multiple keys concatenated in one environment variable", func(t *testing.T) {
+		keys := decoyKey + string(developmentKey)
+		t.Setenv("MM_PLUGINSETTINGS_SIGNATUREPUBLICKEYS", keys)
+		require.NoError(t, th.App.ReloadConfig())
+
+		require.Equal(t, keys, *th.App.Config().PluginSettings.SignaturePublicKeys,
+			"both concatenated keys, and the newlines between them, must reach config intact")
+
+		pluginFile, signatureFile := openPlugin(t)
+		require.Nil(t, ch.verifyPlugin(logger, pluginFile, signatureFile))
+	})
+
+	t.Run("fails when the environment variable holds only an unrelated key", func(t *testing.T) {
+		t.Setenv("MM_PLUGINSETTINGS_SIGNATUREPUBLICKEYS", decoyKey)
+		require.NoError(t, th.App.ReloadConfig())
+
+		pluginFile, signatureFile := openPlugin(t)
+		require.NotNil(t, ch.verifyPlugin(logger, pluginFile, signatureFile))
+	})
+}
+
 func TestVerifySignature(t *testing.T) {
 	mainHelper.Parallel(t)
 	path, _ := fileutils.FindDir("tests")
@@ -81,7 +298,8 @@ func TestVerifySignature(t *testing.T) {
 		signatureFileReader, err := os.Open(filepath.Join(path, armoredSignatureFilename))
 		require.NoError(t, err)
 		defer signatureFileReader.Close()
-		require.NoError(t, verifySignature(publicKeyFileReader, pluginFileReader, signatureFileReader))
+		_, err = verifySignature(publicKeyFileReader, pluginFileReader, signatureFileReader)
+		require.NoError(t, err)
 	})
 	t.Run("verify non armored signature and armored public key", func(t *testing.T) {
 		publicKeyFileReader, err := os.Open(filepath.Join(path, armoredPublicKeyFilename))
@@ -93,7 +311,8 @@ func TestVerifySignature(t *testing.T) {
 		signatureFileReader, err := os.Open(filepath.Join(path, signatureFilename))
 		require.NoError(t, err)
 		defer signatureFileReader.Close()
-		require.NoError(t, verifySignature(publicKeyFileReader, pluginFileReader, signatureFileReader))
+		_, err = verifySignature(publicKeyFileReader, pluginFileReader, signatureFileReader)
+		require.NoError(t, err)
 	})
 	t.Run("verify armored signature and non armored public key", func(t *testing.T) {
 		publicKeyFileReader, err := os.Open(filepath.Join(path, publicKeyFilename))
@@ -105,7 +324,8 @@ func TestVerifySignature(t *testing.T) {
 		armoredSignatureFileReader, err := os.Open(filepath.Join(path, armoredSignatureFilename))
 		require.NoError(t, err)
 		defer armoredSignatureFileReader.Close()
-		require.NoError(t, verifySignature(publicKeyFileReader, pluginFileReader, armoredSignatureFileReader))
+		_, err = verifySignature(publicKeyFileReader, pluginFileReader, armoredSignatureFileReader)
+		require.NoError(t, err)
 	})
 	t.Run("verify non armored signature and non armored public key", func(t *testing.T) {
 		publicKeyFileReader, err := os.Open(filepath.Join(path, publicKeyFilename))
@@ -117,6 +337,7 @@ func TestVerifySignature(t *testing.T) {
 		signatureFileReader, err := os.Open(filepath.Join(path, signatureFilename))
 		require.NoError(t, err)
 		defer signatureFileReader.Close()
-		require.NoError(t, verifySignature(publicKeyFileReader, pluginFileReader, signatureFileReader))
+		_, err = verifySignature(publicKeyFileReader, pluginFileReader, signatureFileReader)
+		require.NoError(t, err)
 	})
 }

--- a/server/config/file_test.go
+++ b/server/config/file_test.go
@@ -450,6 +450,65 @@ func TestFileStoreGetEnvironmentOverrides(t *testing.T) {
 		assert.Equal(t, []string{"user:pwd@db:5432/test-db", "user:pwd@db2:5433/test-db2", "user:pwd@db3:5434/test-db3"}, fs.Get().SqlSettings.DataSourceReplicas)
 		assert.Equal(t, map[string]any{"SqlSettings": map[string]any{"DataSourceReplicas": true}}, fs.GetEnvironmentOverrides())
 	})
+
+	t.Run("get override for a multi-line string variable - single key", func(t *testing.T) {
+		path, tearDown := setupConfigFile(t, testConfig)
+		defer tearDown()
+
+		fsInner, err := NewFileStore(path, false)
+		require.NoError(t, err)
+		fs, err := NewStoreFromBacking(fsInner, nil, false)
+		require.NoError(t, err)
+		defer fs.Close()
+
+		assert.Equal(t, "", *fs.Get().PluginSettings.SignaturePublicKeys)
+		assert.Empty(t, fs.GetEnvironmentOverrides())
+
+		// Unlike DataSourceReplicas above, this value must survive verbatim: PGP-armored key
+		// blocks are multi-line and their header/footer lines contain spaces, so a plain
+		// whitespace-based slice split would corrupt them.
+		key := "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQENBFake==\n-----END PGP PUBLIC KEY BLOCK-----\n"
+		os.Setenv("MM_PLUGINSETTINGS_SIGNATUREPUBLICKEYS", key)
+		defer os.Unsetenv("MM_PLUGINSETTINGS_SIGNATUREPUBLICKEYS")
+
+		fsInner, err = NewFileStore(path, false)
+		require.NoError(t, err)
+		fs, err = NewStoreFromBacking(fsInner, nil, false)
+		require.NoError(t, err)
+		defer fs.Close()
+
+		assert.Equal(t, key, *fs.Get().PluginSettings.SignaturePublicKeys)
+		assert.Equal(t, map[string]any{"PluginSettings": map[string]any{"SignaturePublicKeys": true}}, fs.GetEnvironmentOverrides())
+	})
+
+	t.Run("get override for a multi-line string variable - multiple concatenated keys", func(t *testing.T) {
+		path, tearDown := setupConfigFile(t, testConfig)
+		defer tearDown()
+
+		fsInner, err := NewFileStore(path, false)
+		require.NoError(t, err)
+		fs, err := NewStoreFromBacking(fsInner, nil, false)
+		require.NoError(t, err)
+		defer fs.Close()
+
+		assert.Equal(t, "", *fs.Get().PluginSettings.SignaturePublicKeys)
+		assert.Empty(t, fs.GetEnvironmentOverrides())
+
+		firstKey := "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQENBFakeOne==\n-----END PGP PUBLIC KEY BLOCK-----\n"
+		secondKey := "-----BEGIN PGP PUBLIC KEY BLOCK-----\n\nmQENBFakeTwo==\n-----END PGP PUBLIC KEY BLOCK-----\n"
+		keys := firstKey + secondKey
+		os.Setenv("MM_PLUGINSETTINGS_SIGNATUREPUBLICKEYS", keys)
+		defer os.Unsetenv("MM_PLUGINSETTINGS_SIGNATUREPUBLICKEYS")
+
+		fsInner, err = NewFileStore(path, false)
+		require.NoError(t, err)
+		fs, err = NewStoreFromBacking(fsInner, nil, false)
+		require.NoError(t, err)
+		defer fs.Close()
+
+		assert.Equal(t, keys, *fs.Get().PluginSettings.SignaturePublicKeys)
+		assert.Equal(t, map[string]any{"PluginSettings": map[string]any{"SignaturePublicKeys": true}}, fs.GetEnvironmentOverrides())
+	})
 }
 
 func TestFileStoreSet(t *testing.T) {

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -3646,7 +3646,9 @@ type PluginSettings struct {
 	RequirePluginSignature      *bool                     `access:"plugins,write_restrictable,cloud_restrictable"`
 	MarketplaceURL              *string                   `access:"plugins,write_restrictable,cloud_restrictable"`
 	SignaturePublicKeyFiles     []string                  `access:"plugins,write_restrictable,cloud_restrictable"`
-	ChimeraOAuthProxyURL        *string                   `access:"plugins,write_restrictable,cloud_restrictable"`
+	// SignaturePublicKeys holds one or more armored PGP public keys, concatenated.
+	SignaturePublicKeys  *string `access:"plugins,write_restrictable,cloud_restrictable"` // telemetry: none
+	ChimeraOAuthProxyURL *string `access:"plugins,write_restrictable,cloud_restrictable"`
 }
 
 func (s *PluginSettings) SetDefaults(ls LogSettings) {
@@ -3724,6 +3726,10 @@ func (s *PluginSettings) SetDefaults(ls LogSettings) {
 
 	if s.SignaturePublicKeyFiles == nil {
 		s.SignaturePublicKeyFiles = []string{}
+	}
+
+	if s.SignaturePublicKeys == nil {
+		s.SignaturePublicKeys = new("")
 	}
 
 	if s.ChimeraOAuthProxyURL == nil {


### PR DESCRIPTION
#### Summary

Adds `PluginSettings.SignaturePublicKeys`, a config field that holds one or more concatenated ASCII-armored PGP public keys directly, rather than only names resolved through the configuration store. `verifyPlugin` tries these inline keys during signature verification, alongside the existing hard-coded key and `SignaturePublicKeyFiles`.

This gives a database-backed configuration a way to trust a custom signing key without touching the filesystem or the database at verification time: `config.json`, the config API, and `MM_PLUGINSETTINGS_SIGNATUREPUBLICKEYS` (an environment variable override) all work through the same field, since the value is the key material itself rather than a name that still needs resolving.

This is an alternative to #37780, which solves the same underlying problem (a database-backed deployment needing to trust its own prepackaged-plugin signing key before boot) by having `getPublicKey` fall back to reading an absolute `SignaturePublicKeyFiles` path from disk. That fallback re-opens, for database-backed configs, the filesystem-trust gap that #31785 deliberately closed when it made prepackaged-plugin verification unconditional: an attacker able to plant a rogue prepackaged plugin could also plant a matching key file at the configured path. This PR never touches `getPublicKey`/`GetConfigFile` — verification of a database-backed config still never consults the filesystem.

Also logs which key (key ID and identity) verified a given plugin's signature, across all three verification tiers.

**Details:**
- A single key or several concatenated keys both work; a single `gpg --export key1 key2 --armor`-style multi-key envelope also works transparently, not just naive concatenation of separate exports (covered by test).
- Newlines survive the environment-variable round trip verbatim (covered by test) — config's generic slice-override parsing (whitespace-split) would have corrupted multi-line PGP blocks, so this is a `*string` field, not `[]string`.

**QA:**
1. Sign a plugin with a non-Mattermost key.
2. Start the server with a database-backed configuration, `PluginSettings.SignaturePublicKeys` empty — upload or prepackaged verification against that key fails.
3. Set `MM_PLUGINSETTINGS_SIGNATUREPUBLICKEYS` to the armored public key (or set `PluginSettings.SignaturePublicKeys` via `config.json`) and restart — it verifies.

#### Release Note
```release-note
Added PluginSettings.SignaturePublicKeys, allowing one or more PGP public keys to be trusted for plugin signature verification directly, without a corresponding file in PluginSettings.SignaturePublicKeyFiles.
Added ``PluginSettings.SignaturePublicKeys`` configuration setting.
```