### PR TITLE
MM-69137: allow users to manually pin their status to Online

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/status/status_manual_online_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/status/status_manual_online_spec.ts
@@ -1,0 +1,120 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Group: @channels @status
+
+// Note on coverage: this spec covers the parts of the manual online pin that are
+// observable from the client. Two behaviours are deliberately left to the server tests in
+// server/channels/app/platform/status_test.go, because both are driven by websocket hub
+// events that cannot be triggered deterministically from here: that the pin survives the
+// automatic away transition, and that it is cleared when the last connection goes away.
+
+describe('Manually pinned online status', () => {
+    let testUserId: string;
+
+    beforeEach(() => {
+        // # Login as a new test user and visit a channel
+        cy.apiInitSetup({loginAfter: true}).then(({team, channel, user}) => {
+            testUserId = user.id;
+            cy.visit(`/${team.name}/channels/${channel.name}`);
+        });
+    });
+
+    it('Selecting Online from the status menu pins the status as manual', () => {
+        // # Set away first so the change to online is observable
+        cy.uiGetSetStatusButton().click();
+        cy.findByText('Away').click();
+        verifyStatusIcon('away');
+
+        // # Open the status menu and select Online
+        cy.uiGetSetStatusButton().click();
+        cy.findByText('Online').click();
+
+        // * The status should be online
+        verifyStatusIcon('online');
+
+        // * The server should record the status as manual. This is the flag that stops the
+        // automatic away transition from moving the user off online while they are idle.
+        getStatus(testUserId).then((status) => {
+            expect(status.status).to.equal('online');
+            expect(status.manual).to.equal(true);
+        });
+    });
+
+    it('An explicit away, dnd or offline choice still overrides a pinned online status', () => {
+        // # Pin the status to online
+        cy.uiGetSetStatusButton().click();
+        cy.findByText('Online').click();
+        verifyStatusIcon('online');
+
+        // # Explicitly choose Away
+        cy.uiGetSetStatusButton().click();
+        cy.findByText('Away').click();
+
+        // * An explicit choice always wins over the pin
+        verifyStatusIcon('away');
+
+        // # Explicitly choose Offline
+        cy.uiGetSetStatusButton().click();
+        cy.findByText('Offline').click();
+
+        // * The status should be offline
+        verifyStatusIcon('offline');
+
+        // # Pin back to online
+        cy.uiGetSetStatusButton().click();
+        cy.findByText('Online').click();
+
+        // * The pin can be re-applied after another status was chosen
+        verifyStatusIcon('online');
+        getStatus(testUserId).then((status) => {
+            expect(status.manual).to.equal(true);
+        });
+    });
+
+    it('The /online slash command pins the status as manual', () => {
+        // # Set away first so the change to online is observable
+        cy.postMessage('/away ');
+        cy.findByText('You are now away').should('exist');
+        verifyStatusIcon('away');
+
+        // # Use the slash command to go back online
+        cy.postMessage('/online ');
+        cy.findByText('You are now online').should('exist');
+
+        // * The slash command and the status menu should agree
+        verifyStatusIcon('online');
+        getStatus(testUserId).then((status) => {
+            expect(status.status).to.equal('online');
+            expect(status.manual).to.equal(true);
+        });
+    });
+});
+
+function getStatus(userId: string) {
+    return cy.request({
+        headers: {'X-Requested-With': 'XMLHttpRequest'},
+        url: `/api/v4/users/${userId}/status`,
+        method: 'GET',
+    }).then((response) => {
+        expect(response.status).to.equal(200);
+        return response.body;
+    });
+}
+
+function verifyStatusIcon(status: 'online' | 'away' | 'offline' | 'dnd') {
+    cy.get('[aria-label="Status is \\"Online\\". Open user\'s account menu."]').
+        should(status === 'online' ? 'exist' : 'not.exist');
+    cy.get('[aria-label="Status is \\"Away\\". Open user\'s account menu."]').
+        should(status === 'away' ? 'exist' : 'not.exist');
+    cy.get('[aria-label="Status is \\"Offline\\". Open user\'s account menu."]').
+        should(status === 'offline' ? 'exist' : 'not.exist');
+    cy.get('[aria-label="Status is \\"Do not disturb\\". Open user\'s account menu."]').
+        should(status === 'dnd' ? 'exist' : 'not.exist');
+}

--- a/e2e-tests/cypress/tests/integration/channels/status/status_manual_online_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/status/status_manual_online_spec.ts
@@ -60,6 +60,28 @@ describe('Manually pinned online status', () => {
         // * An explicit choice always wins over the pin
         verifyStatusIcon('away');
 
+        // # Pin back to online so the next step overrides a pin rather than an away status
+        cy.uiGetSetStatusButton().click();
+        cy.findByText('Online').click();
+        verifyStatusIcon('online');
+
+        // # Explicitly choose Do Not Disturb, which is a submenu of end times
+        cy.uiGetSetStatusButton().click();
+        cy.findByText('Do Not Disturb').trigger('mouseover');
+        cy.get('.SubMenuItemContainer li#dndTime-dont_clear_menuitem').click();
+
+        // * DND overrides the pin, and is itself stored as a manual status
+        verifyStatusIcon('dnd');
+        getStatus(testUserId).then((status) => {
+            expect(status.status).to.equal('dnd');
+            expect(status.manual).to.equal(true);
+        });
+
+        // # Pin back to online again
+        cy.uiGetSetStatusButton().click();
+        cy.findByText('Online').click();
+        verifyStatusIcon('online');
+
         // # Explicitly choose Offline
         cy.uiGetSetStatusButton().click();
         cy.findByText('Offline').click();

--- a/server/channels/api4/status_test.go
+++ b/server/channels/api4/status_test.go
@@ -195,6 +195,21 @@ func TestUpdateUserStatus(t *testing.T) {
 		updateUserStatus, _, err := client.UpdateUserStatus(context.Background(), th.BasicUser.Id, toUpdateUserStatus)
 		require.NoError(t, err)
 		assert.Equal(t, "online", updateUserStatus.Status)
+
+		// Setting online through the API is an explicit choice, so it pins the status the
+		// same way away, dnd and offline do.
+		assert.True(t, updateUserStatus.Manual, "an explicitly set online status should be manual")
+	})
+
+	t.Run("online pin survives a round trip", func(t *testing.T) {
+		toUpdateUserStatus := &model.Status{Status: "online", UserId: th.BasicUser.Id}
+		_, _, err := client.UpdateUserStatus(context.Background(), th.BasicUser.Id, toUpdateUserStatus)
+		require.NoError(t, err)
+
+		fetched, _, err := client.GetUserStatus(context.Background(), th.BasicUser.Id, "")
+		require.NoError(t, err)
+		assert.Equal(t, "online", fetched.Status)
+		assert.True(t, fetched.Manual, "the pin should be readable back from the server")
 	})
 
 	t.Run("set away status", func(t *testing.T) {

--- a/server/channels/app/platform/status.go
+++ b/server/channels/app/platform/status.go
@@ -308,7 +308,9 @@ func (ps *PlatformService) SetStatusOnline(userID string, manual bool) {
 	var err *model.AppError
 
 	if status, err = ps.GetStatus(userID); err != nil {
-		status = &model.Status{UserId: userID, Status: model.StatusOnline, Manual: false, LastActivityAt: model.GetMillis(), ActiveChannel: ""}
+		// A user with no status row yet must still be able to pin themselves online, so the
+		// caller's intent is carried here too rather than defaulting to automatic.
+		status = &model.Status{UserId: userID, Status: model.StatusOnline, Manual: manual, LastActivityAt: model.GetMillis(), ActiveChannel: ""}
 		broadcast = true
 	} else {
 		if status.Manual && !manual {
@@ -324,7 +326,7 @@ func (ps *PlatformService) SetStatusOnline(userID string, manual bool) {
 		oldManual = status.Manual
 
 		status.Status = model.StatusOnline
-		status.Manual = false // for "online" there's no manual setting
+		status.Manual = manual
 		status.LastActivityAt = model.GetMillis()
 	}
 
@@ -333,7 +335,9 @@ func (ps *PlatformService) SetStatusOnline(userID string, manual bool) {
 	// Only update the database if the status has changed, the status has been manually set,
 	// or enough time has passed since the previous action
 	if status.Status != oldStatus || status.Manual != oldManual || status.LastActivityAt-oldTime > model.StatusMinUpdateTime {
-		if broadcast {
+		// UpdateLastActivityAt only writes the timestamp column, so a change to the manual
+		// flag alone still needs the full upsert to be persisted.
+		if broadcast || status.Manual != oldManual {
 			if err := ps.Store.Status().SaveOrUpdate(status); err != nil {
 				mlog.Warn("Failed to save status", mlog.String("user_id", userID), mlog.Err(err), mlog.String("user_id", userID))
 			}
@@ -360,7 +364,7 @@ func (ps *PlatformService) SetStatusOffline(userID string, manual bool, force bo
 	status, err := ps.GetStatus(userID)
 	if err != nil {
 		ps.Log().Warn("Error getting status. Setting it to offline forcefully.", mlog.String("user_id", userID), mlog.Err(err))
-	} else if !force && status.Manual && !manual {
+	} else if !force && status.Manual && !manual && !isManualOnline(status) {
 		return // manually set status always overrides non-manual one
 	}
 	ps._setStatusOfflineAndNotify(userID, manual)
@@ -384,7 +388,7 @@ func (ps *PlatformService) QueueSetStatusOffline(userID string, manual bool) {
 	status, err := ps.GetStatus(userID)
 	if err != nil {
 		ps.Log().Warn("Error getting status. Setting it to offline forcefully.", mlog.String("user_id", userID), mlog.Err(err))
-	} else if status.Manual && !manual {
+	} else if status.Manual && !manual && !isManualOnline(status) {
 		// Force will be false here, so no need to add another variable.
 		return // manually set status always overrides non-manual one
 	}
@@ -587,4 +591,11 @@ func (ps *PlatformService) SetStatusOutOfOffice(userID string) {
 
 func (ps *PlatformService) isUserAway(lastActivityAt int64) bool {
 	return model.GetMillis()-lastActivityAt >= *ps.Config().TeamSettings.UserStatusAwayTimeout*1000
+}
+
+// isManualOnline reports whether a user has pinned themselves online. Unlike the other manual
+// statuses, a manual online claims more availability than reality, so it must not survive the
+// loss of the connections that justify it: it overrides inactivity, never disconnection.
+func isManualOnline(status *model.Status) bool {
+	return status.Manual && status.Status == model.StatusOnline
 }

--- a/server/channels/app/platform/status_test.go
+++ b/server/channels/app/platform/status_test.go
@@ -167,10 +167,10 @@ func TestSetStatusOffline(t *testing.T) {
 			*cfg.ServiceSettings.EnableUserStatuses = true
 		})
 
-		// Set initial status to online manually
+		// Set initial status to dnd manually
 		status := &model.Status{
 			UserId: user.Id,
-			Status: model.StatusOnline,
+			Status: model.StatusDnd,
 			Manual: true,
 		}
 		th.Service.SaveAndBroadcastStatus(status)
@@ -181,8 +181,32 @@ func TestSetStatusOffline(t *testing.T) {
 		// Status should remain unchanged because manual status takes precedence
 		after, err := th.Service.GetStatus(user.Id)
 		require.Nil(t, err)
-		assert.Equal(t, model.StatusOnline, after.Status)
+		assert.Equal(t, model.StatusDnd, after.Status)
 		assert.True(t, after.Manual)
+	})
+
+	t.Run("when a manually pinned online status is disconnected", func(t *testing.T) {
+		th.Service.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.EnableUserStatuses = true
+		})
+
+		// Pin the user online
+		status := &model.Status{
+			UserId: user.Id,
+			Status: model.StatusOnline,
+			Manual: true,
+		}
+		th.Service.SaveAndBroadcastStatus(status)
+
+		// A disconnect arrives as a non-manual offline transition
+		th.Service.SetStatusOffline(user.Id, false, false)
+
+		// The pin overrides inactivity but must not survive disconnection, otherwise the
+		// user would be shown as online indefinitely after their last device goes away.
+		after, err := th.Service.GetStatus(user.Id)
+		require.Nil(t, err)
+		assert.Equal(t, model.StatusOffline, after.Status)
+		assert.False(t, after.Manual)
 	})
 
 	t.Run("when force flag is true over manually set status", func(t *testing.T) {
@@ -251,6 +275,173 @@ func TestSetStatusOffline(t *testing.T) {
 		after, err := th.Service.GetStatus(user.Id)
 		require.Nil(t, err)
 		assert.Equal(t, model.StatusOffline, after.Status)
+		assert.True(t, after.Manual)
+	})
+}
+
+func TestSetStatusOnlineManual(t *testing.T) {
+	th := Setup(t).InitBasic(t)
+
+	user := th.BasicUser
+
+	t.Run("persists the manual flag when set explicitly", func(t *testing.T) {
+		th.Service.SetStatusOnline(user.Id, true)
+
+		after, err := th.Service.GetStatus(user.Id)
+		require.Nil(t, err)
+		assert.Equal(t, model.StatusOnline, after.Status)
+		assert.True(t, after.Manual, "an explicitly set online status should be marked manual")
+	})
+
+	t.Run("persists the manual flag to the database when only the flag changes", func(t *testing.T) {
+		// Start from an automatic online status. Pinning from here leaves the status string
+		// untouched, so the only thing that changes is the manual flag.
+		th.Service.SaveAndBroadcastStatus(&model.Status{
+			UserId:         user.Id,
+			Status:         model.StatusOnline,
+			Manual:         false,
+			LastActivityAt: model.GetMillis(),
+		})
+
+		th.Service.SetStatusOnline(user.Id, true)
+
+		// Read straight from the store rather than through the cache. Because the status
+		// string is unchanged, this write would otherwise take the cheaper path that only
+		// updates the last activity column and the pin would be lost on the next cache miss.
+		stored, storeErr := th.Service.Store.Status().Get(user.Id)
+		require.NoError(t, storeErr)
+		assert.Equal(t, model.StatusOnline, stored.Status)
+		assert.True(t, stored.Manual, "the pin must reach the database, not just the cache")
+	})
+
+	t.Run("activity driven updates do not set the manual flag", func(t *testing.T) {
+		th.Service.SaveAndBroadcastStatus(&model.Status{
+			UserId: user.Id,
+			Status: model.StatusOffline,
+			Manual: false,
+		})
+
+		th.Service.SetStatusOnline(user.Id, false)
+
+		after, err := th.Service.GetStatus(user.Id)
+		require.Nil(t, err)
+		assert.Equal(t, model.StatusOnline, after.Status)
+		assert.False(t, after.Manual, "activity driven online must stay automatic")
+	})
+
+	t.Run("does not override a manually set away status", func(t *testing.T) {
+		th.Service.SaveAndBroadcastStatus(&model.Status{
+			UserId: user.Id,
+			Status: model.StatusAway,
+			Manual: true,
+		})
+
+		th.Service.SetStatusOnline(user.Id, false)
+
+		after, err := th.Service.GetStatus(user.Id)
+		require.Nil(t, err)
+		assert.Equal(t, model.StatusAway, after.Status, "activity must not clear a manual away")
+	})
+}
+
+func TestManualOnlineSurvivesInactivity(t *testing.T) {
+	th := Setup(t).InitBasic(t)
+
+	user := th.BasicUser
+
+	// A short away timeout keeps the test fast; isUserAway compares against LastActivityAt.
+	th.Service.UpdateConfig(func(cfg *model.Config) {
+		*cfg.TeamSettings.UserStatusAwayTimeout = 1
+	})
+
+	t.Run("pinned online is not moved to away by inactivity", func(t *testing.T) {
+		th.Service.SaveAndBroadcastStatus(&model.Status{
+			UserId:         user.Id,
+			Status:         model.StatusOnline,
+			Manual:         true,
+			LastActivityAt: model.GetMillis() - (10 * 1000),
+		})
+
+		// This is the transition the inactivity path drives.
+		th.Service.SetStatusAwayIfNeeded(user.Id, false)
+
+		after, err := th.Service.GetStatus(user.Id)
+		require.Nil(t, err)
+		assert.Equal(t, model.StatusOnline, after.Status, "a pinned online must defeat inactivity")
+		assert.True(t, after.Manual)
+	})
+
+	t.Run("automatic online is still moved to away by inactivity", func(t *testing.T) {
+		th.Service.SaveAndBroadcastStatus(&model.Status{
+			UserId:         user.Id,
+			Status:         model.StatusOnline,
+			Manual:         false,
+			LastActivityAt: model.GetMillis() - (10 * 1000),
+		})
+
+		th.Service.SetStatusAwayIfNeeded(user.Id, false)
+
+		after, err := th.Service.GetStatus(user.Id)
+		require.Nil(t, err)
+		assert.Equal(t, model.StatusAway, after.Status, "auto-away must still work for everyone else")
+	})
+
+	t.Run("user can still choose away over a pinned online", func(t *testing.T) {
+		th.Service.SaveAndBroadcastStatus(&model.Status{
+			UserId: user.Id,
+			Status: model.StatusOnline,
+			Manual: true,
+		})
+
+		th.Service.SetStatusAwayIfNeeded(user.Id, true)
+
+		after, err := th.Service.GetStatus(user.Id)
+		require.Nil(t, err)
+		assert.Equal(t, model.StatusAway, after.Status, "an explicit choice must always win")
+		assert.True(t, after.Manual)
+	})
+}
+
+func TestManualOnlineClearedByDisconnect(t *testing.T) {
+	th := Setup(t).InitBasic(t)
+
+	user := th.BasicUser
+
+	t.Run("queued offline clears a pinned online", func(t *testing.T) {
+		th.Service.SaveAndBroadcastStatus(&model.Status{
+			UserId: user.Id,
+			Status: model.StatusOnline,
+			Manual: true,
+		})
+
+		// The hub queues a non-manual offline when a user's last connection goes away.
+		th.Service.QueueSetStatusOffline(user.Id, false)
+
+		var after *model.Status
+		var err *model.AppError
+		require.Eventually(t, func() bool {
+			after, err = th.Service.GetStatus(user.Id)
+			return err == nil && after.Status == model.StatusOffline
+		}, 5*time.Second, 100*time.Millisecond, "a pinned online must not survive disconnection")
+
+		assert.False(t, after.Manual, "the pin must be cleared, not converted into a manual offline")
+	})
+
+	t.Run("queued offline still respects a manual dnd", func(t *testing.T) {
+		th.Service.SaveAndBroadcastStatus(&model.Status{
+			UserId: user.Id,
+			Status: model.StatusDnd,
+			Manual: true,
+		})
+
+		th.Service.QueueSetStatusOffline(user.Id, false)
+
+		// Give the batch processor a chance to run so this is not a vacuous pass.
+		time.Sleep(time.Second)
+
+		after, err := th.Service.GetStatus(user.Id)
+		require.Nil(t, err)
+		assert.Equal(t, model.StatusDnd, after.Status, "the carve-out must be scoped to online only")
 		assert.True(t, after.Manual)
 	})
 }

--- a/server/channels/store/sqlstore/status_store.go
+++ b/server/channels/store/sqlstore/status_store.go
@@ -158,7 +158,10 @@ func (s SqlStatusStore) UpdateExpiredDNDStatuses() (_ []*model.Status, err error
 }
 
 func (s SqlStatusStore) ResetAll() error {
-	if _, err := s.GetMaster().Exec("UPDATE Status SET Status = ? WHERE Manual = false", model.StatusOffline); err != nil {
+	// A manually pinned online status is cleared alongside the automatic ones: it must not
+	// outlive the connections that justify it. Manual is reset too, otherwise the row would
+	// become a manual offline and block the user from coming back online on reconnect.
+	if _, err := s.GetMaster().Exec("UPDATE Status SET Status = ?, Manual = false WHERE Manual = false OR Status = ?", model.StatusOffline, model.StatusOnline); err != nil {
 		return errors.Wrap(err, "failed to update Statuses")
 	}
 	return nil

--- a/server/channels/store/storetest/status_store.go
+++ b/server/channels/store/storetest/status_store.go
@@ -23,6 +23,43 @@ func TestStatusStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore)
 	t.Run("Get", func(t *testing.T) { testStatusGet(t, rctx, ss, s) })
 	t.Run("GetByIds", func(t *testing.T) { testStatusGetByIds(t, rctx, ss, s) })
 	t.Run("SaveOrUpdateMany", func(t *testing.T) { testSaveOrUpdateMany(t, rctx, ss) })
+	t.Run("ResetAll", func(t *testing.T) { testStatusResetAll(t, rctx, ss) })
+}
+
+func testStatusResetAll(t *testing.T, _ request.CTX, ss store.Store) {
+	automaticOnline := &model.Status{UserId: model.NewId(), Status: model.StatusOnline, Manual: false, LastActivityAt: model.GetMillis()}
+	pinnedOnline := &model.Status{UserId: model.NewId(), Status: model.StatusOnline, Manual: true, LastActivityAt: model.GetMillis()}
+	manualAway := &model.Status{UserId: model.NewId(), Status: model.StatusAway, Manual: true, LastActivityAt: model.GetMillis()}
+	manualDND := &model.Status{UserId: model.NewId(), Status: model.StatusDnd, Manual: true, LastActivityAt: model.GetMillis()}
+
+	for _, status := range []*model.Status{automaticOnline, pinnedOnline, manualAway, manualDND} {
+		require.NoError(t, ss.Status().SaveOrUpdate(status))
+	}
+
+	require.NoError(t, ss.Status().ResetAll())
+
+	got, err := ss.Status().Get(automaticOnline.UserId)
+	require.NoError(t, err)
+	assert.Equal(t, model.StatusOffline, got.Status, "an automatic status should be reset")
+
+	// A pinned online claims more availability than reality, so a restart clears it. Manual
+	// must be cleared too, otherwise the row becomes a manual offline and would block the
+	// user from being brought back online when they reconnect.
+	got, err = ss.Status().Get(pinnedOnline.UserId)
+	require.NoError(t, err)
+	assert.Equal(t, model.StatusOffline, got.Status, "a pinned online should not survive a restart")
+	assert.False(t, got.Manual, "the pin should be cleared rather than left as a manual offline")
+
+	// Every other manual status describes less availability than reality, so it is preserved.
+	got, err = ss.Status().Get(manualAway.UserId)
+	require.NoError(t, err)
+	assert.Equal(t, model.StatusAway, got.Status, "a manual away should survive a restart")
+	assert.True(t, got.Manual)
+
+	got, err = ss.Status().Get(manualDND.UserId)
+	require.NoError(t, err)
+	assert.Equal(t, model.StatusDnd, got.Status, "a manual dnd should survive a restart")
+	assert.True(t, got.Manual)
 }
 
 func testSaveOrUpdateMany(t *testing.T, _ request.CTX, ss store.Store) {

--- a/webapp/channels/src/components/user_account_menu/user_account_online_menuitem.test.tsx
+++ b/webapp/channels/src/components/user_account_menu/user_account_online_menuitem.test.tsx
@@ -1,0 +1,87 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+
+import * as userActions from 'mattermost-redux/actions/users';
+
+import * as modalActions from 'actions/views/modals';
+
+import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
+import {UserStatuses, WindowSizes} from 'utils/constants';
+import {TestHelper} from 'utils/test_helper';
+
+import UserAccountOnlineMenuItem from './user_account_online_menuitem';
+
+type Props = React.ComponentProps<typeof UserAccountOnlineMenuItem>;
+
+// Menu items only fire onClick immediately in the mobile view.
+// See handleClick in webapp/channels/src/components/menu/menu_item.tsx
+const mobileState = {
+    views: {
+        browser: {
+            windowSize: WindowSizes.MOBILE_VIEW,
+        },
+    },
+};
+
+describe('UserAccountOnlineMenuItem', () => {
+    let defaultProps: Props;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        defaultProps = {
+            userId: TestHelper.getUserMock().id,
+            shouldConfirmBeforeStatusChange: false,
+            isStatusOnline: false,
+        };
+    });
+
+    test('should render the online option', () => {
+        renderWithContext(<UserAccountOnlineMenuItem {...defaultProps}/>);
+
+        expect(screen.getByText('Online')).toBeInTheDocument();
+    });
+
+    test('should set status to online when clicked', async () => {
+        jest.spyOn(userActions, 'setStatus');
+
+        renderWithContext(<UserAccountOnlineMenuItem {...defaultProps}/>, mobileState);
+
+        await userEvent.click(screen.getByRole('menuitem'));
+
+        // Online must be explicitly settable like away, dnd and offline. The server treats
+        // this call as a manual pin that overrides the automatic away transition.
+        expect(userActions.setStatus).toHaveBeenCalledWith({
+            user_id: defaultProps.userId,
+            status: UserStatuses.ONLINE,
+        });
+    });
+
+    test('should mark the option as checked when the user is online', () => {
+        const props = {...defaultProps, isStatusOnline: true};
+        renderWithContext(<UserAccountOnlineMenuItem {...props}/>);
+
+        expect(screen.getByRole('menuitem')).toHaveAttribute('aria-checked', 'true');
+    });
+
+    test('should not mark the option as checked when the user is not online', () => {
+        renderWithContext(<UserAccountOnlineMenuItem {...defaultProps}/>);
+
+        expect(screen.getByRole('menuitem')).toHaveAttribute('aria-checked', 'false');
+    });
+
+    test('should open reset status modal instead of setting status when confirmation is required', async () => {
+        jest.spyOn(modalActions, 'openModal');
+        jest.spyOn(userActions, 'setStatus');
+
+        const props = {...defaultProps, shouldConfirmBeforeStatusChange: true};
+        renderWithContext(<UserAccountOnlineMenuItem {...props}/>, mobileState);
+
+        await userEvent.click(screen.getByRole('menuitem'));
+
+        expect(modalActions.openModal).toHaveBeenCalledTimes(1);
+        expect(userActions.setStatus).not.toHaveBeenCalled();
+    });
+});


### PR DESCRIPTION
#### Summary

Online is the only status you can't set manually. After `TeamSettings.UserStatusAwayTimeout` (default 5 minutes) of inactivity, someone who is genuinely available gets switched to Away, and colleagues read them as gone. Away, DND and Offline can all be set manually.

Most of the underlying code is already there. `Status.Manual` is respected by every automatic transition through the same check (`if !manual && status.Manual { return }`), `api4/status.go` already routes `"online"` to `SetStatusOnline(userId, true)`, the status menu already dispatches `setStatus`, and `/online` already passes `manual=true`. One line in `SetStatusOnline` threw that intent away:

```go
status.Manual = false // for "online" there's no manual setting
```

Changes, 26 lines of production code across 2 files:

1. `SetStatusOnline` honours its `manual` argument. Both construction paths needed it; the `GetStatus` error branch, hit when a user has no status row yet, also hardcoded `false`. Activity-driven callers pass `manual=false` and are unaffected.
2. Pinning from an already-online state changes only the flag, not the status string, so it took the `UpdateLastActivityAt` path that writes just the timestamp column. It now uses the full upsert whenever the flag changes, otherwise the pin is lost on the next cache miss.
3. `SetStatusOffline` and `QueueSetStatusOffline` let a real disconnect clear a pinned Online. Away, DND and Offline all claim less availability than reality, so they are safe to keep on disconnect. Online claims more, so it should beat inactivity but not disconnection. Without this, closing your laptop leaves you green indefinitely, which is worse than the original problem.
4. `ResetAll` clears pinned Online on restart for the same reason. It resets `Manual` alongside `Status`, otherwise the row becomes a manual Offline and the user can't be brought back online on reconnect.

| Event | Pinned Online | Automatic Online | Manual Away / DND / Offline |
|---|---|---|---|
| Idle past away timeout | stays Online | Away | unchanged |
| Last device disconnects | Offline | Offline | unchanged |
| Server restart | Offline | Offline | unchanged |
| User picks another status | honoured | honoured | honoured |

Not included:

* No migration, no new status value, no API contract change. `Manual` is already in the model, the table and the API response.
* No webapp changes. The Online menu item is already the same shape as Away and Offline, so it starts working once the server persists the flag. Nothing new for UX to review.
* DND expiry still clears the pin, since `UpdateExpiredDNDStatuses` resets `Manual` to false. That just reverts to today's behaviour, and preserving it means conditional SQL in a query the cluster-leader job runs. Happy to add it if you'd rather.
* Mobile lives in a separate repo and needs its own change.

Heads up on one existing test I changed. `TestSetStatusOffline/"when setting status manually over manually set status"` used Online to prove a manual status beats a non-manual offline. That still holds for every other status, so it now uses DND, and a new subtest covers the Online case.

Tests added: `TestSetStatusOnlineManual`, `TestManualOnlineSurvivesInactivity` and `TestManualOnlineClearedByDisconnect` in `platform/status_test.go`; `manual=true` plus a `GET` round trip in `api4/status_test.go`; `ResetAll` coverage across all four status kinds in `storetest/status_store.go`; a new webapp unit test for the Online menu item; and a new Cypress spec. Auto-away survival and disconnect clearing are left to the server tests because both run off websocket hub events that Cypress can't trigger reliably, noted in a comment in the spec.

Ran locally against PostgreSQL 15 and Redis: platform status tests 18/18 subtests, full `app/slashcommands` package, `app` status tests, `TestStatusStore`, `api4` status tests, webapp Jest 29/29, plus build, vet, gofmt, tsc, ESLint and Cypress tsc with no new errors.

QA steps:

1. Set yourself Away, then pick Online from the status menu. `GET /api/v4/users/me/status` should return `"manual": true`.
2. Sit idle past `TeamSettings.UserStatusAwayTimeout` (lower it to speed this up). Status should stay Online.
3. Close every client for that user. Status should go Offline, not stay green.
4. Pin Online, restart the server, confirm the user shows Offline.
5. Check Away, DND and Offline still behave as before, including across a restart.
6. Check `/online` matches the menu option.

#### Ticket Link

https://mattermost.atlassian.net/browse/MPP-220 (originally filed as https://mattermost.atlassian.net/browse/MM-69137)

#### Screenshots

No UI changes. The status menu already had an Online option that dispatched `setStatus`; this makes the server honour it, so the menu looks and behaves the same except the status no longer flips to Away on its own.

#### Release Note

```release-note
Added the ability to manually set your status to Online, which prevents the automatic switch to Away during periods of inactivity. The manually set status is cleared when you disconnect.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes affect shared status logic and persistence across server, store, webapp, and E2E layers. Automated coverage is broad, but status transitions remain a user-facing critical path.

**QA Recommendation:** Manual QA can be skipped. Automated tests provide sufficient coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->