### PR TITLE
Add OnLicenseChanged plugin hook

### DIFF
--- a/server/channels/app/channels.go
+++ b/server/channels/app/channels.go
@@ -49,6 +49,7 @@ type Channels struct {
 	pluginsLock                   sync.RWMutex
 	pluginsEnvironment            *plugin.Environment
 	pluginConfigListenerID        string
+	pluginLicenseListenerID       string
 	pluginClusterLeaderListenerID string
 
 	// guardCache caches ChannelGuards rows by ChannelId -> []*store.ChannelGuard.

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -249,6 +249,38 @@ func (ch *Channels) initPlugins(rctx request.CTX, pluginDir, webappPluginDir str
 			return true
 		}, plugin.OnConfigurationChangeID)
 	})
+
+	ch.srv.RemoveLicenseListener(ch.pluginLicenseListenerID)
+	ch.pluginLicenseListenerID = ch.srv.AddLicenseListener(func(oldLicense, newLicense *model.License) {
+		type failedPlugin struct {
+			id  string
+			err error
+		}
+		var failed []failedPlugin
+
+		ch.RunMultiHook(func(hooks plugin.Hooks, manifest *model.Manifest) bool {
+			if err := hooks.OnLicenseChanged(oldLicense, newLicense); err != nil {
+				ch.srv.Log().Error("Plugin OnLicenseChanged hook failed",
+					mlog.String("plugin_id", manifest.Id),
+					mlog.Err(err),
+				)
+				failed = append(failed, failedPlugin{id: manifest.Id, err: err})
+			}
+			return true
+		}, plugin.OnLicenseChangedID)
+
+		if len(failed) == 0 {
+			return
+		}
+
+		pluginsEnvironment := ch.GetPluginsEnvironment()
+		if pluginsEnvironment == nil {
+			return
+		}
+		for _, f := range failed {
+			pluginsEnvironment.MarkPluginFailedToStayRunning(f.id, f.err)
+		}
+	})
 	ch.pluginsLock.Unlock()
 
 	ch.syncPluginsActiveState()
@@ -359,6 +391,8 @@ func (ch *Channels) ShutDownPlugins() {
 
 	ch.RemoveConfigListener(ch.pluginConfigListenerID)
 	ch.pluginConfigListenerID = ""
+	ch.srv.RemoveLicenseListener(ch.pluginLicenseListenerID)
+	ch.pluginLicenseListenerID = ""
 	ch.srv.RemoveClusterLeaderChangedListener(ch.pluginClusterLeaderListenerID)
 	ch.pluginClusterLeaderListenerID = ""
 

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -252,34 +252,10 @@ func (ch *Channels) initPlugins(rctx request.CTX, pluginDir, webappPluginDir str
 
 	ch.srv.RemoveLicenseListener(ch.pluginLicenseListenerID)
 	ch.pluginLicenseListenerID = ch.srv.AddLicenseListener(func(oldLicense, newLicense *model.License) {
-		type failedPlugin struct {
-			id  string
-			err error
-		}
-		var failed []failedPlugin
-
-		ch.RunMultiHook(func(hooks plugin.Hooks, manifest *model.Manifest) bool {
-			if err := hooks.OnLicenseChanged(oldLicense, newLicense); err != nil {
-				ch.srv.Log().Error("Plugin OnLicenseChanged hook failed",
-					mlog.String("plugin_id", manifest.Id),
-					mlog.Err(err),
-				)
-				failed = append(failed, failedPlugin{id: manifest.Id, err: err})
-			}
+		ch.RunMultiHook(func(hooks plugin.Hooks, _ *model.Manifest) bool {
+			hooks.OnLicenseChanged(oldLicense, newLicense)
 			return true
 		}, plugin.OnLicenseChangedID)
-
-		if len(failed) == 0 {
-			return
-		}
-
-		pluginsEnvironment := ch.GetPluginsEnvironment()
-		if pluginsEnvironment == nil {
-			return
-		}
-		for _, f := range failed {
-			pluginsEnvironment.MarkPluginFailedToStayRunning(f.id, f.err)
-		}
 	})
 	ch.pluginsLock.Unlock()
 

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -1515,6 +1515,135 @@ func TestHookOnCloudLimitsUpdated(t *testing.T) {
 	require.True(t, hookCalled)
 }
 
+func TestHookOnLicenseChanged(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	t.Run("invoked on SetLicense and plugin stays active", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t, StartMetrics)
+
+		tearDown, pluginIDs, activationErrors := SetAppEnvironmentWithPlugins(t,
+			[]string{
+				`
+		package main
+
+		import (
+			"github.com/mattermost/mattermost/server/public/model"
+			"github.com/mattermost/mattermost/server/public/plugin"
+		)
+
+		type MyPlugin struct {
+			plugin.MattermostPlugin
+		}
+
+		func (p *MyPlugin) OnLicenseChanged(oldLicense, newLicense *model.License) error {
+			oldID := "nil"
+			if oldLicense != nil {
+				oldID = oldLicense.Id
+			}
+			newID := "nil"
+			if newLicense != nil {
+				newID = newLicense.Id
+			}
+			if appErr := p.API.KVSet("old_license_id", []byte(oldID)); appErr != nil {
+				return appErr
+			}
+			if appErr := p.API.KVSet("new_license_id", []byte(newID)); appErr != nil {
+				return appErr
+			}
+			return nil
+		}
+
+		func main() {
+			plugin.ClientMain(&MyPlugin{})
+		}
+	`,
+			}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		require.Len(t, pluginIDs, 1)
+		require.NoError(t, activationErrors[0])
+		pluginID := pluginIDs[0]
+		require.True(t, th.App.GetPluginsEnvironment().IsActive(pluginID))
+
+		oldLicense := model.NewTestLicense()
+		oldLicense.Id = model.NewId()
+		require.True(t, th.App.Srv().SetLicense(oldLicense))
+
+		newLicense := model.NewTestLicense()
+		newLicense.Id = model.NewId()
+		require.True(t, th.App.Srv().SetLicense(newLicense))
+
+		oldID, appErr := th.App.GetPluginKey(pluginID, "old_license_id")
+		require.Nil(t, appErr)
+		require.Equal(t, []byte(oldLicense.Id), oldID)
+
+		newID, appErr := th.App.GetPluginKey(pluginID, "new_license_id")
+		require.Nil(t, appErr)
+		require.Equal(t, []byte(newLicense.Id), newID)
+
+		require.True(t, th.App.GetPluginsEnvironment().IsActive(pluginID))
+		require.Equal(t, model.PluginStateRunning, th.App.GetPluginsEnvironment().GetPluginState(pluginID))
+	})
+
+	t.Run("error deactivates plugin without rolling back license", func(t *testing.T) {
+		mainHelper.Parallel(t)
+		th := Setup(t, StartMetrics)
+
+		tearDown, pluginIDs, activationErrors := SetAppEnvironmentWithPlugins(t,
+			[]string{
+				`
+		package main
+
+		import (
+			"errors"
+
+			"github.com/mattermost/mattermost/server/public/model"
+			"github.com/mattermost/mattermost/server/public/plugin"
+		)
+
+		type MyPlugin struct {
+			plugin.MattermostPlugin
+		}
+
+		func (p *MyPlugin) OnLicenseChanged(oldLicense, newLicense *model.License) error {
+			return errors.New("license not supported")
+		}
+
+		func main() {
+			plugin.ClientMain(&MyPlugin{})
+		}
+	`,
+			}, th.App, th.NewPluginAPI)
+		defer tearDown()
+
+		require.Len(t, pluginIDs, 1)
+		require.NoError(t, activationErrors[0])
+		pluginID := pluginIDs[0]
+		require.True(t, th.App.GetPluginsEnvironment().IsActive(pluginID))
+
+		license := model.NewTestLicense()
+		license.Id = model.NewId()
+		require.True(t, th.App.Srv().SetLicense(license))
+
+		require.Equal(t, license.Id, th.App.Srv().License().Id)
+		require.False(t, th.App.GetPluginsEnvironment().IsActive(pluginID))
+		require.Equal(t, model.PluginStateFailedToStayRunning, th.App.GetPluginsEnvironment().GetPluginState(pluginID))
+
+		statuses, err := th.App.GetPluginsEnvironment().Statuses()
+		require.NoError(t, err)
+		var found bool
+		for _, status := range statuses {
+			if status.PluginId == pluginID {
+				found = true
+				require.Equal(t, "license not supported", status.Error)
+				require.Equal(t, model.PluginStateFailedToStayRunning, status.State)
+			}
+		}
+		require.True(t, found)
+	})
+}
+
 //go:embed test_templates/hook_notification_will_be_pushed.tmpl
 var hookNotificationWillBePushedTmpl string
 

--- a/server/channels/app/plugin_hooks_test.go
+++ b/server/channels/app/plugin_hooks_test.go
@@ -1517,14 +1517,11 @@ func TestHookOnCloudLimitsUpdated(t *testing.T) {
 
 func TestHookOnLicenseChanged(t *testing.T) {
 	mainHelper.Parallel(t)
+	th := Setup(t, StartMetrics)
 
-	t.Run("invoked on SetLicense and plugin stays active", func(t *testing.T) {
-		mainHelper.Parallel(t)
-		th := Setup(t, StartMetrics)
-
-		tearDown, pluginIDs, activationErrors := SetAppEnvironmentWithPlugins(t,
-			[]string{
-				`
+	tearDown, pluginIDs, activationErrors := SetAppEnvironmentWithPlugins(t,
+		[]string{
+			`
 		package main
 
 		import (
@@ -1536,7 +1533,7 @@ func TestHookOnLicenseChanged(t *testing.T) {
 			plugin.MattermostPlugin
 		}
 
-		func (p *MyPlugin) OnLicenseChanged(oldLicense, newLicense *model.License) error {
+		func (p *MyPlugin) OnLicenseChanged(oldLicense, newLicense *model.License) {
 			oldID := "nil"
 			if oldLicense != nil {
 				oldID = oldLicense.Id
@@ -1545,103 +1542,39 @@ func TestHookOnLicenseChanged(t *testing.T) {
 			if newLicense != nil {
 				newID = newLicense.Id
 			}
-			if appErr := p.API.KVSet("old_license_id", []byte(oldID)); appErr != nil {
-				return appErr
-			}
-			if appErr := p.API.KVSet("new_license_id", []byte(newID)); appErr != nil {
-				return appErr
-			}
-			return nil
+			p.API.KVSet("old_license_id", []byte(oldID))
+			p.API.KVSet("new_license_id", []byte(newID))
 		}
 
 		func main() {
 			plugin.ClientMain(&MyPlugin{})
 		}
 	`,
-			}, th.App, th.NewPluginAPI)
-		defer tearDown()
+		}, th.App, th.NewPluginAPI)
+	defer tearDown()
 
-		require.Len(t, pluginIDs, 1)
-		require.NoError(t, activationErrors[0])
-		pluginID := pluginIDs[0]
-		require.True(t, th.App.GetPluginsEnvironment().IsActive(pluginID))
+	require.Len(t, pluginIDs, 1)
+	require.NoError(t, activationErrors[0])
+	pluginID := pluginIDs[0]
+	require.True(t, th.App.GetPluginsEnvironment().IsActive(pluginID))
 
-		oldLicense := model.NewTestLicense()
-		oldLicense.Id = model.NewId()
-		require.True(t, th.App.Srv().SetLicense(oldLicense))
+	oldLicense := model.NewTestLicense()
+	oldLicense.Id = model.NewId()
+	require.True(t, th.App.Srv().SetLicense(oldLicense))
 
-		newLicense := model.NewTestLicense()
-		newLicense.Id = model.NewId()
-		require.True(t, th.App.Srv().SetLicense(newLicense))
+	newLicense := model.NewTestLicense()
+	newLicense.Id = model.NewId()
+	require.True(t, th.App.Srv().SetLicense(newLicense))
 
-		oldID, appErr := th.App.GetPluginKey(pluginID, "old_license_id")
-		require.Nil(t, appErr)
-		require.Equal(t, []byte(oldLicense.Id), oldID)
+	oldID, appErr := th.App.GetPluginKey(pluginID, "old_license_id")
+	require.Nil(t, appErr)
+	require.Equal(t, []byte(oldLicense.Id), oldID)
 
-		newID, appErr := th.App.GetPluginKey(pluginID, "new_license_id")
-		require.Nil(t, appErr)
-		require.Equal(t, []byte(newLicense.Id), newID)
+	newID, appErr := th.App.GetPluginKey(pluginID, "new_license_id")
+	require.Nil(t, appErr)
+	require.Equal(t, []byte(newLicense.Id), newID)
 
-		require.True(t, th.App.GetPluginsEnvironment().IsActive(pluginID))
-		require.Equal(t, model.PluginStateRunning, th.App.GetPluginsEnvironment().GetPluginState(pluginID))
-	})
-
-	t.Run("error deactivates plugin without rolling back license", func(t *testing.T) {
-		mainHelper.Parallel(t)
-		th := Setup(t, StartMetrics)
-
-		tearDown, pluginIDs, activationErrors := SetAppEnvironmentWithPlugins(t,
-			[]string{
-				`
-		package main
-
-		import (
-			"errors"
-
-			"github.com/mattermost/mattermost/server/public/model"
-			"github.com/mattermost/mattermost/server/public/plugin"
-		)
-
-		type MyPlugin struct {
-			plugin.MattermostPlugin
-		}
-
-		func (p *MyPlugin) OnLicenseChanged(oldLicense, newLicense *model.License) error {
-			return errors.New("license not supported")
-		}
-
-		func main() {
-			plugin.ClientMain(&MyPlugin{})
-		}
-	`,
-			}, th.App, th.NewPluginAPI)
-		defer tearDown()
-
-		require.Len(t, pluginIDs, 1)
-		require.NoError(t, activationErrors[0])
-		pluginID := pluginIDs[0]
-		require.True(t, th.App.GetPluginsEnvironment().IsActive(pluginID))
-
-		license := model.NewTestLicense()
-		license.Id = model.NewId()
-		require.True(t, th.App.Srv().SetLicense(license))
-
-		require.Equal(t, license.Id, th.App.Srv().License().Id)
-		require.False(t, th.App.GetPluginsEnvironment().IsActive(pluginID))
-		require.Equal(t, model.PluginStateFailedToStayRunning, th.App.GetPluginsEnvironment().GetPluginState(pluginID))
-
-		statuses, err := th.App.GetPluginsEnvironment().Statuses()
-		require.NoError(t, err)
-		var found bool
-		for _, status := range statuses {
-			if status.PluginId == pluginID {
-				found = true
-				require.Equal(t, "license not supported", status.Error)
-				require.Equal(t, model.PluginStateFailedToStayRunning, status.State)
-			}
-		}
-		require.True(t, found)
-	})
+	require.True(t, th.App.GetPluginsEnvironment().IsActive(pluginID))
 }
 
 //go:embed test_templates/hook_notification_will_be_pushed.tmpl

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -1392,10 +1392,9 @@ type Z_OnLicenseChangedArgs struct {
 }
 
 type Z_OnLicenseChangedReturns struct {
-	A error
 }
 
-func (g *hooksRPCClient) OnLicenseChanged(oldLicense, newLicense *model.License) error {
+func (g *hooksRPCClient) OnLicenseChanged(oldLicense, newLicense *model.License) {
 	_args := &Z_OnLicenseChangedArgs{oldLicense, newLicense}
 	_returns := &Z_OnLicenseChangedReturns{}
 	if g.implemented[OnLicenseChangedID] {
@@ -1403,12 +1402,12 @@ func (g *hooksRPCClient) OnLicenseChanged(oldLicense, newLicense *model.License)
 			g.log.Error("RPC call OnLicenseChanged to plugin failed.", mlog.Err(err))
 		}
 	}
-	return _returns.A
+
 }
 
 // OnLicenseChangedWithRPCErr returns the same values as OnLicenseChanged, with an additional trailing error
 // for the RPC transport — always the LAST return slot.
-func (g *hooksRPCClient) OnLicenseChangedWithRPCErr(oldLicense, newLicense *model.License) (error, error) {
+func (g *hooksRPCClient) OnLicenseChangedWithRPCErr(oldLicense, newLicense *model.License) error {
 	_args := &Z_OnLicenseChangedArgs{oldLicense, newLicense}
 	_returns := &Z_OnLicenseChangedReturns{}
 	var _err error
@@ -1421,15 +1420,14 @@ func (g *hooksRPCClient) OnLicenseChangedWithRPCErr(oldLicense, newLicense *mode
 			g.log.Debug("RPC call OnLicenseChanged to plugin failed.", mlog.Err(_err))
 		}
 	}
-	return _returns.A, _err
+	return _err
 }
 
 func (s *hooksRPCServer) OnLicenseChanged(args *Z_OnLicenseChangedArgs, returns *Z_OnLicenseChangedReturns) error {
 	if hook, ok := s.impl.(interface {
-		OnLicenseChanged(oldLicense, newLicense *model.License) error
+		OnLicenseChanged(oldLicense, newLicense *model.License)
 	}); ok {
-		returns.A = hook.OnLicenseChanged(args.A, args.B)
-		returns.A = encodableError(returns.A)
+		hook.OnLicenseChanged(args.A, args.B)
 	} else {
 		return encodableError(fmt.Errorf("Hook OnLicenseChanged called but not implemented."))
 	}
@@ -2305,7 +2303,7 @@ type HooksWithRPCErrGenerated interface {
 
 	OnCloudLimitsUpdatedWithRPCErr(limits *model.ProductLimits) error
 
-	OnLicenseChangedWithRPCErr(oldLicense, newLicense *model.License) (error, error)
+	OnLicenseChangedWithRPCErr(oldLicense, newLicense *model.License) error
 
 	ConfigurationWillBeSavedWithRPCErr(newCfg *model.Config) (*model.Config, error, error)
 

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -1383,6 +1383,60 @@ func (s *hooksRPCServer) OnCloudLimitsUpdated(args *Z_OnCloudLimitsUpdatedArgs, 
 }
 
 func init() {
+	hookNameToId["OnLicenseChanged"] = OnLicenseChangedID
+}
+
+type Z_OnLicenseChangedArgs struct {
+	A *model.License
+	B *model.License
+}
+
+type Z_OnLicenseChangedReturns struct {
+	A error
+}
+
+func (g *hooksRPCClient) OnLicenseChanged(oldLicense, newLicense *model.License) error {
+	_args := &Z_OnLicenseChangedArgs{oldLicense, newLicense}
+	_returns := &Z_OnLicenseChangedReturns{}
+	if g.implemented[OnLicenseChangedID] {
+		if err := g.client.Call("Plugin.OnLicenseChanged", _args, _returns); err != nil {
+			g.log.Error("RPC call OnLicenseChanged to plugin failed.", mlog.Err(err))
+		}
+	}
+	return _returns.A
+}
+
+// OnLicenseChangedWithRPCErr returns the same values as OnLicenseChanged, with an additional trailing error
+// for the RPC transport — always the LAST return slot.
+func (g *hooksRPCClient) OnLicenseChangedWithRPCErr(oldLicense, newLicense *model.License) (error, error) {
+	_args := &Z_OnLicenseChangedArgs{oldLicense, newLicense}
+	_returns := &Z_OnLicenseChangedReturns{}
+	var _err error
+	if g.implemented[OnLicenseChangedID] {
+		_err = g.client.Call("Plugin.OnLicenseChanged", _args, _returns)
+		if _err != nil {
+			// Reset _returns so partial gob decoding can't leak non-zero
+			// values past a transport failure (HooksWithRPCErrGenerated contract).
+			_returns = &Z_OnLicenseChangedReturns{}
+			g.log.Debug("RPC call OnLicenseChanged to plugin failed.", mlog.Err(_err))
+		}
+	}
+	return _returns.A, _err
+}
+
+func (s *hooksRPCServer) OnLicenseChanged(args *Z_OnLicenseChangedArgs, returns *Z_OnLicenseChangedReturns) error {
+	if hook, ok := s.impl.(interface {
+		OnLicenseChanged(oldLicense, newLicense *model.License) error
+	}); ok {
+		returns.A = hook.OnLicenseChanged(args.A, args.B)
+		returns.A = encodableError(returns.A)
+	} else {
+		return encodableError(fmt.Errorf("Hook OnLicenseChanged called but not implemented."))
+	}
+	return nil
+}
+
+func init() {
 	hookNameToId["ConfigurationWillBeSaved"] = ConfigurationWillBeSavedID
 }
 
@@ -2250,6 +2304,8 @@ type HooksWithRPCErrGenerated interface {
 	OnSendDailyTelemetryWithRPCErr() error
 
 	OnCloudLimitsUpdatedWithRPCErr(limits *model.ProductLimits) error
+
+	OnLicenseChangedWithRPCErr(oldLicense, newLicense *model.License) (error, error)
 
 	ConfigurationWillBeSavedWithRPCErr(newCfg *model.Config) (*model.Config, error, error)
 

--- a/server/public/plugin/environment.go
+++ b/server/public/plugin/environment.go
@@ -198,16 +198,6 @@ func (env *Environment) setPluginState(id string, state int) {
 	}
 }
 
-// MarkPluginFailedToStayRunning deactivates a plugin and records it as failed to stay running,
-// matching the health-check crash exhaustion path. Order matters: deactivate first, then set state.
-func (env *Environment) MarkPluginFailedToStayRunning(id string, err error) {
-	env.Deactivate(id)
-	if err != nil {
-		env.SetPluginError(id, err.Error())
-	}
-	env.setPluginState(id, model.PluginStateFailedToStayRunning)
-}
-
 // setPluginSupervisor records the supervisor for a registered plugin.
 func (env *Environment) setPluginSupervisor(id string, supervisor *supervisor) {
 	if rp, ok := env.registeredPlugins.Load(id); ok {

--- a/server/public/plugin/environment.go
+++ b/server/public/plugin/environment.go
@@ -198,6 +198,16 @@ func (env *Environment) setPluginState(id string, state int) {
 	}
 }
 
+// MarkPluginFailedToStayRunning deactivates a plugin and records it as failed to stay running,
+// matching the health-check crash exhaustion path. Order matters: deactivate first, then set state.
+func (env *Environment) MarkPluginFailedToStayRunning(id string, err error) {
+	env.Deactivate(id)
+	if err != nil {
+		env.SetPluginError(id, err.Error())
+	}
+	env.setPluginState(id, model.PluginStateFailedToStayRunning)
+}
+
 // setPluginSupervisor records the supervisor for a registered plugin.
 func (env *Environment) setPluginSupervisor(id string, supervisor *supervisor) {
 	if rp, ok := env.registeredPlugins.Load(id); ok {

--- a/server/public/plugin/hooks.go
+++ b/server/public/plugin/hooks.go
@@ -378,11 +378,8 @@ type Hooks interface {
 	// upload, removal, expiry, and cluster-driven reloads. Either license may
 	// be nil (unlicensed ↔ licensed transitions).
 	//
-	// Returning an error does not prevent or roll back the license change, but
-	// the plugin will be deactivated and marked as failed to stay running.
-	//
 	// Minimum server version: 11.12
-	OnLicenseChanged(oldLicense, newLicense *model.License) error
+	OnLicenseChanged(oldLicense, newLicense *model.License)
 
 	// ConfigurationWillBeSaved is invoked before saving the configuration to the
 	// backing store.

--- a/server/public/plugin/hooks.go
+++ b/server/public/plugin/hooks.go
@@ -378,6 +378,10 @@ type Hooks interface {
 	// upload, removal, expiry, and cluster-driven reloads. Either license may
 	// be nil (unlicensed ↔ licensed transitions).
 	//
+	// This hook is not invoked for the initial license load at startup. Plugins
+	// that need the current license when activated should call API.GetLicense()
+	// from OnActivate.
+	//
 	// Minimum server version: 12.0
 	OnLicenseChanged(oldLicense, newLicense *model.License)
 

--- a/server/public/plugin/hooks.go
+++ b/server/public/plugin/hooks.go
@@ -378,7 +378,7 @@ type Hooks interface {
 	// upload, removal, expiry, and cluster-driven reloads. Either license may
 	// be nil (unlicensed ↔ licensed transitions).
 	//
-	// Minimum server version: 11.12
+	// Minimum server version: 12.0
 	OnLicenseChanged(oldLicense, newLicense *model.License)
 
 	// ConfigurationWillBeSaved is invoked before saving the configuration to the

--- a/server/public/plugin/hooks.go
+++ b/server/public/plugin/hooks.go
@@ -74,6 +74,7 @@ const (
 	ScheduledPostWillBeCreatedID              = 54
 	DraftWillBeUpsertedID                     = 55
 	MessagesWillBeConsumedWithContextID       = 56
+	OnLicenseChangedID                        = 57
 	TotalHooksID                              = iota
 )
 
@@ -372,6 +373,16 @@ type Hooks interface {
 	//
 	// Minimum server version: 7.0
 	OnCloudLimitsUpdated(limits *model.ProductLimits)
+
+	// OnLicenseChanged is invoked when the server license changes, including
+	// upload, removal, expiry, and cluster-driven reloads. Either license may
+	// be nil (unlicensed ↔ licensed transitions).
+	//
+	// Returning an error does not prevent or roll back the license change, but
+	// the plugin will be deactivated and marked as failed to stay running.
+	//
+	// Minimum server version: 11.12
+	OnLicenseChanged(oldLicense, newLicense *model.License) error
 
 	// ConfigurationWillBeSaved is invoked before saving the configuration to the
 	// backing store.

--- a/server/public/plugin/hooks_timer_layer_generated.go
+++ b/server/public/plugin/hooks_timer_layer_generated.go
@@ -262,6 +262,13 @@ func (hooks *hooksTimerLayer) OnCloudLimitsUpdated(limits *model.ProductLimits) 
 	hooks.recordTime(startTime, "OnCloudLimitsUpdated", true)
 }
 
+func (hooks *hooksTimerLayer) OnLicenseChanged(oldLicense, newLicense *model.License) error {
+	startTime := timePkg.Now()
+	_returnsA := hooks.hooksImpl.OnLicenseChanged(oldLicense, newLicense)
+	hooks.recordTime(startTime, "OnLicenseChanged", _returnsA == nil)
+	return _returnsA
+}
+
 func (hooks *hooksTimerLayer) ConfigurationWillBeSaved(newCfg *model.Config) (*model.Config, error) {
 	startTime := timePkg.Now()
 	_returnsA, _returnsB := hooks.hooksImpl.ConfigurationWillBeSaved(newCfg)
@@ -551,6 +558,13 @@ func (hooks *hooksTimerLayer) OnCloudLimitsUpdatedWithRPCErr(limits *model.Produ
 	_returnsRPCErr := hooks.hooksWithRPCErrImpl.OnCloudLimitsUpdatedWithRPCErr(limits)
 	hooks.recordTime(startTime, "OnCloudLimitsUpdatedWithRPCErr", _returnsRPCErr == nil)
 	return _returnsRPCErr
+}
+
+func (hooks *hooksTimerLayer) OnLicenseChangedWithRPCErr(oldLicense, newLicense *model.License) (error, error) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsRPCErr := hooks.hooksWithRPCErrImpl.OnLicenseChangedWithRPCErr(oldLicense, newLicense)
+	hooks.recordTime(startTime, "OnLicenseChangedWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
+	return _returnsA, _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) ConfigurationWillBeSavedWithRPCErr(newCfg *model.Config) (*model.Config, error, error) {

--- a/server/public/plugin/hooks_timer_layer_generated.go
+++ b/server/public/plugin/hooks_timer_layer_generated.go
@@ -262,11 +262,10 @@ func (hooks *hooksTimerLayer) OnCloudLimitsUpdated(limits *model.ProductLimits) 
 	hooks.recordTime(startTime, "OnCloudLimitsUpdated", true)
 }
 
-func (hooks *hooksTimerLayer) OnLicenseChanged(oldLicense, newLicense *model.License) error {
+func (hooks *hooksTimerLayer) OnLicenseChanged(oldLicense, newLicense *model.License) {
 	startTime := timePkg.Now()
-	_returnsA := hooks.hooksImpl.OnLicenseChanged(oldLicense, newLicense)
-	hooks.recordTime(startTime, "OnLicenseChanged", _returnsA == nil)
-	return _returnsA
+	hooks.hooksImpl.OnLicenseChanged(oldLicense, newLicense)
+	hooks.recordTime(startTime, "OnLicenseChanged", true)
 }
 
 func (hooks *hooksTimerLayer) ConfigurationWillBeSaved(newCfg *model.Config) (*model.Config, error) {
@@ -560,11 +559,11 @@ func (hooks *hooksTimerLayer) OnCloudLimitsUpdatedWithRPCErr(limits *model.Produ
 	return _returnsRPCErr
 }
 
-func (hooks *hooksTimerLayer) OnLicenseChangedWithRPCErr(oldLicense, newLicense *model.License) (error, error) {
+func (hooks *hooksTimerLayer) OnLicenseChangedWithRPCErr(oldLicense, newLicense *model.License) error {
 	startTime := timePkg.Now()
-	_returnsA, _returnsRPCErr := hooks.hooksWithRPCErrImpl.OnLicenseChangedWithRPCErr(oldLicense, newLicense)
-	hooks.recordTime(startTime, "OnLicenseChangedWithRPCErr", _returnsRPCErr == nil && _returnsA == nil)
-	return _returnsA, _returnsRPCErr
+	_returnsRPCErr := hooks.hooksWithRPCErrImpl.OnLicenseChangedWithRPCErr(oldLicense, newLicense)
+	hooks.recordTime(startTime, "OnLicenseChangedWithRPCErr", _returnsRPCErr == nil)
+	return _returnsRPCErr
 }
 
 func (hooks *hooksTimerLayer) ConfigurationWillBeSavedWithRPCErr(newCfg *model.Config) (*model.Config, error, error) {

--- a/server/public/plugin/plugintest/hooks.go
+++ b/server/public/plugin/plugintest/hooks.go
@@ -572,6 +572,24 @@ func (_m *Hooks) OnInstall(c *plugin.Context, event model.OnInstallEvent) error 
 	return r0
 }
 
+// OnLicenseChanged provides a mock function with given fields: oldLicense, newLicense
+func (_m *Hooks) OnLicenseChanged(oldLicense *model.License, newLicense *model.License) error {
+	ret := _m.Called(oldLicense, newLicense)
+
+	if len(ret) == 0 {
+		panic("no return value specified for OnLicenseChanged")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*model.License, *model.License) error); ok {
+		r0 = rf(oldLicense, newLicense)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // OnPluginClusterEvent provides a mock function with given fields: c, ev
 func (_m *Hooks) OnPluginClusterEvent(c *plugin.Context, ev model.PluginClusterEvent) {
 	_m.Called(c, ev)

--- a/server/public/plugin/plugintest/hooks.go
+++ b/server/public/plugin/plugintest/hooks.go
@@ -573,21 +573,8 @@ func (_m *Hooks) OnInstall(c *plugin.Context, event model.OnInstallEvent) error 
 }
 
 // OnLicenseChanged provides a mock function with given fields: oldLicense, newLicense
-func (_m *Hooks) OnLicenseChanged(oldLicense *model.License, newLicense *model.License) error {
-	ret := _m.Called(oldLicense, newLicense)
-
-	if len(ret) == 0 {
-		panic("no return value specified for OnLicenseChanged")
-	}
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*model.License, *model.License) error); ok {
-		r0 = rf(oldLicense, newLicense)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
+func (_m *Hooks) OnLicenseChanged(oldLicense *model.License, newLicense *model.License) {
+	_m.Called(oldLicense, newLicense)
 }
 
 // OnPluginClusterEvent provides a mock function with given fields: c, ev


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Adds a new server plugin hook `OnLicenseChanged(oldLicense, newLicense *model.License)` that is invoked whenever the in-memory license changes through `SetLicense` (upload, remove, expiry, trial, cluster reload, etc.).

- Fire-and-forget notification (same pattern as `OnCloudLimitsUpdated`).
- Minimum server version: 12.0.
- Wired via `AddLicenseListener` in `InitPlugins`, cleaned up in `ShutDownPlugins`.
- Not invoked for the initial license load at startup; plugins should use `API.GetLicense()` in `OnActivate`.

Verified with `go test ./channels/app -run TestHookOnLicenseChanged`. Without this change, the plugins have no choice but request the license every time they have a license check to do.

#### Release Note
```release-note
Added plugin hook OnLicenseChanged, invoked when the server license changes.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-43c650e8-5bf0-4ad7-90d6-978e744ab5a9?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-43c650e8-5bf0-4ad7-90d6-978e744ab5a9&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change spans public plugin APIs, RPC dispatch, and plugin lifecycle handling. Automated coverage verifies the main hook flow, but lifecycle and transport paths have limited coverage.  
**QA Recommendation:** Skip manual QA. Run the targeted automated test and standard plugin checks.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->