### PR TITLE
MM-70072: Update team admin assignment during team join

### DIFF
--- a/server/channels/app/import_functions.go
+++ b/server/channels/app/import_functions.go
@@ -1170,7 +1170,7 @@ func (a *App) importUserTeams(rctx request.CTX, user *model.User, data *[]import
 			}
 		}
 
-		if _, appErr := a.UpdateTeamMemberSchemeRoles(rctx, member.TeamId, user.Id, isGuestByTeamID[member.TeamId], isUserByTeamId[member.TeamId], isAdminByTeamID[member.TeamId]); appErr != nil {
+		if _, appErr := a.UpdateTeamMemberSchemeRoles(rctx, member.TeamId, user.Id, isGuestByTeamID[member.TeamId], isUserByTeamId[member.TeamId], member.SchemeAdmin || isAdminByTeamID[member.TeamId]); appErr != nil {
 			rctx.Logger().Warn("Error updating team member scheme roles", mlog.String("team_id", member.TeamId), mlog.String("user_id", user.Id), mlog.Err(appErr))
 		}
 	}

--- a/server/channels/app/import_functions.go
+++ b/server/channels/app/import_functions.go
@@ -1113,7 +1113,7 @@ func (a *App) importUserTeams(rctx request.CTX, user *model.User, data *[]import
 			if appErr != nil {
 				return appErr
 			}
-			member.SchemeAdmin = userShouldBeAdmin
+			member.SchemeAdmin = member.SchemeAdmin || userShouldBeAdmin
 		}
 
 		if tdata.Channels != nil {

--- a/server/channels/app/import_functions_test.go
+++ b/server/channels/app/import_functions_test.go
@@ -1983,6 +1983,37 @@ func TestImportUserTeams(t *testing.T) {
 		appErr := th.App.importUserTeams(th.Context, user, data)
 		require.NotNil(t, appErr)
 	})
+
+	t.Run("Group-synced admin should keep admin when imported roles omit team_admin", func(t *testing.T) {
+		user := th.CreateUser(t)
+
+		group := th.CreateGroup(t)
+		_, err := th.App.UpsertGroupMember(group.Id, user.Id)
+		require.Nil(t, err)
+
+		groupSyncable, err := th.App.UpsertGroupSyncable(&model.GroupSyncable{
+			GroupId:    group.Id,
+			AutoAdd:    false,
+			SyncableId: th.BasicTeam.Id,
+			Type:       model.GroupSyncableTypeTeam,
+		})
+		require.Nil(t, err)
+		groupSyncable.SchemeAdmin = true
+		_, err = th.App.UpdateGroupSyncable(groupSyncable)
+		require.Nil(t, err)
+
+		data := &[]imports.UserTeamImportData{
+			{
+				Name: &th.BasicTeam.Name,
+			},
+		}
+		appErr := th.App.importUserTeams(th.Context, user, data)
+		require.Nil(t, appErr)
+
+		teamMember, nErr := th.App.Srv().Store().Team().GetMember(th.Context, th.BasicTeam.Id, user.Id)
+		require.NoError(t, nErr)
+		require.True(t, teamMember.SchemeAdmin, "group-synced admin should retain admin even though imported roles omit team_admin")
+	})
 }
 
 func TestImportUserChannels(t *testing.T) {

--- a/server/channels/app/teams/teams.go
+++ b/server/channels/app/teams/teams.go
@@ -189,7 +189,7 @@ func (ts *TeamService) JoinUserToTeam(rctx request.CTX, team *model.Team, user *
 		tm.SchemeAdmin = userShouldBeAdmin
 	}
 
-	if team.Email == user.Email {
+	if team.Email == user.Email && !user.IsGuest() {
 		tm.SchemeAdmin = true
 	}
 

--- a/server/channels/app/teams/teams_test.go
+++ b/server/channels/app/teams/teams_test.go
@@ -130,6 +130,38 @@ func TestJoinUserToTeam(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("guest with the team email does not become team admin", func(t *testing.T) {
+		user := model.User{Email: team.Email, Nickname: "Guest Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), Roles: model.SystemGuestRoleId, AuthService: ""}
+		ruser := th.CreateUser(&user)
+		defer th.DeleteUser(&user)
+
+		member, _, err := th.service.JoinUserToTeam(th.Context, team, ruser)
+		require.NoError(t, err)
+		require.True(t, member.SchemeGuest)
+		require.False(t, member.SchemeUser)
+		require.False(t, member.SchemeAdmin)
+
+		err = th.service.RemoveTeamMember(th.Context, member)
+		require.NoError(t, err)
+
+		member, _, err = th.service.JoinUserToTeam(th.Context, team, ruser)
+		require.NoError(t, err)
+		require.True(t, member.SchemeGuest)
+		require.False(t, member.SchemeAdmin)
+	})
+
+	t.Run("regular user with the team email becomes team admin", func(t *testing.T) {
+		user := model.User{Email: team.Email, Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
+		ruser := th.CreateUser(&user)
+		defer th.DeleteUser(&user)
+
+		member, _, err := th.service.JoinUserToTeam(th.Context, team, ruser)
+		require.NoError(t, err)
+		require.False(t, member.SchemeGuest)
+		require.True(t, member.SchemeUser)
+		require.True(t, member.SchemeAdmin)
+	})
+
 	t.Run("new join with limit problem", func(t *testing.T) {
 		user1 := model.User{Email: strings.ToLower(model.NewId()) + "success+test@example.com", Nickname: "Darth Vader", Username: "vader" + model.NewId(), Password: model.NewTestPassword(), AuthService: ""}
 		ruser1 := th.CreateUser(&user1)

--- a/server/channels/app/teams/teams_test.go
+++ b/server/channels/app/teams/teams_test.go
@@ -147,6 +147,7 @@ func TestJoinUserToTeam(t *testing.T) {
 		member, _, err = th.service.JoinUserToTeam(th.Context, team, ruser)
 		require.NoError(t, err)
 		require.True(t, member.SchemeGuest)
+		require.False(t, member.SchemeUser)
 		require.False(t, member.SchemeAdmin)
 	})
 


### PR DESCRIPTION
Follow-up PR of https://github.com/mattermost/mattermost/pull/37791

## Ticket Link

Fixes [MM-70079](https://mattermost.atlassian.net/browse/MM-70079).

```release-note
Updated how team admin status is assigned when a user joins a team.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change affects team admin authorization during team joining and bulk import. The scope is isolated, and automated tests cover guest, regular user, and group-synchronized admin paths.

**QA Recommendation:** Manual QA can be skipped. Rely on automated test coverage.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


[MM-70079]: https://mattermost.atlassian.net/browse/MM-70079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ