### PR TITLE
Open Mattermost in the browser when the desktop landing page setting is disabled, with unit tests

### DIFF
--- a/webapp/channels/src/components/linking_landing_page/index.test.tsx
+++ b/webapp/channels/src/components/linking_landing_page/index.test.tsx
@@ -1,0 +1,61 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {renderWithContext, screen} from 'tests/react_testing_utils';
+import {navigateTo} from 'utils/browser_utils';
+
+import LinkingLandingPage from './index';
+
+jest.mock('utils/browser_utils', () => ({
+    ...jest.requireActual('utils/browser_utils'),
+    navigateTo: jest.fn(),
+}));
+
+const siteUrl = 'http://localhost:8065';
+const landingPath = '/landing#/team-name/channels/town-square';
+const redirectUrl = `${siteUrl}/team-name/channels/town-square`;
+
+describe('components/LinkingLandingPage (connected)', () => {
+    function makeState(enableDesktopLandingPage: 'true' | 'false') {
+        return {
+            entities: {
+                general: {
+                    config: {
+                        SiteURL: siteUrl,
+                        SiteName: 'Mattermost',
+                        AppDownloadLink: 'https://mattermost.com/download/',
+                        EnableDesktopLandingPage: enableDesktopLandingPage,
+                    },
+                },
+            },
+        };
+    }
+
+    beforeEach(() => {
+        // jsdom doesn't implement navigation, so replaceState is used to put the test on a /landing URL
+        // the same way that an email notification link would.
+        window.history.replaceState(null, '', landingPath);
+    });
+
+    afterEach(() => {
+        window.history.replaceState(null, '', '/');
+
+        localStorage.clear();
+    });
+
+    test('should show the landing page when EnableDesktopLandingPage is true', () => {
+        renderWithContext(<LinkingLandingPage/>, makeState('true'));
+
+        expect(screen.getByRole('heading', {name: 'Where would you like to view this?'})).toBeVisible();
+        expect(navigateTo).not.toHaveBeenCalled();
+    });
+
+    test('should redirect to the browser when EnableDesktopLandingPage is false', () => {
+        const {container} = renderWithContext(<LinkingLandingPage/>, makeState('false'));
+
+        expect(container).toBeEmptyDOMElement();
+        expect(navigateTo).toHaveBeenCalledWith(redirectUrl);
+    });
+});

--- a/webapp/channels/src/components/linking_landing_page/index.tsx
+++ b/webapp/channels/src/components/linking_landing_page/index.tsx
@@ -21,6 +21,7 @@ function mapStateToProps(state: GlobalState) {
         siteName: config.SiteName,
         brandImageUrl: Client4.getBrandImageUrl('0'),
         enableCustomBrand: config.EnableCustomBrand === 'true',
+        enableDesktopLandingPage: config.EnableDesktopLandingPage === 'true',
     };
 }
 

--- a/webapp/channels/src/components/linking_landing_page/linking_landing_page.test.tsx
+++ b/webapp/channels/src/components/linking_landing_page/linking_landing_page.test.tsx
@@ -1,0 +1,108 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import BrowserStore from 'stores/browser_store';
+
+import {renderWithContext, screen} from 'tests/react_testing_utils';
+import {navigateTo} from 'utils/browser_utils';
+
+import LinkingLandingPage from './linking_landing_page';
+
+jest.mock('utils/browser_utils', () => ({
+    ...jest.requireActual('utils/browser_utils'),
+    navigateTo: jest.fn(),
+}));
+
+const siteUrl = 'http://localhost:8065';
+const landingPath = '/landing#/team-name/channels/town-square';
+const redirectUrl = `${siteUrl}/team-name/channels/town-square`;
+const nativeUrl = 'mattermost://localhost:8065/team-name/channels/town-square';
+
+describe('components/LinkingLandingPage', () => {
+    const baseProps = {
+        desktopAppLink: 'https://mattermost.com/download/',
+        siteUrl,
+        siteName: 'Mattermost',
+        enableCustomBrand: false,
+        enableDesktopLandingPage: true,
+    };
+
+    beforeEach(() => {
+        // jsdom doesn't implement navigation, so replaceState is used to put the test on a /landing URL
+        // the same way that an email notification link would.
+        window.history.replaceState(null, '', landingPath);
+    });
+
+    afterEach(() => {
+        window.history.replaceState(null, '', '/');
+
+        localStorage.clear();
+    });
+
+    describe('when the desktop landing page is enabled', () => {
+        test('should show the landing page instead of redirecting', () => {
+            renderWithContext(<LinkingLandingPage {...baseProps}/>);
+
+            expect(screen.getByRole('heading', {name: 'Where would you like to view this?'})).toBeVisible();
+            expect(screen.getByRole('link', {name: 'View in Desktop App'})).toBeVisible();
+            expect(screen.getByRole('link', {name: 'View in Browser'})).toBeVisible();
+            expect(navigateTo).not.toHaveBeenCalled();
+        });
+
+        test('should redirect to the browser when the browser preference is stored', () => {
+            BrowserStore.setLandingPreferenceToBrowser(siteUrl);
+
+            const {container} = renderWithContext(<LinkingLandingPage {...baseProps}/>);
+
+            expect(container).toBeEmptyDOMElement();
+            expect(navigateTo).toHaveBeenCalledWith(redirectUrl);
+        });
+
+        test('should redirect to the desktop app when the app preference is stored', () => {
+            BrowserStore.setLandingPreferenceToMattermostApp(siteUrl);
+
+            renderWithContext(<LinkingLandingPage {...baseProps}/>);
+
+            expect(navigateTo).toHaveBeenCalledWith(nativeUrl);
+            expect(screen.getByText('Opening link in Mattermost...')).toBeVisible();
+        });
+    });
+
+    describe('when the desktop landing page is disabled', () => {
+        const props = {...baseProps, enableDesktopLandingPage: false};
+
+        test('should redirect to the browser without showing the landing page', () => {
+            const {container} = renderWithContext(<LinkingLandingPage {...props}/>);
+
+            expect(container).toBeEmptyDOMElement();
+            expect(screen.queryByRole('heading', {name: 'Where would you like to view this?'})).not.toBeInTheDocument();
+            expect(navigateTo).toHaveBeenCalledWith(redirectUrl);
+        });
+
+        test('should redirect to the browser even when the app preference is stored', () => {
+            BrowserStore.setLandingPreferenceToMattermostApp(siteUrl);
+
+            const {container} = renderWithContext(<LinkingLandingPage {...props}/>);
+
+            expect(container).toBeEmptyDOMElement();
+            expect(navigateTo).toHaveBeenCalledTimes(1);
+            expect(navigateTo).toHaveBeenCalledWith(redirectUrl);
+        });
+
+        test('should not store a landing preference when redirecting', () => {
+            renderWithContext(<LinkingLandingPage {...props}/>);
+
+            expect(BrowserStore.getLandingPreference(siteUrl)).toBeNull();
+        });
+
+        test('should ignore a cross-origin redirect target', () => {
+            window.history.replaceState(null, '', '/landing#https://evil.example.com/phishing');
+
+            renderWithContext(<LinkingLandingPage {...props}/>);
+
+            expect(navigateTo).toHaveBeenCalledWith(`${siteUrl}/`);
+        });
+    });
+});

--- a/webapp/channels/src/components/linking_landing_page/linking_landing_page.tsx
+++ b/webapp/channels/src/components/linking_landing_page/linking_landing_page.tsx
@@ -14,6 +14,7 @@ import ExternalLink from 'components/external_link';
 import desktopImg from 'images/deep-linking/deeplinking-desktop-img.png';
 import mobileImg from 'images/deep-linking/deeplinking-mobile-img.png';
 import MattermostLogoSvg from 'images/logo.svg';
+import {navigateTo} from 'utils/browser_utils';
 import {LandingPreferenceTypes} from 'utils/constants';
 
 type Props = {
@@ -165,12 +166,12 @@ export default class LinkingLandingPage extends PureComponent<Props, State> {
     openMattermostApp = () => {
         this.setPreference(LandingPreferenceTypes.MATTERMOSTAPP);
         this.setState({redirectPage: true});
-        window.location.href = this.state.nativeLocation;
+        navigateTo(this.state.nativeLocation);
     };
 
     openInBrowser = () => {
         this.setPreference(LandingPreferenceTypes.BROWSER);
-        window.location.href = this.state.location;
+        navigateTo(this.state.location);
     };
 
     renderSystemDialogMessage = () => {

--- a/webapp/channels/src/components/linking_landing_page/linking_landing_page.tsx
+++ b/webapp/channels/src/components/linking_landing_page/linking_landing_page.tsx
@@ -24,6 +24,7 @@ type Props = {
     siteName?: string;
     brandImageUrl?: string;
     enableCustomBrand: boolean;
+    enableDesktopLandingPage: boolean;
 };
 
 type State = {
@@ -89,7 +90,9 @@ export default class LinkingLandingPage extends PureComponent<Props, State> {
     }
 
     componentDidMount() {
-        if (this.checkLandingPreferenceApp()) {
+        // When the landing page is disabled, render() has already redirected to the browser, so a stale
+        // "open in app" preference must not navigate away from it.
+        if (this.props.enableDesktopLandingPage && this.checkLandingPreferenceApp()) {
             this.openMattermostApp();
         }
 
@@ -475,7 +478,7 @@ export default class LinkingLandingPage extends PureComponent<Props, State> {
     render() {
         const isMobile = UserAgent.isMobile();
 
-        if (this.checkLandingPreferenceBrowser() || this.isEmbedded()) {
+        if (!this.props.enableDesktopLandingPage || this.checkLandingPreferenceBrowser() || this.isEmbedded()) {
             this.openInBrowser();
             return null;
         }

--- a/webapp/channels/src/utils/browser_utils.ts
+++ b/webapp/channels/src/utils/browser_utils.ts
@@ -7,3 +7,10 @@
 export function reloadPage(): void {
     window.location.reload();
 }
+
+/**
+ * Wrapper for assigning window.location.href to make it mockable in tests.
+ */
+export function navigateTo(href: string): void {
+    window.location.href = href;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Reviewed and re-applied the change from [#30107](https://github.com/mattermost/mattermost/pull/30107), then added the unit test coverage it was missing.

Email notification links always point at `<siteURL>/landing#/<team>/...`, so `root.tsx`'s `showLandingPageIfNecessary` guard on `EnableDesktopLandingPage` never gets a chance to run: the user arrives on `/landing` directly and sees the interstitial even when an admin has turned the setting off. `LinkingLandingPage` now redirects straight to the browser URL when `EnableDesktopLandingPage` is `false`.

Two additions on top of the original PR, both found while reviewing it:

- `componentDidMount` opened the desktop app whenever a stored `MATTERMOSTAPP` landing preference existed. Because that runs after `render`, a preference stored before an admin disabled the setting would override the browser redirect that `render` just started. It is now gated on `enableDesktopLandingPage` as well.
- Navigation moved from an inline `window.location.href = ...` assignment to a `navigateTo` wrapper in `utils/browser_utils`, alongside the existing `reloadPage` wrapper that carries the same "to make it mockable in tests" rationale. jsdom's `window.location` is an own non-configurable property, so it can neither be redefined nor spied on, which left the redirect untestable.

QA steps:

1. With `ServiceSettings.EnableDesktopLandingPage` set to `true`, visit `<siteURL>/landing#/<team>/channels/town-square` in a browser and confirm the "Where would you like to view this?" interstitial appears.
2. Set **System Console > Site Configuration > Customization > Enable Desktop App Landing Page** to `False` and save.
3. Visit the same `/landing#/...` URL again and confirm the interstitial is skipped and the channel loads directly, with `/landing` stripped from the address bar.

Tests: 9 new cases across `linking_landing_page.test.tsx` and `index.test.tsx` cover the interstitial rendering while enabled, the redirect while disabled, both stored landing preferences, the stale app-preference case, that no landing preference is persisted by the automatic redirect, and that a cross-origin hash falls back to the site origin. Each production change was verified to fail at least one test when reverted.

#### Screenshots

Landing page still shown while the setting is enabled:

<img width="1280" height="800" alt="image" src="https://github.com/user-attachments/assets/b4ab2fb0-4f0f-4de9-b750-346cf6f677da" />

End-to-end run against a local server:


https://github.com/user-attachments/assets/03bf0ef8-bd65-4df0-8885-06cfef4ece1f



#### Release Note

```release-note
Fixed email notification links opening the desktop app landing page even when the Enable Desktop App Landing Page setting was disabled.
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8edcf913-7f00-4057-b814-6e8ed4a513b0?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8edcf913-7f00-4057-b814-6e8ed4a513b0&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change affects landing-page navigation and adds a shared browser utility. Unit tests cover the main enabled, disabled, preference, and cross-origin flows.

**QA Recommendation:** Manual QA is recommended for email links and desktop landing behavior in supported browsers.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->