### PR TITLE
MM-35269: Highlight the matched post when opening a thread from search results

### DIFF
--- a/webapp/channels/src/actions/views/rhs.test.ts
+++ b/webapp/channels/src/actions/views/rhs.test.ts
@@ -193,6 +193,105 @@ describe('rhs view actions', () => {
                 expect(store.getActions()[0]).toEqual(action);
             });
         });
+
+        describe('it also highlights the post when highlightPost is set', () => {
+            beforeEach(() => {
+                jest.useFakeTimers();
+                jest.setSystemTime(POST_CREATED_TIME);
+            });
+
+            afterEach(() => {
+                jest.useRealTimers();
+            });
+
+            it('dispatches the select and highlight actions, then clears the highlight', async () => {
+                store = mockStore({
+                    ...initialState,
+                    views: {
+                        rhs: {
+                            rhsState: RHSStates.FLAG,
+                            filesSearchExtFilter: [] as string[],
+                        },
+                    } as ViewsState,
+                });
+
+                await store.dispatch(selectPostFromRightHandSideSearch(post, true));
+
+                expect(store.getActions()).toEqual([{
+                    meta: {batch: true},
+                    payload: [{
+                        type: ActionTypes.SELECT_POST,
+                        postId: post.root_id,
+                        channelId: post.channel_id,
+                        previousRhsState: RHSStates.FLAG,
+                        timestamp: POST_CREATED_TIME,
+                    }, {
+                        type: ActionTypes.HIGHLIGHT_REPLY,
+                        postId: post.id,
+                    }],
+                    type: 'BATCHING_REDUCER.BATCH',
+                }]);
+
+                jest.advanceTimersByTime(Constants.PERMALINK_FADEOUT);
+
+                expect(store.getActions()[1]).toEqual({type: ActionTypes.CLEAR_HIGHLIGHT_REPLY});
+            });
+        });
+
+        describe('clearing a leftover highlight', () => {
+            const otherPost = {
+                id: 'post456',
+                channel_id: 'channel123',
+                root_id: 'root456',
+            } as Post;
+
+            beforeEach(() => {
+                jest.useFakeTimers();
+                jest.setSystemTime(POST_CREATED_TIME);
+            });
+
+            afterEach(() => {
+                jest.useRealTimers();
+            });
+
+            it('clears a still-pending highlight when the next selection does not highlight', async () => {
+                store = mockStore({
+                    ...initialState,
+                    views: {
+                        rhs: {
+                            rhsState: RHSStates.FLAG,
+                            highlightedPostId: post.id,
+                            filesSearchExtFilter: [] as string[],
+                        },
+                    } as ViewsState,
+                });
+
+                await store.dispatch(selectPostFromRightHandSideSearch(post, true));
+
+                expect(jest.getTimerCount()).toBe(1);
+
+                await store.dispatch(selectPostFromRightHandSideSearch(otherPost));
+
+                expect(jest.getTimerCount()).toBe(0);
+                expect(store.getActions()[1]).toEqual({
+                    meta: {batch: true},
+                    payload: [{
+                        type: ActionTypes.CLEAR_HIGHLIGHT_REPLY,
+                    }, {
+                        type: ActionTypes.SELECT_POST,
+                        postId: otherPost.root_id,
+                        channelId: otherPost.channel_id,
+                        previousRhsState: RHSStates.FLAG,
+                        timestamp: POST_CREATED_TIME,
+                    }],
+                    type: 'BATCHING_REDUCER.BATCH',
+                });
+
+                jest.advanceTimersByTime(Constants.PERMALINK_FADEOUT);
+
+                expect(store.getActions()).toHaveLength(2);
+            });
+        });
     });
 
     describe('updateSearchTerms', () => {

--- a/webapp/channels/src/actions/views/rhs.ts
+++ b/webapp/channels/src/actions/views/rhs.ts
@@ -27,6 +27,7 @@ import {
     getSearchType,
     getSearchTerms,
     getRhsState,
+    getHighlightedPostId,
     getPluggableId,
     getFilesSearchExtFilter,
     getPreviousRhsState,
@@ -116,8 +117,35 @@ export function goBack(): ActionFuncAsync<boolean> {
     };
 }
 
-export function selectPostFromRightHandSideSearch(post: Post) {
-    return selectPostWithPreviousState(post);
+export function selectPostFromRightHandSideSearch(post: Post, highlightPost = false): ActionFunc<boolean> {
+    return (dispatch, getState) => {
+        const state = getState();
+        const previousRhsState = getRhsState(state);
+
+        if (!highlightPost) {
+            // Drop any highlight left over from a previous selection so it
+            // doesn't carry into the newly opened thread.
+            if (getHighlightedPostId(state)) {
+                debouncedClearHighlightReply.cancel();
+                dispatch(batchActions([
+                    clearHighlightReply,
+                    selectPost(post, previousRhsState),
+                ]));
+            } else {
+                dispatch(selectPost(post, previousRhsState));
+            }
+            return {data: true};
+        }
+
+        dispatch(batchActions([
+            selectPost(post, previousRhsState),
+            highlightReply(post),
+        ]));
+
+        debouncedClearHighlightReply(dispatch);
+
+        return {data: true};
+    };
 }
 
 export function selectPostFromRightHandSideSearchByPostId(postId: string): ActionFuncAsync<boolean> {

--- a/webapp/channels/src/components/common/comment_icon.tsx
+++ b/webapp/channels/src/components/common/comment_icon.tsx
@@ -42,18 +42,23 @@ const CommentIcon = ({
         iconStyle = `${iconStyle} ${searchStyle}`;
     }
 
-    const replyTitle = intl.formatMessage({
+    // In search results the icon opens the post's thread in the RHS rather
+    // than composing a reply, so label it accordingly.
+    const tooltipTitle = location === 'SEARCH' ? intl.formatMessage({
+        id: 'post_info.comment_icon.tooltip.view_thread',
+        defaultMessage: 'View thread',
+    }) : intl.formatMessage({
         id: 'post_info.comment_icon.tooltip.reply',
         defaultMessage: 'Reply',
     });
 
     return (
         <WithTooltip
-            title={replyTitle}
+            title={tooltipTitle}
         >
             <button
                 id={`${location}_commentIcon_${postId}`}
-                aria-label={replyTitle.toLowerCase()}
+                aria-label={tooltipTitle.toLowerCase()}
                 className={`${iconStyle} ${extraClass}`}
                 onClick={handleCommentClick}
             >

--- a/webapp/channels/src/components/post/post_component.test.tsx
+++ b/webapp/channels/src/components/post/post_component.test.tsx
@@ -307,7 +307,7 @@ describe('PostComponent', () => {
                 await userEvent.click(screen.getByText('1 reply'));
 
                 // Yes, this action has a different name than the one you'd expect
-                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost);
+                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost, false);
             });
 
             test('should select post in RHS when clicked in center channel in a DM/GM', async () => {
@@ -320,7 +320,7 @@ describe('PostComponent', () => {
                 await userEvent.click(screen.getByText('1 reply'));
 
                 // Yes, this action has a different name than the one you'd expect
-                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost);
+                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost, false);
                 expect(getHistory().push).not.toHaveBeenCalled();
             });
 
@@ -333,7 +333,7 @@ describe('PostComponent', () => {
 
                 await userEvent.click(screen.getByText('1 reply'));
 
-                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost);
+                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost, true);
                 expect(getHistory().push).not.toHaveBeenCalled();
             });
 
@@ -405,7 +405,7 @@ describe('PostComponent', () => {
 
                 await userEvent.click(screen.getByText('1 reply'));
 
-                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost);
+                expect(propsForRootPost.actions.selectPostFromRightHandSideSearch).toHaveBeenCalledWith(rootPost, false);
                 expect(getHistory().replace).not.toHaveBeenCalled();
 
                 jest.restoreAllMocks();

--- a/webapp/channels/src/components/post/post_component.tsx
+++ b/webapp/channels/src/components/post/post_component.tsx
@@ -103,7 +103,7 @@ export type Props = {
         markPostAsUnread: (post: Post, location: string) => void;
         emitShortcutReactToLastPostFrom: (emittedFrom: 'CENTER' | 'RHS_ROOT' | 'NO_WHERE') => void;
         selectPost: (post: Post) => void;
-        selectPostFromRightHandSideSearch: (post: Post) => void;
+        selectPostFromRightHandSideSearch: (post: Post, highlightPost?: boolean) => void;
         removePost: (post: Post) => void;
         closeRightHandSide: () => void;
         selectPostCard: (post: Post) => void;
@@ -466,8 +466,8 @@ function PostComponent(props: Props) {
             getHistory().replace(`/_popout/thread/${props.teamName}/${post.root_id || post.id}?returnTo=${returnTo}`);
             return;
         }
-        selectPostFromRightHandSideSearch(post);
-    }, [post, props.teamName, selectPostFromRightHandSideSearch, isSearchPopoutWindow]);
+        selectPostFromRightHandSideSearch(post, props.location === Locations.SEARCH);
+    }, [post, props.teamName, selectPostFromRightHandSideSearch, isSearchPopoutWindow, props.location]);
 
     const handleThreadClick = useCallback((e: React.MouseEvent) => {
         if (isSearchPopoutWindow || props.currentTeam?.id === teamId) {

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -6363,6 +6363,7 @@
   "post_info.ai_generated.self": "AI-generated",
   "post_info.auto_responder": "AUTOMATIC REPLY",
   "post_info.comment_icon.tooltip.reply": "Reply",
+  "post_info.comment_icon.tooltip.view_thread": "View thread",
   "post_info.copy": "Copy Text",
   "post_info.del": "Delete",
   "post_info.dot_menu.tooltip.more": "More",


### PR DESCRIPTION
#### Summary

Clicking the thread icon on a search result opens the thread in the RHS, but nothing indicates which post actually matched the search — in a long thread you end up scanning for it manually. This PR dispatches the same highlight used for permalinks alongside the post selection, so the RHS opens with the matched post scrolled into view and briefly highlighted (fading out after the usual permalink delay). Back navigation is unaffected: the previous RHS state is still recorded, so the back button returns to the search results.

The behavior applies to threads opened from RHS lists (search results, saved posts, pinned posts). Reply clicks in the center channel are unchanged.

Since the icon in search results opens the thread rather than starting a reply, its tooltip and aria-label now read "View thread" instead of "Reply".

QA steps:
1. Post a root message in a channel and add several replies; make one reply contain a distinctive term.
2. Search for that term and click the thread icon on the result.
3. The RHS opens the thread scrolled to the matched reply, which is briefly highlighted.
4. Press the back button in the RHS header — it returns to the search results.
5. Repeat from Saved/Pinned posts lists — same behavior.
6. Click the reply icon on a post in the center channel — the thread opens with no highlight, as before.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/18579

JIRA: https://mattermost.atlassian.net/browse/MM-35269

#### Release Note

```release-note
Opening a thread from search results, saved posts, or pinned posts now scrolls to and briefly highlights the selected post. The thread icon tooltip in search results now reads "View thread".
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The changes affect shared RHS actions and post interaction flows across search, center channel, and popout contexts. Tests cover the updated selection and highlighting behavior.

**QA Recommendation:** Manual QA can be skipped because automated test coverage is complete.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->