### PR TITLE
Load sidebar DM/GM profiles once channels have loaded

### DIFF
--- a/webapp/channels/src/components/sidebar/sidebar_channel/index.ts
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/index.ts
@@ -6,8 +6,11 @@ import type {ConnectedProps} from 'react-redux';
 
 import {getCurrentChannelId, makeGetChannel, makeGetChannelUnreadCount} from 'mattermost-redux/selectors/entities/channels';
 import {getCurrentTeam} from 'mattermost-redux/selectors/entities/teams';
+import {getUser} from 'mattermost-redux/selectors/entities/users';
 
 import {getAutoSortedCategoryIds, getDraggingState, isChannelSelected} from 'selectors/views/channel_sidebar';
+
+import Constants from 'utils/constants';
 
 import type {GlobalState} from 'types/store';
 
@@ -39,8 +42,11 @@ function makeMapStateToProps() {
 
         const unreadCount = getUnreadCount(state, channel?.id || '');
 
+        const isMissingTeammateProfile = Boolean(channel && channel.type === Constants.DM_CHANNEL && !getUser(state, channel.teammate_id ?? ''));
+
         return {
             channel,
+            isMissingTeammateProfile,
             isCurrentChannel: channel?.id === currentChannelId,
             currentTeamName: currentTeam?.name,
             unreadMentions: unreadCount.mentions,

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel.test.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel.test.tsx
@@ -36,6 +36,7 @@ describe('components/sidebar/sidebar_channel', () => {
             group_constrained: false,
         },
         channelId: 'channel_id',
+        isMissingTeammateProfile: false,
         isDraggable: false,
         channelIndex: 0,
         currentTeamName: 'team_name',
@@ -115,6 +116,23 @@ describe('components/sidebar/sidebar_channel', () => {
         );
 
         expect(container).toMatchSnapshot();
+    });
+
+    test('should render nothing for a DM channel whose teammate profile has not loaded', () => {
+        const props = {
+            ...baseProps,
+            channel: {
+                ...baseProps.channel,
+                type: 'D' as ChannelType,
+            },
+            isMissingTeammateProfile: true,
+        };
+
+        const {container} = renderWithContext(
+            <SidebarChannel {...props}/>,
+        );
+
+        expect(container).toBeEmptyDOMElement();
     });
 
     test('should match snapshot when GM channel', () => {

--- a/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel.tsx
+++ b/webapp/channels/src/components/sidebar/sidebar_channel/sidebar_channel.tsx
@@ -22,6 +22,7 @@ function SidebarChannel({
     isCurrentChannel,
     setChannelRef,
     channel,
+    isMissingTeammateProfile,
     currentTeamName,
     isDraggable,
     isChannelSelected,
@@ -37,6 +38,12 @@ function SidebarChannel({
     }
 
     if (!currentTeamName) {
+        return null;
+    }
+
+    // SidebarDirectChannel renders nothing until the teammate's profile has loaded. Without this,
+    // the wrapper below still renders, leaving a blank row taking up space in the sidebar.
+    if (isMissingTeammateProfile) {
         return null;
     }
 


### PR DESCRIPTION
#### Summary

The LHS intermittently shows blank rows where favourited DMs should be, and `0` member badges on GMs. Both are the same bug: the sidebar's DM/GM user profiles are never fetched, because the fetch is chained to the wrong request.

Three things load independently at startup:

| What | Where |
| --- | --- |
| Channels + memberships | `team_controller.tsx`, on mount |
| Sidebar categories | `sidebar.tsx`, on mount |
| DM/GM user profiles | `data_prefetch.tsx`, when **categories** land |

`DataPrefetch` is the only thing that loads profiles at startup, and it triggers purely off `getCategoriesForCurrentTeam(state).length > 0` — with no dependency on the channels having arrived:

```js
if (sidebarLoaded && !prevProps.sidebarLoaded) {
    loadProfilesForSidebar();
}
```

Categories is one small request. `fetchAllMyTeamsChannels` is every channel across every team. On an account with a lot of channels the categories routinely win, and then:

- `loadProfilesForDM()` reads `getMyChannels(state)` → `[]` → requests nothing.
- `loadProfilesForGM()` reads `getDisplayedChannels(state)` → `[]` → requests nothing.

Both no-op silently, and nothing re-triggers them once the channels arrive. The profiles stay missing for the rest of the session, which surfaces as:

- **Blank rows** — `SidebarDirectChannel` returns `null` when the teammate's profile is missing, but `SidebarChannel` renders the `<li class="SidebarChannel">` wrapper regardless, and `.SidebarChannel` is `height: 32px`. You get an empty `<li></li>` holding open a row.
- **`0` badges on GMs** — `makeGetGmChannelMemberCount` counts `profilesInChannel[channel.id]`, which is empty.

This only shows up outside the Direct Messages category: `makeFilterAutoclosedDMs` already drops a DM whose teammate profile is missing, but returns early for any category that isn't `DIRECT_MESSAGES`, so Favourites and custom categories keep the row.

It self-heals as soon as you click a channel in the LHS, since `emitChannelClickEvent` calls `loadProfilesForSidebar()` again — which is why it's intermittent.

This PR loads the profiles once the channels and memberships have arrived, mirroring the existing pattern in `loadChannelsForCurrentUser` (`channel_actions.ts`), which already does `await fetchChannelsAndMembers(...)` then `loadProfilesForSidebar()`.

The existing `DataPrefetch` trigger is deliberately left in place — the two cover opposite orderings. `loadProfilesForGM` reads `getDisplayedChannels`, which is category-driven, so it needs categories; `loadProfilesForDM` reads `getMyChannels`, which needs channels and memberships. Whichever request lands last now fires a load that sees complete data.

**QA steps**

1. Favourite a few DMs, and have some GMs in the sidebar.
2. Hard-reload the webapp and watch the network tab without clicking anything in the LHS.
3. Before: on a slow channels response, no `POST /api/v4/users/ids` or `POST /api/v4/users/group_channels` is issued; favourited DMs render as empty 32px rows and GMs show a `0` badge. After: both requests fire once the channels land, and the rows render correctly.

Throttling the network makes this much easier to hit.

**Automated coverage**

`e2e-tests/playwright/specs/functional/channels/sidebar_left/dm_gm_profiles_on_load.spec.ts` reproduces the race deterministically rather than relying on data volume. It delays the two channel list requests so the categories always resolve first, and empties the first page of `GET /api/v4/users` — on a server with a handful of users that one request happens to return every teammate and would mask the missing DM profile, which is exactly why this only shows up on busy accounts.

Verified against `mattermostdevelopment/mattermost-enterprise-edition:master`, i.e. without this fix, where it fails with the reported symptoms:

- the favorited DM renders no `#sidebarItem_` element at all — the blank row
- the GM renders `<div class="status status--group">0</div>`

Both become correct (the teammate's username, and `2`) as soon as `loadProfilesForSidebar()` runs against the settled store, which is what this PR arranges at startup.

**Confirming the diagnosis**

In a session showing the bug, click **Threads** in the LHS. `global_threads.tsx` calls `loadProfilesForSidebar()` on mount with no guards, so it runs the same loader against a store that has since settled: both requests fire immediately and every blank row and `0` badge resolves at once. That isolates the defect to *when* the loader runs rather than to the loader itself, and it is the same call this PR adds at the end of the startup fetch.

#### Release Note
```release-note
Fixed an issue where direct and group message channels in the sidebar could render as blank rows or show a member count of zero until a channel was clicked.
```
