### PR TITLE
Post attributes feature flag group

### DIFF
--- a/server/channels/api4/properties.go
+++ b/server/channels/api4/properties.go
@@ -23,7 +23,8 @@ func (api *API) InitProperties() {
 	if api.srv.Config().FeatureFlags.IntegratedBoards ||
 		api.srv.Config().FeatureFlags.ManagedChannelCategories ||
 		api.srv.Config().FeatureFlags.ClassificationMarkings ||
-		api.srv.Config().FeatureFlags.SessionAttributes {
+		api.srv.Config().FeatureFlags.SessionAttributes ||
+		api.srv.Config().FeatureFlags.PostAttributes {
 		api.BaseRoutes.PropertyFields.Handle("", api.APISessionRequired(getPropertyFields)).Methods(http.MethodGet)
 		api.BaseRoutes.PropertyFieldsSearch.Handle("", api.APISessionRequired(searchPropertyFields)).Methods(http.MethodPost)
 		api.BaseRoutes.PropertyValues.Handle("", api.APISessionRequired(getPropertyValues)).Methods(http.MethodGet)

--- a/server/channels/api4/properties_test.go
+++ b/server/channels/api4/properties_test.go
@@ -158,6 +158,44 @@ func TestPropertyRoutesWithClassificationMarkingsFlag(t *testing.T) {
 	})
 }
 
+func TestPropertyRoutesWithPostAttributesFlag(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	// Routes should be available when PostAttributes=true alone, with every
+	// other peer property flag off. The post_attributes group itself is
+	// registered unconditionally at startup (see RegisterBuiltinGroups in
+	// server.go); only the generic Properties API route registration is
+	// gated by the OR condition in InitProperties.
+	th := SetupConfig(t, func(cfg *model.Config) {
+		cfg.FeatureFlags.IntegratedBoards = false
+		cfg.FeatureFlags.ManagedChannelCategories = false
+		cfg.FeatureFlags.ClassificationMarkings = false
+		cfg.FeatureFlags.SessionAttributes = false
+		cfg.FeatureFlags.PostAttributes = true
+	}).InitBasic(t)
+
+	groupName := model.PostAttributesPropertyGroupName
+
+	t.Run("create field should succeed with PostAttributes flag", func(t *testing.T) {
+		field := &model.PropertyField{
+			Name:       model.NewId(),
+			Type:       model.PropertyFieldTypeText,
+			TargetType: "system",
+		}
+
+		createdField, resp, err := th.SystemAdminClient.CreatePropertyField(context.Background(), groupName, "post", field)
+		require.NoError(t, err)
+		CheckCreatedStatus(t, resp)
+		require.NotEmpty(t, createdField.ID)
+	})
+
+	t.Run("get fields should succeed with PostAttributes flag", func(t *testing.T) {
+		_, resp, err := th.SystemAdminClient.GetPropertyFields(context.Background(), groupName, "post", model.PropertyFieldSearch{TargetType: "system"})
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+	})
+}
+
 func TestCreatePropertyField(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := SetupConfig(t, func(cfg *model.Config) {

--- a/server/channels/app/post_attributes_test.go
+++ b/server/channels/app/post_attributes_test.go
@@ -1,0 +1,28 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+// TestPostAttributesPropertyGroupRegisteredAtStartup verifies that the
+// post_attributes PSAv2 property group is registered unconditionally at
+// server startup (via RegisterBuiltinGroups), independent of the
+// PostAttributes feature flag, which only gates the generic Properties API
+// route registration.
+func TestPostAttributesPropertyGroupRegisteredAtStartup(t *testing.T) {
+	th := Setup(t)
+
+	group, appErr := th.App.GetPropertyGroup(th.Context, model.PostAttributesPropertyGroupName)
+	require.Nil(t, appErr)
+	require.NotNil(t, group)
+	require.NotEmpty(t, group.ID)
+	require.Equal(t, model.PostAttributesPropertyGroupName, group.Name)
+	require.Equal(t, model.PropertyGroupVersionV2, group.Version)
+}

--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -281,6 +281,7 @@ func NewServer(options ...Option) (*Server, error) {
 		{Name: model.SessionAttributesPropertyGroupName, Version: model.PropertyGroupVersionV2},
 		{Name: model.ContentFlaggingGroupName, Version: model.PropertyGroupVersionV1},
 		{Name: model.BoardsPropertyGroupName, Version: model.PropertyGroupVersionV2},
+		{Name: model.PostAttributesPropertyGroupName, Version: model.PropertyGroupVersionV2, SchemaVersion: model.PostAttributesPropertyGroupSchemaVersion},
 	}); err != nil {
 		return nil, errors.Wrap(err, "failed to register builtin property groups")
 	}

--- a/server/config/client_test.go
+++ b/server/config/client_test.go
@@ -955,13 +955,15 @@ func TestGetLimitedClientConfig(t *testing.T) {
 			"Feature Flags",
 			&model.Config{
 				FeatureFlags: &model.FeatureFlags{
-					TestFeature: "myvalue",
+					TestFeature:    "myvalue",
+					PostAttributes: true,
 				},
 			},
 			"",
 			nil,
 			map[string]string{
-				"FeatureFlagTestFeature": "myvalue",
+				"FeatureFlagTestFeature":    "myvalue",
+				"FeatureFlagPostAttributes": "true",
 			},
 		},
 		{

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -119,6 +119,9 @@ type FeatureFlags struct {
 	// Enable collection of request-provided session attributes (user agent, IP address, etc.).
 	SessionAttributes bool
 
+	// Gates the Post Attributes feature (post_attributes property group).
+	PostAttributes bool
+
 	// FEATURE_FLAG_REMOVAL: DiscoverableChannels - Remove this when the feature is GA.
 	// Gates the per-channel Discoverable toggle and the channel-join-request flow that lets
 	// non-members find a private channel in Browse Channels and request to join it.
@@ -198,6 +201,8 @@ func (f *FeatureFlags) SetDefaults() {
 	f.ManagedChannelCategories = false
 
 	f.SessionAttributes = false
+
+	f.PostAttributes = false
 
 	f.DiscoverableChannels = false
 

--- a/server/public/model/feature_flags_test.go
+++ b/server/public/model/feature_flags_test.go
@@ -64,6 +64,14 @@ func TestFeatureFlagsSetDefaults_AttributeValueMasking(t *testing.T) {
 	require.Equal(t, "true", flags.ToMap()["AttributeValueMasking"])
 }
 
+func TestFeatureFlagsSetDefaults_PostAttributes(t *testing.T) {
+	var flags FeatureFlags
+	flags.SetDefaults()
+
+	require.False(t, flags.PostAttributes, "PostAttributes should default to false")
+	require.Equal(t, "false", flags.ToMap()["PostAttributes"])
+}
+
 func TestFeatureFlagsSetDefaults_PropertyFieldRank(t *testing.T) {
 	var flags FeatureFlags
 	flags.SetDefaults()

--- a/server/public/model/post_attributes.go
+++ b/server/public/model/post_attributes.go
@@ -1,0 +1,12 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+// PostAttributesPropertyGroupName is the property group backing the Post Attributes
+// feature.
+const PostAttributesPropertyGroupName = "post_attributes"
+
+// PostAttributesPropertyGroupSchemaVersion is the schema version for post_attributes field
+// definitions.
+const PostAttributesPropertyGroupSchemaVersion = 1

--- a/server/public/model/post_attributes_test.go
+++ b/server/public/model/post_attributes_test.go
@@ -1,0 +1,14 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestPostAttributesPropertyGroupNameIsValid(t *testing.T) {
+	require.True(t, IsValidPropertyGroupName(PostAttributesPropertyGroupName))
+}

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/general.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/general.test.ts
@@ -448,6 +448,35 @@ describe('Selectors.General', () => {
         });
     });
 
+    describe('isPostAttributesEnabled', () => {
+        const buildState = (config: Record<string, string>) => ({
+            entities: {
+                general: {
+                    config,
+                },
+            },
+        } as unknown as GlobalState);
+
+        test('returns true when the flag is on', () => {
+            const state = buildState({
+                FeatureFlagPostAttributes: 'true',
+            });
+            expect(Selectors.isPostAttributesEnabled(state)).toBe(true);
+        });
+
+        test('returns false when the flag is off', () => {
+            const state = buildState({
+                FeatureFlagPostAttributes: 'false',
+            });
+            expect(Selectors.isPostAttributesEnabled(state)).toBe(false);
+        });
+
+        test('returns false when the flag is absent', () => {
+            const state = buildState({});
+            expect(Selectors.isPostAttributesEnabled(state)).toBe(false);
+        });
+    });
+
     describe('firstAdminVisitMarketplaceStatus', () => {
         test('should return empty when status does not exist', () => {
             const state = {

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/general.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/general.ts
@@ -26,6 +26,10 @@ export function isCustomProfileAttributesEnabled(state: GlobalState): boolean {
     return getConfig(state).FeatureFlagCustomProfileAttributes === 'true';
 }
 
+export function isPostAttributesEnabled(state: GlobalState): boolean {
+    return getConfig(state).FeatureFlagPostAttributes === 'true';
+}
+
 // Discoverable Private Channels is gated by the FeatureFlagDiscoverableChannels
 // server flag. When the flag is off the toggle UI, request endpoints, and
 // admin queue routes are all hidden — old clients see today's behavior.

--- a/webapp/platform/types/src/config.ts
+++ b/webapp/platform/types/src/config.ts
@@ -139,6 +139,7 @@ export type ClientConfig = {
     FeatureFlagPropertyFieldRank: string;
     FeatureFlagManagedChannelCategories: string;
     FeatureFlagSessionAttributes: string;
+    FeatureFlagPostAttributes: string;
     FeatureFlagDiscoverableChannels: string;
 
     ForgotPasswordLink: string;


### PR DESCRIPTION
#### Summary
These changes add the `PostAttributes` feature flag, group, registration and helpers around it.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70070

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes span server APIs, feature flags, client configuration, and selectors. Automated tests cover the main registration and flag paths, but feature-flag behavior can affect property API availability.

**QA Recommendation:** Manual QA is not required. Run the automated test suite and verify property API access with `PostAttributes` enabled and disabled.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->