### PR TITLE
[MM-65680] Add new configuration 'AttributeRefreshIntervalSeconds' to Access Control

### DIFF
--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -11775,6 +11775,10 @@
     "translation": "Invalid access control sync job interval. Must be at least 60 seconds."
   },
   {
+    "id": "model.config.is_valid_access_control_attribute_refresh_interval.app_error",
+    "translation": "Invalid access control attribute refresh interval. Must be greater than or equal to 0."
+  },
+  {
     "id": "model.config.is_valid.ai_recap.cooldown_minutes.app_error",
     "translation": "Invalid AI recap cooldown minutes. Must be greater than or equal to 0."
   },

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -11771,12 +11771,12 @@
     "translation": "To must be greater than From."
   },
   {
-    "id": "model.config.is_valid.access_control_sync_interval.app_error",
-    "translation": "Invalid access control sync job interval. Must be at least 60 seconds."
+    "id": "model.config.is_valid.access_control_attribute_refresh_interval.app_error",
+    "translation": "Invalid access control attribute refresh interval. Must be greater than or equal to 0."
   },
   {
-    "id": "model.config.is_valid_access_control_attribute_refresh_interval.app_error",
-    "translation": "Invalid access control attribute refresh interval. Must be greater than or equal to 0."
+    "id": "model.config.is_valid.access_control_sync_interval.app_error",
+    "translation": "Invalid access control sync job interval. Must be at least 60 seconds."
   },
   {
     "id": "model.config.is_valid.ai_recap.cooldown_minutes.app_error",

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -4160,7 +4160,7 @@ func (s *AccessControlSettings) isValid() *AppError {
 		return NewAppError("Config.IsValid", "model.config.is_valid.access_control_sync_interval.app_error", nil, "", http.StatusBadRequest)
 	}
 	// Refresh interval is designed to avoid spamming a refresh of the AttributeView in the database.
-	// Minimum is set to 0, so an operator can effecitvely disable this protection if desired.
+	// Minimum is set to 0, so an operator can effectively disable this protection if desired.
 	if *s.AttributeRefreshIntervalSeconds < 0 {
 		return NewAppError("Config.IsValid", "model.config.is_valid_access_control_attribute_refresh_interval.app_error", nil, "", http.StatusBadRequest)
 	}

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -4113,7 +4113,8 @@ type AccessControlSettings struct {
 	EnableAccessControlAuditLogging   *bool `access:"write_restrictable,cloud_restrictable"`
 	// Shared interval for both the channel and team membership sync schedulers;
 	// applied at scheduler construction (needs a restart to take effect).
-	SyncJobIntervalSeconds *int `access:"write_restrictable,cloud_restrictable"`
+	SyncJobIntervalSeconds          *int `access:"write_restrictable,cloud_restrictable"`
+	AttributeRefreshIntervalSeconds *int `access:"write_restrictable,cloud_restrictable"`
 }
 
 func (s *AccessControlSettings) SetDefaults() {
@@ -4146,6 +4147,10 @@ func (s *AccessControlSettings) SetDefaults() {
 	if s.SyncJobIntervalSeconds == nil {
 		s.SyncJobIntervalSeconds = new(3600)
 	}
+
+	if s.AttributeRefreshIntervalSeconds == nil {
+		s.AttributeRefreshIntervalSeconds = new(30)
+	}
 }
 
 func (s *AccessControlSettings) isValid() *AppError {
@@ -4153,6 +4158,11 @@ func (s *AccessControlSettings) isValid() *AppError {
 	// would hammer the store to no effect, so reject it outright.
 	if *s.SyncJobIntervalSeconds < 60 {
 		return NewAppError("Config.IsValid", "model.config.is_valid.access_control_sync_interval.app_error", nil, "", http.StatusBadRequest)
+	}
+	// Refresh interval is designed to avoid spamming a refresh of the AttributeView in the database.
+	// Minimum is set to 0, so an operator can effecitvely disable this protection if desired.
+	if *s.AttributeRefreshIntervalSeconds < 0 {
+		return NewAppError("Config.IsValid", "model.config.is_valid_access_control_attribute_refresh_interval.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -4162,7 +4162,7 @@ func (s *AccessControlSettings) isValid() *AppError {
 	// Refresh interval is designed to avoid spamming a refresh of the AttributeView in the database.
 	// Minimum is set to 0, so an operator can effectively disable this protection if desired.
 	if *s.AttributeRefreshIntervalSeconds < 0 {
-		return NewAppError("Config.IsValid", "model.config.is_valid_access_control_attribute_refresh_interval.app_error", nil, "", http.StatusBadRequest)
+		return NewAppError("Config.IsValid", "model.config.is_valid.access_control_attribute_refresh_interval.app_error", nil, "", http.StatusBadRequest)
 	}
 
 	return nil

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -126,10 +126,10 @@ func TestAccessControlSettingsIsValid(t *testing.T) {
 		"sync_job_interval_sub-minute rejected": {AccessControlSettings: AccessControlSettings{SyncJobIntervalSeconds: new(30)}, ExpectError: true},
 		"sync_job_interval_just below minimum":  {AccessControlSettings: AccessControlSettings{SyncJobIntervalSeconds: new(59)}, ExpectError: true},
 		"sync_job_interval_minimum":             {AccessControlSettings: AccessControlSettings{SyncJobIntervalSeconds: new(60)}, ExpectError: false},
-		"sync_job_interval_default":             {AccessControlSettings: AccessControlSettings{SyncJobIntervalSeconds: new(3600)}, ExpectError: false},
+		"sync_job_interval_default":             {AccessControlSettings: AccessControlSettings{SyncJobIntervalSeconds: nil}, ExpectError: false}, // Test will set default
 		"attribute_refresh_interval_zero":       {AccessControlSettings: AccessControlSettings{AttributeRefreshIntervalSeconds: new(0)}, ExpectError: false},
 		"attribute_refresh_interval_negative":   {AccessControlSettings: AccessControlSettings{AttributeRefreshIntervalSeconds: new(-1)}, ExpectError: true},
-		"attribute_refresh_interval_default":    {AccessControlSettings: AccessControlSettings{AttributeRefreshIntervalSeconds: new(30)}, ExpectError: false},
+		"attribute_refresh_interval_default":    {AccessControlSettings: AccessControlSettings{AttributeRefreshIntervalSeconds: nil}, ExpectError: false}, // Test will set default
 	} {
 		t.Run(name, func(t *testing.T) {
 			test.AccessControlSettings.SetDefaults()

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -118,23 +118,26 @@ func TestConfigIsValid(t *testing.T) {
 
 func TestAccessControlSettingsIsValid(t *testing.T) {
 	for name, test := range map[string]struct {
-		IntervalSeconds int
-		ExpectError     bool
+		AccessControlSettings AccessControlSettings
+		ExpectError           bool
 	}{
-		"zero":                {IntervalSeconds: 0, ExpectError: true},
-		"negative":            {IntervalSeconds: -1000, ExpectError: true},
-		"sub-minute rejected": {IntervalSeconds: 30, ExpectError: true},
-		"just below minimum":  {IntervalSeconds: 59, ExpectError: true},
-		"minimum":             {IntervalSeconds: 60, ExpectError: false},
-		"default":             {IntervalSeconds: 3600, ExpectError: false},
+		"sync_job_interval_zero":                {AccessControlSettings: AccessControlSettings{SyncJobIntervalSeconds: new(0)}, ExpectError: true},
+		"sync_job_interval_negative":            {AccessControlSettings: AccessControlSettings{SyncJobIntervalSeconds: new(-1000)}, ExpectError: true},
+		"sync_job_interval_sub-minute rejected": {AccessControlSettings: AccessControlSettings{SyncJobIntervalSeconds: new(30)}, ExpectError: true},
+		"sync_job_interval_just below minimum":  {AccessControlSettings: AccessControlSettings{SyncJobIntervalSeconds: new(59)}, ExpectError: true},
+		"sync_job_interval_minimum":             {AccessControlSettings: AccessControlSettings{SyncJobIntervalSeconds: new(60)}, ExpectError: false},
+		"sync_job_interval_default":             {AccessControlSettings: AccessControlSettings{SyncJobIntervalSeconds: new(3600)}, ExpectError: false},
+		"attribute_refresh_interval_zero":       {AccessControlSettings: AccessControlSettings{AttributeRefreshIntervalSeconds: new(0)}, ExpectError: false},
+		"attribute_refresh_interval_negative":   {AccessControlSettings: AccessControlSettings{AttributeRefreshIntervalSeconds: new(-1)}, ExpectError: true},
+		"attribute_refresh_interval_default":    {AccessControlSettings: AccessControlSettings{AttributeRefreshIntervalSeconds: new(30)}, ExpectError: false},
 	} {
 		t.Run(name, func(t *testing.T) {
-			s := AccessControlSettings{SyncJobIntervalSeconds: new(test.IntervalSeconds)}
+			test.AccessControlSettings.SetDefaults()
 
 			if test.ExpectError {
-				require.NotNil(t, s.isValid())
+				require.NotNil(t, test.AccessControlSettings.isValid())
 			} else {
-				require.Nil(t, s.isValid())
+				require.Nil(t, test.AccessControlSettings.isValid())
 			}
 		})
 	}


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
Adds a new `AttributeRefreshIntervalSeconds` setting to Access Control Settings, to allow an operator more control over how much to throttle refreshing the AttributeView when managing ABAC policies and channels.
Note: this ticket works in conjunction with enterprise [PR-2258](https://github.com/mattermost/enterprise/pull/2258)

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-65680

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
Added ``AccessControlSettings.AttributeRefreshIntervalSeconds`` configuration setting.
```

```release-note
NONE
```
-->
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change modifies the public `AccessControlSettings` contract and validation used by ABAC policy and channel management. Tests cover default initialization and interval validation, but the setting affects an authorization-related configuration path.

**QA Recommendation:** Manual QA is not required. Automated test coverage is sufficient for this isolated configuration change.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->