### PR TITLE
Fix repeating 400s for post_persistent_notifications and delte_expired_posts jobs

### DIFF
--- a/server/channels/api4/job_test.go
+++ b/server/channels/api4/job_test.go
@@ -272,8 +272,6 @@ func TestGetJobsByType(t *testing.T) {
 	_, _, err = th.SystemManagerClient.GetJobsByType(context.Background(), model.JobTypeElasticsearchPostIndexing, 0, 60)
 	require.NoError(t, err)
 
-	// These types are broadcast to admins via job_updated and refetched by the
-	// webapp, so a missing read-permission mapping turns into a recurring 400.
 	_, _, err = th.SystemAdminClient.GetJobsByType(context.Background(), model.JobTypePostPersistentNotifications, 0, 60)
 	require.NoError(t, err)
 

--- a/server/channels/api4/job_test.go
+++ b/server/channels/api4/job_test.go
@@ -271,6 +271,14 @@ func TestGetJobsByType(t *testing.T) {
 
 	_, _, err = th.SystemManagerClient.GetJobsByType(context.Background(), model.JobTypeElasticsearchPostIndexing, 0, 60)
 	require.NoError(t, err)
+
+	// These types are broadcast to admins via job_updated and refetched by the
+	// webapp, so a missing read-permission mapping turns into a recurring 400.
+	_, _, err = th.SystemAdminClient.GetJobsByType(context.Background(), model.JobTypePostPersistentNotifications, 0, 60)
+	require.NoError(t, err)
+
+	_, _, err = th.SystemAdminClient.GetJobsByType(context.Background(), model.JobTypeDeleteExpiredPosts, 0, 60)
+	require.NoError(t, err)
 }
 
 func TestGetJobsByTypeWithPolicyIDFilter(t *testing.T) {

--- a/server/channels/app/job.go
+++ b/server/channels/app/job.go
@@ -380,6 +380,8 @@ func (a *App) SessionHasPermissionToReadJob(session model.Session, jobType strin
 		model.JobTypeCloud,
 		model.JobTypeMobileSessionMetadata,
 		model.JobTypeExtractContent,
+		model.JobTypePostPersistentNotifications,
+		model.JobTypeDeleteExpiredPosts,
 		model.JobTypeCleanupExpiredAccessTokens:
 		return a.SessionHasPermissionTo(session, model.PermissionReadJobs), model.PermissionReadJobs
 	case model.JobTypeAccessControlSync:

--- a/server/channels/app/job_test.go
+++ b/server/channels/app/job_test.go
@@ -695,46 +695,24 @@ func TestSessionHasPermissionToReadJob(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t)
 
-	jobs := []model.Job{
-		{
-			Id:       model.NewId(),
-			Type:     model.JobTypeDataRetention,
-			CreateAt: 999,
-		},
-		{
-			Id:       model.NewId(),
-			Type:     model.JobTypeMessageExport,
-			CreateAt: 1001,
-		},
-		{
-			Id:       model.NewId(),
-			Type:     model.JobTypePostPersistentNotifications,
-			CreateAt: 1002,
-		},
-		{
-			Id:       model.NewId(),
-			Type:     model.JobTypeDeleteExpiredPosts,
-			CreateAt: 1003,
-		},
-	}
 	testCases := []struct {
-		Job                model.Job
+		JobType            string
 		PermissionRequired *model.Permission
 	}{
 		{
-			Job:                jobs[0],
+			JobType:            model.JobTypeDataRetention,
 			PermissionRequired: model.PermissionReadDataRetentionJob,
 		},
 		{
-			Job:                jobs[1],
+			JobType:            model.JobTypeMessageExport,
 			PermissionRequired: model.PermissionReadComplianceExportJob,
 		},
 		{
-			Job:                jobs[2],
+			JobType:            model.JobTypePostPersistentNotifications,
 			PermissionRequired: model.PermissionReadJobs,
 		},
 		{
-			Job:                jobs[3],
+			JobType:            model.JobTypeDeleteExpiredPosts,
 			PermissionRequired: model.PermissionReadJobs,
 		},
 	}
@@ -745,7 +723,7 @@ func TestSessionHasPermissionToReadJob(t *testing.T) {
 
 	// Check to see if admin has permission to all the jobs
 	for _, testCase := range testCases {
-		hasPermission, permissionRequired := th.App.SessionHasPermissionToReadJob(session, testCase.Job.Type)
+		hasPermission, permissionRequired := th.App.SessionHasPermissionToReadJob(session, testCase.JobType)
 		assert.Equal(t, true, hasPermission)
 		require.NotNil(t, permissionRequired)
 		assert.Equal(t, testCase.PermissionRequired.Id, permissionRequired.Id)
@@ -757,7 +735,7 @@ func TestSessionHasPermissionToReadJob(t *testing.T) {
 
 	// Initially the system manager should not have access to read these jobs
 	for _, testCase := range testCases {
-		hasPermission, permissionRequired := th.App.SessionHasPermissionToReadJob(session, testCase.Job.Type)
+		hasPermission, permissionRequired := th.App.SessionHasPermissionToReadJob(session, testCase.JobType)
 		assert.Equal(t, false, hasPermission)
 		require.NotNil(t, permissionRequired)
 		assert.Equal(t, testCase.PermissionRequired.Id, permissionRequired.Id)
@@ -772,8 +750,8 @@ func TestSessionHasPermissionToReadJob(t *testing.T) {
 
 	// Now system manager should have ability to read data retention jobs
 	for _, testCase := range testCases {
-		hasPermission, permissionRequired := th.App.SessionHasPermissionToReadJob(session, testCase.Job.Type)
-		expectedHasPermission := testCase.Job.Type == model.JobTypeDataRetention
+		hasPermission, permissionRequired := th.App.SessionHasPermissionToReadJob(session, testCase.JobType)
+		expectedHasPermission := testCase.JobType == model.JobTypeDataRetention
 		assert.Equal(t, expectedHasPermission, hasPermission)
 		require.NotNil(t, permissionRequired)
 		assert.Equal(t, testCase.PermissionRequired.Id, permissionRequired.Id)
@@ -786,7 +764,7 @@ func TestSessionHasPermissionToReadJob(t *testing.T) {
 
 	// Now system read only admin should have ability to read all jobs
 	for _, testCase := range testCases {
-		hasPermission, permissionRequired := th.App.SessionHasPermissionToReadJob(session, testCase.Job.Type)
+		hasPermission, permissionRequired := th.App.SessionHasPermissionToReadJob(session, testCase.JobType)
 		assert.Equal(t, true, hasPermission)
 		require.NotNil(t, permissionRequired)
 		assert.Equal(t, testCase.PermissionRequired.Id, permissionRequired.Id)

--- a/server/channels/app/job_test.go
+++ b/server/channels/app/job_test.go
@@ -706,6 +706,16 @@ func TestSessionHasPermissionToReadJob(t *testing.T) {
 			Type:     model.JobTypeMessageExport,
 			CreateAt: 1001,
 		},
+		{
+			Id:       model.NewId(),
+			Type:     model.JobTypePostPersistentNotifications,
+			CreateAt: 1002,
+		},
+		{
+			Id:       model.NewId(),
+			Type:     model.JobTypeDeleteExpiredPosts,
+			CreateAt: 1003,
+		},
 	}
 	testCases := []struct {
 		Job                model.Job
@@ -718,6 +728,14 @@ func TestSessionHasPermissionToReadJob(t *testing.T) {
 		{
 			Job:                jobs[1],
 			PermissionRequired: model.PermissionReadComplianceExportJob,
+		},
+		{
+			Job:                jobs[2],
+			PermissionRequired: model.PermissionReadJobs,
+		},
+		{
+			Job:                jobs[3],
+			PermissionRequired: model.PermissionReadJobs,
 		},
 	}
 

--- a/server/channels/app/job_test.go
+++ b/server/channels/app/job_test.go
@@ -779,12 +779,12 @@ func TestSessionHasPermissionToReadJob(t *testing.T) {
 		assert.Equal(t, testCase.PermissionRequired.Id, permissionRequired.Id)
 	}
 
-	role.Permissions = append(role.Permissions, model.PermissionReadComplianceExportJob.Id)
+	role.Permissions = append(role.Permissions, model.PermissionReadComplianceExportJob.Id, model.PermissionReadJobs.Id)
 
 	_, err = th.App.UpdateRole(role)
 	require.Nil(t, err)
 
-	// Now system read only admin should have ability to create all jobs
+	// Now system read only admin should have ability to read all jobs
 	for _, testCase := range testCases {
 		hasPermission, permissionRequired := th.App.SessionHasPermissionToReadJob(session, testCase.Job.Type)
 		assert.Equal(t, true, hasPermission)


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->


#### Summary
<!-- What does this PR do? Include QA steps if not covered in the ticket. -->
This PR is a focused fix to resolve repeated, failing GET requests being sent by the Mattermost web client on each tab opened by an admin user.  While these failures are ultimately benign, they can cause unwanted distraction and confusion to admins and developers who are relying on their browser's console logs during testing and troubleshooting.

In debugging these errors, I traced the issue to two specific job types (`post_persistent_notifications` and `delete_expired_posts`) that the webapp refetches as a reaction to a periodic incoming `job_updated` event.  The failure occurs due to a gap in the permission method (`SessionHasPermissionToReadJob`) that does not currently cover all job types.

There is a Jira ticket ([MM-69559](https://mattermost.atlassian.net/browse/MM-69559)) that already captures this issue more holistically.  My goal with this PR is simply to patch these two missing job types so that these noticeable errors will stop in the meantime.  The change is intentionally minimal and shouldn't complicate the more comprehensive changes that the ticket calls for.

To verify/reproduce: on a Professional+ licensed server with `EnableDeveloper=true`, log in as a system admin and sit on any tab for ~5 minutes with devtools open — the request should now return 200 and the console should stay clean. For `delete_expired_posts`, also enable the `BurnOnRead` feature flag and `EnableBurnOnRead` and wait 10 minutes.

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note
Fixed an error when retrieving post_persistent_notifications and delete_expired_posts jobs from the jobs API.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change updates shared job-read authorization logic and affects administrator access to two job types. Automated tests cover the updated permission checks and job retrieval paths.

**QA Recommendation:** Manual QA is not required. Automated test coverage is sufficient for this isolated authorization change.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[MM-69559]: https://mattermost.atlassian.net/browse/MM-69559?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ