### PR TITLE
Preserve icon_emoji on post action updates

### DIFF
--- a/server/channels/app/integration_action_test.go
+++ b/server/channels/app/integration_action_test.go
@@ -685,9 +685,10 @@ func TestPostActionProps(t *testing.T) {
 					},
 				},
 			},
-			model.PostPropsOverrideIconURL: "old_override_icon",
-			model.PostPropsFromWebhook:     "false",
-			"B":                            "BB",
+			model.PostPropsOverrideIconURL:   "old_override_icon",
+			model.PostPropsOverrideIconEmoji: "old_override_emoji",
+			model.PostPropsFromWebhook:       "false",
+			"B":                              "BB",
 		},
 	}
 
@@ -709,6 +710,7 @@ func TestPostActionProps(t *testing.T) {
 	assert.Nil(t, newPost.GetProp(model.PostPropsOverrideUsername))
 	assert.Equal(t, "AA", newPost.GetProp("A"))
 	assert.Equal(t, "old_override_icon", newPost.GetProp(model.PostPropsOverrideIconURL))
+	assert.Equal(t, "old_override_emoji", newPost.GetProp(model.PostPropsOverrideIconEmoji))
 	// from_webhook is NOT in the default SanitizeProps strip list under hardened-OFF (v11) — it
 	// remains user-settable for backward compatibility with the user-PAT-impersonation idiom.
 	// The client-supplied value survives sanitization. PostActionRetainPropKeys includes

--- a/server/public/model/integration_action.go
+++ b/server/public/model/integration_action.go
@@ -70,6 +70,7 @@ var PostActionRetainPropKeys = []string{
 	PostPropsFromPlugin,
 	PostPropsOverrideUsername,
 	PostPropsOverrideIconURL,
+	PostPropsOverrideIconEmoji,
 }
 
 // PostActionPreserve captures post fields preserved across an interactive action update.

--- a/server/public/model/integration_action_test.go
+++ b/server/public/model/integration_action_test.go
@@ -1690,6 +1690,7 @@ func TestPost_PostActionPreserveState(t *testing.T) {
 		assert.Equal(t, "true", state.Retain[PostPropsFromWebhook])
 		assert.Contains(t, state.Remove, PostPropsOverrideUsername)
 		assert.Contains(t, state.Remove, PostPropsOverrideIconURL)
+		assert.Contains(t, state.Remove, PostPropsOverrideIconEmoji)
 		assert.Equal(t, "true", state.OriginalProps[PostPropsFromWebhook])
 		assert.Equal(t, "x", state.OriginalProps["other"])
 		assert.True(t, state.OriginalIsPinned)


### PR DESCRIPTION
#### Summary

`icon_emoji` from an incoming webhook was lost when a message action returned an `update` response that included props (e.g. `props.attachments`). The avatar reverted to the default incoming webhook one.

The root cause: `PostActionRetainPropKeys` preserved `override_username` and `override_icon_url` across action updates but was missing `override_icon_emoji`, so the emoji avatar prop was silently dropped whenever an action update rewrote the post props.

Added `PostPropsOverrideIconEmoji` to `PostActionRetainPropKeys`, which fixes both the post-based and cookie-based action flows (all three consumers of the list). Extended `TestPostActionProps` with an `override_icon_emoji` regression assertion, plus coverage in `TestPost_PostActionPreserveState`.

This is the action-update counterpart to the #31026 fix (which covered webhook post creation).

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/37792

#### Release Note

```release-note
Fixed an issue where a post's `icon_emoji` was not preserved when an interactive message action returned an update response.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change updates a shared retention-key list used by interactive action updates. Regression risk is low because targeted automated tests cover post-based and cookie-based action flows.

**QA Recommendation:** Skip manual QA. Automated test coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->