### PR TITLE
[MM-69911] Include PAT token ID in server and audit logs for request traceability

### DIFF
--- a/server/channels/web/context.go
+++ b/server/channels/web/context.go
@@ -35,6 +35,9 @@ func (c *Context) LogAuditRec(rec *model.AuditRecord) {
 	if rec.Actor.SessionId == "" {
 		rec.Actor.SessionId = c.AppContext.Session().Id
 	}
+	if rec.Actor.TokenId == "" && c.AppContext.Session().IsUserAccessToken() {
+		rec.Actor.TokenId = c.AppContext.Session().Props[model.SessionPropUserAccessTokenId]
+	}
 
 	c.LogAuditRecWithLevel(rec, app.LevelAPI)
 }
@@ -59,16 +62,21 @@ func (c *Context) LogAuditRecWithLevel(rec *model.AuditRecord, level mlog.Level)
 
 // MakeAuditRecord creates an audit record pre-populated with data from this context.
 func (c *Context) MakeAuditRecord(event string, initialStatus string) *model.AuditRecord {
+	actor := model.AuditEventActor{
+		UserId:        c.AppContext.Session().UserId,
+		SessionId:     c.AppContext.Session().Id,
+		Client:        c.AppContext.UserAgent(),
+		IpAddress:     c.AppContext.IPAddress(),
+		XForwardedFor: c.AppContext.XForwardedFor(),
+	}
+	if c.AppContext.Session().IsUserAccessToken() {
+		actor.TokenId = c.AppContext.Session().Props[model.SessionPropUserAccessTokenId]
+	}
+
 	rec := &model.AuditRecord{
 		EventName: event,
 		Status:    initialStatus,
-		Actor: model.AuditEventActor{
-			UserId:        c.AppContext.Session().UserId,
-			SessionId:     c.AppContext.Session().Id,
-			Client:        c.AppContext.UserAgent(),
-			IpAddress:     c.AppContext.IPAddress(),
-			XForwardedFor: c.AppContext.XForwardedFor(),
-		},
+		Actor:     actor,
 		Meta: map[string]any{
 			model.AuditKeyAPIPath:   c.AppContext.Path(),
 			model.AuditKeyClusterID: c.App.GetClusterId(),

--- a/server/channels/web/context.go
+++ b/server/channels/web/context.go
@@ -35,8 +35,8 @@ func (c *Context) LogAuditRec(rec *model.AuditRecord) {
 	if rec.Actor.SessionId == "" {
 		rec.Actor.SessionId = c.AppContext.Session().Id
 	}
-	if rec.Actor.TokenId == "" && c.AppContext.Session().IsUserAccessToken() {
-		rec.Actor.TokenId = c.AppContext.Session().Props[model.SessionPropUserAccessTokenId]
+	if _, exists := rec.Meta[model.SessionPropUserAccessTokenId]; !exists && c.AppContext.Session().IsUserAccessToken() {
+		rec.Meta[model.SessionPropUserAccessTokenId] = c.AppContext.Session().Props[model.SessionPropUserAccessTokenId]
 	}
 
 	c.LogAuditRecWithLevel(rec, app.LevelAPI)
@@ -62,25 +62,25 @@ func (c *Context) LogAuditRecWithLevel(rec *model.AuditRecord, level mlog.Level)
 
 // MakeAuditRecord creates an audit record pre-populated with data from this context.
 func (c *Context) MakeAuditRecord(event string, initialStatus string) *model.AuditRecord {
-	actor := model.AuditEventActor{
-		UserId:        c.AppContext.Session().UserId,
-		SessionId:     c.AppContext.Session().Id,
-		Client:        c.AppContext.UserAgent(),
-		IpAddress:     c.AppContext.IPAddress(),
-		XForwardedFor: c.AppContext.XForwardedFor(),
+	meta := map[string]any{
+		model.AuditKeyAPIPath:   c.AppContext.Path(),
+		model.AuditKeyClusterID: c.App.GetClusterId(),
 	}
 	if c.AppContext.Session().IsUserAccessToken() {
-		actor.TokenId = c.AppContext.Session().Props[model.SessionPropUserAccessTokenId]
+		meta[model.SessionPropUserAccessTokenId] = c.AppContext.Session().Props[model.SessionPropUserAccessTokenId]
 	}
 
 	rec := &model.AuditRecord{
 		EventName: event,
 		Status:    initialStatus,
-		Actor:     actor,
-		Meta: map[string]any{
-			model.AuditKeyAPIPath:   c.AppContext.Path(),
-			model.AuditKeyClusterID: c.App.GetClusterId(),
+		Actor: model.AuditEventActor{
+			UserId:        c.AppContext.Session().UserId,
+			SessionId:     c.AppContext.Session().Id,
+			Client:        c.AppContext.UserAgent(),
+			IpAddress:     c.AppContext.IPAddress(),
+			XForwardedFor: c.AppContext.XForwardedFor(),
 		},
+		Meta: meta,
 		EventData: model.AuditEventData{
 			Parameters:  map[string]any{},
 			PriorState:  map[string]any{},

--- a/server/channels/web/context_test.go
+++ b/server/channels/web/context_test.go
@@ -16,91 +16,97 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
 )
 
-func TestMakeAuditRecord_WithPATSession(t *testing.T) {
-	th := SetupWithStoreMock(t)
+func TestMakeAuditRecord(t *testing.T) {
+	t.Run("PAT session includes token ID in meta", func(t *testing.T) {
+		th := SetupWithStoreMock(t)
 
-	tokenID := model.NewId()
-	th.Context = th.Context.WithSession(&model.Session{
-		Id:     model.NewId(),
-		UserId: model.NewId(),
-		Props: model.StringMap{
-			model.SessionPropType:              model.SessionTypeUserAccessToken,
-			model.SessionPropUserAccessTokenId: tokenID,
-		},
+		tokenID := model.NewId()
+		th.Context = th.Context.WithSession(&model.Session{
+			Id:     model.NewId(),
+			UserId: model.NewId(),
+			Props: model.StringMap{
+				model.SessionPropType:              model.SessionTypeUserAccessToken,
+				model.SessionPropUserAccessTokenId: tokenID,
+			},
+		})
+
+		c := &Context{App: th.App, AppContext: th.Context}
+		rec := c.MakeAuditRecord("test_event", model.AuditStatusAttempt)
+
+		require.NotNil(t, rec)
+		assert.Equal(t, tokenID, rec.Meta[model.SessionPropUserAccessTokenId])
 	})
 
-	c := &Context{App: th.App, AppContext: th.Context}
-	rec := c.MakeAuditRecord("test_event", model.AuditStatusAttempt)
+	t.Run("non-PAT session omits token ID from meta", func(t *testing.T) {
+		th := SetupWithStoreMock(t)
 
-	require.NotNil(t, rec)
-	assert.Equal(t, tokenID, rec.Meta[model.SessionPropUserAccessTokenId])
+		th.Context = th.Context.WithSession(&model.Session{
+			Id:     model.NewId(),
+			UserId: model.NewId(),
+		})
+
+		c := &Context{App: th.App, AppContext: th.Context}
+		rec := c.MakeAuditRecord("test_event", model.AuditStatusAttempt)
+
+		require.NotNil(t, rec)
+		_, exists := rec.Meta[model.SessionPropUserAccessTokenId]
+		assert.False(t, exists, "token ID key should be absent from Meta for non-PAT sessions")
+	})
 }
 
-func TestMakeAuditRecord_WithNonPATSession(t *testing.T) {
-	th := SetupWithStoreMock(t)
+func TestLogAuditRec(t *testing.T) {
+	t.Run("late-fills token ID for PAT session", func(t *testing.T) {
+		th := SetupWithStoreMock(t)
 
-	th.Context = th.Context.WithSession(&model.Session{
-		Id:     model.NewId(),
-		UserId: model.NewId(),
+		tokenID := model.NewId()
+		th.Context = th.Context.WithSession(&model.Session{
+			Id:     model.NewId(),
+			UserId: model.NewId(),
+			Props: model.StringMap{
+				model.SessionPropType:              model.SessionTypeUserAccessToken,
+				model.SessionPropUserAccessTokenId: tokenID,
+			},
+		})
+
+		c := &Context{App: th.App, AppContext: th.Context}
+
+		// Simulate a record created before the session was established (e.g., login flow)
+		rec := &model.AuditRecord{
+			EventName: "test_event",
+			Status:    model.AuditStatusAttempt,
+			Actor:     model.AuditEventActor{},
+			Meta:      map[string]any{},
+			EventData: model.AuditEventData{},
+		}
+
+		c.LogAuditRec(rec)
+
+		assert.Equal(t, tokenID, rec.Meta[model.SessionPropUserAccessTokenId])
 	})
 
-	c := &Context{App: th.App, AppContext: th.Context}
-	rec := c.MakeAuditRecord("test_event", model.AuditStatusAttempt)
+	t.Run("does not add token ID for non-PAT session", func(t *testing.T) {
+		th := SetupWithStoreMock(t)
 
-	require.NotNil(t, rec)
-	assert.Nil(t, rec.Meta[model.SessionPropUserAccessTokenId])
-}
+		th.Context = th.Context.WithSession(&model.Session{
+			Id:     model.NewId(),
+			UserId: model.NewId(),
+		})
 
-func TestLogAuditRec_LateFilledTokenId(t *testing.T) {
-	th := SetupWithStoreMock(t)
+		c := &Context{App: th.App, AppContext: th.Context}
 
-	tokenID := model.NewId()
-	th.Context = th.Context.WithSession(&model.Session{
-		Id:     model.NewId(),
-		UserId: model.NewId(),
-		Props: model.StringMap{
-			model.SessionPropType:              model.SessionTypeUserAccessToken,
-			model.SessionPropUserAccessTokenId: tokenID,
-		},
+		rec := &model.AuditRecord{
+			EventName: "test_event",
+			Status:    model.AuditStatusAttempt,
+			Actor:     model.AuditEventActor{},
+			Meta:      map[string]any{},
+			EventData: model.AuditEventData{},
+		}
+
+		c.LogAuditRec(rec)
+
+		_, exists := rec.Meta[model.SessionPropUserAccessTokenId]
+		assert.False(t, exists, "token ID key should be absent from Meta for non-PAT sessions")
 	})
-
-	c := &Context{App: th.App, AppContext: th.Context}
-
-	// Simulate a record created before the session was established (e.g., login flow)
-	rec := &model.AuditRecord{
-		EventName: "test_event",
-		Status:    model.AuditStatusAttempt,
-		Actor:     model.AuditEventActor{},
-		Meta:      map[string]any{},
-		EventData: model.AuditEventData{},
-	}
-
-	c.LogAuditRec(rec)
-
-	assert.Equal(t, tokenID, rec.Meta[model.SessionPropUserAccessTokenId])
-}
-
-func TestLogAuditRec_NonPATSession_NoTokenId(t *testing.T) {
-	th := SetupWithStoreMock(t)
-
-	th.Context = th.Context.WithSession(&model.Session{
-		Id:     model.NewId(),
-		UserId: model.NewId(),
-	})
-
-	c := &Context{App: th.App, AppContext: th.Context}
-
-	rec := &model.AuditRecord{
-		EventName: "test_event",
-		Status:    model.AuditStatusAttempt,
-		Actor:     model.AuditEventActor{},
-		Meta:      map[string]any{},
-		EventData: model.AuditEventData{},
-	}
-
-	c.LogAuditRec(rec)
-
-	assert.Nil(t, rec.Meta[model.SessionPropUserAccessTokenId])
 }
 
 func TestRequireHookId(t *testing.T) {

--- a/server/channels/web/context_test.go
+++ b/server/channels/web/context_test.go
@@ -16,6 +16,93 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
 )
 
+func TestMakeAuditRecord_WithPATSession(t *testing.T) {
+	th := SetupWithStoreMock(t)
+
+	tokenID := model.NewId()
+	th.Context = th.Context.WithSession(&model.Session{
+		Id:     model.NewId(),
+		UserId: model.NewId(),
+		Props: model.StringMap{
+			model.SessionPropType:              model.SessionTypeUserAccessToken,
+			model.SessionPropUserAccessTokenId: tokenID,
+		},
+	})
+
+	c := &Context{App: th.App, AppContext: th.Context}
+	rec := c.MakeAuditRecord("test_event", model.AuditStatusAttempt)
+
+	require.NotNil(t, rec)
+	assert.Equal(t, tokenID, rec.Meta[model.SessionPropUserAccessTokenId])
+}
+
+func TestMakeAuditRecord_WithNonPATSession(t *testing.T) {
+	th := SetupWithStoreMock(t)
+
+	th.Context = th.Context.WithSession(&model.Session{
+		Id:     model.NewId(),
+		UserId: model.NewId(),
+	})
+
+	c := &Context{App: th.App, AppContext: th.Context}
+	rec := c.MakeAuditRecord("test_event", model.AuditStatusAttempt)
+
+	require.NotNil(t, rec)
+	assert.Nil(t, rec.Meta[model.SessionPropUserAccessTokenId])
+}
+
+func TestLogAuditRec_LateFilledTokenId(t *testing.T) {
+	th := SetupWithStoreMock(t)
+
+	tokenID := model.NewId()
+	th.Context = th.Context.WithSession(&model.Session{
+		Id:     model.NewId(),
+		UserId: model.NewId(),
+		Props: model.StringMap{
+			model.SessionPropType:              model.SessionTypeUserAccessToken,
+			model.SessionPropUserAccessTokenId: tokenID,
+		},
+	})
+
+	c := &Context{App: th.App, AppContext: th.Context}
+
+	// Simulate a record created before the session was established (e.g., login flow)
+	rec := &model.AuditRecord{
+		EventName: "test_event",
+		Status:    model.AuditStatusAttempt,
+		Actor:     model.AuditEventActor{},
+		Meta:      map[string]any{},
+		EventData: model.AuditEventData{},
+	}
+
+	c.LogAuditRec(rec)
+
+	assert.Equal(t, tokenID, rec.Meta[model.SessionPropUserAccessTokenId])
+}
+
+func TestLogAuditRec_NonPATSession_NoTokenId(t *testing.T) {
+	th := SetupWithStoreMock(t)
+
+	th.Context = th.Context.WithSession(&model.Session{
+		Id:     model.NewId(),
+		UserId: model.NewId(),
+	})
+
+	c := &Context{App: th.App, AppContext: th.Context}
+
+	rec := &model.AuditRecord{
+		EventName: "test_event",
+		Status:    model.AuditStatusAttempt,
+		Actor:     model.AuditEventActor{},
+		Meta:      map[string]any{},
+		EventData: model.AuditEventData{},
+	}
+
+	c.LogAuditRec(rec)
+
+	assert.Nil(t, rec.Meta[model.SessionPropUserAccessTokenId])
+}
+
 func TestRequireHookId(t *testing.T) {
 	c := &Context{}
 	t.Run("WhenHookIdIsValid", func(t *testing.T) {

--- a/server/channels/web/handlers.go
+++ b/server/channels/web/handlers.go
@@ -170,6 +170,9 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// if there is a valid session and userID then include the user_id
 		if c.AppContext.Session() != nil && c.AppContext.Session().UserId != "" {
 			responseLogFields = append(responseLogFields, mlog.String("user_id", c.AppContext.Session().UserId))
+			if c.AppContext.Session().IsUserAccessToken() {
+				responseLogFields = append(responseLogFields, mlog.String("user_access_token_id", c.AppContext.Session().Props[model.SessionPropUserAccessTokenId]))
+			}
 		}
 
 		statusCode := strconv.Itoa(w.(*responseWriterWrapper).StatusCode())
@@ -321,13 +324,17 @@ func (h Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	c.Logger = c.App.Log().With(
+	loggerFields := []mlog.Field{
 		mlog.String("path", c.AppContext.Path()),
 		mlog.String("request_id", c.AppContext.RequestId()),
 		mlog.String("ip_addr", c.AppContext.IPAddress()),
 		mlog.String("user_id", c.AppContext.Session().UserId),
 		mlog.String("method", r.Method),
-	)
+	}
+	if c.AppContext.Session().IsUserAccessToken() {
+		loggerFields = append(loggerFields, mlog.String("user_access_token_id", c.AppContext.Session().Props[model.SessionPropUserAccessTokenId]))
+	}
+	c.Logger = c.App.Log().With(loggerFields...)
 	c.AppContext = c.AppContext.WithLogger(c.Logger)
 	c.App.ProcessSessionAttributesRequest(c.AppContext, r)
 

--- a/server/public/model/audit_record.go
+++ b/server/public/model/audit_record.go
@@ -14,7 +14,6 @@ const (
 	AuditKeyStatus    = "status"
 	AuditKeyUserID    = "user_id"
 	AuditKeySessionID = "session_id"
-	AuditKeyTokenID   = "token_id"
 	AuditKeyClient    = "client"
 	AuditKeyIPAddress = "ip_address"
 	AuditKeyClusterID = "cluster_id"
@@ -46,7 +45,6 @@ type AuditEventData struct {
 type AuditEventActor struct {
 	UserId        string `json:"user_id"`
 	SessionId     string `json:"session_id"`
-	TokenId       string `json:"token_id,omitempty"`
 	Client        string `json:"client"`
 	IpAddress     string `json:"ip_address"`
 	XForwardedFor string `json:"x_forwarded_for"`

--- a/server/public/model/audit_record.go
+++ b/server/public/model/audit_record.go
@@ -14,6 +14,7 @@ const (
 	AuditKeyStatus    = "status"
 	AuditKeyUserID    = "user_id"
 	AuditKeySessionID = "session_id"
+	AuditKeyTokenID   = "token_id"
 	AuditKeyClient    = "client"
 	AuditKeyIPAddress = "ip_address"
 	AuditKeyClusterID = "cluster_id"
@@ -45,6 +46,7 @@ type AuditEventData struct {
 type AuditEventActor struct {
 	UserId        string `json:"user_id"`
 	SessionId     string `json:"session_id"`
+	TokenId       string `json:"token_id,omitempty"`
 	Client        string `json:"client"`
 	IpAddress     string `json:"ip_address"`
 	XForwardedFor string `json:"x_forwarded_for"`


### PR DESCRIPTION
#### Summary

Adds the Personal Access Token (PAT) identifier to server logs and audit log records for any request authenticated via a PAT. This allows enterprise operators to directly trace which token was used for a given API request without requiring a manual cross-reference against the `Sessions` database table.

Changes:
- `public/model/audit_record.go`: Added `AuditKeyTokenID` constant and a `TokenId` field (with `omitempty`) to `AuditEventActor`.
- `channels/web/context.go`: `MakeAuditRecord` populates `actor.TokenId` for PAT-authenticated sessions; `LogAuditRec` late-fills it using the same guard pattern already used for `UserId`/`SessionId` (handles the login flow where the session isn't set at record creation time).
- `channels/web/handlers.go`: Both the `defer` response log and the persistent per-request logger now append `user_access_token_id` when `session.IsUserAccessToken()` is true.

The full token value is never logged — only the internal token identifier (UUID) from the session props (`user_access_token_id`). This applies to both human and bot PATs, covering AI agent traffic.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-69911

#### Screenshots

N/A — log output change. Server log example (PAT request):
```json
{
  "method": "POST",
  "url": "/api/v4/posts",
  "request_id": "nc5aggf9wp88jq1hmo7jkae63w",
  "user_id": "o15bjpa8nt83xbqno8nwu1iirw",
  "user_access_token_id": "ita5zwo8a3gm5ecaz1h8hrhp4o",
  "status_code": "201"
}
```

#### Release Note

```release-note
Added user_access_token_id field to server logs and audit log actor records for requests authenticated via Personal Access Token, enabling direct token traceability without manual database lookups.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The changes affect PAT session handling and request logging across multiple modules. Automated tests cover PAT and non-PAT audit flows.

**QA Recommendation:** Manual QA can be skipped. Automated test coverage is sufficient, and rollback is straightforward.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->