### PR TITLE
Make config saves resilient to slow plugins and lost cluster messages

### DIFF
--- a/server/channels/app/channels.go
+++ b/server/channels/app/channels.go
@@ -344,6 +344,14 @@ func (ch *Channels) RunMultiHook(hookRunnerFunc func(hooks plugin.Hooks, manifes
 	}
 }
 
+// RunMultiHookConcurrent is like RunMultiHook but dispatches the hook to all plugins concurrently,
+// waiting at most waitLimit for them to complete. See Environment.RunMultiPluginHookConcurrent.
+func (ch *Channels) RunMultiHookConcurrent(hookRunnerFunc func(hooks plugin.Hooks, manifest *model.Manifest), hookId int, waitLimit time.Duration) {
+	if env := ch.GetPluginsEnvironment(); env != nil {
+		env.RunMultiPluginHookConcurrent(hookRunnerFunc, hookId, waitLimit)
+	}
+}
+
 // RunMultiHookExcluding is like RunMultiHook but skips plugins whose IDs appear in excludePluginIDs.
 // Fail-open semantics are preserved.
 func (ch *Channels) RunMultiHookExcluding(excludePluginIDs []string, hookRunnerFunc func(plugin.Hooks, *model.Manifest) bool, hookId int) {

--- a/server/channels/app/platform/config.go
+++ b/server/channels/app/platform/config.go
@@ -128,6 +128,18 @@ func (ps *PlatformService) SaveConfig(newCfg *model.Config, sendConfigChangeClus
 	return oldCfg, newCfg, nil
 }
 
+// ApplyConfigFromCluster applies a configuration change pushed by another
+// cluster node. Unlike SaveConfig it never re-notifies the cluster and skips
+// the ConfigurationWillBeSaved plugin hooks: the configuration was already
+// finalized and persisted by the sending node, so a local veto or mutation
+// would only make this node diverge.
+func (ps *PlatformService) ApplyConfigFromCluster(newCfg *model.Config) *model.AppError {
+	if err := ps.configStore.ApplyClusterConfig(newCfg); err != nil {
+		return model.NewAppError("ApplyConfigFromCluster", "app.save_config.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	return nil
+}
+
 func (ps *PlatformService) ReloadConfig() error {
 	if err := ps.configStore.Load(); err != nil {
 		return err

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -15,6 +15,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Masterminds/semver/v3"
 	svg "github.com/h2non/go-is-svg"
@@ -31,6 +32,10 @@ import (
 // prepackagedPluginsDir is the hard-coded folder name where prepackaged plugins are bundled
 // alongside the server.
 const prepackagedPluginsDir = "prepackaged_plugins"
+
+// pluginOnConfigurationChangeWaitLimit bounds how long a config save waits for plugin
+// OnConfigurationChange hooks. Hooks exceeding it finish in the background.
+const pluginOnConfigurationChangeWaitLimit = 15 * time.Second
 
 // pluginSignaturePath tracks the path to the plugin bundle and signature for the given plugin.
 type pluginSignaturePath struct {
@@ -242,12 +247,16 @@ func (ch *Channels) initPlugins(rctx request.CTX, pluginDir, webappPluginDir str
 			ch.syncPluginsActiveState()
 		}
 
-		ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
+		// Notify plugins concurrently with a bounded wait: this listener runs
+		// synchronously inside every config save (including saves relayed from
+		// cluster peers), so serial dispatch would make save latency grow with
+		// the number of plugins and a single slow plugin could block it
+		// entirely.
+		ch.RunMultiHookConcurrent(func(hooks plugin.Hooks, manifest *model.Manifest) {
 			if err := hooks.OnConfigurationChange(); err != nil {
-				ch.srv.Log().Error("Plugin OnConfigurationChange hook failed", mlog.Err(err))
+				ch.srv.Log().Error("Plugin OnConfigurationChange hook failed", mlog.String("plugin_id", manifest.Id), mlog.Err(err))
 			}
-			return true
-		}, plugin.OnConfigurationChangeID)
+		}, plugin.OnConfigurationChangeID, pluginOnConfigurationChangeWaitLimit)
 	})
 	ch.pluginsLock.Unlock()
 

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -1188,6 +1188,92 @@ func TestActiveHooks(t *testing.T) {
 	})
 }
 
+func TestOnConfigurationChangeConcurrentDispatch(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t)
+
+	// The hook only sleeps when a marker value is set so that plugin
+	// activation and test setup config changes stay fast.
+	sleepingPluginCode := `
+	package main
+
+	import (
+		"time"
+
+		"github.com/mattermost/mattermost/server/public/plugin"
+	)
+
+	type MyPlugin struct {
+		plugin.MattermostPlugin
+	}
+
+	func (p *MyPlugin) OnConfigurationChange() error {
+		cfg := p.API.GetConfig()
+		if cfg != nil && cfg.TeamSettings.SiteName != nil && *cfg.TeamSettings.SiteName == "sleep-now" {
+			time.Sleep(2 * time.Second)
+		}
+		return nil
+	}
+
+	func main() {
+		plugin.ClientMain(&MyPlugin{})
+	}
+	`
+
+	tearDown, pluginIDs, activationErrors := SetAppEnvironmentWithPlugins(t,
+		[]string{sleepingPluginCode, sleepingPluginCode, sleepingPluginCode, sleepingPluginCode}, th.App, th.NewPluginAPI)
+	defer tearDown()
+
+	require.Len(t, pluginIDs, 4)
+	for _, activationErr := range activationErrors {
+		require.NoError(t, activationErr)
+	}
+
+	t.Run("hooks run concurrently through the config listener", func(t *testing.T) {
+		start := time.Now()
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.TeamSettings.SiteName = model.NewPointer("sleep-now")
+		})
+		elapsed := time.Since(start)
+
+		// Serial dispatch would take at least 8s (4 plugins x 2s); concurrent
+		// dispatch is bounded by the slowest plugin. Leave headroom for CI.
+		require.GreaterOrEqual(t, elapsed, 2*time.Second)
+		require.Less(t, elapsed, 6*time.Second)
+	})
+
+	// Buffered so abandoned hook closures never block on send.
+	hooksDone := make(chan struct{}, len(pluginIDs))
+
+	t.Run("wait is bounded for slow hooks", func(t *testing.T) {
+		env := th.App.GetPluginsEnvironment()
+		require.NotNil(t, env)
+
+		start := time.Now()
+		env.RunMultiPluginHookConcurrent(func(hooks plugin.Hooks, _ *model.Manifest) {
+			// No assertions here: this closure outlives the subtest when the
+			// wait limit expires.
+			_ = hooks.OnConfigurationChange()
+			hooksDone <- struct{}{}
+		}, plugin.OnConfigurationChangeID, 500*time.Millisecond)
+		elapsed := time.Since(start)
+
+		// SiteName is still "sleep-now", so each hook sleeps 2s, exceeding the
+		// 500ms wait limit; the dispatch must return without waiting for them.
+		require.Less(t, elapsed, 2*time.Second)
+	})
+
+	// Wait for the abandoned hooks from the bounded-wait subtest to finish
+	// before tearing down the plugin environment.
+	for range pluginIDs {
+		select {
+		case <-hooksDone:
+		case <-time.After(10 * time.Second):
+			require.Fail(t, "abandoned hooks did not finish")
+		}
+	}
+}
+
 func TestHookMetrics(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t, StartMetrics)

--- a/server/config/database.go
+++ b/server/config/database.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 
 	"github.com/jmoiron/sqlx"
 	"github.com/pkg/errors"
@@ -46,6 +47,11 @@ type DatabaseStore struct {
 	driverName     string
 	dataSourceName string
 	db             *sqlx.DB
+
+	// lastChecksum is the SHA-256 (hex) of the active configuration row as of
+	// the last Load or persist through this store. Used to cheaply detect
+	// writes made by other nodes sharing the same configuration database.
+	lastChecksum atomic.Value
 }
 
 // NewDatabaseStore creates a new instance of a config store backed by the given database.
@@ -182,6 +188,7 @@ func (ds *DatabaseStore) persist(cfg *model.Config) error {
 
 	// compare checksums, it's more efficient rather than comparing entire config itself
 	if bytes.Equal(oldSum, sum[0:]) {
+		ds.lastChecksum.Store(hex.EncodeToString(sum[0:]))
 		return nil
 	}
 
@@ -216,25 +223,60 @@ func (ds *DatabaseStore) persist(cfg *model.Config) error {
 		return errors.Wrap(err, "failed to commit transaction")
 	}
 
+	ds.lastChecksum.Store(hex.EncodeToString(sum[0:]))
+
 	return nil
+}
+
+// activeChecksum returns the SHA-256 (hex) of the active configuration row, or
+// an empty string if no active configuration exists.
+func (ds *DatabaseStore) activeChecksum() (string, error) {
+	var sha sql.NullString
+	row := ds.db.QueryRow("SELECT SHA FROM Configurations WHERE Active")
+	if err := row.Scan(&sha); err != nil && err != sql.ErrNoRows {
+		return "", errors.Wrap(err, "failed to query active configuration checksum")
+	}
+
+	// postgres returns blank-padded therefore we trim the space
+	return strings.TrimSpace(sha.String), nil
+}
+
+// hasChangedExternally returns true if the active configuration row no longer
+// matches the configuration last loaded or persisted through this store,
+// meaning another node (or a manual edit) changed it.
+func (ds *DatabaseStore) hasChangedExternally() (bool, error) {
+	activeSum, err := ds.activeChecksum()
+	if err != nil {
+		return false, err
+	}
+
+	lastSum, _ := ds.lastChecksum.Load().(string)
+
+	return activeSum != lastSum, nil
 }
 
 // Load updates the current configuration from the backing store.
 func (ds *DatabaseStore) Load() ([]byte, error) {
 	var configurationData []byte
+	var sha sql.NullString
 
-	row := ds.db.QueryRow("SELECT Value FROM Configurations WHERE Active")
-	if err := row.Scan(&configurationData); err != nil && err != sql.ErrNoRows {
+	row := ds.db.QueryRow("SELECT Value, SHA FROM Configurations WHERE Active")
+	if err := row.Scan(&configurationData, &sha); err != nil && err != sql.ErrNoRows {
 		return nil, errors.Wrap(err, "failed to query active configuration")
 	}
 
 	// Initialize from the default config if no active configuration could be found.
 	if len(configurationData) == 0 {
+		ds.lastChecksum.Store("")
+
 		configWithDB := model.Config{}
 		configWithDB.SqlSettings.DriverName = new(ds.driverName)
 		configWithDB.SqlSettings.DataSource = new(ds.dataSourceName)
 		return json.Marshal(configWithDB)
 	}
+
+	// postgres returns blank-padded therefore we trim the space
+	ds.lastChecksum.Store(strings.TrimSpace(sha.String))
 
 	return configurationData, nil
 }

--- a/server/config/database_test.go
+++ b/server/config/database_test.go
@@ -1128,10 +1128,12 @@ func TestDatabaseStoreReconcileExternalChanges(t *testing.T) {
 		assert.False(t, changed)
 	})
 
-	t.Run("cluster-pushed config re-reads the database instead of persisting", func(t *testing.T) {
+	t.Run("cluster push with no new active row visible is deferred to the reconciler", func(t *testing.T) {
 		activeID, _ := getActualDatabaseConfig(t)
 
-		// A stale payload pushed by a peer must not overwrite the active row.
+		// A stale payload pushed by a peer must not overwrite the active row
+		// or the in-memory config; with no unseen active row (as with a
+		// lagging replica read), the apply is skipped after bounded retries.
 		staleCfg := ds.Get().Clone()
 		staleCfg.TeamSettings.SiteName = model.NewPointer("stale cluster payload")
 		require.NoError(t, ds.ApplyClusterConfig(staleCfg))
@@ -1140,6 +1142,31 @@ func TestDatabaseStoreReconcileExternalChanges(t *testing.T) {
 		assert.Equal(t, activeID, newActiveID, "active row must not be rewritten")
 		assert.Equal(t, "external write", *actualCfg.TeamSettings.SiteName)
 		assert.Equal(t, "external write", *ds.Get().TeamSettings.SiteName)
+		assert.Empty(t, listenerInvocations)
+	})
+
+	t.Run("cluster push applies the database content, not the payload", func(t *testing.T) {
+		// Simulate the sender having persisted a new row before pushing.
+		otherStore, err := newTestDatabaseStore(nil)
+		require.NoError(t, err)
+		defer otherStore.Close()
+		otherStore.stopReconciler()
+
+		newCfg := otherStore.Get().Clone()
+		newCfg.TeamSettings.SiteName = model.NewPointer("sender persisted")
+		_, _, err = otherStore.Set(newCfg)
+		require.NoError(t, err)
+		activeID, _ := getActualDatabaseConfig(t)
+
+		// The pushed payload carries a different (older) value than the row.
+		payload := ds.Get().Clone()
+		payload.TeamSettings.SiteName = model.NewPointer("pushed payload")
+		require.NoError(t, ds.ApplyClusterConfig(payload))
+
+		newActiveID, _ := getActualDatabaseConfig(t)
+		assert.Equal(t, activeID, newActiveID, "active row must not be rewritten")
+		assert.Equal(t, "sender persisted", *ds.Get().TeamSettings.SiteName)
+		<-listenerInvocations
 	})
 }
 

--- a/server/config/database_test.go
+++ b/server/config/database_test.go
@@ -1060,6 +1060,89 @@ func TestDatabaseStoreString(t *testing.T) {
 	assert.False(t, strings.Contains(maskedDSN, "mostest"))
 }
 
+func TestDatabaseStoreReconcileExternalChanges(t *testing.T) {
+	if testing.Short() {
+		t.SkipNow()
+	}
+	_, tearDown := setupConfigDatabase(t, minimalConfig, nil)
+	defer tearDown()
+
+	ds, err := newTestDatabaseStore(nil)
+	require.NoError(t, err)
+	require.NotNil(t, ds)
+	defer ds.Close()
+
+	// Stop the background reconciler so its tick cannot race the manual
+	// reconcile calls below.
+	ds.stopReconciler()
+
+	databaseStore, ok := ds.backingStore.(*DatabaseStore)
+	require.True(t, ok, "should be a DatabaseStore instance")
+
+	listenerInvocations := make(chan struct{}, 10)
+	ds.AddListener(func(oldCfg, newCfg *model.Config) {
+		listenerInvocations <- struct{}{}
+	})
+
+	t.Run("no change detected after own persist", func(t *testing.T) {
+		newCfg := ds.Get().Clone()
+		newCfg.TeamSettings.SiteName = model.NewPointer("self write")
+		_, _, err := ds.Set(newCfg)
+		require.NoError(t, err)
+		<-listenerInvocations
+
+		changed, err := databaseStore.hasChangedExternally()
+		require.NoError(t, err)
+		assert.False(t, changed)
+
+		ds.reconcileFromDatabase(databaseStore)
+		assert.Empty(t, listenerInvocations)
+	})
+
+	t.Run("reload on external write", func(t *testing.T) {
+		// Simulate another node writing to the same configuration database.
+		otherStore, err := newTestDatabaseStore(nil)
+		require.NoError(t, err)
+		defer otherStore.Close()
+		otherStore.stopReconciler()
+
+		newCfg := otherStore.Get().Clone()
+		newCfg.TeamSettings.SiteName = model.NewPointer("external write")
+		_, _, err = otherStore.Set(newCfg)
+		require.NoError(t, err)
+
+		// The first store hasn't seen the change yet.
+		assert.Equal(t, "self write", *ds.Get().TeamSettings.SiteName)
+
+		changed, err := databaseStore.hasChangedExternally()
+		require.NoError(t, err)
+		assert.True(t, changed)
+
+		ds.reconcileFromDatabase(databaseStore)
+		assert.Equal(t, "external write", *ds.Get().TeamSettings.SiteName)
+		<-listenerInvocations
+
+		// A second reconcile is a no-op.
+		changed, err = databaseStore.hasChangedExternally()
+		require.NoError(t, err)
+		assert.False(t, changed)
+	})
+
+	t.Run("cluster-pushed config re-reads the database instead of persisting", func(t *testing.T) {
+		activeID, _ := getActualDatabaseConfig(t)
+
+		// A stale payload pushed by a peer must not overwrite the active row.
+		staleCfg := ds.Get().Clone()
+		staleCfg.TeamSettings.SiteName = model.NewPointer("stale cluster payload")
+		require.NoError(t, ds.ApplyClusterConfig(staleCfg))
+
+		newActiveID, actualCfg := getActualDatabaseConfig(t)
+		assert.Equal(t, activeID, newActiveID, "active row must not be rewritten")
+		assert.Equal(t, "external write", *actualCfg.TeamSettings.SiteName)
+		assert.Equal(t, "external write", *ds.Get().TeamSettings.SiteName)
+	})
+}
+
 func TestCleanUp(t *testing.T) {
 	_, tearDown := setupConfigDatabase(t, emptyConfig, nil)
 	defer tearDown()

--- a/server/config/store.go
+++ b/server/config/store.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/i18n"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/public/utils"
 )
 
@@ -21,6 +22,12 @@ var (
 	// configuration store is made.
 	ErrReadOnlyStore = errors.New("configuration store is read-only")
 )
+
+// databaseStoreReconcileInterval is how often a database-backed store checks
+// the active configuration row for changes made by other nodes. The check is a
+// single-row indexed query, so it is cheap relative to the convergence it
+// guarantees when a cluster config-change notification is lost.
+const databaseStoreReconcileInterval = 30 * time.Second
 
 // Store is the higher level object that handles storing and retrieval of config data.
 // To do so it relies on a variety of backing stores (e.g. file, database, memory).
@@ -35,6 +42,10 @@ type Store struct {
 
 	readOnly   bool
 	readOnlyFF bool
+
+	reconcilerDone chan struct{}
+	reconcilerWg   sync.WaitGroup
+	reconcilerOnce sync.Once
 }
 
 // BackingStore defines the behaviour exposed by the underlying store
@@ -80,7 +91,82 @@ func NewStoreFromBacking(backingStore BackingStore, customDefaults *model.Config
 		return nil, errors.Wrap(err, "unable to load on store creation")
 	}
 
+	if databaseStore, ok := backingStore.(*DatabaseStore); ok && !readOnly {
+		store.startReconciler(databaseStore)
+	}
+
 	return store, nil
+}
+
+// startReconciler periodically compares the active configuration row against
+// the last configuration loaded or persisted through this store and reloads on
+// mismatch. Cluster peers normally learn about config changes through a
+// cluster message, but that delivery is best effort once the sender gives up;
+// this poll guarantees every node sharing a configuration database converges
+// on the latest configuration even if a notification is lost.
+func (s *Store) startReconciler(databaseStore *DatabaseStore) {
+	s.reconcilerDone = make(chan struct{})
+
+	s.reconcilerWg.Go(func() {
+		ticker := time.NewTicker(databaseStoreReconcileInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-s.reconcilerDone:
+				return
+			case <-ticker.C:
+				s.reconcileFromDatabase(databaseStore)
+			}
+		}
+	})
+}
+
+// stopReconciler signals the reconciler goroutine to stop and waits for it to
+// exit. Safe to call multiple times and when no reconciler was started.
+func (s *Store) stopReconciler() {
+	s.reconcilerOnce.Do(func() {
+		if s.reconcilerDone != nil {
+			close(s.reconcilerDone)
+			s.reconcilerWg.Wait()
+		}
+	})
+}
+
+// reconcileFromDatabase reloads the configuration if the active configuration
+// row was changed by another writer. The reload never writes back to the
+// database: the other writer owns the active row, and normalization
+// differences (e.g. between server versions during a rolling upgrade) must not
+// cause nodes to rewrite each other's rows in a loop.
+func (s *Store) reconcileFromDatabase(databaseStore *DatabaseStore) {
+	changed, err := databaseStore.hasChangedExternally()
+	if err != nil {
+		mlog.Warn("Failed to check configuration store for external changes", mlog.Err(err))
+		return
+	}
+	if !changed {
+		return
+	}
+
+	mlog.Info("Configuration changed externally in the database, reloading")
+	if err := s.load(false); err != nil {
+		mlog.Error("Failed to reload configuration after external change", mlog.Err(err))
+	}
+}
+
+// ApplyClusterConfig applies a configuration received from another cluster
+// node. Database-backed stores re-read the shared database, which the sender
+// already updated, rather than persisting the pushed payload: concurrent
+// pushes can be applied out of order, and rewriting the active row could
+// reactivate a stale configuration. File-backed stores persist the payload
+// locally as usual, since each node owns its copy of the file.
+func (s *Store) ApplyClusterConfig(newCfg *model.Config) error {
+	if _, ok := s.backingStore.(*DatabaseStore); ok {
+		return s.load(false)
+	}
+
+	_, _, err := s.Set(newCfg)
+	return err
 }
 
 // NewStoreFromDSN creates and returns a new config store backed by either a database or file store
@@ -242,6 +328,13 @@ func (s *Store) Set(newCfg *model.Config) (*model.Config, *model.Config, error) 
 
 // Load updates the current configuration from the backing store, possibly initializing.
 func (s *Store) Load() error {
+	return s.load(true)
+}
+
+// load updates the current configuration from the backing store. When
+// persistOnChange is true, a changed or missing configuration is normalized
+// and written back to the backing store.
+func (s *Store) load(persistOnChange bool) error {
 	s.configLock.Lock()
 	defer s.configLock.Unlock()
 
@@ -315,9 +408,9 @@ func (s *Store) Load() error {
 		return errors.Wrap(err, "failed to compare configs")
 	}
 
-	// We write back to the backing store only if the store is not read-only
-	// and the config has either changed or is missing.
-	if !s.readOnly && (hasChanged || len(configBytes) == 0) {
+	// We write back to the backing store only if requested, the store is not
+	// read-only, and the config has either changed or is missing.
+	if persistOnChange && !s.readOnly && (hasChanged || len(configBytes) == 0) {
 		err := s.backingStore.Set(loadedCfgNoEnv)
 		if err != nil && !errors.Is(err, ErrReadOnlyConfiguration) {
 			return errors.Wrap(err, "failed to persist")
@@ -387,6 +480,10 @@ func (s *Store) String() string {
 
 // Close cleans up resources associated with the store.
 func (s *Store) Close() error {
+	// Wait for any in-flight reconcile before closing the backing store; the
+	// reconciler takes configLock itself, so this must happen before locking.
+	s.stopReconciler()
+
 	s.configLock.Lock()
 	defer s.configLock.Unlock()
 	return s.backingStore.Close()

--- a/server/config/store.go
+++ b/server/config/store.go
@@ -29,6 +29,17 @@ var (
 // guarantees when a cluster config-change notification is lost.
 const databaseStoreReconcileInterval = 30 * time.Second
 
+// Retry schedule for reading a cluster-pushed configuration change back from
+// the database. The sender persists a new active row before notifying peers,
+// so a read that still matches the last known checksum means the read landed
+// on a lagging replica (e.g. behind a load-balancing proxy) or the change was
+// already applied; a few short retries cover typical replication lag, and the
+// periodic reconciler covers anything longer.
+const (
+	clusterConfigReadRetries    = 5
+	clusterConfigReadRetryDelay = 500 * time.Millisecond
+)
+
 // Store is the higher level object that handles storing and retrieval of config data.
 // To do so it relies on a variety of backing stores (e.g. file, database, memory).
 type Store struct {
@@ -161,12 +172,32 @@ func (s *Store) reconcileFromDatabase(databaseStore *DatabaseStore) {
 // reactivate a stale configuration. File-backed stores persist the payload
 // locally as usual, since each node owns its copy of the file.
 func (s *Store) ApplyClusterConfig(newCfg *model.Config) error {
-	if _, ok := s.backingStore.(*DatabaseStore); ok {
-		return s.load(false)
+	databaseStore, ok := s.backingStore.(*DatabaseStore)
+	if !ok {
+		_, _, err := s.Set(newCfg)
+		return err
 	}
 
-	_, _, err := s.Set(newCfg)
-	return err
+	// The sender persisted a new active row before notifying, so a fresh read
+	// must expose a checksum we haven't seen. If it doesn't, either the read
+	// hit a lagging replica or the change was already applied locally; retry
+	// briefly and otherwise leave convergence to the reconciler.
+	for attempt := 0; ; attempt++ {
+		changed, err := databaseStore.hasChangedExternally()
+		if err != nil {
+			return err
+		}
+		if changed {
+			break
+		}
+		if attempt >= clusterConfigReadRetries {
+			mlog.Debug("Cluster config change not yet visible in the database; deferring to the reconciler")
+			return nil
+		}
+		time.Sleep(clusterConfigReadRetryDelay)
+	}
+
+	return s.load(false)
 }
 
 // NewStoreFromDSN creates and returns a new config store backed by either a database or file store

--- a/server/public/plugin/environment.go
+++ b/server/public/plugin/environment.go
@@ -657,6 +657,70 @@ func (env *Environment) RunMultiPluginHook(hookRunnerFunc func(hooks Hooks, mani
 	}
 }
 
+// RunMultiPluginHookConcurrent invokes hookRunnerFunc for each active plugin that implements the
+// given hookId, dispatching all hooks concurrently instead of serially so total latency is bounded
+// by the slowest plugin rather than the sum of all plugins.
+//
+// The call returns once every hook completes or waitLimit elapses, whichever comes first. Hooks
+// still running when waitLimit expires are abandoned by the caller but run to completion in the
+// background; the plugins still pending are logged. An abandoned hook can therefore overlap with a
+// later dispatch of the same hook to the same plugin. Unlike RunMultiPluginHook, hookRunnerFunc
+// cannot short-circuit the remaining plugins.
+func (env *Environment) RunMultiPluginHookConcurrent(hookRunnerFunc func(hooks Hooks, manifest *model.Manifest), hookId int, waitLimit time.Duration) {
+	startTime := time.Now()
+
+	var wg sync.WaitGroup
+	var pending sync.Map
+	env.registeredPlugins.Range(func(key, value any) bool {
+		rp := value.(registeredPlugin)
+
+		if rp.supervisor == nil || !rp.supervisor.Implements(hookId) || !env.IsActive(rp.BundleInfo.Manifest.Id) {
+			return true
+		}
+
+		pluginID := rp.BundleInfo.Manifest.Id
+		pending.Store(pluginID, struct{}{})
+		wg.Go(func() {
+			hookStartTime := time.Now()
+			hookRunnerFunc(rp.supervisor.Hooks(), rp.BundleInfo.Manifest)
+			pending.Delete(pluginID)
+
+			if env.metrics != nil {
+				elapsedTime := float64(time.Since(hookStartTime)) / float64(time.Second)
+				env.metrics.ObservePluginMultiHookIterationDuration(pluginID, elapsedTime)
+			}
+		})
+
+		return true
+	})
+
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(waitLimit):
+		var stragglers []string
+		pending.Range(func(key, _ any) bool {
+			stragglers = append(stragglers, key.(string))
+			return true
+		})
+		env.logger.Warn("Some plugin hooks did not complete in time; they will finish in the background",
+			mlog.Int("hook_id", hookId),
+			mlog.String("wait_limit", waitLimit.String()),
+			mlog.Array("plugin_ids", stragglers),
+		)
+	}
+
+	if env.metrics != nil {
+		elapsedTime := float64(time.Since(startTime)) / float64(time.Second)
+		env.metrics.ObservePluginMultiHookDuration(elapsedTime)
+	}
+}
+
 // RunMultiPluginHookExcluding is like RunMultiPluginHook but skips plugins whose IDs appear in
 // excludePluginIDs, otherwise the semantics are the same as RunMultiPluginHook. The exclusion check
 // is a linear scan.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

In HA with many plugins (especially database-driven config via `MM_CONFIG`), System Console config saves often returned HTTP 500 even though the write had already succeeded. Typical error: `ent.cluster.timeout.error` / `Error saving plugin state in config.` The new value was already in the DB and on peer nodes.

This PR is the **server-side half**. The false 500 itself is fixed in companion mattermost/enterprise#2255 (peers ack config pushes on receipt, and peer failures no longer fail the save). **This PR must merge first** — the enterprise PR calls the new `PlatformService.ApplyConfigFromCluster`.

What each change is for:

- **Concurrent `OnConfigurationChange` (15s bound):** save latency follows the slowest plugin, not the sum. A hung plugin can no longer stall saves until `ServiceSettings.WriteTimeout`. This is not sufficient by itself when a *single* apply still exceeds the 5s cluster reply timeout (one slow hook, or work outside the hook such as plugin-state sync).
- **Database config reconciler (30s SHA poll, read-only reload):** if a cluster config push is lost, peers still converge from the shared config row. This does not change save HTTP success/failure.
- **`ApplyConfigFromCluster` / `Store.ApplyClusterConfig`:** receivers re-read the DB the sender already wrote, instead of persisting the gossip payload (which can reactivate a stale active row). Relayed configs skip `ConfigurationWillBeSaved`. Needed for correct apply after the enterprise ack-on-receipt change.
- **Replica-lag retries:** if a receiver’s re-read hits a lagged replica and still sees the old checksum, retry briefly then defer to the reconciler. Correctness for statement-level read/write-splitting proxies; not involved in the saver HTTP path.

`ConfigurationWillBeSaved` on the saving node is still serial and unbounded (it may mutate/veto the config).

Companion PR: mattermost/enterprise#2255.

#### Release Note

```release-note
Plugin OnConfigurationChange hooks now run concurrently with a bounded wait during configuration saves, so save latency no longer grows with the number of installed plugins and a hung plugin cannot block configuration changes. Servers using database-driven configuration (MM_CONFIG set to a database DSN) now detect external changes to the stored configuration and reload it automatically within 30 seconds, guaranteeing configuration convergence across High Availability cluster nodes even if a cluster notification is lost.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fcf40-8e63-7db5-9331-13c8b85021d3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fcf40-8e63-7db5-9331-13c8b85021d3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🔴 High

**Regression Risk:** Changes affect shared configuration persistence, cluster synchronization, plugin execution, and public APIs. Replica lag, timeout handling, shutdown paths, and external configuration updates can cause regressions despite targeted tests.

**QA Recommendation:** Run focused manual QA for HA configuration updates, external database changes, replica lag, slow plugins, cluster pushes, read-only reloads, and shutdown behavior.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->