### PR TITLE
fix: resolve unicode emoji to reaction when TAB-selected from autocomplete

### DIFF
--- a/webapp/channels/src/actions/views/create_comment.tsx
+++ b/webapp/channels/src/actions/views/create_comment.tsx
@@ -198,7 +198,7 @@ export function onSubmit(
             // rather than the colon-wrapped name, so REACTION_PATTERN won't match. Resolve it
             // back to a name via EmojiMap.getUnicode.
             if (!isReaction) {
-                const unicodeMatch = /^([+-])(\S+)\s*$/.exec(message.trim());
+                const unicodeMatch = /^([+-])(\S+)\s*$/.exec(message);
                 if (unicodeMatch) {
                     const codepoint = [...unicodeMatch[2]]
                         .map((c) => c.codePointAt(0)!.toString(16))

--- a/webapp/channels/src/actions/views/create_comment.tsx
+++ b/webapp/channels/src/actions/views/create_comment.tsx
@@ -191,10 +191,30 @@ export function onSubmit(
             const emojis = getCustomEmojisByName(state);
             const emojiMap = new EmojiMap(emojis);
 
-            if (isReaction && emojiMap.has(isReaction[2])) {
+            let reactionAction = isReaction ? isReaction[1] : null;
+            let reactionName = isReaction ? isReaction[2] : null;
+
+            // TAB-completing an emoji from autocomplete inserts its unicode character (e.g. "+🤯 ")
+            // rather than the colon-wrapped name, so REACTION_PATTERN won't match. Resolve it
+            // back to a name via EmojiMap.getUnicode.
+            if (!isReaction) {
+                const unicodeMatch = /^([+-])(\S+)\s*$/.exec(message.trim());
+                if (unicodeMatch) {
+                    const codepoint = [...unicodeMatch[2]]
+                        .map((c) => c.codePointAt(0)!.toString(16))
+                        .join('-');
+                    const emoji = emojiMap.getUnicode(codepoint);
+                    if (emoji) {
+                        reactionAction = unicodeMatch[1];
+                        reactionName = emoji.short_names[0];
+                    }
+                }
+            }
+
+            if (reactionAction && reactionName && emojiMap.has(reactionName)) {
                 const latestPostId = getLatestInteractablePostId(state, channelId, rootId);
                 if (latestPostId) {
-                    return dispatch(PostActions.submitReaction(latestPostId, isReaction[1], isReaction[2]));
+                    return dispatch(PostActions.submitReaction(latestPostId, reactionAction, reactionName));
                 }
                 return {error: new Error('no post to react to')};
             }


### PR DESCRIPTION
When a user types `+:emoji_name` and presses TAB to accept an emoji from the autocomplete suggestions, the autocomplete inserts the emoji's unicode character (e.g. `+🤯 `) rather than the colon-wrapped name (e.g. `+:exploding_head: `).

`REACTION_PATTERN` only matches `:colon:` names, so the message falls through to `submitPost` as plain text instead of adding a reaction to the latest post. Manually typing the full `:emoji_name:` and pressing Enter works correctly.

## Fix

After the existing `REACTION_PATTERN` check, add a fallback that:

1. Matches `+<char> ` or `-<char> ` using a plain regex
2. Converts the character to its Unicode codepoint string
3. Looks up the emoji via `EmojiMap.getUnicode(codepoint)`
4. If found, proceeds with `submitReaction` using the emoji's canonical short name

No behavior change for the existing colon-wrapped path.

Fixes #37351.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to emoji reaction submission in `create_comment.tsx`. Existing colon-wrapped reactions remain unchanged, and automated test coverage is full.
**QA Recommendation:** Manual QA can be skipped. Automated testing is sufficient.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->