### PR TITLE
MM-70229: Adjust status response serialization

### DIFF
--- a/server/channels/api4/status.go
+++ b/server/channels/api4/status.go
@@ -43,7 +43,13 @@ func getUserStatus(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := json.NewEncoder(w).Encode(statusMap[0]); err != nil {
+	js, jsonErr := statusMap[0].ToJSON()
+	if jsonErr != nil {
+		c.Err = model.NewAppError("getUserStatus", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(jsonErr)
+		return
+	}
+
+	if _, err := w.Write(js); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}
 }
@@ -72,7 +78,7 @@ func getUserStatusesByIds(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	js, err := json.Marshal(statuses)
+	js, err := model.StatusListToJSON(statuses)
 	if err != nil {
 		c.Err = model.NewAppError("getUserStatusesByIds", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
 		return

--- a/server/channels/api4/status_test.go
+++ b/server/channels/api4/status_test.go
@@ -5,6 +5,8 @@ package api4
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
 	"strings"
 	"testing"
 	"time"
@@ -182,6 +184,116 @@ func TestGetUsersStatusesByIds(t *testing.T) {
 		_, resp, err := client.GetUsersStatusesByIds(context.Background(), usersIds)
 		require.Error(t, err)
 		CheckUnauthorizedStatus(t, resp)
+	})
+}
+
+func TestGetUserStatusActiveChannel(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	privateChannel := th.CreatePrivateChannel(t)
+
+	_, _, err := th.Client.ViewChannel(context.Background(), th.BasicUser.Id, &model.ChannelView{ChannelId: privateChannel.Id})
+	require.NoError(t, err)
+
+	status, appErr := th.App.GetStatus(th.BasicUser.Id)
+	require.Nil(t, appErr)
+	require.Equal(t, privateChannel.Id, status.ActiveChannel, "precondition: the target user must have an active channel set")
+
+	getRawStatus := func(t *testing.T, client *model.Client4, userID string) map[string]any {
+		t.Helper()
+		resp, err := client.DoAPIGet(context.Background(), "/users/"+userID+"/status", "")
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var raw map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&raw))
+		return raw
+	}
+
+	getRawStatusesByIds := func(t *testing.T, client *model.Client4, userIDs []string) []map[string]any {
+		t.Helper()
+		body, jsonErr := json.Marshal(userIDs)
+		require.NoError(t, jsonErr)
+
+		resp, err := client.DoAPIPost(context.Background(), "/users/status/ids", string(body))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var raw []map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&raw))
+		return raw
+	}
+
+	t.Run("get status of a user active in a channel the caller is not a member of", func(t *testing.T) {
+		th.LoginBasic2(t)
+
+		_, resp, err := th.Client.GetChannel(context.Background(), privateChannel.Id)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+
+		raw := getRawStatus(t, th.Client, th.BasicUser.Id)
+		assert.NotContains(t, raw, "active_channel")
+		assert.Equal(t, th.BasicUser.Id, raw["user_id"])
+		assert.Equal(t, model.StatusOnline, raw["status"])
+	})
+
+	t.Run("get statuses by ids of a user active in a channel the caller is not a member of", func(t *testing.T) {
+		th.LoginBasic2(t)
+
+		raw := getRawStatusesByIds(t, th.Client, []string{th.BasicUser.Id, th.BasicUser2.Id})
+		require.Len(t, raw, 2)
+		for _, status := range raw {
+			assert.NotContains(t, status, "active_channel")
+			assert.NotEmpty(t, status["user_id"])
+			assert.NotEmpty(t, status["status"])
+		}
+	})
+
+	t.Run("get own status", func(t *testing.T) {
+		th.LoginBasic(t)
+
+		raw := getRawStatus(t, th.Client, th.BasicUser.Id)
+		assert.NotContains(t, raw, "active_channel")
+
+		rawList := getRawStatusesByIds(t, th.Client, []string{th.BasicUser.Id})
+		require.Len(t, rawList, 1)
+		assert.NotContains(t, rawList[0], "active_channel")
+	})
+
+	t.Run("get status as system admin", func(t *testing.T) {
+		raw := getRawStatus(t, th.SystemAdminClient, th.BasicUser.Id)
+		assert.NotContains(t, raw, "active_channel")
+
+		rawList := getRawStatusesByIds(t, th.SystemAdminClient, []string{th.BasicUser.Id})
+		require.Len(t, rawList, 1)
+		assert.NotContains(t, rawList[0], "active_channel")
+	})
+
+	t.Run("update own status", func(t *testing.T) {
+		th.LoginBasic(t)
+
+		toUpdate := &model.Status{UserId: th.BasicUser.Id, Status: model.StatusDnd, Manual: true}
+		body, jsonErr := json.Marshal(toUpdate)
+		require.NoError(t, jsonErr)
+
+		resp, err := th.Client.DoAPIPut(context.Background(), "/users/"+th.BasicUser.Id+"/status", string(body))
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+
+		var raw map[string]any
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&raw))
+		assert.NotContains(t, raw, "active_channel")
+		assert.Equal(t, model.StatusDnd, raw["status"])
+	})
+
+	t.Run("the active channel is still tracked server side", func(t *testing.T) {
+		status, appErr := th.App.GetStatus(th.BasicUser.Id)
+		require.Nil(t, appErr)
+		assert.Equal(t, privateChannel.Id, status.ActiveChannel)
 	})
 }
 


### PR DESCRIPTION
## Ticket Link

Fixes [MM-70229](https://mattermost.atlassian.net/browse/MM-70229).

```release-note
Updated how user presence status responses are serialized.
```

[MM-70229]: https://mattermost.atlassian.net/browse/MM-70229?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
