### PR TITLE
Stop double-writing HTTP responses in streaming channel handlers

### DIFF
--- a/server/channels/api4/channel.go
+++ b/server/channels/api4/channel.go
@@ -1469,14 +1469,17 @@ func getChannelsForUser(c *Context, w http.ResponseWriter, r *http.Request) {
 			if fromChannelID != "" && err.Id == "app.channel.get_channels.not_found.app_error" {
 				break
 			}
-			c.Err = err
-			return
+			// The opening `[` above has already committed the response to
+			// status 200, so setting c.Err here would only cause a second,
+			// conflicting WriteHeader call. Log and end the stream instead.
+			c.Logger.Warn("Error while streaming channels for user", mlog.Err(err))
+			break
 		}
 
 		err = c.App.FillInChannelsProps(c.AppContext, channels)
 		if err != nil {
-			c.Err = err
-			return
+			c.Logger.Warn("Error while streaming channels for user", mlog.Err(err))
+			break
 		}
 
 		// intermediary comma between sets

--- a/server/channels/api4/user.go
+++ b/server/channels/api4/user.go
@@ -3792,6 +3792,13 @@ func getChannelMembersForUser(c *Context, w http.ResponseWriter, r *http.Request
 			if fromChannelID != "" && err.Id == app.MissingChannelMemberError {
 				break
 			}
+			if fromChannelID != "" {
+				// Earlier pages have already streamed, committing the response
+				// to status 200. Setting c.Err here would only cause a second,
+				// conflicting WriteHeader call, so log and end the stream instead.
+				c.Logger.Warn("Error while streaming channel members for user", mlog.Err(err))
+				break
+			}
 			c.Err = err
 			return
 		}


### PR DESCRIPTION
#### Summary
`getChannelsForUser` (`GET /api/v4/users/{user_id}/channels`) and `getChannelMembersForUser` (`GET /api/v4/users/{user_id}/channels/members`) stream paginated results directly to the `ResponseWriter` instead of buffering the full result set. Once streaming has started, the response's status code (200) is already committed to the client.

Both handlers had a path where a page-fetch failure *after* streaming had begun still set `c.Err`. This caused `web.Handler.ServeHTTP` to call `handleContextError`, which tried to `WriteHeader` a second time (logged by Go's `net/http` as `http: superfluous response.WriteHeader call`) and appended the error's JSON body onto the already-sent, now-truncated response — corrupting it for the client.

Fix: once bytes have already been streamed, a later page-fetch failure is logged and ends the stream gracefully instead of going through `c.Err`/`handleContextError`. `getChannelMembersForUser` still returns a normal error response if the very first page fails, since nothing has been written to the client yet at that point.

QA steps:
1. Point either endpoint at an account with more channels/members than one page size (100).
2. Simulate a failure on a page after the first (e.g. via a temporary induced DB error) and confirm the server no longer logs `superfluous response.WriteHeader call` and the client-visible stream still terminates with valid syntax for the data received so far, without an appended error blob.

#### Ticket Link
N/A — found via a `superfluous response.WriteHeader call` warning in server logs, not tied to a ticket.

#### Screenshots
N/A — backend-only change.

#### Release Note
\`\`\`release-note
NONE
\`\`\`