### PR TITLE
Fix Cloud Agent environment: pin Go 1.26.4 and tolerate missing enterprise during prebuilds

### DIFF
--- a/.cursor/Dockerfile
+++ b/.cursor/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:24.04
 
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
-ARG GO_VERSION=1.25.9
+ARG GO_VERSION=1.26.4
 ARG NODE_VERSION=24.11.1
 ARG NVM_VERSION=0.40.3
 ARG DOCKER_VERSION=5:28.5.2-1~ubuntu.24.04~noble

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -8,7 +8,7 @@ The Docker build context is `.cursor/` only. The Dockerfile intentionally does n
 
 - Ubuntu 24.04.
 - Docker CE 28.5.2 with `fuse-overlayfs` and `iptables-legacy`, matching Cursor's Docker-in-Cloud guidance for complex compose setups.
-- Go 1.25.9 from `server/.go-version`.
+- Go 1.26.4 from `server/.go-version`.
 - Node 24.11.1/npm 11 via nvm, matching `.nvmrc` and `webapp/package.json`.
 - Browser runtime libraries for the Playwright e2e suite.
 - AWS CLI v2 for S3 uploads.

--- a/.cursor/scripts/cloud-agent-install.sh
+++ b/.cursor/scripts/cloud-agent-install.sh
@@ -95,8 +95,15 @@ verify_enterprise_checkout() {
 
   local target
   if ! target="$(find_enterprise_checkout)"; then
-    log "Enterprise checkout not found. Ensure the Cursor multi-repo environment includes github.com/mattermost/enterprise."
-    return 1
+    # The multi-repo enterprise sibling is provided when Cursor checks out the
+    # workspace for a running agent, but it is not present during environment
+    # prebuilds (which clone only the primary repo). Don't hard-fail here:
+    # `make setup-go-work` and `go mod download` work without enterprise, and
+    # `run-server` re-runs setup-go-work at boot, picking up the enterprise
+    # sibling once it is present. Failing would break otherwise-valid builds.
+    log "Enterprise checkout not found; proceeding without it (team-edition workspace)."
+    log "For an enterprise workspace, ensure the Cursor multi-repo environment includes github.com/mattermost/enterprise."
+    return 0
   fi
 
   log "Enterprise checkout ready at $target."


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Fixes two issues in the checked-in Cursor Cloud Agent environment (`.cursor/`) that prevented it from building/installing cleanly, then validates the environment end to end.

- **Go toolchain mismatch**: `.cursor/Dockerfile` pinned `GO_VERSION=1.25.9`, but `server/.go-version` and both `server/go.mod` and `enterprise/go.mod` require `go 1.26.4`. Building with 1.25.9 would force a `GOTOOLCHAIN` auto-download (or fail under a stricter policy). Pinned the image to `1.26.4` and updated the stale reference in `.cursor/README.md`.
- **Install hook hard-failed without the `enterprise` sibling**: `cloud-agent-install.sh` called `verify_enterprise_checkout` and exited non-zero when the `github.com/mattermost/enterprise` sibling was absent. That sibling is provided by Cursor's multi-repo checkout at normal agent boot, but it is **not** present during an environment prebuild (which clones only the primary repo). The hard failure made the environment un-buildable. The check now logs a warning and continues (team-edition workspace) instead of failing. `make setup-go-work` already conditionally includes enterprise, `go mod download` for `server`/`public` does not need it, and `run-server` re-runs `setup-go-work` at boot, so a running agent still gets the full enterprise workspace once the sibling is present. This does not clone or symlink enterprise (consistent with the environment's documented design).

QA / validation:

- Triggered an environment build from this branch. The Docker image built successfully; the install hook completed with `go1.26.4`, `node v24.11.1`, `npm 11.6.2`, created `go.work`, installed webapp deps (1954 packages) and Playwright deps (613 packages).
- Booted a fresh Cloud Agent from that build and ran the real stack via `ENABLED_DOCKER_SERVICES='postgres redis' RUN_SERVER_IN_BACKGROUND=true make run`. Postgres + Redis came up healthy, the server compiled and returned `{"status":"OK"}` at `/api/v4/system/ping`, and the web app was served at `http://127.0.0.1:8065/`. A real end-to-end action succeeded: created an admin user + team + channel via `mmctl`, logged in over the REST API, created a post, and retrieved it back with matching text (data persisted).

#### Release Note
```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bcb46f6e-4bb5-49e0-8aea-3073f2163747?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bcb46f6e-4bb5-49e0-8aea-3073f2163747&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

