### PR TITLE
[MM-70130] Add permanent banner for non-production developer license keys

### DIFF
--- a/api/v4/source/system.yaml
+++ b/api/v4/source/system.yaml
@@ -973,6 +973,9 @@
                   is_gov_sku:
                     type: boolean
                     description: Whether this is a government SKU license
+                  is_non_production:
+                    type: boolean
+                    description: Whether the license is a non-production (developer) key
                   customer:
                     type: object
                     properties:

--- a/server/channels/app/platform/license.go
+++ b/server/channels/app/platform/license.go
@@ -412,6 +412,7 @@ func (ps *PlatformService) logLicense(message string, license *model.License) {
 		mlog.String("sku_short_name", license.SkuShortName),
 		mlog.Bool("is_trial", license.IsTrial),
 		mlog.Bool("is_gov_sku", license.IsGovSku),
+		mlog.Bool("is_non_production", license.IsNonProduction),
 	)
 
 	if license.Customer != nil {

--- a/server/channels/app/platform/support_packet.go
+++ b/server/channels/app/platform/support_packet.go
@@ -152,6 +152,7 @@ func (ps *PlatformService) getSupportPacketDiagnostics(rctx request.CTX) (*model
 		d.License.SkuShortName = license.SkuShortName
 		d.License.IsTrial = license.IsTrial
 		d.License.IsGovSKU = license.IsGovSku
+		d.License.IsNonProduction = license.IsNonProduction
 	}
 
 	/* Server */

--- a/server/channels/utils/license.go
+++ b/server/channels/utils/license.go
@@ -264,6 +264,7 @@ func GetClientLicense(l *model.License) map[string]string {
 		props["OutgoingOAuthConnections"] = strconv.FormatBool(*l.Features.OutgoingOAuthConnections)
 		props["IsTrial"] = strconv.FormatBool(l.IsTrial)
 		props["IsGovSku"] = strconv.FormatBool(l.IsGovSku)
+		props["IsNonProduction"] = strconv.FormatBool(l.IsNonProduction)
 	}
 
 	return props

--- a/server/channels/utils/license_test.go
+++ b/server/channels/utils/license_test.go
@@ -253,6 +253,25 @@ func TestGetLicenseFileLocation(t *testing.T) {
 	require.Equal(t, fileName, "mattermost.mattermost-license", "invalid file name")
 }
 
+func TestGetClientLicense(t *testing.T) {
+	license := &model.License{
+		Customer: &model.Customer{},
+		Features: &model.Features{},
+	}
+	license.Features.SetDefaults()
+
+	props := GetClientLicense(license)
+	require.Equal(t, "false", props["IsNonProduction"])
+
+	license.IsNonProduction = true
+	props = GetClientLicense(license)
+	require.Equal(t, "true", props["IsNonProduction"])
+
+	// The flag must survive sanitization so all users can see the non-production banner.
+	sanitized := GetSanitizedClientLicense(props)
+	require.Equal(t, "true", sanitized["IsNonProduction"])
+}
+
 func TestGetLicenseFileFromDisk(t *testing.T) {
 	t.Run("missing file", func(t *testing.T) {
 		fileBytes := GetLicenseFileFromDisk("thisfileshouldnotexist.mattermost-license")

--- a/server/public/model/license.go
+++ b/server/public/model/license.go
@@ -86,6 +86,7 @@ type License struct {
 	SkuShortName        string    `json:"sku_short_name"`
 	IsTrial             bool      `json:"is_trial"`
 	IsGovSku            bool      `json:"is_gov_sku"`
+	IsNonProduction     bool      `json:"is_non_production"`
 	IsSeatCountEnforced bool      `json:"is_seat_count_enforced"`
 	// ExtraUsers provides a grace mechanism that allows a configurable number of users
 	// beyond the base license limit before restricting user creation. When nil, defaults to 0.

--- a/server/public/model/support_packet.go
+++ b/server/public/model/support_packet.go
@@ -14,11 +14,12 @@ type SupportPacketDiagnostics struct {
 	Version int `yaml:"version"`
 
 	License struct {
-		Company      string `yaml:"company"`
-		Users        int    `yaml:"users"`
-		SkuShortName string `yaml:"sku_short_name"`
-		IsTrial      bool   `yaml:"is_trial,omitempty"`
-		IsGovSKU     bool   `yaml:"is_gov_sku,omitempty"`
+		Company         string `yaml:"company"`
+		Users           int    `yaml:"users"`
+		SkuShortName    string `yaml:"sku_short_name"`
+		IsTrial         bool   `yaml:"is_trial,omitempty"`
+		IsGovSKU        bool   `yaml:"is_gov_sku,omitempty"`
+		IsNonProduction bool   `yaml:"is_non_production,omitempty"`
 	} `yaml:"license"`
 
 	Server struct {

--- a/webapp/channels/src/components/announcement_bar/announcement_bar_controller.tsx
+++ b/webapp/channels/src/components/announcement_bar/announcement_bar_controller.tsx
@@ -12,6 +12,7 @@ import CloudTrialAnnouncementBar from './cloud_trial_announcement_bar';
 import CloudTrialEndAnnouncementBar from './cloud_trial_ended_announcement_bar';
 import ConfigurationAnnouncementBar from './configuration_bar';
 import AnnouncementBar from './default_announcement_bar';
+import NonProductionLicenseAnnouncementBar from './non_production_license_bar';
 import NotificationPermissionBar from './notification_permission_bar';
 import OverageUsersBanner from './overage_users_banner';
 import PaymentAnnouncementBar from './payment_announcement_bar';
@@ -105,6 +106,8 @@ class AnnouncementBarController extends React.PureComponent<Props> {
         // If set with class 'admin-announcement', they will always be visible, stacked vertically.
         return (
             <>
+                {/* Lowest priority: urgent bars temporarily override it, and it reappears once they clear. */}
+                <NonProductionLicenseAnnouncementBar/>
                 <NotificationPermissionBar/>
                 {adminConfiguredAnnouncementBar}
                 {errorBar}

--- a/webapp/channels/src/components/announcement_bar/non_production_license_bar/index.tsx
+++ b/webapp/channels/src/components/announcement_bar/non_production_license_bar/index.tsx
@@ -27,7 +27,7 @@ const NonProductionLicenseAnnouncementBar: React.FC = () => {
             message={
                 <FormattedMessage
                     id='announcement_bar.non_production_license.message'
-                    defaultMessage='Developer key — not for use in production environments.'
+                    defaultMessage='Non-production license. Test or staging use only.'
                 />
             }
             icon={<AlertOutlineIcon size={16}/>}

--- a/webapp/channels/src/components/announcement_bar/non_production_license_bar/index.tsx
+++ b/webapp/channels/src/components/announcement_bar/non_production_license_bar/index.tsx
@@ -1,0 +1,38 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+import {useSelector} from 'react-redux';
+
+import {AlertOutlineIcon} from '@mattermost/compass-icons/components';
+
+import {getLicense} from 'mattermost-redux/selectors/entities/general';
+
+import {AnnouncementBarTypes} from 'utils/constants';
+
+import AnnouncementBar from '../default_announcement_bar';
+
+const NonProductionLicenseAnnouncementBar: React.FC = () => {
+    const license = useSelector(getLicense);
+
+    if (license?.IsNonProduction !== 'true') {
+        return null;
+    }
+
+    return (
+        <AnnouncementBar
+            type={AnnouncementBarTypes.ADVISOR}
+            showCloseButton={false}
+            message={
+                <FormattedMessage
+                    id='announcement_bar.non_production_license.message'
+                    defaultMessage='Developer key — not for use in production environments.'
+                />
+            }
+            icon={<AlertOutlineIcon size={16}/>}
+        />
+    );
+};
+
+export default NonProductionLicenseAnnouncementBar;

--- a/webapp/channels/src/components/announcement_bar/non_production_license_bar/non_production_license_bar.test.tsx
+++ b/webapp/channels/src/components/announcement_bar/non_production_license_bar/non_production_license_bar.test.tsx
@@ -26,7 +26,7 @@ describe('components/announcement_bar/NonProductionLicenseAnnouncementBar', () =
         );
 
         expect(container.querySelector('.announcement-bar')).not.toBeNull();
-        expect(container.textContent).toContain('Developer key — not for use in production environments.');
+        expect(container.textContent).toContain('Non-production license. Test or staging use only.');
     });
 
     it('should not show banner when license is not non-production', () => {

--- a/webapp/channels/src/components/announcement_bar/non_production_license_bar/non_production_license_bar.test.tsx
+++ b/webapp/channels/src/components/announcement_bar/non_production_license_bar/non_production_license_bar.test.tsx
@@ -1,0 +1,73 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import {renderWithContext} from 'tests/react_testing_utils';
+
+import NonProductionLicenseAnnouncementBar from './index';
+
+describe('components/announcement_bar/NonProductionLicenseAnnouncementBar', () => {
+    const initialState = {
+        entities: {
+            general: {
+                license: {
+                    IsLicensed: 'true',
+                    IsNonProduction: 'true',
+                },
+            },
+        },
+    };
+
+    it('should show banner when license is non-production', () => {
+        const {container} = renderWithContext(
+            <NonProductionLicenseAnnouncementBar/>,
+            initialState,
+        );
+
+        expect(container.querySelector('.announcement-bar')).not.toBeNull();
+        expect(container.textContent).toContain('Developer key — not for use in production environments.');
+    });
+
+    it('should not show banner when license is not non-production', () => {
+        const state = JSON.parse(JSON.stringify(initialState));
+        state.entities.general.license.IsNonProduction = 'false';
+
+        const {container} = renderWithContext(
+            <NonProductionLicenseAnnouncementBar/>,
+            state,
+        );
+
+        expect(container.querySelector('.announcement-bar')).toBeNull();
+    });
+
+    it('should not show banner when the flag is absent from the license', () => {
+        const state = JSON.parse(JSON.stringify(initialState));
+        delete state.entities.general.license.IsNonProduction;
+
+        const {container} = renderWithContext(
+            <NonProductionLicenseAnnouncementBar/>,
+            state,
+        );
+
+        expect(container.querySelector('.announcement-bar')).toBeNull();
+    });
+
+    it('should not be dismissable', () => {
+        const {container} = renderWithContext(
+            <NonProductionLicenseAnnouncementBar/>,
+            initialState,
+        );
+
+        expect(container.querySelector('.announcement-bar__close')).toBeNull();
+    });
+
+    it('should have advisor type', () => {
+        const {container} = renderWithContext(
+            <NonProductionLicenseAnnouncementBar/>,
+            initialState,
+        );
+
+        expect(container.querySelector('.announcement-bar.announcement-bar-advisor')).not.toBeNull();
+    });
+});

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4009,6 +4009,7 @@
   "announcement_bar.error.trial_license_expiring": "There are {days} days left on your free trial.",
   "announcement_bar.error.trial_license_expiring_last_day": "This is the last day of your free trial. Purchase a license now to continue using Mattermost Professional and Enterprise features.",
   "announcement_bar.error.trial_license_expiring_last_day.short": "This is the last day of your free trial.",
+  "announcement_bar.non_production_license.message": "Developer key — not for use in production environments.",
   "announcement_bar.notification.email_verified": "Email verified",
   "announcement_bar.warn.contact_support_email": "<a>Contact support</a>.",
   "announcement_bar.warn.contact_support_text": "To renew your license, contact support at support@mattermost.com.",

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -4009,7 +4009,7 @@
   "announcement_bar.error.trial_license_expiring": "There are {days} days left on your free trial.",
   "announcement_bar.error.trial_license_expiring_last_day": "This is the last day of your free trial. Purchase a license now to continue using Mattermost Professional and Enterprise features.",
   "announcement_bar.error.trial_license_expiring_last_day.short": "This is the last day of your free trial.",
-  "announcement_bar.non_production_license.message": "Developer key — not for use in production environments.",
+  "announcement_bar.non_production_license.message": "Non-production license. Test or staging use only.",
   "announcement_bar.notification.email_verified": "Email verified",
   "announcement_bar.warn.contact_support_email": "<a>Contact support</a>.",
   "announcement_bar.warn.contact_support_text": "To renew your license, contact support at support@mattermost.com.",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Premier Support customers can receive license entitlements for non-production environments. Licenses minted with the new `is_non_production` flag ([mattermost/license-generator#35](https://github.com/mattermost/license-generator/pull/35), issued via [mattermost/customer-web-server#1432](https://github.com/mattermost/customer-web-server/pull/1432)) now cause a permanent, non-dismissible banner reading "Developer key — not for use in production environments." to be shown to all users.

Server:
- Added `IsNonProduction` (`is_non_production`) to `model.License`.
- Exposed it via `GetClientLicense` following the `IsGovSku` pattern; it intentionally survives `GetSanitizedClientLicense` so all users (not just admins) receive it.
- Included the flag in support-packet diagnostics and license logging, mirroring `IsGovSku`.

Webapp:
- New `NonProductionLicenseAnnouncementBar` (modeled on the cloud preview bar): renders when `license.IsNonProduction === 'true'`, advisor style, no close button.
- Mounted at the lowest priority in the announcement bar controller, so more urgent bars (version refresh, errors, license expiry) temporarily override it and it reappears once they clear.

QA steps: apply a license generated with `is_non_production: true`; every user should see the banner on all pages with no dismiss control. Production licenses are unaffected.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70130

#### Screenshots
Demo (local server with an injected non-production license): the banner appears on login, persists across channels and the System Console, and has no dismiss control.

[non-production-license-banner-demo.mp4](https://cursor.com/agents/bc-2464c0d7-157c-43d9-897b-bce40d47bfd3/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnon-production-license-banner-demo.mp4)

#### Release Note
```release-note
Licenses marked as non-production (is_non_production) now display a permanent, non-dismissible banner stating the server is licensed with a developer key and is not for use in production environments. The flag is exposed in the client license, support packet, and GET /api/v4/license/client response.
```

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-2464c0d7-157c-43d9-897b-bce40d47bfd3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2464c0d7-157c-43d9-897b-bce40d47bfd3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes span server license models, diagnostics, API responses, and the shared announcement bar. Automated tests cover the banner and license mapping, but some API and diagnostics consumers may need validation.

**QA Recommendation:** Manual QA is recommended for non-production and production licenses. Verify banner priority, non-dismissability, localization, and unaffected production behavior.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->