### PR TITLE
fix: remove alt attr from the avatar image in user profile popover

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_image_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/accessibility/accessibility_image_spec.js
@@ -58,9 +58,9 @@ describe('Verify Accessibility Support in Different Images', () => {
                 cy.get('.status-wrapper').click();
             });
 
-            // * Verify image alt in profile popover
+            // * Verify the profile popover image is decorative since the popover already shows the user's name
             cy.get('.user-profile-popover').within(() => {
-                cy.get('.Avatar').should('have.attr', 'alt', `${otherUser.username} profile image`);
+                cy.get('.Avatar').should('have.attr', 'alt', '');
             });
         });
 

--- a/webapp/channels/src/components/profile_popover/profile_popover_avatar.tsx
+++ b/webapp/channels/src/components/profile_popover/profile_popover_avatar.tsx
@@ -26,6 +26,7 @@ const ProfilePopoverAvatar = ({
                 username={username}
                 url={urlSrc}
                 tabIndex={-1}
+                alt=''
             />
             <StatusIcon
                 className='status user-popover-status'


### PR DESCRIPTION
#### Summary

This pull request updates the accessibility handling of profile images in the user profile popover to improve support for assistive technologies as well as the usability in the bad network connections.

#### Details

The most important changes are:

**Accessibility Improvements:**

* The `alt` attribute for the profile image in the profile popover is now set to an empty string (`''`), making it decorative since the user's name is already displayed elsewhere in the popover.
* The related Cypress test has been updated to verify that the profile popover image is decorative by checking for an empty `alt` attribute, instead of expecting the username in the `alt` text.

#### Ticket Link

- Fixes: #37884

#### Screenshots

n/a

#### Release Note

```release-note
Fix accessibility and usability in user popover
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to the profile popover avatar and its Cypress test. It does not affect shared utilities, critical flows, or data handling.
**QA Recommendation:** Manual QA can be skipped because automated coverage verifies the expected `alt` attribute.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->