### PR TITLE
fix(webapp): stop edit-form buttons wrapping at narrow widths (#37778)

### DIFF
--- a/webapp/channels/src/sass/components/_post.scss
+++ b/webapp/channels/src/sass/components/_post.scss
@@ -405,10 +405,12 @@
     > button {
         @include mixins.button-small;
 
+        flex-shrink: 0;
         padding: 10px 16px;
         border-width: 0;
         border-radius: 4px;
         box-shadow: none;
+        white-space: nowrap;
 
         &.cancel {
             background: rgba(var(--button-bg-rgb), 0.08);


### PR DESCRIPTION
Fixes #37778

## What

Two declarations on `.post-body__footer > button` so the Save/Cancel buttons in the inline post editor keep their intrinsic width instead of wrapping.

## Why

The footer is a `nowrap` inline-flex row with three items: Save, Cancel, and the keyboard-hint text. At a 400px viewport that row is 320px and the items measure 54.7 + 87.1 + 162.2 plus two 8px gaps — **exactly 320.0px**, with no slack.

Any narrower and the buttons have to shrink. `min-width` resolves to `min-content`, and CJK text breaks between any two characters, so the label wraps. `@mixin button-small` hard-codes `height: 32px`, so the button cannot grow to fit the extra lines and the text overflows instead.

This pins the buttons and lets the hint text — the least important item in the row — absorb the shrink.

## Verification

Measured line-box count on the Japanese Cancel label (`span.getClientRects().length`), on a patched `master` build:

| footer width | before | after |
|---|---|---|
| 320px | 2 | 1 |
| 280px | 2 | 1 |
| 240px | 2 | 1 |
| 200px | 3 | 1 |
| 160px | 5 | 1 |

After the change both buttons hold their natural width (保存 56.5px, キャンセル 91.6px) at every width tested, and the footer never overflows its container.

Note for anyone re-testing: button *height* is not a usable signal here — it is pinned at 32px at every width by the mixin. Count line boxes instead.

## Not specific to ja

English survives only because "Save"/"Cancel" are short enough to stay under the threshold. Any locale with longer labels for these two buttons hits the same issue.

## Open question

This fixes the buttons but pushes the shrink onto the hint text, whose box goes 175px → 156 → 116 → 76 → 36 as the container narrows, so it clips before 200px. I raised three options on the issue (hide below a breakpoint / let it wrap / ellipsis) and am happy to follow up in this PR with whichever fits the design intent — my inclination is hiding it, since it describes keyboard shortcuts that mostly don't apply on the narrow touch layouts where the overflow happens.

`post-body__footer` is rendered by both `advanced_text_editor/edit_post_footer.tsx` and `edit_scheduled_post/edit_post_footer.tsx`, so this covers both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to post footer button layout styles. Risk is low because it does not affect shared logic, data, APIs, or critical flows.

**QA Recommendation:** Manual QA can be skipped because automated testing has full coverage and verification includes narrow and localized layouts.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->