### PR TITLE
Autolink gemini:// URLs in messages

### DIFF
--- a/server/public/shared/markdown/autolink.go
+++ b/server/public/shared/markdown/autolink.go
@@ -13,7 +13,7 @@ import (
 // Based off of extensions/autolink.c from https://github.com/github/cmark
 
 var (
-	DefaultURLSchemes = []string{"http", "https", "ftp", "mailto", "tel"}
+	DefaultURLSchemes = []string{"http", "https", "ftp", "mailto", "tel", "gemini"}
 	wwwAutoLinkRegex  = regexp.MustCompile(`^www\d{0,3}\.`)
 )
 

--- a/server/public/shared/markdown/autolink_test.go
+++ b/server/public/shared/markdown/autolink_test.go
@@ -49,6 +49,12 @@ func TestParseURLAutolink(t *testing.T) {
 			Expected:    "ftp://example.com",
 		},
 		{
+			Description: "link with gemini",
+			Input:       "gemini://example.com and some text",
+			Position:    6,
+			Expected:    "gemini://example.com",
+		},
+		{
 			Description: "link with a path",
 			Input:       "https://example.com/abcd and some text",
 			Position:    5,
@@ -851,6 +857,10 @@ func TestAutolinking(t *testing.T) {
 		"valid-link-3": {
 			Markdown:     `ftp://example.com`,
 			ExpectedHTML: `<p><a href="ftp://example.com">ftp://example.com</a></p>`,
+		},
+		"valid-link-3b": {
+			Markdown:     `gemini://example.com`,
+			ExpectedHTML: `<p><a href="gemini://example.com">gemini://example.com</a></p>`,
 		},
 		// "valid-link-4": {
 		// 	Markdown:     `ts3server://example.com?port=9000`,

--- a/webapp/channels/src/packages/mattermost-redux/src/constants/general.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/constants/general.ts
@@ -69,7 +69,7 @@ export default {
     MIN_USERS_IN_GM: 3,
     MAX_GROUP_CHANNELS_FOR_PROFILES: 50,
     DEFAULT_LOCALE: 'en',
-    DEFAULT_AUTOLINKED_URL_SCHEMES: ['http', 'https', 'ftp', 'mailto', 'tel', 'mattermost'],
+    DEFAULT_AUTOLINKED_URL_SCHEMES: ['http', 'https', 'ftp', 'mailto', 'tel', 'gemini', 'mattermost'],
     DISABLED: 'disabled',
     DEFAULT_ON: 'default_on',
     DEFAULT_OFF: 'default_off',

--- a/webapp/channels/src/utils/text_formatting_links.test.ts
+++ b/webapp/channels/src/utils/text_formatting_links.test.ts
@@ -423,6 +423,8 @@ describe('Markdown.Links', () => {
 
             expect(Markdown.format('mailto:test@example.com').trim()).toBe(`<p>${link('mailto:test@example.com')}</p>`);
 
+            expect(Markdown.format('gemini://example.com').trim()).toBe(`<p>${link('gemini://example.com')}</p>`);
+
             // These aren't linked since they're not configured on the server
             expect(Markdown.format('git://git.example.com').trim()).toBe('<p>git://git.example.com</p>');
 


### PR DESCRIPTION
#### Summary

`gemini://` URLs were rendered as plain text instead of clickable links in messages. Added `gemini` to the default autolinked URL schemes in both the server-side markdown renderer and the webapp, with test coverage for both.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/37803

#### Release Note

```release-note
Added `gemini` to the default autolinked URL schemes so `gemini://` links are now clickable.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change adds one URL scheme to existing server and webapp autolink lists. Tests cover server-side and webapp autolinking, with no impact on high-risk flows.

**QA Recommendation:** Manual QA can be skipped because automated tests provide full coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->