### PR TITLE
[MM-70114] Fix flaky channel guard broadcast test

### DIFF
--- a/server/channels/app/channel_guards_test.go
+++ b/server/channels/app/channel_guards_test.go
@@ -42,9 +42,9 @@ func (c *captureClusterMock) snapshot() []*model.ClusterMessage {
 	return out
 }
 
-// reset drops everything captured so far. Call this after TestHelper setup
-// completes so the test only sees messages produced by the code under test
-// (TestHelper init produces ~1000 unrelated cluster messages).
+// reset drops everything captured so far. TestHelper setup produces many unrelated
+// cluster messages, and some setup work can finish asynchronously, so callers
+// must still filter for the event produced by the code under test.
 func (c *captureClusterMock) reset() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -96,9 +96,9 @@ func TestChannelGuardCacheBroadcastShape(t *testing.T) {
 
 	th.App.Channels().broadcastChannelGuardInvalidation()
 
-	captured := cluster.snapshot()
-	require.Len(t, captured, 1)
-	msg := captured[0]
+	guardEvents := filterGuardCacheEvents(cluster.snapshot())
+	require.Len(t, guardEvents, 1, "broadcast must produce exactly one guard-cache invalidation")
+	msg := guardEvents[0]
 	assert.Equal(t, clusterEventInvalidateChannelGuardCache, msg.Event)
 	assert.Equal(t, model.ClusterSendReliable, msg.SendType)
 	assert.Empty(t, msg.Data, "broadcast payload should be empty (D9: receiver does a full reload)")


### PR DESCRIPTION
#### Summary

Fix `TestChannelGuardCacheBroadcastShape` by filtering captured cluster messages to the channel-guard cache invalidation event before asserting that exactly one was sent. Test setup emits unrelated cluster traffic asynchronously; the production broadcast behavior is unchanged.

#### Ticket Link
- Jira: https://mattermost.atlassian.net/browse/MM-70114
- Source flake report: https://github.com/mattermost/mattermost/pull/37839

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change affects only test assertions in one module. It does not modify production behavior or shared code.

**QA Recommendation:** Skip manual QA. Automated test coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->