### PR TITLE
Fix unused context import breaking Server CI on master

### DIFF
--- a/server/channels/app/post_persistent_notification.go
+++ b/server/channels/app/post_persistent_notification.go
@@ -4,7 +4,6 @@
 package app
 
 import (
-	"context"
 	"maps"
 	"net/http"
 	"time"

--- a/server/channels/store/localcachelayer/user_layer.go
+++ b/server/channels/store/localcachelayer/user_layer.go
@@ -5,7 +5,6 @@ package localcachelayer
 
 import (
 	"bytes"
-	"context"
 	"sort"
 	"sync"
 

--- a/server/channels/store/localcachelayer/user_layer_test.go
+++ b/server/channels/store/localcachelayer/user_layer_test.go
@@ -4,7 +4,6 @@
 package localcachelayer
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/server/channels/store/sqlstore/user_store.go
+++ b/server/channels/store/sqlstore/user_store.go
@@ -4,7 +4,6 @@
 package sqlstore
 
 import (
-	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"

--- a/server/channels/store/storetest/mocks/UserStore.go
+++ b/server/channels/store/storetest/mocks/UserStore.go
@@ -5,8 +5,6 @@
 package mocks
 
 import (
-	context "context"
-
 	model "github.com/mattermost/mattermost/server/public/model"
 	request "github.com/mattermost/mattermost/server/public/shared/request"
 	store "github.com/mattermost/mattermost/server/v8/channels/store"

--- a/server/channels/store/storetest/user_store.go
+++ b/server/channels/store/storetest/user_store.go
@@ -4,7 +4,6 @@
 package storetest
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"sort"


### PR DESCRIPTION
#### Summary
Server CI on `master` broke after #37646 ("Migrate UserStore Get to request context") merged: `go vet`/build failed with `"context" imported and not used` in several files, which cascaded into failures across the whole Server CI matrix (Vet API, check-style, Check generated files, Build mattermost server app, mmctl tests, and all Postgres/OpenSearch/Elasticsearch shards).

Root cause: #37646 replaced `context.Background()` call sites with `request.CTX` (`rctx`) but relied on other, untouched call sites in the same files to keep the `"context"` import alive. A sibling PR (#37637, "Migrate GetAllProfilesInChannel to request context") merged into `master` in between and migrated those other call sites away first. Since #37646 was tested against its (older) base and not re-tested against the final integrated state before merging, the combination left several files with a dead `"context"` import that only surfaced once both changes landed together on `master`.

This PR removes the now-unused `"context"` import from each affected file (no other changes):
- `server/channels/store/sqlstore/user_store.go`
- `server/channels/store/storetest/user_store.go`
- `server/channels/store/storetest/mocks/UserStore.go`
- `server/channels/store/localcachelayer/user_layer.go`
- `server/channels/store/localcachelayer/user_layer_test.go`
- `server/channels/app/post_persistent_notification.go`

Verified with `go build ./...`, `go vet ./channels/store/... ./channels/app/...`, and `gofmt -l` on the changed files — all clean.

#### Ticket Link


#### Screenshots


#### Release Note
```release-note
NONE
```


---
_Generated by [Claude Code](https://claude.ai/code/session_01CBDaCjBmx5UtywGjzA8g4X)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes remove unused imports only. They do not alter runtime behavior, public APIs, data persistence, or critical user flows.  
**QA Recommendation:** Manual QA is not required. Existing `go build`, `go vet`, and `gofmt` checks are sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->