### PR TITLE
MM-69974: keep focus in the WYSIWYG composer and stop the Enter crash

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/wysiwyg_editor/wysiwyg_editor.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/wysiwyg_editor/wysiwyg_editor.test.tsx
@@ -14,6 +14,7 @@ const mockConstructorError: {current: Error | null} = {current: null};
 
 const mockChainCalls: {current: string[]} = {current: []};
 const mockSetNodeThrows: {current: boolean} = {current: false};
+const mockRunReturnsFalse: {current: boolean} = {current: false};
 
 jest.mock('@tiptap/react', () => {
     const ReactMock = require('react') as typeof import('react');
@@ -48,7 +49,7 @@ jest.mock('@tiptap/react', () => {
                         setNode: link('setNode'),
                         run: () => {
                             mockChainCalls.current.push('run');
-                            return true;
+                            return !mockRunReturnsFalse.current;
                         },
                     };
                     return chainStub;
@@ -98,6 +99,7 @@ describe('WysiwygEditor', () => {
         mockConstructorError.current = null;
         mockChainCalls.current = [];
         mockSetNodeThrows.current = false;
+        mockRunReturnsFalse.current = false;
         jest.clearAllMocks();
     });
 
@@ -532,6 +534,15 @@ describe('WysiwygEditor', () => {
                 'focus', 'splitBlock', 'setNode',
                 'focus', 'splitBlock', 'run',
             ]);
+        });
+
+        test('does not split a second time when run() reports failure', () => {
+            mockRunReturnsFalse.current = true;
+
+            const {handled} = pressEnter();
+
+            expect(handled).toBe(true);
+            expect(mockChainCalls.current).toEqual(['focus', 'splitBlock', 'setNode', 'run']);
         });
     });
 });

--- a/webapp/channels/src/components/advanced_text_editor/wysiwyg_editor/wysiwyg_editor.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/wysiwyg_editor/wysiwyg_editor.test.tsx
@@ -12,6 +12,9 @@ const mockCapturedConfig: {current: any} = {current: null};
 // matching Tiptap's render-phase emit.
 const mockConstructorError: {current: Error | null} = {current: null};
 
+const mockChainCalls: {current: string[]} = {current: []};
+const mockSetNodeThrows: {current: boolean} = {current: false};
+
 jest.mock('@tiptap/react', () => {
     const ReactMock = require('react') as typeof import('react');
     return {
@@ -30,6 +33,26 @@ jest.mock('@tiptap/react', () => {
                 setEditable: () => undefined,
                 getJSON: () => ({type: 'doc', content: [{type: 'paragraph', content: [{type: 'text', text: 'hi'}]}]}),
                 view: {dom: globalThis.document.createElement('div')},
+
+                chain: () => {
+                    const link = (name: string) => () => {
+                        mockChainCalls.current.push(name);
+                        if (name === 'setNode' && mockSetNodeThrows.current) {
+                            throw new RangeError('Invalid content for node type paragraph');
+                        }
+                        return chainStub;
+                    };
+                    const chainStub: any = {
+                        focus: link('focus'),
+                        splitBlock: link('splitBlock'),
+                        setNode: link('setNode'),
+                        run: () => {
+                            mockChainCalls.current.push('run');
+                            return true;
+                        },
+                    };
+                    return chainStub;
+                },
             };
 
             // Mirrors the real library: getMarkdown is attached by the Markdown
@@ -73,6 +96,8 @@ describe('WysiwygEditor', () => {
     beforeEach(() => {
         mockCapturedConfig.current = null;
         mockConstructorError.current = null;
+        mockChainCalls.current = [];
+        mockSetNodeThrows.current = false;
         jest.clearAllMocks();
     });
 
@@ -450,5 +475,63 @@ describe('WysiwygEditor', () => {
         );
 
         expect(ref.current!.hasContentError()).toBe(false);
+    });
+
+    describe('Enter inside a heading', () => {
+        const headingView = () => ({
+            state: {
+                selection: {
+                    $from: {
+                        depth: 1,
+                        node: () => ({type: {name: 'heading'}}),
+                    },
+                },
+                schema: {nodes: {listItem: {}}},
+            },
+            dom: globalThis.document.createElement('div'),
+            dispatch: jest.fn(),
+        });
+
+        const enterEvent = () => ({
+            key: 'Enter',
+            shiftKey: false,
+            metaKey: false,
+            ctrlKey: false,
+            altKey: false,
+            preventDefault: jest.fn(),
+        });
+
+        const pressEnter = () => {
+            renderWithContext(<WysiwygEditor {...baseProps}/>);
+
+            const event = enterEvent();
+            const handled = mockCapturedConfig.current.editorProps.handleKeyDown(
+                headingView() as any,
+                event as unknown as KeyboardEvent,
+            );
+
+            return {handled, event};
+        };
+
+        test('exits the heading into a paragraph', () => {
+            const {handled, event} = pressEnter();
+
+            expect(handled).toBe(true);
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(mockChainCalls.current).toEqual(['focus', 'splitBlock', 'setNode', 'run']);
+        });
+
+        test('falls back to a plain split when the paragraph conversion throws', () => {
+            mockSetNodeThrows.current = true;
+
+            const {handled, event} = pressEnter();
+
+            expect(handled).toBe(true);
+            expect(event.preventDefault).toHaveBeenCalled();
+            expect(mockChainCalls.current).toEqual([
+                'focus', 'splitBlock', 'setNode',
+                'focus', 'splitBlock', 'run',
+            ]);
+        });
     });
 });

--- a/webapp/channels/src/components/advanced_text_editor/wysiwyg_editor/wysiwyg_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/wysiwyg_editor/wysiwyg_editor.tsx
@@ -387,7 +387,12 @@ const WysiwygEditor = forwardRef<WysiwygEditorHandle, Props>(({
                     const ed = editorRef.current;
                     if (ed && !ed.isDestroyed) {
                         event.preventDefault();
-                        ed.chain().focus().splitBlock().setNode('paragraph').run();
+
+                        try {
+                            ed.chain().focus().splitBlock().setNode('paragraph').run();
+                        } catch {
+                            ed.chain().focus().splitBlock().run();
+                        }
                         return true;
                     }
                 }

--- a/webapp/channels/src/utils/post_utils.test.tsx
+++ b/webapp/channels/src/utils/post_utils.test.tsx
@@ -475,9 +475,26 @@ describe('PostUtils.shouldFocusMainTextbox', () => {
                 expected: false,
             },
         ]) {
-            const shouldFocus = PostUtils.shouldFocusMainTextbox(data.event as unknown as KeyboardEvent, data.activeElement as unknown as Element);
+            const activeElement = data.activeElement ? document.createElement(data.activeElement.tagName) : null;
+            const shouldFocus = PostUtils.shouldFocusMainTextbox(data.event as unknown as KeyboardEvent, activeElement);
             expect(shouldFocus).toEqual(data.expected);
         }
+    });
+
+    test('does not steal focus from a rich text editor', () => {
+        const event = {key: 'a'} as unknown as KeyboardEvent;
+
+        const editor = document.createElement('div');
+        editor.setAttribute('contenteditable', 'true');
+        const paragraph = document.createElement('p');
+        editor.appendChild(paragraph);
+
+        expect(PostUtils.shouldFocusMainTextbox(event, editor)).toBe(false);
+        expect(PostUtils.shouldFocusMainTextbox(event, paragraph)).toBe(false);
+
+        const readOnly = document.createElement('div');
+        readOnly.setAttribute('contenteditable', 'false');
+        expect(PostUtils.shouldFocusMainTextbox(event, readOnly)).toBe(true);
     });
 });
 

--- a/webapp/channels/src/utils/post_utils.ts
+++ b/webapp/channels/src/utils/post_utils.ts
@@ -248,9 +248,13 @@ export function shouldFocusMainTextbox(e: React.KeyboardEvent | KeyboardEvent, a
         return false;
     }
 
-    // Do not focus if we're currently focused on a textarea or input
+    // Do not focus if we're currently focused on a textarea, an input, or a
+    // rich text editor
     const keepFocusTags = ['TEXTAREA', 'INPUT'];
     if (!activeElement || keepFocusTags.includes(activeElement.tagName)) {
+        return false;
+    }
+    if (activeElement.closest('[contenteditable="true"]')) {
         return false;
     }
 


### PR DESCRIPTION

#### Summary

Two bugs with the same root cause tthat core assumes the message composer is a `<textarea>` which stopped being true once the WYSIWYG editor replaced it with a ProseMirror `contenteditable`. A document-level `keydown` listener in `use_textbox_focus.tsx` asks `shouldFocusMainTextbox` whether the center composer should grab focus. That check only exempted `TEXTAREA` and `INPUT` so with rich text editing on it never recognised the focused editor.

The check uses `closest('[contenteditable="true"]')` rather than `isContentEditable` bc jsdom returns `undefined` for `isContentEditable` so a test would pass against broken code and `closest` also handles focus landing on a descendant node.

Splitting out of a heading ran `splitBlock().setNode('paragraph')` whch falls back to Tiptap's `clearNodes` and threw `RangeError: Invalid content for node type paragraph` when the heading sits inside a wrapper whose content model can't hold a paragraph like a blockquote in the channels composer. It now falls back to a plain block split so the caret still lands on a new block.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-69974

#### Release Note

```release-note
Fixed an issue where typing in a thread or the right-hand sidebar with rich text editing enabled moved focus to the center channel message box. Fixed an issue where pressing Enter inside a heading could crash the web app.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The changes affect a shared focus utility and editor behavior. Tests cover the main focus and heading-split paths, but user-facing editor interactions can still regress.

**QA Recommendation:** Perform targeted manual QA for composer focus, thread and sidebar focus, and heading split interactions.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->