### PR TITLE
Log an error instead of refusing to start on unsupported Postgres, Elasticsearch, and OpenSearch versions

### DIFF
--- a/server/channels/store/sqlstore/migrate.go
+++ b/server/channels/store/sqlstore/migrate.go
@@ -47,7 +47,9 @@ func NewMigrator(settings model.SqlSettings, logger mlog.LoggerIFace, dryRun boo
 		return nil, fmt.Errorf("error while getting DB version: %w", err)
 	}
 
-	ss.checkVersion(ver)
+	if err = ss.checkVersion(ver); err != nil {
+		return nil, fmt.Errorf("error while checking DB version: %w", err)
+	}
 
 	engine, err := ss.initMorph(dryRun, true)
 	if err != nil {

--- a/server/channels/store/sqlstore/migrate.go
+++ b/server/channels/store/sqlstore/migrate.go
@@ -47,10 +47,7 @@ func NewMigrator(settings model.SqlSettings, logger mlog.LoggerIFace, dryRun boo
 		return nil, fmt.Errorf("error while getting DB version: %w", err)
 	}
 
-	ok, err := ss.ensureMinimumDBVersion(ver)
-	if !ok {
-		return nil, fmt.Errorf("error while checking DB version: %w", err)
-	}
+	ss.checkVersion(ver)
 
 	engine, err := ss.initMorph(dryRun, true)
 	if err != nil {

--- a/server/channels/store/sqlstore/store.go
+++ b/server/channels/store/sqlstore/store.go
@@ -228,7 +228,9 @@ func New(settings model.SqlSettings, logger mlog.LoggerIFace, metrics einterface
 		return nil, errors.Wrap(err, "error while getting DB version")
 	}
 
-	store.checkVersion(ver)
+	if err = store.checkVersion(ver); err != nil {
+		return nil, errors.Wrap(err, "error while checking DB version")
+	}
 
 	if !store.skipMigrations {
 		err = store.preMigration()
@@ -1041,16 +1043,13 @@ func IsDuplicate(err error) bool {
 	return false
 }
 
-// checkVersion logs an error if the given Postgres version is unsupported.
-// Running an unsupported version is discouraged, but not prevented.
-func (ss *SqlStore) checkVersion(ver string) {
+// checkVersion returns an error if the given Postgres version cannot be
+// determined. An unsupported version is only logged: running one is discouraged,
+// but not prevented.
+func (ss *SqlStore) checkVersion(ver string) error {
 	intVer, err := strconv.Atoi(ver)
 	if err != nil {
-		ss.logger.Error("Cannot parse Postgres version.",
-			mlog.String("version", ver),
-			mlog.Err(err),
-		)
-		return
+		return fmt.Errorf("cannot parse DB version: %v", err)
 	}
 
 	if intVer < minimumRequiredPostgresVersion {
@@ -1059,6 +1058,8 @@ func (ss *SqlStore) checkVersion(ver string) {
 			mlog.String("min_version", versionString(minimumRequiredPostgresVersion)),
 		)
 	}
+
+	return nil
 }
 
 // versionString converts an integer representation of a Postgres DB version

--- a/server/channels/store/sqlstore/store.go
+++ b/server/channels/store/sqlstore/store.go
@@ -1066,9 +1066,12 @@ func (ss *SqlStore) checkVersion(ver string) {
 // Postgres doesn't follow three-part version numbers from 10.0 onwards:
 // https://www.postgresql.org/docs/13/libpq-status.html#LIBPQ-PQSERVERVERSION.
 func versionString(v int) string {
-	minor := v % 10000
 	major := v / 10000
-	return strconv.Itoa(major) + "." + strconv.Itoa(minor)
+	if major < 10 {
+		return fmt.Sprintf("%d.%d.%d", major, (v/100)%100, v%100)
+	}
+
+	return fmt.Sprintf("%d.%d", major, v%10000)
 }
 
 func (ss *SqlStore) toReserveCase(str string) string {

--- a/server/channels/store/sqlstore/store.go
+++ b/server/channels/store/sqlstore/store.go
@@ -1063,7 +1063,9 @@ func (ss *SqlStore) checkVersion(ver string) {
 
 // versionString converts an integer representation of a Postgres DB version
 // to a pretty-printed string.
-// Postgres doesn't follow three-part version numbers from 10.0 onwards:
+// From 10.0 onwards, the version is the major version multiplied by 10000 plus
+// the minor version, e.g. 10.1 is 100001. Prior to 10, the version used two
+// digits for each of the three parts, e.g. 9.1.5 is 90105:
 // https://www.postgresql.org/docs/13/libpq-status.html#LIBPQ-PQSERVERVERSION.
 func versionString(v int) string {
 	major := v / 10000

--- a/server/channels/store/sqlstore/store.go
+++ b/server/channels/store/sqlstore/store.go
@@ -228,10 +228,7 @@ func New(settings model.SqlSettings, logger mlog.LoggerIFace, metrics einterface
 		return nil, errors.Wrap(err, "error while getting DB version")
 	}
 
-	ok, err := store.ensureMinimumDBVersion(ver)
-	if !ok {
-		return nil, errors.Wrap(err, "error while checking DB version")
-	}
+	store.checkVersion(ver)
 
 	if !store.skipMigrations {
 		err = store.preMigration()
@@ -1044,17 +1041,24 @@ func IsDuplicate(err error) bool {
 	return false
 }
 
-// ensureMinimumDBVersion gets the DB version and ensures it is
-// above the required minimum version requirements.
-func (ss *SqlStore) ensureMinimumDBVersion(ver string) (bool, error) {
+// checkVersion logs an error if the given Postgres version is unsupported.
+// Running an unsupported version is discouraged, but not prevented.
+func (ss *SqlStore) checkVersion(ver string) {
 	intVer, err := strconv.Atoi(ver)
 	if err != nil {
-		return false, fmt.Errorf("cannot parse DB version: %v", err)
+		ss.logger.Error("Cannot parse Postgres version.",
+			mlog.String("version", ver),
+			mlog.Err(err),
+		)
+		return
 	}
+
 	if intVer < minimumRequiredPostgresVersion {
-		return false, fmt.Errorf("minimum Postgres version requirements not met. Found: %s, Wanted: %s", versionString(intVer), versionString(minimumRequiredPostgresVersion))
+		ss.logger.Error("Unsupported Postgres version. Running an unsupported version may lead to unexpected behaviour.",
+			mlog.String("version", versionString(intVer)),
+			mlog.String("min_version", versionString(minimumRequiredPostgresVersion)),
+		)
 	}
-	return true, nil
 }
 
 // versionString converts an integer representation of a Postgres DB version

--- a/server/channels/store/sqlstore/store_test.go
+++ b/server/channels/store/sqlstore/store_test.go
@@ -560,7 +560,7 @@ func TestCheckVersion(t *testing.T) {
 		{
 			ver:            "90603",
 			wantLog:        "Unsupported Postgres version",
-			wantVersion:    "9.603",
+			wantVersion:    "9.6.3",
 			wantMinVersion: "14.0",
 		},
 		{
@@ -779,7 +779,7 @@ func TestVersionString(t *testing.T) {
 		},
 		{
 			input:  90603,
-			output: "9.603",
+			output: "9.6.3",
 		},
 		{
 			input:  120005,

--- a/server/channels/store/sqlstore/store_test.go
+++ b/server/channels/store/sqlstore/store_test.go
@@ -552,7 +552,7 @@ func TestCheckVersion(t *testing.T) {
 			ver: "140000",
 		},
 		{
-			ver: "141900",
+			ver: "140019",
 		},
 		{
 			ver: "150000",
@@ -785,11 +785,32 @@ func TestVersionString(t *testing.T) {
 			input:  120005,
 			output: "12.5",
 		},
+		// Examples given by the PQserverVersion documentation.
+		{
+			input:  100001,
+			output: "10.1",
+		},
+		{
+			input:  110000,
+			output: "11.0",
+		},
+		{
+			input:  90105,
+			output: "9.1.5",
+		},
+		{
+			input:  90200,
+			output: "9.2.0",
+		},
+		{
+			input:  140019,
+			output: "14.19",
+		},
 	}
 
 	for _, v := range versions {
 		out := versionString(v.input)
-		assert.Equal(t, v.output, out)
+		assert.Equal(t, v.output, out, "input: %d", v.input)
 	}
 }
 

--- a/server/channels/store/sqlstore/store_test.go
+++ b/server/channels/store/sqlstore/store_test.go
@@ -532,6 +532,7 @@ func TestCheckVersion(t *testing.T) {
 
 	tests := []struct {
 		ver            string
+		wantErr        string
 		wantLog        string
 		wantVersion    string
 		wantMinVersion string
@@ -564,9 +565,8 @@ func TestCheckVersion(t *testing.T) {
 			wantMinVersion: "14.0",
 		},
 		{
-			ver:         "12.34.1",
-			wantLog:     "Cannot parse Postgres version",
-			wantVersion: "12.34.1",
+			ver:     "12.34.1",
+			wantErr: "cannot parse DB version",
 		},
 	}
 
@@ -584,8 +584,15 @@ func TestCheckVersion(t *testing.T) {
 			store.settings = pgSettings
 			store.logger = logger
 
-			store.checkVersion(tc.ver)
+			err := store.checkVersion(tc.ver)
 			require.NoError(t, logger.Flush())
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
 
 			if tc.wantLog == "" {
 				assert.Empty(t, buf.String())

--- a/server/channels/store/sqlstore/store_test.go
+++ b/server/channels/store/sqlstore/store_test.go
@@ -525,58 +525,48 @@ func TestGetDbVersion(t *testing.T) {
 	}
 }
 
-func TestEnsureMinimumDBVersion(t *testing.T) {
+func TestCheckVersion(t *testing.T) {
 	if enableFullyParallelTests {
 		t.Parallel()
 	}
 
 	tests := []struct {
-		driver string
-		ver    string
-		ok     bool
-		err    string
+		ver            string
+		wantLog        string
+		wantVersion    string
+		wantMinVersion string
 	}{
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "110001",
-			ok:     false,
-			err:    "",
+			ver:            "110001",
+			wantLog:        "Unsupported Postgres version",
+			wantVersion:    "11.1",
+			wantMinVersion: "14.0",
 		},
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "130001",
-			ok:     false,
-			err:    "",
+			ver:            "130001",
+			wantLog:        "Unsupported Postgres version",
+			wantVersion:    "13.1",
+			wantMinVersion: "14.0",
 		},
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "140000",
-			ok:     true,
-			err:    "",
+			ver: "140000",
 		},
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "141900",
-			ok:     true,
-			err:    "",
+			ver: "141900",
 		},
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "150000",
-			ok:     true,
-			err:    "",
+			ver: "150000",
 		},
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "90603",
-			ok:     false,
-			err:    "minimum Postgres version requirements not met",
+			ver:            "90603",
+			wantLog:        "Unsupported Postgres version",
+			wantVersion:    "9.603",
+			wantMinVersion: "14.0",
 		},
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "12.34.1",
-			ok:     false,
-			err:    "cannot parse DB version",
+			ver:         "12.34.1",
+			wantLog:     "Cannot parse Postgres version",
+			wantVersion: "12.34.1",
 		},
 	}
 
@@ -585,13 +575,29 @@ func TestEnsureMinimumDBVersion(t *testing.T) {
 		DriverName: &pg,
 	}
 	for _, tc := range tests {
-		store := &SqlStore{}
-		store.settings = pgSettings
-		ok, err := store.ensureMinimumDBVersion(tc.ver)
-		assert.Equal(t, tc.ok, ok, "driver: %s, version: %s", tc.driver, tc.ver)
-		if tc.err != "" {
-			assert.Contains(t, err.Error(), tc.err)
-		}
+		t.Run(tc.ver, func(t *testing.T) {
+			logger := mlog.CreateConsoleTestLogger(t)
+			var buf mlog.Buffer
+			require.NoError(t, mlog.AddWriterTarget(logger, &buf, true, mlog.LvlError))
+
+			store := &SqlStore{}
+			store.settings = pgSettings
+			store.logger = logger
+
+			store.checkVersion(tc.ver)
+			require.NoError(t, logger.Flush())
+
+			if tc.wantLog == "" {
+				assert.Empty(t, buf.String())
+				return
+			}
+
+			assert.Contains(t, buf.String(), tc.wantLog)
+			assert.Contains(t, buf.String(), fmt.Sprintf(`"version":%q`, tc.wantVersion))
+			if tc.wantMinVersion != "" {
+				assert.Contains(t, buf.String(), fmt.Sprintf(`"min_version":%q`, tc.wantMinVersion))
+			}
+		})
 	}
 }
 

--- a/server/enterprise/elasticsearch/elasticsearch/check_version_test.go
+++ b/server/enterprise/elasticsearch/elasticsearch/check_version_test.go
@@ -39,12 +39,12 @@ func infoHandler(version string) http.HandlerFunc {
 
 func TestCheckVersion(t *testing.T) {
 	tests := []struct {
-		name          string
-		version       string
-		wantVersion   string
-		wantMajor     int
-		wantLog       string
-		wantLogFields []string
+		name            string
+		version         string
+		wantVersion     string
+		wantMajor       int
+		wantErrID       string
+		wantUnsupported bool
 	}{
 		{
 			name:        "ES 8 is supported",
@@ -59,28 +59,23 @@ func TestCheckVersion(t *testing.T) {
 			wantMajor:   9,
 		},
 		{
-			name:          "ES 7 is too old, but allowed",
-			version:       "7.17.0",
-			wantVersion:   "7.17.0",
-			wantMajor:     7,
-			wantLog:       "Unsupported Elasticsearch version",
-			wantLogFields: []string{`"version":"7.17.0"`, `"min_version":8`, `"max_version":9`},
+			name:            "ES 7 is too old, but allowed",
+			version:         "7.17.0",
+			wantVersion:     "7.17.0",
+			wantMajor:       7,
+			wantUnsupported: true,
 		},
 		{
-			name:          "ES 10 is too new, but allowed",
-			version:       "10.0.0",
-			wantVersion:   "10.0.0",
-			wantMajor:     10,
-			wantLog:       "Unsupported Elasticsearch version",
-			wantLogFields: []string{`"version":"10.0.0"`, `"min_version":8`, `"max_version":9`},
+			name:            "ES 10 is too new, but allowed",
+			version:         "10.0.0",
+			wantVersion:     "10.0.0",
+			wantMajor:       10,
+			wantUnsupported: true,
 		},
 		{
-			name:          "unparseable version is allowed",
-			version:       "invalid",
-			wantVersion:   "invalid",
-			wantMajor:     0,
-			wantLog:       "Failed to parse the Elasticsearch version",
-			wantLogFields: []string{`"version":"invalid"`},
+			name:      "invalid version string",
+			version:   "invalid",
+			wantErrID: "ent.elasticsearch.start.parse_server_version.app_error",
 		},
 	}
 
@@ -91,20 +86,25 @@ func TestCheckVersion(t *testing.T) {
 			require.NoError(t, mlog.AddWriterTarget(logger, &buf, true, mlog.LvlError))
 
 			client := newTestClient(t, infoHandler(tc.version))
-			version, major := checkVersion(context.Background(), client, logger)
+			version, major, appErr := checkVersion(context.Background(), client, logger)
 			require.NoError(t, logger.Flush())
 
-			assert.Equal(t, tc.wantVersion, version)
-			assert.Equal(t, tc.wantMajor, major)
-
-			if tc.wantLog == "" {
-				assert.Empty(t, buf.String())
+			if tc.wantErrID != "" {
+				require.NotNil(t, appErr)
+				assert.Equal(t, tc.wantErrID, appErr.Id)
 				return
 			}
 
-			assert.Contains(t, buf.String(), tc.wantLog)
-			for _, field := range tc.wantLogFields {
-				assert.Contains(t, buf.String(), field)
+			require.Nil(t, appErr)
+			assert.Equal(t, tc.wantVersion, version)
+			assert.Equal(t, tc.wantMajor, major)
+			if tc.wantUnsupported {
+				assert.Contains(t, buf.String(), "Unsupported Elasticsearch version")
+				assert.Contains(t, buf.String(), fmt.Sprintf(`"version":%q`, tc.wantVersion))
+				assert.Contains(t, buf.String(), `"min_version":8`)
+				assert.Contains(t, buf.String(), `"max_version":9`)
+			} else {
+				assert.Empty(t, buf.String())
 			}
 		})
 	}
@@ -120,15 +120,7 @@ func TestCheckVersionConnectionError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	logger := mlog.CreateConsoleTestLogger(t)
-	var buf mlog.Buffer
-	require.NoError(t, mlog.AddWriterTarget(logger, &buf, true, mlog.LvlError))
-
-	// An unreachable server is logged, but must not fail the caller.
-	version, major := checkVersion(context.Background(), client, logger)
-	require.NoError(t, logger.Flush())
-
-	assert.Empty(t, version)
-	assert.Zero(t, major)
-	assert.Contains(t, buf.String(), "Failed to get the Elasticsearch version")
+	_, _, appErr := checkVersion(context.Background(), client, mlog.CreateConsoleTestLogger(t))
+	require.NotNil(t, appErr)
+	assert.Equal(t, "ent.elasticsearch.start.get_server_version.app_error", appErr.Id)
 }

--- a/server/enterprise/elasticsearch/elasticsearch/check_version_test.go
+++ b/server/enterprise/elasticsearch/elasticsearch/check_version_test.go
@@ -13,6 +13,8 @@ import (
 	elastic "github.com/elastic/go-elasticsearch/v8"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
 func newTestClient(t *testing.T, handler http.Handler) *elastic.TypedClient {
@@ -37,11 +39,12 @@ func infoHandler(version string) http.HandlerFunc {
 
 func TestCheckVersion(t *testing.T) {
 	tests := []struct {
-		name        string
-		version     string
-		wantVersion string
-		wantMajor   int
-		wantErrID   string
+		name            string
+		version         string
+		wantVersion     string
+		wantMajor       int
+		wantErrID       string
+		wantUnsupported bool
 	}{
 		{
 			name:        "ES 8 is supported",
@@ -56,14 +59,18 @@ func TestCheckVersion(t *testing.T) {
 			wantMajor:   9,
 		},
 		{
-			name:      "ES 7 is too old",
-			version:   "7.17.0",
-			wantErrID: "ent.elasticsearch.min_version.app_error",
+			name:            "ES 7 is too old, but allowed",
+			version:         "7.17.0",
+			wantVersion:     "7.17.0",
+			wantMajor:       7,
+			wantUnsupported: true,
 		},
 		{
-			name:      "ES 10 is too new",
-			version:   "10.0.0",
-			wantErrID: "ent.elasticsearch.max_version.app_error",
+			name:            "ES 10 is too new, but allowed",
+			version:         "10.0.0",
+			wantVersion:     "10.0.0",
+			wantMajor:       10,
+			wantUnsupported: true,
 		},
 		{
 			name:      "invalid version string",
@@ -74,15 +81,27 @@ func TestCheckVersion(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			logger := mlog.CreateConsoleTestLogger(t)
+			var buf mlog.Buffer
+			require.NoError(t, mlog.AddWriterTarget(logger, &buf, true, mlog.LvlError))
+
 			client := newTestClient(t, infoHandler(tc.version))
-			version, major, appErr := checkVersion(context.Background(), client)
+			version, major, appErr := checkVersion(context.Background(), client, logger)
+			require.NoError(t, logger.Flush())
+
 			if tc.wantErrID != "" {
 				require.NotNil(t, appErr)
 				assert.Equal(t, tc.wantErrID, appErr.Id)
+				return
+			}
+
+			require.Nil(t, appErr)
+			assert.Equal(t, tc.wantVersion, version)
+			assert.Equal(t, tc.wantMajor, major)
+			if tc.wantUnsupported {
+				assert.Contains(t, buf.String(), "Unsupported Elasticsearch version")
 			} else {
-				require.Nil(t, appErr)
-				assert.Equal(t, tc.wantVersion, version)
-				assert.Equal(t, tc.wantMajor, major)
+				assert.Empty(t, buf.String())
 			}
 		})
 	}
@@ -98,7 +117,7 @@ func TestCheckVersionConnectionError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, _, appErr := checkVersion(context.Background(), client)
+	_, _, appErr := checkVersion(context.Background(), client, mlog.CreateConsoleTestLogger(t))
 	require.NotNil(t, appErr)
 	assert.Equal(t, "ent.elasticsearch.start.get_server_version.app_error", appErr.Id)
 }

--- a/server/enterprise/elasticsearch/elasticsearch/check_version_test.go
+++ b/server/enterprise/elasticsearch/elasticsearch/check_version_test.go
@@ -39,12 +39,12 @@ func infoHandler(version string) http.HandlerFunc {
 
 func TestCheckVersion(t *testing.T) {
 	tests := []struct {
-		name            string
-		version         string
-		wantVersion     string
-		wantMajor       int
-		wantErrID       string
-		wantUnsupported bool
+		name          string
+		version       string
+		wantVersion   string
+		wantMajor     int
+		wantLog       string
+		wantLogFields []string
 	}{
 		{
 			name:        "ES 8 is supported",
@@ -59,23 +59,28 @@ func TestCheckVersion(t *testing.T) {
 			wantMajor:   9,
 		},
 		{
-			name:            "ES 7 is too old, but allowed",
-			version:         "7.17.0",
-			wantVersion:     "7.17.0",
-			wantMajor:       7,
-			wantUnsupported: true,
+			name:          "ES 7 is too old, but allowed",
+			version:       "7.17.0",
+			wantVersion:   "7.17.0",
+			wantMajor:     7,
+			wantLog:       "Unsupported Elasticsearch version",
+			wantLogFields: []string{`"version":"7.17.0"`, `"min_version":8`, `"max_version":9`},
 		},
 		{
-			name:            "ES 10 is too new, but allowed",
-			version:         "10.0.0",
-			wantVersion:     "10.0.0",
-			wantMajor:       10,
-			wantUnsupported: true,
+			name:          "ES 10 is too new, but allowed",
+			version:       "10.0.0",
+			wantVersion:   "10.0.0",
+			wantMajor:     10,
+			wantLog:       "Unsupported Elasticsearch version",
+			wantLogFields: []string{`"version":"10.0.0"`, `"min_version":8`, `"max_version":9`},
 		},
 		{
-			name:      "invalid version string",
-			version:   "invalid",
-			wantErrID: "ent.elasticsearch.start.parse_server_version.app_error",
+			name:          "unparseable version is allowed",
+			version:       "invalid",
+			wantVersion:   "invalid",
+			wantMajor:     0,
+			wantLog:       "Failed to parse the Elasticsearch version",
+			wantLogFields: []string{`"version":"invalid"`},
 		},
 	}
 
@@ -86,25 +91,20 @@ func TestCheckVersion(t *testing.T) {
 			require.NoError(t, mlog.AddWriterTarget(logger, &buf, true, mlog.LvlError))
 
 			client := newTestClient(t, infoHandler(tc.version))
-			version, major, appErr := checkVersion(context.Background(), client, logger)
+			version, major := checkVersion(context.Background(), client, logger)
 			require.NoError(t, logger.Flush())
 
-			if tc.wantErrID != "" {
-				require.NotNil(t, appErr)
-				assert.Equal(t, tc.wantErrID, appErr.Id)
+			assert.Equal(t, tc.wantVersion, version)
+			assert.Equal(t, tc.wantMajor, major)
+
+			if tc.wantLog == "" {
+				assert.Empty(t, buf.String())
 				return
 			}
 
-			require.Nil(t, appErr)
-			assert.Equal(t, tc.wantVersion, version)
-			assert.Equal(t, tc.wantMajor, major)
-			if tc.wantUnsupported {
-				assert.Contains(t, buf.String(), "Unsupported Elasticsearch version")
-				assert.Contains(t, buf.String(), fmt.Sprintf(`"version":%q`, tc.wantVersion))
-				assert.Contains(t, buf.String(), `"min_version":8`)
-				assert.Contains(t, buf.String(), `"max_version":9`)
-			} else {
-				assert.Empty(t, buf.String())
+			assert.Contains(t, buf.String(), tc.wantLog)
+			for _, field := range tc.wantLogFields {
+				assert.Contains(t, buf.String(), field)
 			}
 		})
 	}
@@ -120,7 +120,15 @@ func TestCheckVersionConnectionError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, _, appErr := checkVersion(context.Background(), client, mlog.CreateConsoleTestLogger(t))
-	require.NotNil(t, appErr)
-	assert.Equal(t, "ent.elasticsearch.start.get_server_version.app_error", appErr.Id)
+	logger := mlog.CreateConsoleTestLogger(t)
+	var buf mlog.Buffer
+	require.NoError(t, mlog.AddWriterTarget(logger, &buf, true, mlog.LvlError))
+
+	// An unreachable server is logged, but must not fail the caller.
+	version, major := checkVersion(context.Background(), client, logger)
+	require.NoError(t, logger.Flush())
+
+	assert.Empty(t, version)
+	assert.Zero(t, major)
+	assert.Contains(t, buf.String(), "Failed to get the Elasticsearch version")
 }

--- a/server/enterprise/elasticsearch/elasticsearch/check_version_test.go
+++ b/server/enterprise/elasticsearch/elasticsearch/check_version_test.go
@@ -100,6 +100,9 @@ func TestCheckVersion(t *testing.T) {
 			assert.Equal(t, tc.wantMajor, major)
 			if tc.wantUnsupported {
 				assert.Contains(t, buf.String(), "Unsupported Elasticsearch version")
+				assert.Contains(t, buf.String(), fmt.Sprintf(`"version":%q`, tc.wantVersion))
+				assert.Contains(t, buf.String(), `"min_version":8`)
+				assert.Contains(t, buf.String(), `"max_version":9`)
 			} else {
 				assert.Empty(t, buf.String())
 			}

--- a/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
+++ b/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
@@ -105,11 +105,15 @@ func (es *ElasticsearchInterfaceImpl) IsIndexingSync() bool {
 	return *es.Platform.Config().ElasticsearchSettings.LiveIndexingBatchSize <= 1
 }
 
-// fetchServerInfo retrieves and stores the server version and plugins from the
-// given client. The version is only reported, never acted upon, so failures are
-// logged and left behind instead of preventing a start.
-func (es *ElasticsearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *elastic.TypedClient) {
-	es.fullVersion, es.version = checkVersion(ctx, client, es.Platform.Log())
+// fetchServerInfo retrieves and stores the server version and plugins from the given client.
+func (es *ElasticsearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *elastic.TypedClient) *model.AppError {
+	version, major, appErr := checkVersion(ctx, client, es.Platform.Log())
+	if appErr != nil {
+		return appErr
+	}
+
+	es.version = major
+	es.fullVersion = version
 
 	// Since we are only retrieving plugins for the Support Packet generation, it doesn't make sense to kill the process if we get an error
 	// Instead, we will log it and move forward
@@ -122,6 +126,8 @@ func (es *ElasticsearchInterfaceImpl) fetchServerInfo(ctx context.Context, clien
 			es.plugins = append(es.plugins, *p.Component)
 		}
 	}
+
+	return nil
 }
 
 func (es *ElasticsearchInterfaceImpl) Start(ctx context.Context) *model.AppError {
@@ -144,7 +150,9 @@ func (es *ElasticsearchInterfaceImpl) Start(ctx context.Context) *model.AppError
 		return appErr
 	}
 
-	es.fetchServerInfo(ctx, es.client)
+	if appErr = es.fetchServerInfo(ctx, es.client); appErr != nil {
+		return appErr
+	}
 
 	var err error
 	esSettings := es.Platform.Config().ElasticsearchSettings
@@ -1582,13 +1590,9 @@ func (es *ElasticsearchInterfaceImpl) TestConfig(rctx request.CTX, cfg *model.Co
 		return appErr
 	}
 
-	// Unlike starting up, testing the configuration must report an unreachable
-	// server: it's the only thing this is asked to find out.
-	if ok, err := client.API.Core.Ping().Do(rctx.Context()); err != nil || !ok {
-		return model.NewAppError("Elasticsearch.TestConfig", "ent.elasticsearch.test_config.reachable.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError).Wrap(err)
+	if appErr = es.fetchServerInfo(context.Background(), client); appErr != nil {
+		return appErr
 	}
-
-	es.fetchServerInfo(context.Background(), client)
 
 	// Resetting the state.
 	if es.ready.CompareAndSwap(0, 1) {
@@ -2165,24 +2169,18 @@ func (es *ElasticsearchInterfaceImpl) DeleteFilesBatch(rctx request.CTX, endTime
 	return nil
 }
 
-// checkVersion returns the full version and major version of the connected
-// Elasticsearch server, or zero values if it cannot be determined. Nothing here
-// is fatal: an unsupported version, an unreachable server and an unparseable
-// version are all logged and allowed to proceed.
-func checkVersion(ctx context.Context, client *elastic.TypedClient, logger mlog.LoggerIFace) (string, int) {
+// checkVersion returns the version of the connected Elasticsearch server. An
+// unsupported version is logged but not treated as fatal, allowing the server to
+// start regardless.
+func checkVersion(ctx context.Context, client *elastic.TypedClient, logger mlog.LoggerIFace) (string, int, *model.AppError) {
 	resp, err := client.API.Core.Info().Do(ctx)
 	if err != nil {
-		logger.Error("Failed to get the Elasticsearch version.", mlog.Err(err))
-		return "", 0
+		return "", 0, model.NewAppError("Elasticsearch.checkVersion", "ent.elasticsearch.start.get_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	major, _, _, err := common.GetVersionComponents(resp.Version.Int)
-	if err != nil {
-		logger.Error("Failed to parse the Elasticsearch version.",
-			mlog.String("version", resp.Version.Int),
-			mlog.Err(err),
-		)
-		return resp.Version.Int, 0
+	major, _, _, esErr := common.GetVersionComponents(resp.Version.Int)
+	if esErr != nil {
+		return "", 0, model.NewAppError("Elasticsearch.checkVersion", "ent.elasticsearch.start.parse_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError).Wrap(esErr)
 	}
 
 	if major < elasticsearchMinVersion || major > elasticsearchMaxVersion {
@@ -2193,5 +2191,5 @@ func checkVersion(ctx context.Context, client *elastic.TypedClient, logger mlog.
 		)
 	}
 
-	return resp.Version.Int, major
+	return resp.Version.Int, major, nil
 }

--- a/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
+++ b/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
@@ -105,15 +105,11 @@ func (es *ElasticsearchInterfaceImpl) IsIndexingSync() bool {
 	return *es.Platform.Config().ElasticsearchSettings.LiveIndexingBatchSize <= 1
 }
 
-// fetchServerInfo retrieves and stores the server version and plugins from the given client.
-func (es *ElasticsearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *elastic.TypedClient) *model.AppError {
-	version, major, appErr := checkVersion(ctx, client, es.Platform.Log())
-	if appErr != nil {
-		return appErr
-	}
-
-	es.version = major
-	es.fullVersion = version
+// fetchServerInfo retrieves and stores the server version and plugins from the
+// given client. The version is only reported, never acted upon, so failures are
+// logged and left behind instead of preventing a start.
+func (es *ElasticsearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *elastic.TypedClient) {
+	es.fullVersion, es.version = checkVersion(ctx, client, es.Platform.Log())
 
 	// Since we are only retrieving plugins for the Support Packet generation, it doesn't make sense to kill the process if we get an error
 	// Instead, we will log it and move forward
@@ -126,8 +122,6 @@ func (es *ElasticsearchInterfaceImpl) fetchServerInfo(ctx context.Context, clien
 			es.plugins = append(es.plugins, *p.Component)
 		}
 	}
-
-	return nil
 }
 
 func (es *ElasticsearchInterfaceImpl) Start(ctx context.Context) *model.AppError {
@@ -150,9 +144,7 @@ func (es *ElasticsearchInterfaceImpl) Start(ctx context.Context) *model.AppError
 		return appErr
 	}
 
-	if appErr = es.fetchServerInfo(ctx, es.client); appErr != nil {
-		return appErr
-	}
+	es.fetchServerInfo(ctx, es.client)
 
 	var err error
 	esSettings := es.Platform.Config().ElasticsearchSettings
@@ -1590,9 +1582,13 @@ func (es *ElasticsearchInterfaceImpl) TestConfig(rctx request.CTX, cfg *model.Co
 		return appErr
 	}
 
-	if appErr = es.fetchServerInfo(context.Background(), client); appErr != nil {
-		return appErr
+	// Unlike starting up, testing the configuration must report an unreachable
+	// server: it's the only thing this is asked to find out.
+	if ok, err := client.API.Core.Ping().Do(rctx.Context()); err != nil || !ok {
+		return model.NewAppError("Elasticsearch.TestConfig", "ent.elasticsearch.test_config.reachable.error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError).Wrap(err)
 	}
+
+	es.fetchServerInfo(context.Background(), client)
 
 	// Resetting the state.
 	if es.ready.CompareAndSwap(0, 1) {
@@ -2169,18 +2165,24 @@ func (es *ElasticsearchInterfaceImpl) DeleteFilesBatch(rctx request.CTX, endTime
 	return nil
 }
 
-// checkVersion returns the version of the connected Elasticsearch server. An
-// unsupported version is logged but not treated as fatal, allowing the server to
-// start regardless.
-func checkVersion(ctx context.Context, client *elastic.TypedClient, logger mlog.LoggerIFace) (string, int, *model.AppError) {
+// checkVersion returns the full version and major version of the connected
+// Elasticsearch server, or zero values if it cannot be determined. Nothing here
+// is fatal: an unsupported version, an unreachable server and an unparseable
+// version are all logged and allowed to proceed.
+func checkVersion(ctx context.Context, client *elastic.TypedClient, logger mlog.LoggerIFace) (string, int) {
 	resp, err := client.API.Core.Info().Do(ctx)
 	if err != nil {
-		return "", 0, model.NewAppError("Elasticsearch.checkVersion", "ent.elasticsearch.start.get_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError).Wrap(err)
+		logger.Error("Failed to get the Elasticsearch version.", mlog.Err(err))
+		return "", 0
 	}
 
-	major, _, _, esErr := common.GetVersionComponents(resp.Version.Int)
-	if esErr != nil {
-		return "", 0, model.NewAppError("Elasticsearch.checkVersion", "ent.elasticsearch.start.parse_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError).Wrap(esErr)
+	major, _, _, err := common.GetVersionComponents(resp.Version.Int)
+	if err != nil {
+		logger.Error("Failed to parse the Elasticsearch version.",
+			mlog.String("version", resp.Version.Int),
+			mlog.Err(err),
+		)
+		return resp.Version.Int, 0
 	}
 
 	if major < elasticsearchMinVersion || major > elasticsearchMaxVersion {
@@ -2191,5 +2193,5 @@ func checkVersion(ctx context.Context, client *elastic.TypedClient, logger mlog.
 		)
 	}
 
-	return resp.Version.Int, major, nil
+	return resp.Version.Int, major
 }

--- a/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
+++ b/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
@@ -107,7 +107,7 @@ func (es *ElasticsearchInterfaceImpl) IsIndexingSync() bool {
 
 // fetchServerInfo retrieves and stores the server version and plugins from the given client.
 func (es *ElasticsearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *elastic.TypedClient) *model.AppError {
-	version, major, appErr := checkVersion(ctx, client)
+	version, major, appErr := checkVersion(ctx, client, es.Platform.Log())
 	if appErr != nil {
 		return appErr
 	}
@@ -2169,7 +2169,10 @@ func (es *ElasticsearchInterfaceImpl) DeleteFilesBatch(rctx request.CTX, endTime
 	return nil
 }
 
-func checkVersion(ctx context.Context, client *elastic.TypedClient) (string, int, *model.AppError) {
+// checkVersion returns the version of the connected Elasticsearch server. An
+// unsupported version is logged but not treated as fatal, allowing the server to
+// start regardless.
+func checkVersion(ctx context.Context, client *elastic.TypedClient, logger mlog.LoggerIFace) (string, int, *model.AppError) {
 	resp, err := client.API.Core.Info().Do(ctx)
 	if err != nil {
 		return "", 0, model.NewAppError("Elasticsearch.checkVersion", "ent.elasticsearch.start.get_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError).Wrap(err)
@@ -2180,11 +2183,13 @@ func checkVersion(ctx context.Context, client *elastic.TypedClient) (string, int
 		return "", 0, model.NewAppError("Elasticsearch.checkVersion", "ent.elasticsearch.start.parse_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError).Wrap(esErr)
 	}
 
-	if major < elasticsearchMinVersion {
-		return "", 0, model.NewAppError("Elasticsearch.checkVersion", "ent.elasticsearch.min_version.app_error", map[string]any{"Version": major, "MinVersion": elasticsearchMinVersion, "Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusBadRequest)
+	if major < elasticsearchMinVersion || major > elasticsearchMaxVersion {
+		logger.Error("Unsupported Elasticsearch version. Running an unsupported version may lead to unexpected behaviour.",
+			mlog.String("version", resp.Version.Int),
+			mlog.Int("min_version", elasticsearchMinVersion),
+			mlog.Int("max_version", elasticsearchMaxVersion),
+		)
 	}
-	if major > elasticsearchMaxVersion {
-		return "", 0, model.NewAppError("Elasticsearch.checkVersion", "ent.elasticsearch.max_version.app_error", map[string]any{"Version": major, "MaxVersion": elasticsearchMaxVersion, "Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusBadRequest)
-	}
+
 	return resp.Version.Int, major, nil
 }

--- a/server/enterprise/elasticsearch/opensearch/check_version_test.go
+++ b/server/enterprise/elasticsearch/opensearch/check_version_test.go
@@ -42,12 +42,12 @@ func infoHandler(version string) http.HandlerFunc {
 
 func TestCheckVersion(t *testing.T) {
 	tests := []struct {
-		name            string
-		version         string
-		wantVersion     string
-		wantMajor       int
-		wantErrID       string
-		wantUnsupported bool
+		name          string
+		version       string
+		wantVersion   string
+		wantMajor     int
+		wantLog       string
+		wantLogFields []string
 	}{
 		{
 			name:        "OpenSearch 2 is supported",
@@ -62,16 +62,20 @@ func TestCheckVersion(t *testing.T) {
 			wantMajor:   3,
 		},
 		{
-			name:            "OpenSearch 4 is too new, but allowed",
-			version:         "4.0.0",
-			wantVersion:     "4.0.0",
-			wantMajor:       4,
-			wantUnsupported: true,
+			name:          "OpenSearch 4 is too new, but allowed",
+			version:       "4.0.0",
+			wantVersion:   "4.0.0",
+			wantMajor:     4,
+			wantLog:       "Unsupported OpenSearch version",
+			wantLogFields: []string{`"version":"4.0.0"`, `"max_version":3`},
 		},
 		{
-			name:      "invalid version string",
-			version:   "invalid",
-			wantErrID: "ent.elasticsearch.start.parse_server_version.app_error",
+			name:          "unparseable version is allowed",
+			version:       "invalid",
+			wantVersion:   "invalid",
+			wantMajor:     0,
+			wantLog:       "Failed to parse the OpenSearch version",
+			wantLogFields: []string{`"version":"invalid"`},
 		},
 	}
 
@@ -82,24 +86,20 @@ func TestCheckVersion(t *testing.T) {
 			require.NoError(t, mlog.AddWriterTarget(logger, &buf, true, mlog.LvlError))
 
 			client := newTestClient(t, infoHandler(tc.version))
-			version, major, appErr := checkVersion(context.Background(), client, logger)
+			version, major := checkVersion(context.Background(), client, logger)
 			require.NoError(t, logger.Flush())
 
-			if tc.wantErrID != "" {
-				require.NotNil(t, appErr)
-				assert.Equal(t, tc.wantErrID, appErr.Id)
+			assert.Equal(t, tc.wantVersion, version)
+			assert.Equal(t, tc.wantMajor, major)
+
+			if tc.wantLog == "" {
+				assert.Empty(t, buf.String())
 				return
 			}
 
-			require.Nil(t, appErr)
-			assert.Equal(t, tc.wantVersion, version)
-			assert.Equal(t, tc.wantMajor, major)
-			if tc.wantUnsupported {
-				assert.Contains(t, buf.String(), "Unsupported OpenSearch version")
-				assert.Contains(t, buf.String(), fmt.Sprintf(`"version":%q`, tc.wantVersion))
-				assert.Contains(t, buf.String(), `"max_version":3`)
-			} else {
-				assert.Empty(t, buf.String())
+			assert.Contains(t, buf.String(), tc.wantLog)
+			for _, field := range tc.wantLogFields {
+				assert.Contains(t, buf.String(), field)
 			}
 		})
 	}
@@ -117,7 +117,15 @@ func TestCheckVersionConnectionError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	_, _, appErr := checkVersion(context.Background(), client, mlog.CreateConsoleTestLogger(t))
-	require.NotNil(t, appErr)
-	assert.Equal(t, "ent.elasticsearch.start.get_server_version.app_error", appErr.Id)
+	logger := mlog.CreateConsoleTestLogger(t)
+	var buf mlog.Buffer
+	require.NoError(t, mlog.AddWriterTarget(logger, &buf, true, mlog.LvlError))
+
+	// An unreachable server is logged, but must not fail the caller.
+	version, major := checkVersion(context.Background(), client, logger)
+	require.NoError(t, logger.Flush())
+
+	assert.Empty(t, version)
+	assert.Zero(t, major)
+	assert.Contains(t, buf.String(), "Failed to get the OpenSearch version")
 }

--- a/server/enterprise/elasticsearch/opensearch/check_version_test.go
+++ b/server/enterprise/elasticsearch/opensearch/check_version_test.go
@@ -1,0 +1,123 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.enterprise for license information.
+
+package opensearch
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/opensearch-project/opensearch-go/v4"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+)
+
+func newTestClient(t *testing.T, handler http.Handler) *opensearchapi.Client {
+	t.Helper()
+	ts := httptest.NewServer(handler)
+	t.Cleanup(ts.Close)
+
+	client, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: opensearch.Config{
+			Addresses:  []string{ts.URL},
+			MaxRetries: 0,
+		},
+	})
+	require.NoError(t, err)
+	return client
+}
+
+func infoHandler(version string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"name":"node","cluster_name":"test","cluster_uuid":"abc","version":{"distribution":"opensearch","number":%q,"build_type":"tar","build_hash":"abc","build_date":"2024-01-01","build_snapshot":false,"lucene_version":"9.7.0","minimum_wire_compatibility_version":"7.10.0","minimum_index_compatibility_version":"7.0.0"},"tagline":"The OpenSearch Project: https://opensearch.org/"}`, version)
+	}
+}
+
+func TestCheckVersion(t *testing.T) {
+	tests := []struct {
+		name            string
+		version         string
+		wantVersion     string
+		wantMajor       int
+		wantErrID       string
+		wantUnsupported bool
+	}{
+		{
+			name:        "OpenSearch 2 is supported",
+			version:     "2.11.0",
+			wantVersion: "2.11.0",
+			wantMajor:   2,
+		},
+		{
+			name:        "OpenSearch 3 is supported",
+			version:     "3.0.0",
+			wantVersion: "3.0.0",
+			wantMajor:   3,
+		},
+		{
+			name:            "OpenSearch 4 is too new, but allowed",
+			version:         "4.0.0",
+			wantVersion:     "4.0.0",
+			wantMajor:       4,
+			wantUnsupported: true,
+		},
+		{
+			name:      "invalid version string",
+			version:   "invalid",
+			wantErrID: "ent.elasticsearch.start.parse_server_version.app_error",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			logger := mlog.CreateConsoleTestLogger(t)
+			var buf mlog.Buffer
+			require.NoError(t, mlog.AddWriterTarget(logger, &buf, true, mlog.LvlError))
+
+			client := newTestClient(t, infoHandler(tc.version))
+			version, major, appErr := checkVersion(context.Background(), client, logger)
+			require.NoError(t, logger.Flush())
+
+			if tc.wantErrID != "" {
+				require.NotNil(t, appErr)
+				assert.Equal(t, tc.wantErrID, appErr.Id)
+				return
+			}
+
+			require.Nil(t, appErr)
+			assert.Equal(t, tc.wantVersion, version)
+			assert.Equal(t, tc.wantMajor, major)
+			if tc.wantUnsupported {
+				assert.Contains(t, buf.String(), "Unsupported OpenSearch version")
+				assert.Contains(t, buf.String(), fmt.Sprintf(`"version":%q`, tc.wantVersion))
+				assert.Contains(t, buf.String(), `"max_version":3`)
+			} else {
+				assert.Empty(t, buf.String())
+			}
+		})
+	}
+}
+
+func TestCheckVersionConnectionError(t *testing.T) {
+	ts := httptest.NewServer(http.NotFoundHandler())
+	ts.Close() // close immediately to force connection error
+
+	client, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: opensearch.Config{
+			Addresses:  []string{ts.URL},
+			MaxRetries: 0,
+		},
+	})
+	require.NoError(t, err)
+
+	_, _, appErr := checkVersion(context.Background(), client, mlog.CreateConsoleTestLogger(t))
+	require.NotNil(t, appErr)
+	assert.Equal(t, "ent.elasticsearch.start.get_server_version.app_error", appErr.Id)
+}

--- a/server/enterprise/elasticsearch/opensearch/check_version_test.go
+++ b/server/enterprise/elasticsearch/opensearch/check_version_test.go
@@ -42,12 +42,12 @@ func infoHandler(version string) http.HandlerFunc {
 
 func TestCheckVersion(t *testing.T) {
 	tests := []struct {
-		name          string
-		version       string
-		wantVersion   string
-		wantMajor     int
-		wantLog       string
-		wantLogFields []string
+		name            string
+		version         string
+		wantVersion     string
+		wantMajor       int
+		wantErrID       string
+		wantUnsupported bool
 	}{
 		{
 			name:        "OpenSearch 2 is supported",
@@ -62,20 +62,16 @@ func TestCheckVersion(t *testing.T) {
 			wantMajor:   3,
 		},
 		{
-			name:          "OpenSearch 4 is too new, but allowed",
-			version:       "4.0.0",
-			wantVersion:   "4.0.0",
-			wantMajor:     4,
-			wantLog:       "Unsupported OpenSearch version",
-			wantLogFields: []string{`"version":"4.0.0"`, `"max_version":3`},
+			name:            "OpenSearch 4 is too new, but allowed",
+			version:         "4.0.0",
+			wantVersion:     "4.0.0",
+			wantMajor:       4,
+			wantUnsupported: true,
 		},
 		{
-			name:          "unparseable version is allowed",
-			version:       "invalid",
-			wantVersion:   "invalid",
-			wantMajor:     0,
-			wantLog:       "Failed to parse the OpenSearch version",
-			wantLogFields: []string{`"version":"invalid"`},
+			name:      "invalid version string",
+			version:   "invalid",
+			wantErrID: "ent.elasticsearch.start.parse_server_version.app_error",
 		},
 	}
 
@@ -86,20 +82,24 @@ func TestCheckVersion(t *testing.T) {
 			require.NoError(t, mlog.AddWriterTarget(logger, &buf, true, mlog.LvlError))
 
 			client := newTestClient(t, infoHandler(tc.version))
-			version, major := checkVersion(context.Background(), client, logger)
+			version, major, appErr := checkVersion(context.Background(), client, logger)
 			require.NoError(t, logger.Flush())
 
-			assert.Equal(t, tc.wantVersion, version)
-			assert.Equal(t, tc.wantMajor, major)
-
-			if tc.wantLog == "" {
-				assert.Empty(t, buf.String())
+			if tc.wantErrID != "" {
+				require.NotNil(t, appErr)
+				assert.Equal(t, tc.wantErrID, appErr.Id)
 				return
 			}
 
-			assert.Contains(t, buf.String(), tc.wantLog)
-			for _, field := range tc.wantLogFields {
-				assert.Contains(t, buf.String(), field)
+			require.Nil(t, appErr)
+			assert.Equal(t, tc.wantVersion, version)
+			assert.Equal(t, tc.wantMajor, major)
+			if tc.wantUnsupported {
+				assert.Contains(t, buf.String(), "Unsupported OpenSearch version")
+				assert.Contains(t, buf.String(), fmt.Sprintf(`"version":%q`, tc.wantVersion))
+				assert.Contains(t, buf.String(), `"max_version":3`)
+			} else {
+				assert.Empty(t, buf.String())
 			}
 		})
 	}
@@ -117,15 +117,7 @@ func TestCheckVersionConnectionError(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	logger := mlog.CreateConsoleTestLogger(t)
-	var buf mlog.Buffer
-	require.NoError(t, mlog.AddWriterTarget(logger, &buf, true, mlog.LvlError))
-
-	// An unreachable server is logged, but must not fail the caller.
-	version, major := checkVersion(context.Background(), client, logger)
-	require.NoError(t, logger.Flush())
-
-	assert.Empty(t, version)
-	assert.Zero(t, major)
-	assert.Contains(t, buf.String(), "Failed to get the OpenSearch version")
+	_, _, appErr := checkVersion(context.Background(), client, mlog.CreateConsoleTestLogger(t))
+	require.NotNil(t, appErr)
+	assert.Equal(t, "ent.elasticsearch.start.get_server_version.app_error", appErr.Id)
 }

--- a/server/enterprise/elasticsearch/opensearch/opensearch.go
+++ b/server/enterprise/elasticsearch/opensearch/opensearch.go
@@ -117,7 +117,7 @@ func (os *OpensearchInterfaceImpl) IsIndexingSync() bool {
 
 // fetchServerInfo retrieves and stores the server version and plugins from the given client.
 func (os *OpensearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *opensearchapi.Client) *model.AppError {
-	version, major, appErr := checkMaxVersion(ctx, client)
+	version, major, appErr := checkVersion(ctx, client, os.Platform.Log())
 	if appErr != nil {
 		return appErr
 	}
@@ -2333,19 +2333,26 @@ func (os *OpensearchInterfaceImpl) DeleteFilesBatch(rctx request.CTX, endTime, l
 	return nil
 }
 
-func checkMaxVersion(ctx context.Context, client *opensearchapi.Client) (string, int, *model.AppError) {
+// checkVersion returns the version of the connected OpenSearch server. An
+// unsupported version is logged but not treated as fatal, allowing the server to
+// start regardless.
+func checkVersion(ctx context.Context, client *opensearchapi.Client, logger mlog.LoggerIFace) (string, int, *model.AppError) {
 	resp, err := client.Info(ctx, nil)
 	if err != nil {
-		return "", 0, model.NewAppError("Opensearch.checkMaxVersion", "ent.elasticsearch.start.get_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
+		return "", 0, model.NewAppError("Opensearch.checkVersion", "ent.elasticsearch.start.get_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	major, _, _, esErr := common.GetVersionComponents(resp.Version.Number)
 	if esErr != nil {
-		return "", 0, model.NewAppError("Opensearch.checkMaxVersion", "ent.elasticsearch.start.parse_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(esErr)
+		return "", 0, model.NewAppError("Opensearch.checkVersion", "ent.elasticsearch.start.parse_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(esErr)
 	}
 
 	if major > opensearchMaxVersion {
-		return "", 0, model.NewAppError("Opensearch.checkMaxVersion", "ent.elasticsearch.max_version.app_error", map[string]any{"Version": major, "MaxVersion": opensearchMaxVersion, "Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusBadRequest)
+		logger.Error("Unsupported OpenSearch version. Running an unsupported version may lead to unexpected behaviour.",
+			mlog.String("version", resp.Version.Number),
+			mlog.Int("max_version", opensearchMaxVersion),
+		)
 	}
+
 	return resp.Version.Number, major, nil
 }

--- a/server/enterprise/elasticsearch/opensearch/opensearch.go
+++ b/server/enterprise/elasticsearch/opensearch/opensearch.go
@@ -115,15 +115,11 @@ func (os *OpensearchInterfaceImpl) IsIndexingSync() bool {
 	return *os.Platform.Config().ElasticsearchSettings.LiveIndexingBatchSize <= 1
 }
 
-// fetchServerInfo retrieves and stores the server version and plugins from the given client.
-func (os *OpensearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *opensearchapi.Client) *model.AppError {
-	version, major, appErr := checkVersion(ctx, client, os.Platform.Log())
-	if appErr != nil {
-		return appErr
-	}
-
-	os.version = major
-	os.fullVersion = version
+// fetchServerInfo retrieves and stores the server version and plugins from the
+// given client. The version is only reported, never acted upon, so failures are
+// logged and left behind instead of preventing a start.
+func (os *OpensearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *opensearchapi.Client) {
+	os.fullVersion, os.version = checkVersion(ctx, client, os.Platform.Log())
 
 	// Since we are only retrieving plugins for the Support Packet generation, it doesn't make sense to kill the process if we get an error
 	// Instead, we will log it and move forward
@@ -136,8 +132,6 @@ func (os *OpensearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *
 			os.plugins = append(os.plugins, p.Component)
 		}
 	}
-
-	return nil
 }
 
 func (os *OpensearchInterfaceImpl) Start(ctx context.Context) *model.AppError {
@@ -160,9 +154,7 @@ func (os *OpensearchInterfaceImpl) Start(ctx context.Context) *model.AppError {
 		return appErr
 	}
 
-	if appErr = os.fetchServerInfo(ctx, os.client); appErr != nil {
-		return appErr
-	}
+	os.fetchServerInfo(ctx, os.client)
 
 	esSettings := os.Platform.Config().ElasticsearchSettings
 	if *esSettings.LiveIndexingBatchSize > 1 {
@@ -1702,9 +1694,13 @@ func (os *OpensearchInterfaceImpl) TestConfig(rctx request.CTX, cfg *model.Confi
 		return appErr
 	}
 
-	if appErr = os.fetchServerInfo(context.Background(), client); appErr != nil {
-		return appErr
+	// Unlike starting up, testing the configuration must report an unreachable
+	// server: it's the only thing this is asked to find out.
+	if _, err := client.Ping(rctx.Context(), nil); err != nil {
+		return model.NewAppError("Opensearch.TestConfig", "ent.elasticsearch.test_config.reachable.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
 	}
+
+	os.fetchServerInfo(context.Background(), client)
 
 	// Resetting the state.
 	if os.ready.CompareAndSwap(0, 1) {
@@ -2333,18 +2329,24 @@ func (os *OpensearchInterfaceImpl) DeleteFilesBatch(rctx request.CTX, endTime, l
 	return nil
 }
 
-// checkVersion returns the version of the connected OpenSearch server. An
-// unsupported version is logged but not treated as fatal, allowing the server to
-// start regardless.
-func checkVersion(ctx context.Context, client *opensearchapi.Client, logger mlog.LoggerIFace) (string, int, *model.AppError) {
+// checkVersion returns the full version and major version of the connected
+// OpenSearch server, or zero values if it cannot be determined. Nothing here is
+// fatal: an unsupported version, an unreachable server and an unparseable
+// version are all logged and allowed to proceed.
+func checkVersion(ctx context.Context, client *opensearchapi.Client, logger mlog.LoggerIFace) (string, int) {
 	resp, err := client.Info(ctx, nil)
 	if err != nil {
-		return "", 0, model.NewAppError("Opensearch.checkVersion", "ent.elasticsearch.start.get_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
+		logger.Error("Failed to get the OpenSearch version.", mlog.Err(err))
+		return "", 0
 	}
 
-	major, _, _, esErr := common.GetVersionComponents(resp.Version.Number)
-	if esErr != nil {
-		return "", 0, model.NewAppError("Opensearch.checkVersion", "ent.elasticsearch.start.parse_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(esErr)
+	major, _, _, err := common.GetVersionComponents(resp.Version.Number)
+	if err != nil {
+		logger.Error("Failed to parse the OpenSearch version.",
+			mlog.String("version", resp.Version.Number),
+			mlog.Err(err),
+		)
+		return resp.Version.Number, 0
 	}
 
 	if major > opensearchMaxVersion {
@@ -2354,5 +2356,5 @@ func checkVersion(ctx context.Context, client *opensearchapi.Client, logger mlog
 		)
 	}
 
-	return resp.Version.Number, major, nil
+	return resp.Version.Number, major
 }

--- a/server/enterprise/elasticsearch/opensearch/opensearch.go
+++ b/server/enterprise/elasticsearch/opensearch/opensearch.go
@@ -115,11 +115,15 @@ func (os *OpensearchInterfaceImpl) IsIndexingSync() bool {
 	return *os.Platform.Config().ElasticsearchSettings.LiveIndexingBatchSize <= 1
 }
 
-// fetchServerInfo retrieves and stores the server version and plugins from the
-// given client. The version is only reported, never acted upon, so failures are
-// logged and left behind instead of preventing a start.
-func (os *OpensearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *opensearchapi.Client) {
-	os.fullVersion, os.version = checkVersion(ctx, client, os.Platform.Log())
+// fetchServerInfo retrieves and stores the server version and plugins from the given client.
+func (os *OpensearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *opensearchapi.Client) *model.AppError {
+	version, major, appErr := checkVersion(ctx, client, os.Platform.Log())
+	if appErr != nil {
+		return appErr
+	}
+
+	os.version = major
+	os.fullVersion = version
 
 	// Since we are only retrieving plugins for the Support Packet generation, it doesn't make sense to kill the process if we get an error
 	// Instead, we will log it and move forward
@@ -132,6 +136,8 @@ func (os *OpensearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *
 			os.plugins = append(os.plugins, p.Component)
 		}
 	}
+
+	return nil
 }
 
 func (os *OpensearchInterfaceImpl) Start(ctx context.Context) *model.AppError {
@@ -154,7 +160,9 @@ func (os *OpensearchInterfaceImpl) Start(ctx context.Context) *model.AppError {
 		return appErr
 	}
 
-	os.fetchServerInfo(ctx, os.client)
+	if appErr = os.fetchServerInfo(ctx, os.client); appErr != nil {
+		return appErr
+	}
 
 	esSettings := os.Platform.Config().ElasticsearchSettings
 	if *esSettings.LiveIndexingBatchSize > 1 {
@@ -1694,13 +1702,9 @@ func (os *OpensearchInterfaceImpl) TestConfig(rctx request.CTX, cfg *model.Confi
 		return appErr
 	}
 
-	// Unlike starting up, testing the configuration must report an unreachable
-	// server: it's the only thing this is asked to find out.
-	if _, err := client.Ping(rctx.Context(), nil); err != nil {
-		return model.NewAppError("Opensearch.TestConfig", "ent.elasticsearch.test_config.reachable.error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
+	if appErr = os.fetchServerInfo(context.Background(), client); appErr != nil {
+		return appErr
 	}
-
-	os.fetchServerInfo(context.Background(), client)
 
 	// Resetting the state.
 	if os.ready.CompareAndSwap(0, 1) {
@@ -2329,24 +2333,18 @@ func (os *OpensearchInterfaceImpl) DeleteFilesBatch(rctx request.CTX, endTime, l
 	return nil
 }
 
-// checkVersion returns the full version and major version of the connected
-// OpenSearch server, or zero values if it cannot be determined. Nothing here is
-// fatal: an unsupported version, an unreachable server and an unparseable
-// version are all logged and allowed to proceed.
-func checkVersion(ctx context.Context, client *opensearchapi.Client, logger mlog.LoggerIFace) (string, int) {
+// checkVersion returns the version of the connected OpenSearch server. An
+// unsupported version is logged but not treated as fatal, allowing the server to
+// start regardless.
+func checkVersion(ctx context.Context, client *opensearchapi.Client, logger mlog.LoggerIFace) (string, int, *model.AppError) {
 	resp, err := client.Info(ctx, nil)
 	if err != nil {
-		logger.Error("Failed to get the OpenSearch version.", mlog.Err(err))
-		return "", 0
+		return "", 0, model.NewAppError("Opensearch.checkVersion", "ent.elasticsearch.start.get_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
 	}
 
-	major, _, _, err := common.GetVersionComponents(resp.Version.Number)
-	if err != nil {
-		logger.Error("Failed to parse the OpenSearch version.",
-			mlog.String("version", resp.Version.Number),
-			mlog.Err(err),
-		)
-		return resp.Version.Number, 0
+	major, _, _, esErr := common.GetVersionComponents(resp.Version.Number)
+	if esErr != nil {
+		return "", 0, model.NewAppError("Opensearch.checkVersion", "ent.elasticsearch.start.parse_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(esErr)
 	}
 
 	if major > opensearchMaxVersion {
@@ -2356,5 +2354,5 @@ func checkVersion(ctx context.Context, client *opensearchapi.Client, logger mlog
 		)
 	}
 
-	return resp.Version.Number, major
+	return resp.Version.Number, major, nil
 }

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10515,14 +10515,6 @@
     "translation": "Trying to index a new batch when all the entities are completed"
   },
   {
-    "id": "ent.elasticsearch.max_version.app_error",
-    "translation": "{{.Backend}} version {{.Version}} is higher than max supported version of {{.MaxVersion}}"
-  },
-  {
-    "id": "ent.elasticsearch.min_version.app_error",
-    "translation": "{{.Backend}} version {{.Version}} is lower than min supported version of {{.MinVersion}}"
-  },
-  {
     "id": "ent.elasticsearch.not_started.error",
     "translation": "{{.Backend}} is not started"
   },

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10587,20 +10587,16 @@
     "translation": "Failed to decode search results"
   },
   {
-    "id": "ent.elasticsearch.start.get_server_version.app_error",
-    "translation": "Failed to get {{.Backend}} server version."
-  },
-  {
-    "id": "ent.elasticsearch.start.parse_server_version.app_error",
-    "translation": "Failed to parse {{.Backend}} server version."
-  },
-  {
     "id": "ent.elasticsearch.test_config.indexing_disabled.error",
     "translation": "{{.Backend}} is disabled."
   },
   {
     "id": "ent.elasticsearch.test_config.license.error",
     "translation": "Your Mattermost license doesn't support indexed search."
+  },
+  {
+    "id": "ent.elasticsearch.test_config.reachable.error",
+    "translation": "Failed to reach {{.Backend}}."
   },
   {
     "id": "ent.elasticsearch.test_config.reenter_password",

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -10587,16 +10587,20 @@
     "translation": "Failed to decode search results"
   },
   {
+    "id": "ent.elasticsearch.start.get_server_version.app_error",
+    "translation": "Failed to get {{.Backend}} server version."
+  },
+  {
+    "id": "ent.elasticsearch.start.parse_server_version.app_error",
+    "translation": "Failed to parse {{.Backend}} server version."
+  },
+  {
     "id": "ent.elasticsearch.test_config.indexing_disabled.error",
     "translation": "{{.Backend}} is disabled."
   },
   {
     "id": "ent.elasticsearch.test_config.license.error",
     "translation": "Your Mattermost license doesn't support indexed search."
-  },
-  {
-    "id": "ent.elasticsearch.test_config.reachable.error",
-    "translation": "Failed to reach {{.Backend}}."
   },
   {
     "id": "ent.elasticsearch.test_config.reenter_password",


### PR DESCRIPTION
#### Summary

Unsupported Postgres, Elasticsearch and OpenSearch versions used to abort startup. Now they log an `ERROR` and the server starts anyway, leaving the decision to run an unsupported configuration to the administrator.

Example logs:
```
Unsupported Postgres version. Running an unsupported version may lead to unexpected behaviour.  version=11.1 min_version=14.0
Unsupported Elasticsearch version. Running an unsupported version may lead to unexpected behaviour.  version=7.17.0 min_version=8 max_version=9
Unsupported OpenSearch version. Running an unsupported version may lead to unexpected behaviour.  version=4.0.0 max_version=3
```

#### Release Note

```release-note
The server now logs an error and continues to start when connected to an unsupported Postgres, Elasticsearch, or OpenSearch version, instead of refusing to start.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Startup behavior changes across PostgreSQL, Elasticsearch, and OpenSearch version checks. Automated tests cover supported, unsupported, parse-error, and connection-error cases.

**QA Recommendation:** Rely on automated tests. Manual QA is optional for startup and error-log verification.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->