### PR TITLE
MM-70100: Adjust Slack import user handling based on import type

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -3691,6 +3691,10 @@
     "translation": "Slack user merged with an existing Mattermost user with matching email {{.Email}} and username {{.Username}}, but was unable to add the user to their team.\r\n"
   },
   {
+    "id": "api.slackimport.slack_add_users.merge_existing_skipped_non_admin",
+    "translation": "Slack user with email {{.Email}} matches an existing Mattermost user with username {{.Username}}, but a new account was created instead since only admin imports can merge into existing accounts.\r\n"
+  },
+  {
     "id": "api.slackimport.slack_add_users.missing_email_address",
     "translation": "User {{.Username}} does not have an email address in the Slack export. Used {{.Email}} as a placeholder. The user should update their email address once logged in to the system.\r\n"
   },

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -3692,7 +3692,7 @@
   },
   {
     "id": "api.slackimport.slack_add_users.merge_existing_skipped_non_admin",
-    "translation": "Slack user with email {{.Email}} matches existing Mattermost user {{.Username}} who is not a member of this team. This user's posts and channel memberships will not be imported. Re-run as a system admin to merge them into the team.\r\n"
+    "translation": "Slack user with email {{.Email}} matches existing Mattermost user {{.Username}}. Merging into an existing Mattermost account is only available for imports run by a system admin, so this user's posts and channel memberships will not be imported. Re-run the import as a system admin to merge them.\r\n"
   },
   {
     "id": "api.slackimport.slack_add_users.missing_email_address",

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -3691,8 +3691,12 @@
     "translation": "Slack user merged with an existing Mattermost user with matching email {{.Email}} and username {{.Username}}, but was unable to add the user to their team.\r\n"
   },
   {
+    "id": "api.slackimport.slack_add_users.merge_existing_already_member",
+    "translation": "Slack user with email {{.Email}} merged with existing Mattermost user {{.Username}} who is already a member of this team.\r\n"
+  },
+  {
     "id": "api.slackimport.slack_add_users.merge_existing_skipped_non_admin",
-    "translation": "Slack user with email {{.Email}} matches an existing Mattermost user with username {{.Username}}, but a new account was created instead since only admin imports can merge into existing accounts.\r\n"
+    "translation": "Slack user with email {{.Email}} matches existing Mattermost user {{.Username}} who is not a member of this team. This user's posts and channel memberships will not be imported. Re-run as a system admin to merge them into the team.\r\n"
   },
   {
     "id": "api.slackimport.slack_add_users.missing_email_address",

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -3691,10 +3691,6 @@
     "translation": "Slack user merged with an existing Mattermost user with matching email {{.Email}} and username {{.Username}}, but was unable to add the user to their team.\r\n"
   },
   {
-    "id": "api.slackimport.slack_add_users.merge_existing_already_member",
-    "translation": "Slack user with email {{.Email}} merged with existing Mattermost user {{.Username}} who is already a member of this team.\r\n"
-  },
-  {
     "id": "api.slackimport.slack_add_users.merge_existing_skipped_non_admin",
     "translation": "Slack user with email {{.Email}} matches existing Mattermost user {{.Username}} who is not a member of this team. This user's posts and channel memberships will not be imported. Re-run as a system admin to merge them into the team.\r\n"
   },

--- a/server/platform/services/slackimport/slackimport.go
+++ b/server/platform/services/slackimport/slackimport.go
@@ -269,8 +269,7 @@ func (si *SlackImporter) slackAddUsers(rctx request.CTX, teamId string, slackuse
 			rctx.Logger().Warn("Slack Import: User does not have an email address in the Slack export. Used username as a placeholder. The user should update their email address once logged in to the system.", mlog.String("user_email", email), mlog.String("user_name", sUser.Username))
 		}
 
-		// Check for email conflict; only admin imports may merge into an existing account,
-		// unless the existing user is already a member of the team (idempotent re-import).
+		// Check for email conflict; only admin imports may merge into an existing account.
 		if existingUser, err := si.store.User().GetByEmail(email); err == nil {
 			if si.isAdminImport {
 				addedUsers[sUser.Id] = existingUser
@@ -279,12 +278,6 @@ func (si *SlackImporter) slackAddUsers(rctx request.CTX, teamId string, slackuse
 				} else {
 					importerLog.WriteString(i18n.T("api.slackimport.slack_add_users.merge_existing", map[string]any{"Email": existingUser.Email, "Username": existingUser.Username}))
 				}
-				continue
-			}
-			if _, err := si.store.Team().GetMember(rctx, team.Id, existingUser.Id); err == nil {
-				// User is already on the team; safe to merge without forcing a new team membership.
-				addedUsers[sUser.Id] = existingUser
-				importerLog.WriteString(i18n.T("api.slackimport.slack_add_users.merge_existing_already_member", map[string]any{"Email": existingUser.Email, "Username": existingUser.Username}))
 				continue
 			}
 			importerLog.WriteString(i18n.T("api.slackimport.slack_add_users.merge_existing_skipped_non_admin", map[string]any{"Email": existingUser.Email, "Username": existingUser.Username}))

--- a/server/platform/services/slackimport/slackimport.go
+++ b/server/platform/services/slackimport/slackimport.go
@@ -269,7 +269,8 @@ func (si *SlackImporter) slackAddUsers(rctx request.CTX, teamId string, slackuse
 			rctx.Logger().Warn("Slack Import: User does not have an email address in the Slack export. Used username as a placeholder. The user should update their email address once logged in to the system.", mlog.String("user_email", email), mlog.String("user_name", sUser.Username))
 		}
 
-		// Check for email conflict; only admin imports may merge into an existing account.
+		// Check for email conflict; only admin imports may merge into an existing account,
+		// unless the existing user is already a member of the team (idempotent re-import).
 		if existingUser, err := si.store.User().GetByEmail(email); err == nil {
 			if si.isAdminImport {
 				addedUsers[sUser.Id] = existingUser
@@ -280,7 +281,14 @@ func (si *SlackImporter) slackAddUsers(rctx request.CTX, teamId string, slackuse
 				}
 				continue
 			}
+			if _, err := si.store.Team().GetMember(rctx, team.Id, existingUser.Id); err == nil {
+				// User is already on the team; safe to merge without forcing a new team membership.
+				addedUsers[sUser.Id] = existingUser
+				importerLog.WriteString(i18n.T("api.slackimport.slack_add_users.merge_existing_already_member", map[string]any{"Email": existingUser.Email, "Username": existingUser.Username}))
+				continue
+			}
 			importerLog.WriteString(i18n.T("api.slackimport.slack_add_users.merge_existing_skipped_non_admin", map[string]any{"Email": existingUser.Email, "Username": existingUser.Username}))
+			continue
 		}
 
 		email = strings.ToLower(email)

--- a/server/platform/services/slackimport/slackimport.go
+++ b/server/platform/services/slackimport/slackimport.go
@@ -269,15 +269,18 @@ func (si *SlackImporter) slackAddUsers(rctx request.CTX, teamId string, slackuse
 			rctx.Logger().Warn("Slack Import: User does not have an email address in the Slack export. Used username as a placeholder. The user should update their email address once logged in to the system.", mlog.String("user_email", email), mlog.String("user_name", sUser.Username))
 		}
 
-		// Check for email conflict and use existing user if found
+		// Check for email conflict; only admin imports may merge into an existing account.
 		if existingUser, err := si.store.User().GetByEmail(email); err == nil {
-			addedUsers[sUser.Id] = existingUser
-			if _, err := si.actions.JoinUserToTeam(team, addedUsers[sUser.Id], ""); err != nil {
-				importerLog.WriteString(i18n.T("api.slackimport.slack_add_users.merge_existing_failed", map[string]any{"Email": existingUser.Email, "Username": existingUser.Username}))
-			} else {
-				importerLog.WriteString(i18n.T("api.slackimport.slack_add_users.merge_existing", map[string]any{"Email": existingUser.Email, "Username": existingUser.Username}))
+			if si.isAdminImport {
+				addedUsers[sUser.Id] = existingUser
+				if _, err := si.actions.JoinUserToTeam(team, addedUsers[sUser.Id], ""); err != nil {
+					importerLog.WriteString(i18n.T("api.slackimport.slack_add_users.merge_existing_failed", map[string]any{"Email": existingUser.Email, "Username": existingUser.Username}))
+				} else {
+					importerLog.WriteString(i18n.T("api.slackimport.slack_add_users.merge_existing", map[string]any{"Email": existingUser.Email, "Username": existingUser.Username}))
+				}
+				continue
 			}
-			continue
+			importerLog.WriteString(i18n.T("api.slackimport.slack_add_users.merge_existing_skipped_non_admin", map[string]any{"Email": existingUser.Email, "Username": existingUser.Username}))
 		}
 
 		email = strings.ToLower(email)

--- a/server/platform/services/slackimport/slackimport_test.go
+++ b/server/platform/services/slackimport/slackimport_test.go
@@ -796,6 +796,12 @@ func (s *slackAddUsersTestSetup) newImporter(actions Actions) *SlackImporter {
 	return New(s.store, actions, config)
 }
 
+func (s *slackAddUsersTestSetup) newImporterWithAdminFlag(actions Actions, isAdminImport bool) *SlackImporter {
+	config := &model.Config{}
+	config.SetDefaults()
+	return NewWithAdminFlag(s.store, actions, config, isAdminImport)
+}
+
 func (s *slackAddUsersTestSetup) defaultActions() Actions {
 	return Actions{
 		JoinUserToTeam: func(team *model.Team, user *model.User, userRequestorId string) (*model.TeamMember, *model.AppError) {
@@ -871,4 +877,127 @@ func TestSlackAddUsersTriggersPasswordResetFlow(t *testing.T) {
 	importer.slackAddUsers(rctx, "test-team-id", defaultSlackUsers(), importerLog)
 
 	assert.True(t, passwordResetCalled, "SendPasswordReset should be called for each imported user")
+}
+
+// TestSlackAddUsersNonAdminImportDoesNotMergeExistingUser tests that a non-admin import does
+// not adopt an existing Mattermost account that happens to share an email with a Slack user,
+// and instead creates a brand new account for that Slack identity.
+func TestSlackAddUsersNonAdminImportDoesNotMergeExistingUser(t *testing.T) {
+	rctx := request.TestContext(t)
+
+	store := &mocks.Store{}
+	teamStore := &mocks.TeamStore{}
+	userStore := &mocks.UserStore{}
+	store.On("Team").Return(teamStore)
+	store.On("User").Return(userStore)
+
+	team := &model.Team{Id: "test-team-id", Name: "test-team"}
+	teamStore.On("Get", "test-team-id").Return(team, nil)
+
+	existingUser := &model.User{Id: "existing-user-id", Username: "existinguser", Email: "shared@example.com"}
+	userStore.On("GetByEmail", "shared@example.com").Return(existingUser, nil)
+
+	newUser := &model.User{Id: "new-user-id", Username: "slackuser", Email: "shared@example.com"}
+	userStore.On("Save", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("*model.User")).Return(newUser, nil)
+
+	var joinedUserIDs []string
+	actions := Actions{
+		JoinUserToTeam: func(team *model.Team, user *model.User, userRequestorId string) (*model.TeamMember, *model.AppError) {
+			joinedUserIDs = append(joinedUserIDs, user.Id)
+			return &model.TeamMember{}, nil
+		},
+		SendPasswordReset: func(email string) (bool, *model.AppError) {
+			return true, nil
+		},
+	}
+
+	config := &model.Config{}
+	config.SetDefaults()
+	importer := NewWithAdminFlag(store, actions, config, false)
+
+	slackUsers := []slackUser{
+		{Id: "U001", Username: "slackuser", Profile: slackProfile{FirstName: "Slack", LastName: "User", Email: "shared@example.com"}},
+	}
+
+	importerLog := new(bytes.Buffer)
+	addedUsers := importer.slackAddUsers(rctx, "test-team-id", slackUsers, importerLog)
+
+	require.Contains(t, addedUsers, "U001")
+	assert.Equal(t, "new-user-id", addedUsers["U001"].Id, "non-admin import should not adopt the existing account")
+	assert.Len(t, joinedUserIDs, 1, "only the newly created account should be joined to the team")
+	assert.NotContains(t, joinedUserIDs, "existing-user-id", "existing account should never be joined to the team by a non-admin import")
+
+	expectedLog := "api.slackimport.slack_add_users.created" +
+		"===============\r\n\r\n" +
+		"api.slackimport.slack_add_users.merge_existing_skipped_non_admin" +
+		"api.slackimport.slack_add_users.email"
+	assert.Equal(t, expectedLog, importerLog.String())
+}
+
+// TestSlackAddUsersAdminImportMergesExistingUser tests that an admin import preserves the
+// existing behavior of adopting an existing Mattermost account that shares an email with a
+// Slack user.
+func TestSlackAddUsersAdminImportMergesExistingUser(t *testing.T) {
+	rctx := request.TestContext(t)
+
+	store := &mocks.Store{}
+	teamStore := &mocks.TeamStore{}
+	userStore := &mocks.UserStore{}
+	store.On("Team").Return(teamStore)
+	store.On("User").Return(userStore)
+
+	team := &model.Team{Id: "test-team-id", Name: "test-team"}
+	teamStore.On("Get", "test-team-id").Return(team, nil)
+
+	existingUser := &model.User{Id: "existing-user-id", Username: "existinguser", Email: "shared@example.com"}
+	userStore.On("GetByEmail", "shared@example.com").Return(existingUser, nil)
+
+	var joinedUserIDs []string
+	actions := Actions{
+		JoinUserToTeam: func(team *model.Team, user *model.User, userRequestorId string) (*model.TeamMember, *model.AppError) {
+			joinedUserIDs = append(joinedUserIDs, user.Id)
+			return &model.TeamMember{}, nil
+		},
+		SendPasswordReset: func(email string) (bool, *model.AppError) {
+			return true, nil
+		},
+	}
+
+	config := &model.Config{}
+	config.SetDefaults()
+	importer := NewWithAdminFlag(store, actions, config, true)
+
+	slackUsers := []slackUser{
+		{Id: "U001", Username: "slackuser", Profile: slackProfile{FirstName: "Slack", LastName: "User", Email: "shared@example.com"}},
+	}
+
+	importerLog := new(bytes.Buffer)
+	addedUsers := importer.slackAddUsers(rctx, "test-team-id", slackUsers, importerLog)
+
+	require.Contains(t, addedUsers, "U001")
+	assert.Equal(t, "existing-user-id", addedUsers["U001"].Id, "admin import should still adopt the existing account")
+	assert.Contains(t, joinedUserIDs, "existing-user-id")
+
+	userStore.AssertNotCalled(t, "Save", mock.Anything, mock.Anything)
+
+	expectedLog := "api.slackimport.slack_add_users.created" +
+		"===============\r\n\r\n" +
+		"api.slackimport.slack_add_users.merge_existing"
+	assert.Equal(t, expectedLog, importerLog.String())
+}
+
+// TestSlackAddUsersCreatesNewAccountWhenNoExistingMatch tests that when no existing account
+// matches the Slack user's email, a new account is created and joined to the team, regardless
+// of whether the import is an admin import.
+func TestSlackAddUsersCreatesNewAccountWhenNoExistingMatch(t *testing.T) {
+	rctx := request.TestContext(t)
+	s := newSlackAddUsersTestSetup(t)
+
+	importer := s.newImporterWithAdminFlag(s.defaultActions(), false)
+	importerLog := new(bytes.Buffer)
+	addedUsers := importer.slackAddUsers(rctx, "test-team-id", defaultSlackUsers(), importerLog)
+
+	require.Contains(t, addedUsers, "U001")
+	assert.Equal(t, s.savedUser.Id, addedUsers["U001"].Id)
+	assert.Contains(t, importerLog.String(), "api.slackimport.slack_add_users.email")
 }

--- a/server/platform/services/slackimport/slackimport_test.go
+++ b/server/platform/services/slackimport/slackimport_test.go
@@ -982,6 +982,7 @@ func TestSlackAddUsersNonAdminImportSaveFailsOnEmailConflict(t *testing.T) {
 	assert.Empty(t, joinedUserIDs, "no account should be joined to the team when the save fails")
 	assert.NotContains(t, importerLog.String(), "api.slackimport.slack_add_users.email", "no creation message should be logged when the save fails")
 	assert.Contains(t, importerLog.String(), "api.slackimport.slack_add_users.unable_import")
+	userStore.AssertCalled(t, "Save", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("*model.User"))
 }
 
 // TestSlackAddUsersAdminImportMergesExistingUser tests that an admin import preserves the

--- a/server/platform/services/slackimport/slackimport_test.go
+++ b/server/platform/services/slackimport/slackimport_test.go
@@ -6,7 +6,6 @@ package slackimport
 import (
 	"archive/zip"
 	"bytes"
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -897,8 +896,6 @@ func TestSlackAddUsersNonAdminImportDoesNotMergeExistingUser(t *testing.T) {
 
 	existingUser := &model.User{Id: "existing-user-id", Username: "existinguser", Email: "shared@example.com"}
 	userStore.On("GetByEmail", "shared@example.com").Return(existingUser, nil)
-	teamStore.On("GetMember", mock.AnythingOfType("*request.Context"), "test-team-id", "existing-user-id").
-		Return(nil, errors.New("not found"))
 
 	var joinedUserIDs []string
 	actions := Actions{
@@ -922,7 +919,7 @@ func TestSlackAddUsersNonAdminImportDoesNotMergeExistingUser(t *testing.T) {
 	importerLog := new(bytes.Buffer)
 	addedUsers := importer.slackAddUsers(rctx, "test-team-id", slackUsers, importerLog)
 
-	assert.NotContains(t, addedUsers, "U001", "user not on the team should be skipped entirely")
+	assert.NotContains(t, addedUsers, "U001", "user should be skipped entirely on email conflict")
 	assert.Empty(t, joinedUserIDs, "no account should be joined to the team")
 	userStore.AssertNotCalled(t, "Save", mock.Anything, mock.Anything)
 	assert.Contains(t, importerLog.String(), "api.slackimport.slack_add_users.merge_existing_skipped_non_admin")
@@ -930,10 +927,10 @@ func TestSlackAddUsersNonAdminImportDoesNotMergeExistingUser(t *testing.T) {
 	assert.NotContains(t, importerLog.String(), "api.slackimport.slack_add_users.unable_import")
 }
 
-// TestSlackAddUsersNonAdminImportMergesExistingTeamMember tests that a non-admin import
-// correctly merges a Slack user into an existing Mattermost account when that account is
-// already a member of the target team. This supports idempotent re-imports.
-func TestSlackAddUsersNonAdminImportMergesExistingTeamMember(t *testing.T) {
+// TestSlackAddUsersNonAdminImportSkipsExistingTeamMember tests that a non-admin import skips
+// a Slack user whose email matches an existing Mattermost account even when that account is
+// already a team member, preventing post authorship forgery.
+func TestSlackAddUsersNonAdminImportSkipsExistingTeamMember(t *testing.T) {
 	rctx := request.TestContext(t)
 
 	store := &mocks.Store{}
@@ -947,8 +944,6 @@ func TestSlackAddUsersNonAdminImportMergesExistingTeamMember(t *testing.T) {
 
 	existingUser := &model.User{Id: "existing-user-id", Username: "existinguser", Email: "shared@example.com"}
 	userStore.On("GetByEmail", "shared@example.com").Return(existingUser, nil)
-	teamStore.On("GetMember", mock.AnythingOfType("*request.Context"), "test-team-id", "existing-user-id").
-		Return(&model.TeamMember{TeamId: "test-team-id", UserId: "existing-user-id"}, nil)
 
 	var joinedUserIDs []string
 	actions := Actions{
@@ -972,11 +967,10 @@ func TestSlackAddUsersNonAdminImportMergesExistingTeamMember(t *testing.T) {
 	importerLog := new(bytes.Buffer)
 	addedUsers := importer.slackAddUsers(rctx, "test-team-id", slackUsers, importerLog)
 
-	require.Contains(t, addedUsers, "U001")
-	assert.Equal(t, "existing-user-id", addedUsers["U001"].Id, "non-admin import should merge into existing account when already on team")
-	assert.Empty(t, joinedUserIDs, "JoinUserToTeam should not be called when user is already a team member")
+	assert.NotContains(t, addedUsers, "U001", "existing account should be skipped even when already on the team")
+	assert.Empty(t, joinedUserIDs, "no account should be joined to the team")
 	userStore.AssertNotCalled(t, "Save", mock.Anything, mock.Anything)
-	assert.Contains(t, importerLog.String(), "api.slackimport.slack_add_users.merge_existing_already_member")
+	assert.Contains(t, importerLog.String(), "api.slackimport.slack_add_users.merge_existing_skipped_non_admin")
 }
 
 // TestSlackAddUsersAdminImportMergesExistingUser tests that an admin import preserves the

--- a/server/platform/services/slackimport/slackimport_test.go
+++ b/server/platform/services/slackimport/slackimport_test.go
@@ -6,8 +6,8 @@ package slackimport
 import (
 	"archive/zip"
 	"bytes"
+	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -880,9 +880,9 @@ func TestSlackAddUsersTriggersPasswordResetFlow(t *testing.T) {
 	assert.True(t, passwordResetCalled, "SendPasswordReset should be called for each imported user")
 }
 
-// TestSlackAddUsersNonAdminImportDoesNotMergeExistingUser tests that a non-admin import does
-// not adopt an existing Mattermost account that happens to share an email with a Slack user,
-// and instead creates a brand new account for that Slack identity.
+// TestSlackAddUsersNonAdminImportDoesNotMergeExistingUser tests that a non-admin import skips
+// a Slack user whose email matches an existing Mattermost account that is not already on the
+// team, rather than force-enrolling that account into the team.
 func TestSlackAddUsersNonAdminImportDoesNotMergeExistingUser(t *testing.T) {
 	rctx := request.TestContext(t)
 
@@ -897,9 +897,58 @@ func TestSlackAddUsersNonAdminImportDoesNotMergeExistingUser(t *testing.T) {
 
 	existingUser := &model.User{Id: "existing-user-id", Username: "existinguser", Email: "shared@example.com"}
 	userStore.On("GetByEmail", "shared@example.com").Return(existingUser, nil)
+	teamStore.On("GetMember", mock.AnythingOfType("*request.Context"), "test-team-id", "existing-user-id").
+		Return(nil, errors.New("not found"))
 
-	newUser := &model.User{Id: "new-user-id", Username: "slackuser", Email: "shared@example.com"}
-	userStore.On("Save", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("*model.User")).Return(newUser, nil)
+	var joinedUserIDs []string
+	actions := Actions{
+		JoinUserToTeam: func(team *model.Team, user *model.User, userRequestorId string) (*model.TeamMember, *model.AppError) {
+			joinedUserIDs = append(joinedUserIDs, user.Id)
+			return &model.TeamMember{}, nil
+		},
+		SendPasswordReset: func(email string) (bool, *model.AppError) {
+			return true, nil
+		},
+	}
+
+	config := &model.Config{}
+	config.SetDefaults()
+	importer := NewWithAdminFlag(store, actions, config, false)
+
+	slackUsers := []slackUser{
+		{Id: "U001", Username: "slackuser", Profile: slackProfile{FirstName: "Slack", LastName: "User", Email: "shared@example.com"}},
+	}
+
+	importerLog := new(bytes.Buffer)
+	addedUsers := importer.slackAddUsers(rctx, "test-team-id", slackUsers, importerLog)
+
+	assert.NotContains(t, addedUsers, "U001", "user not on the team should be skipped entirely")
+	assert.Empty(t, joinedUserIDs, "no account should be joined to the team")
+	userStore.AssertNotCalled(t, "Save", mock.Anything, mock.Anything)
+	assert.Contains(t, importerLog.String(), "api.slackimport.slack_add_users.merge_existing_skipped_non_admin")
+	assert.NotContains(t, importerLog.String(), "api.slackimport.slack_add_users.email")
+	assert.NotContains(t, importerLog.String(), "api.slackimport.slack_add_users.unable_import")
+}
+
+// TestSlackAddUsersNonAdminImportMergesExistingTeamMember tests that a non-admin import
+// correctly merges a Slack user into an existing Mattermost account when that account is
+// already a member of the target team. This supports idempotent re-imports.
+func TestSlackAddUsersNonAdminImportMergesExistingTeamMember(t *testing.T) {
+	rctx := request.TestContext(t)
+
+	store := &mocks.Store{}
+	teamStore := &mocks.TeamStore{}
+	userStore := &mocks.UserStore{}
+	store.On("Team").Return(teamStore)
+	store.On("User").Return(userStore)
+
+	team := &model.Team{Id: "test-team-id", Name: "test-team"}
+	teamStore.On("Get", "test-team-id").Return(team, nil)
+
+	existingUser := &model.User{Id: "existing-user-id", Username: "existinguser", Email: "shared@example.com"}
+	userStore.On("GetByEmail", "shared@example.com").Return(existingUser, nil)
+	teamStore.On("GetMember", mock.AnythingOfType("*request.Context"), "test-team-id", "existing-user-id").
+		Return(&model.TeamMember{TeamId: "test-team-id", UserId: "existing-user-id"}, nil)
 
 	var joinedUserIDs []string
 	actions := Actions{
@@ -924,65 +973,10 @@ func TestSlackAddUsersNonAdminImportDoesNotMergeExistingUser(t *testing.T) {
 	addedUsers := importer.slackAddUsers(rctx, "test-team-id", slackUsers, importerLog)
 
 	require.Contains(t, addedUsers, "U001")
-	assert.Equal(t, "new-user-id", addedUsers["U001"].Id, "non-admin import should not adopt the existing account")
-	assert.Len(t, joinedUserIDs, 1, "only the newly created account should be joined to the team")
-	assert.NotContains(t, joinedUserIDs, "existing-user-id", "existing account should never be joined to the team by a non-admin import")
-
-	expectedLog := "api.slackimport.slack_add_users.created" +
-		"===============\r\n\r\n" +
-		"api.slackimport.slack_add_users.merge_existing_skipped_non_admin" +
-		"api.slackimport.slack_add_users.email"
-	assert.Equal(t, expectedLog, importerLog.String())
-}
-
-// TestSlackAddUsersNonAdminImportSaveFailsOnEmailConflict tests that when a non-admin import
-// falls through to account creation for a Slack profile whose email matches an existing
-// account, and the store rejects the save (as a real database would for a duplicate email),
-// no account is added and no creation message is logged.
-func TestSlackAddUsersNonAdminImportSaveFailsOnEmailConflict(t *testing.T) {
-	rctx := request.TestContext(t)
-
-	store := &mocks.Store{}
-	teamStore := &mocks.TeamStore{}
-	userStore := &mocks.UserStore{}
-	store.On("Team").Return(teamStore)
-	store.On("User").Return(userStore)
-
-	team := &model.Team{Id: "test-team-id", Name: "test-team"}
-	teamStore.On("Get", "test-team-id").Return(team, nil)
-
-	existingUser := &model.User{Id: "existing-user-id", Username: "existinguser", Email: "shared@example.com"}
-	userStore.On("GetByEmail", "shared@example.com").Return(existingUser, nil)
-	userStore.On("Save", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("*model.User")).
-		Return(nil, model.NewAppError("Save", "app.user.save.email_exists", nil, "", http.StatusBadRequest))
-
-	var joinedUserIDs []string
-	actions := Actions{
-		JoinUserToTeam: func(team *model.Team, user *model.User, userRequestorId string) (*model.TeamMember, *model.AppError) {
-			joinedUserIDs = append(joinedUserIDs, user.Id)
-			return &model.TeamMember{}, nil
-		},
-		SendPasswordReset: func(email string) (bool, *model.AppError) {
-			return true, nil
-		},
-	}
-
-	config := &model.Config{}
-	config.SetDefaults()
-	importer := NewWithAdminFlag(store, actions, config, false)
-
-	slackUsers := []slackUser{
-		{Id: "U001", Username: "slackuser", Profile: slackProfile{FirstName: "Slack", LastName: "User", Email: "shared@example.com"}},
-	}
-
-	importerLog := new(bytes.Buffer)
-	addedUsers := importer.slackAddUsers(rctx, "test-team-id", slackUsers, importerLog)
-
-	assert.NotContains(t, addedUsers, "U001", "no account should be added when the save fails")
-	assert.Empty(t, joinedUserIDs, "no account should be joined to the team when the save fails")
-	assert.NotContains(t, importerLog.String(), "api.slackimport.slack_add_users.email", "no creation message should be logged when the save fails")
-	assert.Contains(t, importerLog.String(), "api.slackimport.slack_add_users.unable_import")
-	userStore.AssertCalled(t, "Save", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("*model.User"))
+	assert.Equal(t, "existing-user-id", addedUsers["U001"].Id, "non-admin import should merge into existing account when already on team")
+	assert.Empty(t, joinedUserIDs, "JoinUserToTeam should not be called when user is already a team member")
+	userStore.AssertNotCalled(t, "Save", mock.Anything, mock.Anything)
+	assert.Contains(t, importerLog.String(), "api.slackimport.slack_add_users.merge_existing_already_member")
 }
 
 // TestSlackAddUsersAdminImportMergesExistingUser tests that an admin import preserves the

--- a/server/platform/services/slackimport/slackimport_test.go
+++ b/server/platform/services/slackimport/slackimport_test.go
@@ -7,6 +7,7 @@ import (
 	"archive/zip"
 	"bytes"
 	"fmt"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -932,6 +933,55 @@ func TestSlackAddUsersNonAdminImportDoesNotMergeExistingUser(t *testing.T) {
 		"api.slackimport.slack_add_users.merge_existing_skipped_non_admin" +
 		"api.slackimport.slack_add_users.email"
 	assert.Equal(t, expectedLog, importerLog.String())
+}
+
+// TestSlackAddUsersNonAdminImportSaveFailsOnEmailConflict tests that when a non-admin import
+// falls through to account creation for a Slack profile whose email matches an existing
+// account, and the store rejects the save (as a real database would for a duplicate email),
+// no account is added and no creation message is logged.
+func TestSlackAddUsersNonAdminImportSaveFailsOnEmailConflict(t *testing.T) {
+	rctx := request.TestContext(t)
+
+	store := &mocks.Store{}
+	teamStore := &mocks.TeamStore{}
+	userStore := &mocks.UserStore{}
+	store.On("Team").Return(teamStore)
+	store.On("User").Return(userStore)
+
+	team := &model.Team{Id: "test-team-id", Name: "test-team"}
+	teamStore.On("Get", "test-team-id").Return(team, nil)
+
+	existingUser := &model.User{Id: "existing-user-id", Username: "existinguser", Email: "shared@example.com"}
+	userStore.On("GetByEmail", "shared@example.com").Return(existingUser, nil)
+	userStore.On("Save", mock.AnythingOfType("*request.Context"), mock.AnythingOfType("*model.User")).
+		Return(nil, model.NewAppError("Save", "app.user.save.email_exists", nil, "", http.StatusBadRequest))
+
+	var joinedUserIDs []string
+	actions := Actions{
+		JoinUserToTeam: func(team *model.Team, user *model.User, userRequestorId string) (*model.TeamMember, *model.AppError) {
+			joinedUserIDs = append(joinedUserIDs, user.Id)
+			return &model.TeamMember{}, nil
+		},
+		SendPasswordReset: func(email string) (bool, *model.AppError) {
+			return true, nil
+		},
+	}
+
+	config := &model.Config{}
+	config.SetDefaults()
+	importer := NewWithAdminFlag(store, actions, config, false)
+
+	slackUsers := []slackUser{
+		{Id: "U001", Username: "slackuser", Profile: slackProfile{FirstName: "Slack", LastName: "User", Email: "shared@example.com"}},
+	}
+
+	importerLog := new(bytes.Buffer)
+	addedUsers := importer.slackAddUsers(rctx, "test-team-id", slackUsers, importerLog)
+
+	assert.NotContains(t, addedUsers, "U001", "no account should be added when the save fails")
+	assert.Empty(t, joinedUserIDs, "no account should be joined to the team when the save fails")
+	assert.NotContains(t, importerLog.String(), "api.slackimport.slack_add_users.email", "no creation message should be logged when the save fails")
+	assert.Contains(t, importerLog.String(), "api.slackimport.slack_add_users.unable_import")
 }
 
 // TestSlackAddUsersAdminImportMergesExistingUser tests that an admin import preserves the


### PR DESCRIPTION
## Ticket Link

Fixes https://mattermost.atlassian.net/browse/MM-70100

Docs PR: https://github.com/mattermost/docs/pull/9123

```release-note
Updated Slack import to handle user matching differently depending on the import type.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change affects Slack user matching and account creation during email conflicts. Automated tests cover admin imports, non-admin imports, existing team members, and unmatched users.

**QA Recommendation:** Manual QA can be skipped. Rely on the automated test coverage.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MM-70095]: https://mattermost.atlassian.net/browse/MM-70095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
