### PR TITLE
Fix Repeat weekly attachments tooltip alignment

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/send_button/scheduled_post_custom_time_modal/scheduled_post_custom_time_modal.scss
+++ b/webapp/channels/src/components/advanced_text_editor/send_button/scheduled_post_custom_time_modal/scheduled_post_custom_time_modal.scss
@@ -1,6 +1,8 @@
 .scheduled_post_custom_time_modal {
     .ScheduledPostCustomTimeModal__repeat {
+        // Shrink-wrap so WithTooltip anchors to the checkbox/label, not the modal width.
         display: flex;
+        width: fit-content;
         align-items: flex-start;
         margin-bottom: 12px;
         gap: 8px;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
On the recurring scheduled posts branch (#37746), the "Messages with attachments can't repeat" tooltip was centered on the full modal row instead of sitting over the "Repeat weekly" checkbox/label.

`WithTooltip` uses its child as the Floating UI reference. That child was `.ScheduledPostCustomTimeModal__repeat`, a full-width flex row, so the tooltip centered on the modal body. This shrink-wraps the row with `width: fit-content` so the tooltip anchors to the control.

**QA steps**
1. Compose a message with a file attachment
2. Open Schedule message
3. Hover the disabled "Repeat weekly" checkbox/label
4. Confirm the tooltip sits above the label (not centered in the modal)

**computerUse validation (VERIFIED)**
Local Mattermost at `http://127.0.0.1:8065` with professional license + `RecurringScheduledPosts=true`:
1. Logged in as `cursoradmin`, opened Off-Topic
2. Drafted a message with `attachment.txt` attached
3. Opened Schedule message modal — "Repeat weekly" disabled
4. Hovered the control — tooltip text correct
5. Measured screenshot: tooltip center ~15% from modal left (over the checkbox/label), **not** at modal horizontal center (~50%)

[Tooltip anchored to Repeat weekly](https://cursor.com/agents/bc-ed665e19-45e9-4037-a614-2ad4ccf81a22/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Frepeat-weekly-tooltip-fixed.png)

[Annotated: red = tooltip, blue = modal center](https://cursor.com/agents/bc-ed665e19-45e9-4037-a614-2ad4ccf81a22/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fscreenshots%2Ftooltip-annotated.png)

#### Screenshots
See computerUse validation images above.

#### Release Note
```release-note
NONE
```


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ed665e19-45e9-4037-a614-2ad4ccf81a22?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ed665e19-45e9-4037-a614-2ad4ccf81a22&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

