### PR TITLE
fix(mmctl): lengthen sampledata passwords to meet FIPS minimum

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -621,7 +621,7 @@ inject-test-data: # add test data to the local instance.
 	@echo You may need to restart the Mattermost server before using the following
 	@echo ========================================================================
 	@echo Login with a system admin account username=sysadmin password=Sys@dmin-sample1
-	@echo Login with a regular account username=user-1 password=SampleUs@r-1
+	@echo Login with a regular account username=user-1 password=SampleUs@r-001
 	@echo ========================================================================
 
 .PHONY: test-mmctl-unit

--- a/server/cmd/mmctl/commands/sampledata_util.go
+++ b/server/cmd/mmctl/commands/sampledata_util.go
@@ -116,19 +116,18 @@ func createUser(idx int, teamMemberships int, channelMemberships int, teamsAndCh
 
 	switch userType {
 	case guestUser:
-		password = fmt.Sprintf("SampleGu@st-%d", idx)
+		password = fmt.Sprintf("SampleGu@st-%03d", idx)
 		email = fmt.Sprintf("guest-%d@sample.mattermost.com", idx)
 		roles = "system_guest"
 		if idx == 0 {
 			username = "guest"
-			password = "SampleGu@st1"
 			email = "guest@sample.mattermost.com"
 		}
 	case deactivatedUser:
 		password = fmt.Sprintf("SampleDe@ctivated-%d", idx)
 		email = fmt.Sprintf("deactivated-%d@sample.mattermost.com", idx)
 	default:
-		password = fmt.Sprintf("SampleUs@r-%d", idx)
+		password = fmt.Sprintf("SampleUs@r-%03d", idx)
 		email = fmt.Sprintf("user-%d@sample.mattermost.com", idx)
 		if idx == 0 {
 			username = "sysadmin"

--- a/server/cmd/mmctl/commands/sampledata_util_test.go
+++ b/server/cmd/mmctl/commands/sampledata_util_test.go
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateUserPasswordLength ensures all generated sampledata passwords meet the
+// FIPS minimum length requirement (14 chars) for every user type and index range.
+func TestCreateUserPasswordLength(t *testing.T) {
+	const minLen = model.PasswordFIPSMinimumLength
+
+	indices := []int{0, 1, 9, 10, 99, 100, 999, 1000}
+	userTypes := []string{guestUser, deactivatedUser, ""}
+
+	for _, userType := range userTypes {
+		for _, idx := range indices {
+			data := createUser(idx, 0, 0, map[string][]string{}, nil, userType)
+			pwd := *data.User.Password
+			require.GreaterOrEqualf(t, len(pwd), minLen,
+				"password %q (userType=%q idx=%d) is shorter than FIPS minimum %d",
+				pwd, userType, idx, minLen)
+		}
+	}
+}

--- a/server/cmd/mmctl/commands/sampledata_util_test.go
+++ b/server/cmd/mmctl/commands/sampledata_util_test.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -19,11 +20,13 @@ func TestCreateUserPasswordLength(t *testing.T) {
 
 	for _, userType := range userTypes {
 		for _, idx := range indices {
-			data := createUser(idx, 0, 0, map[string][]string{}, nil, userType)
-			pwd := *data.User.Password
-			require.GreaterOrEqualf(t, len(pwd), minLen,
-				"password %q (userType=%q idx=%d) is shorter than FIPS minimum %d",
-				pwd, userType, idx, minLen)
+			t.Run(fmt.Sprintf("%s/idx=%d", userType, idx), func(t *testing.T) {
+				data := createUser(idx, 0, 0, map[string][]string{}, nil, userType)
+				pwd := *data.User.Password
+				require.GreaterOrEqualf(t, len(pwd), minLen,
+					"password %q (userType=%q idx=%d) is shorter than FIPS minimum %d",
+					pwd, userType, idx, minLen)
+			})
 		}
 	}
 }

--- a/server/cmd/mmctl/commands/sampledata_util_test.go
+++ b/server/cmd/mmctl/commands/sampledata_util_test.go
@@ -25,6 +25,7 @@ func TestCreateUserPasswordLength(t *testing.T) {
 				name = "user"
 			}
 			t.Run(fmt.Sprintf("%s/idx=%d", name, idx), func(t *testing.T) {
+				t.Parallel()
 				data := createUser(idx, 0, 0, map[string][]string{}, nil, userType)
 				pwd := *data.User.Password
 				require.GreaterOrEqualf(t, len(pwd), minLen,

--- a/server/cmd/mmctl/commands/sampledata_util_test.go
+++ b/server/cmd/mmctl/commands/sampledata_util_test.go
@@ -20,7 +20,11 @@ func TestCreateUserPasswordLength(t *testing.T) {
 
 	for _, userType := range userTypes {
 		for _, idx := range indices {
-			t.Run(fmt.Sprintf("%s/idx=%d", userType, idx), func(t *testing.T) {
+			name := userType
+			if name == "" {
+				name = "user"
+			}
+			t.Run(fmt.Sprintf("%s/idx=%d", name, idx), func(t *testing.T) {
 				data := createUser(idx, 0, 0, map[string][]string{}, nil, userType)
 				pwd := *data.User.Password
 				require.GreaterOrEqualf(t, len(pwd), minLen,

--- a/server/cmd/mmctl/commands/sampledata_util_test.go
+++ b/server/cmd/mmctl/commands/sampledata_util_test.go
@@ -10,8 +10,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestCreateUserPasswordLength ensures all generated sampledata passwords meet the
-// FIPS minimum length requirement (14 chars) for every user type and index range.
+// Verifies all sampledata passwords meet the FIPS minimum length (PasswordFIPSMinimumLength).
 func TestCreateUserPasswordLength(t *testing.T) {
 	const minLen = model.PasswordFIPSMinimumLength
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
`mmctl sampledata` (used by `make inject-test-data`) generated passwords as short as 12 chars (e.g. `SampleUs@r-1`, `SampleGu@st1`). When `PasswordSettings.MinimumLength` is 14 — the FIPS default (`PasswordFIPSMinimumLength`) — import fails with `importUser: Unable to save the account., invalid password`.

Fix: zero-pad the index to 3 digits (`%d` → `%03d`) so every generated password is ≥ 14 chars. Guest `idx == 0` no longer overrides the password (avoids colliding with `idx == 1`). Also updates the `inject-test-data` Makefile echo and adds a regression test covering all user types × index edge cases.

QA steps:
1. Set `PasswordSettings.MinimumLength = 14` (or build with `requirefips`)
2. Run `make inject-test-data` or `mmctl sampledata --local`
3. Confirm import succeeds; log in as `user-1` / `SampleUs@r-001` and `guest` / `SampleGu@st-000`

#### Ticket Link
Related: https://mattermost.atlassian.net/browse/MM-68498

#### Release Note
```release-note
Fixed mmctl sampledata generating passwords shorter than the FIPS minimum length of 14 characters.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bf9357db-c5b1-4004-8058-d2224c937003?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bf9357db-c5b1-4004-8058-d2224c937003&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The changes are isolated to sample-data password generation and its login hint. Automated tests cover user types and index edge cases.

**QA Recommendation:** Skip manual QA. Automated coverage is sufficient.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->