### PR TITLE
Automated cherry pick of #37781

### DIFF
--- a/e2e-tests/playwright/lib/src/server/default_config.ts
+++ b/e2e-tests/playwright/lib/src/server/default_config.ts
@@ -828,7 +828,7 @@ const defaultServerConfig: AdminConfig = {
         DiscoverableChannels: false,
         MobileEphemeralMode: false,
         PropertyFieldRank: false,
-        TeamMembershipAccessControl: false,
+        TeamMembershipAccessControl: true,
         MmBlocksEnabled: true,
     },
     ImportSettings: {

--- a/server/channels/app/team_membership_access_control_test.go
+++ b/server/channels/app/team_membership_access_control_test.go
@@ -323,18 +323,12 @@ func TestTeamAccessControlled(t *testing.T) {
 	})
 }
 
-// TestTeamAccessControlledFeatureFlagOff exercises the kill switch. The
-// FeatureFlags section is read-only at runtime, so the off state is the
-// default (no SetupConfig override) — license and config are on, yet an
-// assigned membership policy must not engage the gate.
+// TestTeamAccessControlledFeatureFlagOff exercises the kill switch: with the
+// flag explicitly off — license and config on, and a membership policy
+// assigned — the gate must not engage. The flag is set at construction because
+// the config store treats the FeatureFlags section as read-only at runtime.
 func TestTeamAccessControlledFeatureFlagOff(t *testing.T) {
-	th := Setup(t).InitBasic(t)
-	th.App.UpdateConfig(func(cfg *model.Config) {
-		*cfg.AccessControlSettings.EnableAttributeBasedAccessControl = true
-	})
-	ok := th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced))
-	require.True(t, ok)
-	defer th.App.Srv().SetLicense(nil)
+	th := setupTeamABACPrereqsFlagOff(t)
 
 	team := th.CreateTeam(t)
 	saveTestTeamPolicy(t, th, team.Id, model.AccessControlPolicyActionMembership)

--- a/server/channels/app/team_membership_enforcement_test.go
+++ b/server/channels/app/team_membership_enforcement_test.go
@@ -30,6 +30,21 @@ func setupTeamABACEnforcement(t *testing.T) *TestHelper {
 	return th
 }
 
+// setupTeamABACPrereqsFlagOff enables the license and config prerequisites but
+// leaves the TeamMembershipAccessControl flag off, so a governed team exercises
+// the kill-switch branch with everything else in place.
+func setupTeamABACPrereqsFlagOff(t *testing.T) *TestHelper {
+	th := SetupConfig(t, func(cfg *model.Config) {
+		cfg.FeatureFlags.TeamMembershipAccessControl = false
+	}).InitBasic(t)
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.AccessControlSettings.EnableAttributeBasedAccessControl = true
+	})
+	require.True(t, th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterpriseAdvanced)))
+	t.Cleanup(func() { th.App.Srv().SetLicense(nil) })
+	return th
+}
+
 func setMockACS(t *testing.T, th *TestHelper) *mocks.AccessControlServiceInterface {
 	t.Helper()
 	mockACS := &mocks.AccessControlServiceInterface{}
@@ -240,10 +255,16 @@ func TestFilterNonQualifyingTeamsForUser(t *testing.T) {
 	}
 
 	t.Run("feature flag off is a no-op pass-through", func(t *testing.T) {
-		thOff := Setup(t).InitBasic(t) // flag defaults off
+		// Prerequisites on, flag off, team governed by a policy: only the
+		// kill switch keeps this a pass-through.
+		thOff := setupTeamABACPrereqsFlagOff(t)
 		team := thOff.CreateTeam(t)
+		saveTestTeamPolicy(t, thOff, team.Id, model.AccessControlPolicyActionMembership)
+		reloaded, err := thOff.App.Srv().Store().Team().Get(team.Id)
+		require.NoError(t, err)
+		require.True(t, reloaded.PolicyEnforced, "team must be policy-governed so only the flag keeps it a pass-through")
 		user := thOff.CreateUser(t)
-		out, dropped, appErr := thOff.App.FilterNonQualifyingTeamsForUser(thOff.Context, []*model.Team{team}, user.Id)
+		out, dropped, appErr := thOff.App.FilterNonQualifyingTeamsForUser(thOff.Context, []*model.Team{reloaded}, user.Id)
 		require.Nil(t, appErr)
 		require.Zero(t, dropped)
 		require.Len(t, out, 1)
@@ -398,11 +419,21 @@ func TestAnnotateRecommendedTeamsForUser(t *testing.T) {
 	}
 
 	t.Run("feature flag off is a no-op", func(t *testing.T) {
-		thOff := Setup(t).InitBasic(t)
+		// Prerequisites on, flag off, public governed team (otherwise
+		// recommend-eligible): only the kill switch suppresses the tag.
+		thOff := setupTeamABACPrereqsFlagOff(t)
 		team := thOff.CreateTeam(t)
+		team.AllowOpenInvite = true
+		updated, appErr := thOff.App.UpdateTeam(team)
+		require.Nil(t, appErr)
+		saveTestTeamPolicy(t, thOff, updated.Id, model.AccessControlPolicyActionMembership)
+		reloaded, err := thOff.App.Srv().Store().Team().Get(updated.Id)
+		require.NoError(t, err)
+		require.True(t, reloaded.PolicyEnforced, "team must be policy-governed so only the flag suppresses the tag")
+		require.True(t, reloaded.AllowOpenInvite)
 		user := thOff.CreateUser(t)
-		thOff.App.AnnotateRecommendedTeamsForUser(thOff.Context, []*model.Team{team}, user.Id)
-		require.False(t, team.Recommended)
+		thOff.App.AnnotateRecommendedTeamsForUser(thOff.Context, []*model.Team{reloaded}, user.Id)
+		require.False(t, reloaded.Recommended)
 	})
 
 	t.Run("non-governed team is never recommended and never evaluated", func(t *testing.T) {

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -163,7 +163,7 @@ func (f *FeatureFlags) SetDefaults() {
 	f.CustomProfileAttributes = true
 	f.AttributeValueMasking = true
 	f.PermissionPolicies = true
-	f.TeamMembershipAccessControl = false
+	f.TeamMembershipAccessControl = true
 	f.ChannelPermissionPolicies = true
 	f.PolicySimulation = true
 	f.ContentFlagging = true

--- a/server/public/model/feature_flags_test.go
+++ b/server/public/model/feature_flags_test.go
@@ -72,6 +72,14 @@ func TestFeatureFlagsSetDefaults_PropertyFieldRank(t *testing.T) {
 	require.Equal(t, "true", flags.ToMap()["PropertyFieldRank"])
 }
 
+func TestFeatureFlagsSetDefaults_TeamMembershipAccessControl(t *testing.T) {
+	var flags FeatureFlags
+	flags.SetDefaults()
+
+	require.True(t, flags.TeamMembershipAccessControl, "TeamMembershipAccessControl should default to true")
+	require.Equal(t, "true", flags.ToMap()["TeamMembershipAccessControl"])
+}
+
 // TestFeatureFlagsPermissionPoliciesDependencies pins down the
 // "sub-flag is gated by the umbrella PermissionPolicies flag"
 // contract for both ChannelPermissionPolicies and PolicySimulation.


### PR DESCRIPTION
Cherry pick of #37781 on release-11.10.

/cc  @pvev

```release-note
NONE
```