### PR TITLE
[6/6] Add Client4 methods and API tests for recaps and scheduled recaps

### DIFF
--- a/server/channels/api4/recap.go
+++ b/server/channels/api4/recap.go
@@ -240,7 +240,7 @@ func markRecapsAsViewed(c *Context, w http.ResponseWriter, r *http.Request) {
 	auditRec.AddMeta("recap_count", len(ids))
 	auditRec.AddMeta("recap_ids", ids)
 
-	if err := json.NewEncoder(w).Encode(map[string]any{"recap_ids": ids}); err != nil {
+	if err := json.NewEncoder(w).Encode(model.MarkRecapsViewedResponse{RecapIds: ids}); err != nil {
 		c.Logger.Warn("Error encoding response", mlog.Err(err))
 	}
 }

--- a/server/channels/api4/recap_test.go
+++ b/server/channels/api4/recap_test.go
@@ -1,0 +1,385 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package api4
+
+import (
+	"context"
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/require"
+)
+
+// enableRecapsForTest turns on the AI Recaps feature and disables the manual
+// cooldown so tests can create multiple recaps back to back.
+func enableRecapsForTest(th *TestHelper) {
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		cfg.FeatureFlags.EnableAIRecaps = true
+		cfg.AIRecapSettings.DefaultLimits.CooldownMinutes = model.NewPointer(0)
+	})
+}
+
+func TestCreateRecap(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	t.Run("feature disabled", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.EnableAIRecaps = false })
+
+		_, resp, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
+			Title:      "My recap",
+			ChannelIds: []string{th.BasicChannel.Id},
+			AgentID:    model.NewId(),
+		})
+		require.Error(t, err)
+		CheckNotImplementedStatus(t, resp)
+	})
+
+	enableRecapsForTest(th)
+
+	t.Run("invalid request bodies", func(t *testing.T) {
+		for name, req := range map[string]*model.CreateRecapRequest{
+			"missing channel ids": {Title: "My recap", AgentID: model.NewId()},
+			"missing title":       {ChannelIds: []string{th.BasicChannel.Id}, AgentID: model.NewId()},
+			"missing agent id":    {Title: "My recap", ChannelIds: []string{th.BasicChannel.Id}},
+		} {
+			t.Run(name, func(t *testing.T) {
+				_, resp, err := th.Client.CreateRecap(context.Background(), req)
+				require.Error(t, err)
+				CheckBadRequestStatus(t, resp)
+			})
+		}
+	})
+
+	t.Run("channel the user cannot read", func(t *testing.T) {
+		privateChannel := th.CreatePrivateChannel(t)
+		th.RemoveUserFromChannel(t, th.BasicUser, privateChannel)
+
+		_, resp, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
+			Title:      "My recap",
+			ChannelIds: []string{privateChannel.Id},
+			AgentID:    model.NewId(),
+		})
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		agentID := model.NewId()
+		recap, resp, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
+			Title:      "My recap",
+			ChannelIds: []string{th.BasicChannel.Id},
+			AgentID:    agentID,
+		})
+		require.NoError(t, err)
+		CheckCreatedStatus(t, resp)
+		require.NotNil(t, recap)
+		require.NotEmpty(t, recap.Id)
+		require.Equal(t, th.BasicUser.Id, recap.UserId)
+		require.Equal(t, "My recap", recap.Title)
+		require.Equal(t, agentID, recap.BotID)
+		require.Equal(t, model.RecapStatusPending, recap.Status)
+	})
+}
+
+func TestGetRecap(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+	enableRecapsForTest(th)
+
+	created, _, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
+		Title:      "My recap",
+		ChannelIds: []string{th.BasicChannel.Id},
+		AgentID:    model.NewId(),
+	})
+	require.NoError(t, err)
+
+	t.Run("owner can fetch", func(t *testing.T) {
+		recap, _, err := th.Client.GetRecap(context.Background(), created.Id)
+		require.NoError(t, err)
+		require.Equal(t, created.Id, recap.Id)
+		require.Equal(t, created.Title, recap.Title)
+	})
+
+	t.Run("other user is forbidden", func(t *testing.T) {
+		th.LoginBasic2(t)
+		defer th.LoginBasic(t)
+
+		_, resp, err := th.Client.GetRecap(context.Background(), created.Id)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("unknown recap", func(t *testing.T) {
+		_, resp, err := th.Client.GetRecap(context.Background(), model.NewId())
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+	})
+}
+
+func TestGetRecaps(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+	enableRecapsForTest(th)
+
+	first, _, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
+		Title:      "First recap",
+		ChannelIds: []string{th.BasicChannel.Id},
+		AgentID:    model.NewId(),
+	})
+	require.NoError(t, err)
+
+	second, _, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
+		Title:      "Second recap",
+		ChannelIds: []string{th.BasicChannel.Id},
+		AgentID:    model.NewId(),
+	})
+	require.NoError(t, err)
+
+	t.Run("lists own recaps", func(t *testing.T) {
+		recaps, _, err := th.Client.GetRecaps(context.Background(), 0, 10)
+		require.NoError(t, err)
+
+		ids := make([]string, 0, len(recaps))
+		for _, recap := range recaps {
+			require.Equal(t, th.BasicUser.Id, recap.UserId)
+			ids = append(ids, recap.Id)
+		}
+		require.Contains(t, ids, first.Id)
+		require.Contains(t, ids, second.Id)
+	})
+
+	t.Run("pagination", func(t *testing.T) {
+		recaps, _, err := th.Client.GetRecaps(context.Background(), 0, 1)
+		require.NoError(t, err)
+		require.Len(t, recaps, 1)
+	})
+
+	t.Run("other user sees none of them", func(t *testing.T) {
+		th.LoginBasic2(t)
+		defer th.LoginBasic(t)
+
+		recaps, _, err := th.Client.GetRecaps(context.Background(), 0, 10)
+		require.NoError(t, err)
+		for _, recap := range recaps {
+			require.NotEqual(t, th.BasicUser.Id, recap.UserId)
+		}
+	})
+}
+
+func TestGetRecapLimitStatus(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+	enableRecapsForTest(th)
+
+	status, _, err := th.Client.GetRecapLimitStatus(context.Background())
+	require.NoError(t, err)
+	require.NotNil(t, status)
+	require.Equal(t, 10, status.EffectiveLimits.MaxRecapsPerDay)
+	require.Equal(t, 0, status.Daily.Used)
+
+	_, _, err = th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
+		Title:      "My recap",
+		ChannelIds: []string{th.BasicChannel.Id},
+		AgentID:    model.NewId(),
+	})
+	require.NoError(t, err)
+
+	status, _, err = th.Client.GetRecapLimitStatus(context.Background())
+	require.NoError(t, err)
+	require.Equal(t, 1, status.Daily.Used)
+}
+
+func TestMarkRecapReadAndViewed(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+	enableRecapsForTest(th)
+
+	created, _, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
+		Title:      "My recap",
+		ChannelIds: []string{th.BasicChannel.Id},
+		AgentID:    model.NewId(),
+	})
+	require.NoError(t, err)
+
+	t.Run("other user cannot mark read", func(t *testing.T) {
+		th.LoginBasic2(t)
+		defer th.LoginBasic(t)
+
+		_, resp, err := th.Client.MarkRecapAsRead(context.Background(), created.Id)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("mark read", func(t *testing.T) {
+		recap, _, err := th.Client.MarkRecapAsRead(context.Background(), created.Id)
+		require.NoError(t, err)
+		require.Greater(t, recap.ReadAt, int64(0))
+	})
+
+	t.Run("mark viewed", func(t *testing.T) {
+		viewed, _, err := th.Client.MarkRecapsAsViewed(context.Background())
+		require.NoError(t, err)
+		require.Contains(t, viewed.RecapIds, created.Id)
+
+		recap, _, err := th.Client.GetRecap(context.Background(), created.Id)
+		require.NoError(t, err)
+		require.Greater(t, recap.ViewedAt, int64(0))
+	})
+}
+
+func TestDeleteRecap(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+	enableRecapsForTest(th)
+
+	created, _, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
+		Title:      "My recap",
+		ChannelIds: []string{th.BasicChannel.Id},
+		AgentID:    model.NewId(),
+	})
+	require.NoError(t, err)
+
+	t.Run("other user cannot delete", func(t *testing.T) {
+		th.LoginBasic2(t)
+		defer th.LoginBasic(t)
+
+		resp, err := th.Client.DeleteRecap(context.Background(), created.Id)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("owner can delete", func(t *testing.T) {
+		_, err := th.Client.DeleteRecap(context.Background(), created.Id)
+		require.NoError(t, err)
+
+		_, resp, err := th.Client.GetRecap(context.Background(), created.Id)
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+	})
+}
+
+func newTestScheduledRecap(th *TestHelper) *model.ScheduledRecap {
+	return &model.ScheduledRecap{
+		Title:       "Morning recap",
+		DaysOfWeek:  model.Weekdays,
+		TimeOfDay:   "09:00",
+		Timezone:    "UTC",
+		TimePeriod:  model.TimePeriodLast24h,
+		ChannelMode: model.ChannelModeSpecific,
+		ChannelIds:  model.StringArray{th.BasicChannel.Id},
+		AgentId:     model.NewId(),
+		IsRecurring: true,
+	}
+}
+
+func TestCreateScheduledRecap(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	t.Run("feature disabled", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.EnableAIRecaps = false })
+
+		_, resp, err := th.Client.CreateScheduledRecap(context.Background(), newTestScheduledRecap(th))
+		require.Error(t, err)
+		CheckNotImplementedStatus(t, resp)
+	})
+
+	enableRecapsForTest(th)
+
+	t.Run("missing required fields", func(t *testing.T) {
+		scheduledRecap := newTestScheduledRecap(th)
+		scheduledRecap.TimeOfDay = ""
+
+		_, resp, err := th.Client.CreateScheduledRecap(context.Background(), scheduledRecap)
+		require.Error(t, err)
+		CheckBadRequestStatus(t, resp)
+	})
+
+	t.Run("happy path", func(t *testing.T) {
+		created, resp, err := th.Client.CreateScheduledRecap(context.Background(), newTestScheduledRecap(th))
+		require.NoError(t, err)
+		CheckCreatedStatus(t, resp)
+		require.NotEmpty(t, created.Id)
+		require.Equal(t, th.BasicUser.Id, created.UserId)
+		require.True(t, created.Enabled)
+		require.Greater(t, created.NextRunAt, int64(0))
+	})
+}
+
+func TestScheduledRecapLifecycle(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+	enableRecapsForTest(th)
+
+	created, _, err := th.Client.CreateScheduledRecap(context.Background(), newTestScheduledRecap(th))
+	require.NoError(t, err)
+
+	t.Run("get", func(t *testing.T) {
+		fetched, _, err := th.Client.GetScheduledRecap(context.Background(), created.Id)
+		require.NoError(t, err)
+		require.Equal(t, created.Id, fetched.Id)
+	})
+
+	t.Run("list", func(t *testing.T) {
+		scheduledRecaps, _, err := th.Client.GetScheduledRecaps(context.Background(), 0, 10)
+		require.NoError(t, err)
+
+		ids := make([]string, 0, len(scheduledRecaps))
+		for _, scheduledRecap := range scheduledRecaps {
+			ids = append(ids, scheduledRecap.Id)
+		}
+		require.Contains(t, ids, created.Id)
+	})
+
+	t.Run("update", func(t *testing.T) {
+		updateRequest := newTestScheduledRecap(th)
+		updateRequest.Id = created.Id
+		updateRequest.Title = "Evening recap"
+		updateRequest.TimeOfDay = "18:00"
+
+		updated, _, err := th.Client.UpdateScheduledRecap(context.Background(), updateRequest)
+		require.NoError(t, err)
+		require.Equal(t, "Evening recap", updated.Title)
+		require.Equal(t, "18:00", updated.TimeOfDay)
+	})
+
+	t.Run("pause and resume", func(t *testing.T) {
+		paused, _, err := th.Client.PauseScheduledRecap(context.Background(), created.Id)
+		require.NoError(t, err)
+		require.False(t, paused.Enabled)
+
+		resumed, _, err := th.Client.ResumeScheduledRecap(context.Background(), created.Id)
+		require.NoError(t, err)
+		require.True(t, resumed.Enabled)
+	})
+
+	t.Run("other user is forbidden", func(t *testing.T) {
+		th.LoginBasic2(t)
+		defer th.LoginBasic(t)
+
+		_, resp, err := th.Client.GetScheduledRecap(context.Background(), created.Id)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+
+		otherUserUpdate := newTestScheduledRecap(th)
+		otherUserUpdate.Id = created.Id
+		_, resp, err = th.Client.UpdateScheduledRecap(context.Background(), otherUserUpdate)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+
+		resp, err = th.Client.DeleteScheduledRecap(context.Background(), created.Id)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("delete", func(t *testing.T) {
+		_, err := th.Client.DeleteScheduledRecap(context.Background(), created.Id)
+		require.NoError(t, err)
+
+		_, resp, err := th.Client.GetScheduledRecap(context.Background(), created.Id)
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+	})
+}

--- a/server/channels/api4/recap_test.go
+++ b/server/channels/api4/recap_test.go
@@ -11,32 +11,40 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// enableRecapsForTest turns on the AI Recaps feature and disables the manual
-// cooldown so tests can create multiple recaps back to back.
-func enableRecapsForTest(th *TestHelper) {
-	th.App.UpdateConfig(func(cfg *model.Config) {
-		cfg.FeatureFlags.EnableAIRecaps = true
-		cfg.AIRecapSettings.DefaultLimits.CooldownMinutes = model.NewPointer(0)
-	})
+// recapTestConfig enables AI Recaps (must happen at setup time: SetupConfig
+// unlocks feature-flag writes, which plain Setup keeps read-only), stops job
+// workers so recaps stay in the status the API wrote, and defensively zeroes
+// the manual cooldown so tests can create recaps back to back.
+func recapTestConfig(cfg *model.Config) {
+	cfg.FeatureFlags.EnableAIRecaps = true
+	cfg.AIRecapSettings.DefaultLimits.CooldownMinutes = model.NewPointer(0)
+	cfg.AIRecapSettings.DefaultLimits.MaxRecapsPerDay = model.NewPointer(10)
+	cfg.JobSettings.RunJobs = model.NewPointer(false)
+}
+
+// withRecapsDisabled toggles the AI Recaps feature flag off for the duration
+// of the callback.
+func withRecapsDisabled(th *TestHelper, fn func()) {
+	th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.EnableAIRecaps = false })
+	defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.EnableAIRecaps = true })
+	fn()
 }
 
 func TestCreateRecap(t *testing.T) {
 	mainHelper.Parallel(t)
-	th := Setup(t).InitBasic(t)
+	th := SetupConfig(t, recapTestConfig).InitBasic(t)
 
 	t.Run("feature disabled", func(t *testing.T) {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.EnableAIRecaps = false })
-
-		_, resp, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
-			Title:      "My recap",
-			ChannelIds: []string{th.BasicChannel.Id},
-			AgentID:    model.NewId(),
+		withRecapsDisabled(th, func() {
+			_, resp, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
+				Title:      "My recap",
+				ChannelIds: []string{th.BasicChannel.Id},
+				AgentID:    model.NewId(),
+			})
+			require.Error(t, err)
+			CheckNotImplementedStatus(t, resp)
 		})
-		require.Error(t, err)
-		CheckNotImplementedStatus(t, resp)
 	})
-
-	enableRecapsForTest(th)
 
 	t.Run("invalid request bodies", func(t *testing.T) {
 		for name, req := range map[string]*model.CreateRecapRequest{
@@ -85,8 +93,7 @@ func TestCreateRecap(t *testing.T) {
 
 func TestGetRecap(t *testing.T) {
 	mainHelper.Parallel(t)
-	th := Setup(t).InitBasic(t)
-	enableRecapsForTest(th)
+	th := SetupConfig(t, recapTestConfig).InitBasic(t)
 
 	created, _, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
 		Title:      "My recap",
@@ -120,8 +127,7 @@ func TestGetRecap(t *testing.T) {
 
 func TestGetRecaps(t *testing.T) {
 	mainHelper.Parallel(t)
-	th := Setup(t).InitBasic(t)
-	enableRecapsForTest(th)
+	th := SetupConfig(t, recapTestConfig).InitBasic(t)
 
 	first, _, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
 		Title:      "First recap",
@@ -162,16 +168,13 @@ func TestGetRecaps(t *testing.T) {
 
 		recaps, _, err := th.Client.GetRecaps(context.Background(), 0, 10)
 		require.NoError(t, err)
-		for _, recap := range recaps {
-			require.NotEqual(t, th.BasicUser.Id, recap.UserId)
-		}
+		require.Empty(t, recaps)
 	})
 }
 
 func TestGetRecapLimitStatus(t *testing.T) {
 	mainHelper.Parallel(t)
-	th := Setup(t).InitBasic(t)
-	enableRecapsForTest(th)
+	th := SetupConfig(t, recapTestConfig).InitBasic(t)
 
 	status, _, err := th.Client.GetRecapLimitStatus(context.Background())
 	require.NoError(t, err)
@@ -193,8 +196,7 @@ func TestGetRecapLimitStatus(t *testing.T) {
 
 func TestMarkRecapReadAndViewed(t *testing.T) {
 	mainHelper.Parallel(t)
-	th := Setup(t).InitBasic(t)
-	enableRecapsForTest(th)
+	th := SetupConfig(t, recapTestConfig).InitBasic(t)
 
 	created, _, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
 		Title:      "My recap",
@@ -219,6 +221,10 @@ func TestMarkRecapReadAndViewed(t *testing.T) {
 	})
 
 	t.Run("mark viewed", func(t *testing.T) {
+		// Only completed/failed recaps get marked viewed; nothing processes
+		// the pending recap in this harness, so complete it directly.
+		require.NoError(t, th.App.Srv().Store().Recap().UpdateRecapStatus(created.Id, model.RecapStatusCompleted))
+
 		viewed, _, err := th.Client.MarkRecapsAsViewed(context.Background())
 		require.NoError(t, err)
 		require.Contains(t, viewed.RecapIds, created.Id)
@@ -229,10 +235,43 @@ func TestMarkRecapReadAndViewed(t *testing.T) {
 	})
 }
 
+func TestRegenerateRecap(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := SetupConfig(t, recapTestConfig).InitBasic(t)
+
+	created, _, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
+		Title:      "My recap",
+		ChannelIds: []string{th.BasicChannel.Id},
+		AgentID:    model.NewId(),
+	})
+	require.NoError(t, err)
+
+	t.Run("other user cannot regenerate", func(t *testing.T) {
+		th.LoginBasic2(t)
+		defer th.LoginBasic(t)
+
+		_, resp, err := th.Client.RegenerateRecap(context.Background(), created.Id)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("unknown recap", func(t *testing.T) {
+		_, resp, err := th.Client.RegenerateRecap(context.Background(), model.NewId())
+		require.Error(t, err)
+		CheckNotFoundStatus(t, resp)
+	})
+
+	t.Run("owner can regenerate", func(t *testing.T) {
+		recap, _, err := th.Client.RegenerateRecap(context.Background(), created.Id)
+		require.NoError(t, err)
+		require.Equal(t, created.Id, recap.Id)
+		require.Equal(t, model.RecapStatusPending, recap.Status)
+	})
+}
+
 func TestDeleteRecap(t *testing.T) {
 	mainHelper.Parallel(t)
-	th := Setup(t).InitBasic(t)
-	enableRecapsForTest(th)
+	th := SetupConfig(t, recapTestConfig).InitBasic(t)
 
 	created, _, err := th.Client.CreateRecap(context.Background(), &model.CreateRecapRequest{
 		Title:      "My recap",
@@ -276,17 +315,15 @@ func newTestScheduledRecap(th *TestHelper) *model.ScheduledRecap {
 
 func TestCreateScheduledRecap(t *testing.T) {
 	mainHelper.Parallel(t)
-	th := Setup(t).InitBasic(t)
+	th := SetupConfig(t, recapTestConfig).InitBasic(t)
 
 	t.Run("feature disabled", func(t *testing.T) {
-		th.App.UpdateConfig(func(cfg *model.Config) { cfg.FeatureFlags.EnableAIRecaps = false })
-
-		_, resp, err := th.Client.CreateScheduledRecap(context.Background(), newTestScheduledRecap(th))
-		require.Error(t, err)
-		CheckNotImplementedStatus(t, resp)
+		withRecapsDisabled(th, func() {
+			_, resp, err := th.Client.CreateScheduledRecap(context.Background(), newTestScheduledRecap(th))
+			require.Error(t, err)
+			CheckNotImplementedStatus(t, resp)
+		})
 	})
-
-	enableRecapsForTest(th)
 
 	t.Run("missing required fields", func(t *testing.T) {
 		scheduledRecap := newTestScheduledRecap(th)
@@ -310,8 +347,7 @@ func TestCreateScheduledRecap(t *testing.T) {
 
 func TestScheduledRecapLifecycle(t *testing.T) {
 	mainHelper.Parallel(t)
-	th := Setup(t).InitBasic(t)
-	enableRecapsForTest(th)
+	th := SetupConfig(t, recapTestConfig).InitBasic(t)
 
 	created, _, err := th.Client.CreateScheduledRecap(context.Background(), newTestScheduledRecap(th))
 	require.NoError(t, err)

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -361,6 +361,22 @@ func (c *Client4) aiBridgeTestHelperRoute() clientRoute {
 	return c.systemRoute().Join("e2e", "ai_bridge")
 }
 
+func (c *Client4) recapsRoute() clientRoute {
+	return newClientRoute("recaps")
+}
+
+func (c *Client4) recapRoute(recapId string) clientRoute {
+	return c.recapsRoute().Join(recapId)
+}
+
+func (c *Client4) scheduledRecapsRoute() clientRoute {
+	return newClientRoute("scheduled_recaps")
+}
+
+func (c *Client4) scheduledRecapRoute(scheduledRecapId string) clientRoute {
+	return c.scheduledRecapsRoute().Join(scheduledRecapId)
+}
+
 func (c *Client4) cloudRoute() clientRoute {
 	return newClientRoute("cloud")
 }
@@ -7862,6 +7878,167 @@ func (c *Client4) DeleteAIBridgeTestHelper(ctx context.Context) (*Response, erro
 	}
 	defer closeBody(r)
 	return BuildResponse(r), nil
+}
+
+// AI Recaps Section
+
+// CreateRecap creates a new recap for the given channels. The recap is
+// processed asynchronously; the returned recap starts in the pending status.
+func (c *Client4) CreateRecap(ctx context.Context, request *CreateRecapRequest) (*Recap, *Response, error) {
+	r, err := c.doAPIPostJSON(ctx, c.recapsRoute(), request)
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[*Recap](r)
+}
+
+// GetRecap returns a recap owned by the current user, including its per-channel summaries.
+func (c *Client4) GetRecap(ctx context.Context, recapId string) (*Recap, *Response, error) {
+	r, err := c.doAPIGet(ctx, c.recapRoute(recapId), "")
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[*Recap](r)
+}
+
+// GetRecaps returns a page of the current user's recaps.
+func (c *Client4) GetRecaps(ctx context.Context, page, perPage int) ([]*Recap, *Response, error) {
+	values := url.Values{}
+	values.Set("page", strconv.Itoa(page))
+	values.Set("per_page", strconv.Itoa(perPage))
+	r, err := c.doAPIGetWithQuery(ctx, c.recapsRoute(), values, "")
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[[]*Recap](r)
+}
+
+// GetRecapLimitStatus returns the current user's recap limits, daily usage and cooldown state.
+func (c *Client4) GetRecapLimitStatus(ctx context.Context) (*RecapLimitStatus, *Response, error) {
+	r, err := c.doAPIGet(ctx, c.recapsRoute().Join("limit_status"), "")
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[*RecapLimitStatus](r)
+}
+
+// MarkRecapsAsViewed marks all of the current user's unviewed recaps as viewed
+// and returns the affected recap IDs.
+func (c *Client4) MarkRecapsAsViewed(ctx context.Context) (*MarkRecapsViewedResponse, *Response, error) {
+	r, err := c.doAPIPost(ctx, c.recapsRoute().Join("mark_viewed"), "")
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[*MarkRecapsViewedResponse](r)
+}
+
+// MarkRecapAsRead marks a recap owned by the current user as read.
+func (c *Client4) MarkRecapAsRead(ctx context.Context, recapId string) (*Recap, *Response, error) {
+	r, err := c.doAPIPost(ctx, c.recapRoute(recapId).Join("read"), "")
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[*Recap](r)
+}
+
+// RegenerateRecap re-runs processing for a recap owned by the current user.
+func (c *Client4) RegenerateRecap(ctx context.Context, recapId string) (*Recap, *Response, error) {
+	r, err := c.doAPIPost(ctx, c.recapRoute(recapId).Join("regenerate"), "")
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[*Recap](r)
+}
+
+// DeleteRecap soft-deletes a recap owned by the current user.
+func (c *Client4) DeleteRecap(ctx context.Context, recapId string) (*Response, error) {
+	r, err := c.doAPIDelete(ctx, c.recapRoute(recapId))
+	if err != nil {
+		return BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return BuildResponse(r), nil
+}
+
+// CreateScheduledRecap creates a recurring or one-shot recap schedule for the current user.
+func (c *Client4) CreateScheduledRecap(ctx context.Context, scheduledRecap *ScheduledRecap) (*ScheduledRecap, *Response, error) {
+	r, err := c.doAPIPostJSON(ctx, c.scheduledRecapsRoute(), scheduledRecap)
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[*ScheduledRecap](r)
+}
+
+// GetScheduledRecaps returns a page of the current user's scheduled recaps.
+func (c *Client4) GetScheduledRecaps(ctx context.Context, page, perPage int) ([]*ScheduledRecap, *Response, error) {
+	values := url.Values{}
+	values.Set("page", strconv.Itoa(page))
+	values.Set("per_page", strconv.Itoa(perPage))
+	r, err := c.doAPIGetWithQuery(ctx, c.scheduledRecapsRoute(), values, "")
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[[]*ScheduledRecap](r)
+}
+
+// GetScheduledRecap returns a scheduled recap owned by the current user.
+func (c *Client4) GetScheduledRecap(ctx context.Context, scheduledRecapId string) (*ScheduledRecap, *Response, error) {
+	r, err := c.doAPIGet(ctx, c.scheduledRecapRoute(scheduledRecapId), "")
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[*ScheduledRecap](r)
+}
+
+// UpdateScheduledRecap updates a scheduled recap owned by the current user.
+// The ID is taken from the given scheduled recap.
+func (c *Client4) UpdateScheduledRecap(ctx context.Context, scheduledRecap *ScheduledRecap) (*ScheduledRecap, *Response, error) {
+	r, err := c.doAPIPutJSON(ctx, c.scheduledRecapRoute(scheduledRecap.Id), scheduledRecap)
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[*ScheduledRecap](r)
+}
+
+// DeleteScheduledRecap soft-deletes a scheduled recap owned by the current user.
+func (c *Client4) DeleteScheduledRecap(ctx context.Context, scheduledRecapId string) (*Response, error) {
+	r, err := c.doAPIDelete(ctx, c.scheduledRecapRoute(scheduledRecapId))
+	if err != nil {
+		return BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return BuildResponse(r), nil
+}
+
+// PauseScheduledRecap disables future runs of a scheduled recap owned by the current user.
+func (c *Client4) PauseScheduledRecap(ctx context.Context, scheduledRecapId string) (*ScheduledRecap, *Response, error) {
+	r, err := c.doAPIPost(ctx, c.scheduledRecapRoute(scheduledRecapId).Join("pause"), "")
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[*ScheduledRecap](r)
+}
+
+// ResumeScheduledRecap re-enables a paused scheduled recap owned by the current user.
+func (c *Client4) ResumeScheduledRecap(ctx context.Context, scheduledRecapId string) (*ScheduledRecap, *Response, error) {
+	r, err := c.doAPIPost(ctx, c.scheduledRecapRoute(scheduledRecapId).Join("resume"), "")
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[*ScheduledRecap](r)
 }
 
 // Usage Section

--- a/server/public/model/recap.go
+++ b/server/public/model/recap.go
@@ -42,6 +42,11 @@ type AIRecapSummaryResponse struct {
 	ActionItems []string `json:"action_items"`
 }
 
+// MarkRecapsViewedResponse is the response of POST /api/v4/recaps/mark_viewed.
+type MarkRecapsViewedResponse struct {
+	RecapIds []string `json:"recap_ids"`
+}
+
 type RecapProcessingOptions struct {
 	TimePeriod         string
 	CustomInstructions string


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Adds `Client4` coverage for the AI Recaps REST API so Go consumers (notably `mattermost-load-test-ng`, which will drive recap load testing ahead of GA) can exercise the endpoints with typed clients instead of raw HTTP:

- Recaps: `CreateRecap`, `GetRecap`, `GetRecaps`, `GetRecapLimitStatus`, `MarkRecapsAsViewed`, `MarkRecapAsRead`, `RegenerateRecap`, `DeleteRecap`.
- Scheduled recaps: `CreateScheduledRecap`, `GetScheduledRecaps`, `GetScheduledRecap`, `UpdateScheduledRecap`, `DeleteScheduledRecap`, `PauseScheduledRecap`, `ResumeScheduledRecap`.
- Adds a typed `MarkRecapsViewedResponse` model and uses it in the `mark_viewed` handler in place of an ad-hoc map.
- Adds api4 round-trip tests for both endpoint groups (feature-flag gating, validation, ownership/permission checks, pagination, read/viewed transitions, pause/resume lifecycle) — these endpoints previously had no api4 coverage because no client methods existed.

No server endpoint behavior changes.

#### Release Note

```release-note
🆕 New API file: `recap_test.go`
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-019fd3e2-b922-7399-8d96-37a9ef9c3f75?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-019fd3e2-b922-7399-8d96-37a9ef9c3f75&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>