### PR TITLE
Validate reaction emoji names on bulk import

### DIFF
--- a/server/channels/app/imports/import_validators.go
+++ b/server/channels/app/imports/import_validators.go
@@ -457,8 +457,11 @@ func ValidateReactionImportData(data *ReactionImportData, parentCreateAt int64) 
 
 	if data.EmojiName == nil {
 		return model.NewAppError("BulkImport", "app.import.validate_reaction_import_data.emoji_name_missing.error", nil, "", http.StatusBadRequest)
-	} else if utf8.RuneCountInString(*data.EmojiName) > model.EmojiNameMaxLength {
-		return model.NewAppError("BulkImport", "app.import.validate_reaction_import_data.emoji_name_length.error", nil, "", http.StatusBadRequest)
+	}
+	// Same empty/length/charset rules as Reaction.IsValid. Do not use IsValidEmojiName —
+	// it rejects system emoji names, which are valid on reactions.
+	if *data.EmojiName == "" || len(*data.EmojiName) > model.EmojiNameMaxLength || !model.IsValidAlphaNumHyphenUnderscorePlus(*data.EmojiName) {
+		return model.NewAppError("BulkImport", "app.import.validate_reaction_import_data.emoji_name_invalid.error", nil, "emoji_name="+*data.EmojiName, http.StatusBadRequest)
 	}
 
 	if data.CreateAt == nil {

--- a/server/channels/app/imports/import_validators_test.go
+++ b/server/channels/app/imports/import_validators_test.go
@@ -889,6 +889,16 @@ func TestImportValidateReactionImportData(t *testing.T) {
 	err = ValidateReactionImportData(&data, parentCreateAt)
 	require.NotNil(t, err, "Should have failed due to missing required property.")
 
+	// Empty emoji name is present but invalid (distinct from missing).
+	data = ReactionImportData{
+		User:      new("username"),
+		EmojiName: new(""),
+		CreateAt:  new(model.GetMillis()),
+	}
+	err = ValidateReactionImportData(&data, parentCreateAt)
+	require.NotNil(t, err, "Should have failed due to empty emoji name.")
+	require.Equal(t, "app.import.validate_reaction_import_data.emoji_name_invalid.error", err.Id)
+
 	// Test with too long emoji name.
 	data = ReactionImportData{
 		User:      new("username"),

--- a/server/channels/app/imports/import_validators_test.go
+++ b/server/channels/app/imports/import_validators_test.go
@@ -889,7 +889,7 @@ func TestImportValidateReactionImportData(t *testing.T) {
 	err = ValidateReactionImportData(&data, parentCreateAt)
 	require.NotNil(t, err, "Should have failed due to missing required property.")
 
-	// Test with invalid emoji name.
+	// Test with too long emoji name.
 	data = ReactionImportData{
 		User:      new("username"),
 		EmojiName: new(strings.Repeat("1234567890", 500)),
@@ -897,6 +897,36 @@ func TestImportValidateReactionImportData(t *testing.T) {
 	}
 	err = ValidateReactionImportData(&data, parentCreateAt)
 	require.NotNil(t, err, "Should have failed due to too long emoji name.")
+	require.Equal(t, "app.import.validate_reaction_import_data.emoji_name_invalid.error", err.Id)
+
+	// Test with non-ASCII emoji name (same charset rules as Reaction.IsValid).
+	data = ReactionImportData{
+		User:      new("username"),
+		EmojiName: new("リハテスト"),
+		CreateAt:  new(model.GetMillis()),
+	}
+	err = ValidateReactionImportData(&data, parentCreateAt)
+	require.NotNil(t, err, "Should have failed due to invalid emoji name characters.")
+	require.Equal(t, "app.import.validate_reaction_import_data.emoji_name_invalid.error", err.Id)
+
+	// Test with invalid characters in emoji name.
+	data = ReactionImportData{
+		User:      new("username"),
+		EmojiName: new("emoji:"),
+		CreateAt:  new(model.GetMillis()),
+	}
+	err = ValidateReactionImportData(&data, parentCreateAt)
+	require.NotNil(t, err, "Should have failed due to invalid emoji name characters.")
+	require.Equal(t, "app.import.validate_reaction_import_data.emoji_name_invalid.error", err.Id)
+
+	// System emoji names are allowed on reactions.
+	data = ReactionImportData{
+		User:      new("username"),
+		EmojiName: new("+1"),
+		CreateAt:  new(model.GetMillis()),
+	}
+	err = ValidateReactionImportData(&data, parentCreateAt)
+	require.Nil(t, err, "Validation failed but should have been valid.")
 
 	// Test with invalid CreateAt
 	data = ReactionImportData{

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -7257,6 +7257,10 @@
     "translation": "Reaction CreateAt property must not be zero."
   },
   {
+    "id": "app.import.validate_reaction_import_data.emoji_name_invalid.error",
+    "translation": "Reaction EmojiName property is invalid. It must be 1 to 64 letters, numbers, +, -, or _."
+  },
+  {
     "id": "app.import.validate_reaction_import_data.emoji_name_length.error",
     "translation": "Reaction EmojiName property is longer than the maximum permitted length."
   },

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -7258,7 +7258,7 @@
   },
   {
     "id": "app.import.validate_reaction_import_data.emoji_name_invalid.error",
-    "translation": "Reaction EmojiName property is invalid. It must be 1 to 64 letters, numbers, +, -, or _."
+    "translation": "Reaction EmojiName property is invalid. It must be 1 to 64 ASCII letters and numbers, +, -, or _."
   },
   {
     "id": "app.import.validate_reaction_import_data.emoji_name_length.error",


### PR DESCRIPTION
#### Summary
Update bulk import reaction validation to use the same empty/length/charset rules as `Reaction.IsValid`, so invalid names (e.g. non-ASCII like `リハテスト`) fail during `mmctl import validate` / import validation instead of later at save time.

Does not use `IsValidEmojiName`, which rejects system emoji names that are valid on reactions.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change affects reaction import validation and rejects names that previously reached the save stage. Tests cover empty, oversized, non-ASCII, punctuation-containing, and valid system emoji names.

**QA Recommendation:** Manual QA is not required. Automated test coverage is sufficient.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->