### PR TITLE
[MM-69946] Harden outgoing webhook user assignment

### DIFF
--- a/server/channels/api4/webhook.go
+++ b/server/channels/api4/webhook.go
@@ -442,6 +442,20 @@ func updateOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Moving the hook to a different channel requires the retained owner to have access to it.
+	if updatedHook.ChannelId != "" && updatedHook.ChannelId != oldHook.ChannelId {
+		channel, appErr := c.App.GetChannel(c.AppContext, updatedHook.ChannelId)
+		if appErr != nil {
+			c.Err = appErr
+			return
+		}
+		if appErr := c.App.ValidateOutgoingWebhookUserChannelAccess(c.AppContext, oldHook.CreatorId, channel); appErr != nil {
+			c.LogAudit("fail - invalid webhook user")
+			c.Err = appErr
+			return
+		}
+	}
+
 	updatedHook.CreatorId = c.AppContext.Session().UserId
 
 	rhook, err := c.App.UpdateOutgoingWebhook(c.AppContext, oldHook, &updatedHook)
@@ -484,9 +498,25 @@ func createOutgoingHook(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		_, err := c.App.GetUser(hook.CreatorId)
-		if err != nil {
+		var hookUser *model.User
+		var err *model.AppError
+		if hookUser, err = c.App.GetUser(hook.CreatorId); err != nil {
 			c.Err = err
+			return
+		}
+
+		var channel *model.Channel
+		if hook.ChannelId != "" {
+			channel, err = c.App.GetChannel(c.AppContext, hook.ChannelId)
+			if err != nil {
+				c.Err = err
+				return
+			}
+		}
+
+		if appErr := c.App.ValidateOutgoingWebhookUser(c.AppContext, *c.AppContext.Session(), hookUser, hook.TeamId, channel); appErr != nil {
+			c.LogAudit("fail - invalid webhook user")
+			c.Err = appErr
 			return
 		}
 	}

--- a/server/channels/api4/webhook_test.go
+++ b/server/channels/api4/webhook_test.go
@@ -261,6 +261,128 @@ func TestIncomingWebhookValidateUser(t *testing.T) {
 	})
 }
 
+func TestOutgoingWebhookValidateUser(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) { *cfg.ServiceSettings.EnableOutgoingWebhooks = true })
+
+	defaultRolePermissions := th.SaveDefaultRolePermissions(t)
+	defer th.RestoreDefaultRolePermissions(t, defaultRolePermissions)
+	th.AddPermissionToRole(t, model.PermissionManageOwnOutgoingWebhooks.Id, model.TeamAdminRoleId)
+	th.AddPermissionToRole(t, model.PermissionManageOthersOutgoingWebhooks.Id, model.TeamAdminRoleId)
+	th.RemovePermissionFromRole(t, model.PermissionManageOwnOutgoingWebhooks.Id, model.TeamUserRoleId)
+
+	th.LoginTeamAdmin(t)
+
+	t.Run("cannot assign a user who is not a member of the team or channel", func(t *testing.T) {
+		nonMember := th.CreateUser(t)
+
+		hook := &model.OutgoingWebhook{
+			ChannelId:    th.BasicChannel.Id,
+			TeamId:       th.BasicTeam.Id,
+			CallbackURLs: []string{"http://nowhere.com"},
+			CreatorId:    nonMember.Id,
+		}
+		_, resp, err := th.Client.CreateOutgoingWebhook(context.Background(), hook)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("cannot assign a user with higher privileges than the requester", func(t *testing.T) {
+		th.LinkUserToTeam(t, th.SystemAdminUser, th.BasicTeam)
+		_, appErr := th.App.AddUserToChannel(th.Context, th.SystemAdminUser, th.BasicChannel, false)
+		require.Nil(t, appErr)
+
+		hook := &model.OutgoingWebhook{
+			ChannelId:    th.BasicChannel.Id,
+			TeamId:       th.BasicTeam.Id,
+			CallbackURLs: []string{"http://nowhere.com"},
+			CreatorId:    th.SystemAdminUser.Id,
+		}
+		_, resp, err := th.Client.CreateOutgoingWebhook(context.Background(), hook)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("cannot assign a user with higher privileges than the requester without a channel", func(t *testing.T) {
+		th.LinkUserToTeam(t, th.SystemAdminUser, th.BasicTeam)
+
+		hook := &model.OutgoingWebhook{
+			TeamId:       th.BasicTeam.Id,
+			CallbackURLs: []string{"http://nowhere.com"},
+			TriggerWords: []string{"validate-user"},
+			CreatorId:    th.SystemAdminUser.Id,
+		}
+		_, resp, err := th.Client.CreateOutgoingWebhook(context.Background(), hook)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("can assign a user who is a member of the channel", func(t *testing.T) {
+		hook := &model.OutgoingWebhook{
+			ChannelId:    th.BasicChannel.Id,
+			TeamId:       th.BasicTeam.Id,
+			CallbackURLs: []string{"http://nowhere.com"},
+			CreatorId:    th.BasicUser2.Id,
+		}
+		created, _, err := th.Client.CreateOutgoingWebhook(context.Background(), hook)
+		require.NoError(t, err)
+		require.Equal(t, th.BasicUser2.Id, created.CreatorId)
+	})
+
+	t.Run("cannot assign a user who is not a member of the team without a channel", func(t *testing.T) {
+		nonMember := th.CreateUser(t)
+
+		hook := &model.OutgoingWebhook{
+			TeamId:       th.BasicTeam.Id,
+			CallbackURLs: []string{"http://nowhere.com"},
+			TriggerWords: []string{"team-membership"},
+			CreatorId:    nonMember.Id,
+		}
+		_, resp, err := th.Client.CreateOutgoingWebhook(context.Background(), hook)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("update cannot move another user's hook to a channel they cannot access", func(t *testing.T) {
+		hook := &model.OutgoingWebhook{
+			ChannelId:    th.BasicChannel.Id,
+			TeamId:       th.BasicTeam.Id,
+			CallbackURLs: []string{"http://nowhere.com"},
+			CreatorId:    th.BasicUser2.Id,
+		}
+		created, _, err := th.Client.CreateOutgoingWebhook(context.Background(), hook)
+		require.NoError(t, err)
+
+		otherChannel := th.CreatePublicChannel(t)
+		created.ChannelId = otherChannel.Id
+
+		_, resp, err := th.Client.UpdateOutgoingWebhook(context.Background(), created)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("update validates the retained owner even when the payload also changes the owner", func(t *testing.T) {
+		hook := &model.OutgoingWebhook{
+			ChannelId:    th.BasicChannel.Id,
+			TeamId:       th.BasicTeam.Id,
+			CallbackURLs: []string{"http://nowhere.com"},
+			CreatorId:    th.BasicUser2.Id,
+		}
+		created, _, err := th.Client.CreateOutgoingWebhook(context.Background(), hook)
+		require.NoError(t, err)
+
+		otherChannel := th.CreatePublicChannel(t)
+		created.ChannelId = otherChannel.Id
+		created.CreatorId = th.TeamAdminUser.Id
+
+		_, resp, err := th.Client.UpdateOutgoingWebhook(context.Background(), created)
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+}
+
 func TestGetIncomingWebhooks(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)

--- a/server/channels/app/webhook.go
+++ b/server/channels/app/webhook.go
@@ -514,10 +514,8 @@ func (a *App) CreateWebhookPost(rctx request.CTX, userID string, channel *model.
 	return returnPost, nil
 }
 
-// ValidateIncomingWebhookUser ensures a user being assigned as an incoming webhook's owner can
-// legitimately be attributed posts in the target channel: the user must have access to the
-// channel and must not hold privileges the requester lacks, so a requester cannot forge posts
-// as a non-member or higher-privileged user.
+// ValidateIncomingWebhookUser ensures a user being assigned as an incoming webhook's owner
+// does not hold privileges the requester lacks and can access the target channel.
 func (a *App) ValidateIncomingWebhookUser(rctx request.CTX, session model.Session, user *model.User, channel *model.Channel) *model.AppError {
 	if user.IsSystemAdmin() && !a.SessionHasPermissionTo(session, model.PermissionManageSystem) {
 		return model.NewAppError("ValidateIncomingWebhookUser", "api.webhook.incoming.user_role.app_error", nil, "user_id="+user.Id, http.StatusForbidden)
@@ -526,12 +524,46 @@ func (a *App) ValidateIncomingWebhookUser(rctx request.CTX, session model.Sessio
 	return a.ValidateIncomingWebhookUserChannelAccess(rctx, user.Id, channel)
 }
 
-// ValidateIncomingWebhookUserChannelAccess ensures the webhook owner can read the channel its
-// posts are attributed to, preventing attribution to a user who is not a member of the channel
-// (or its team, for open channels).
+// ValidateIncomingWebhookUserChannelAccess ensures the incoming webhook owner can read the channel
+// the hook is bound to.
 func (a *App) ValidateIncomingWebhookUserChannelAccess(rctx request.CTX, userID string, channel *model.Channel) *model.AppError {
 	if hasPermission, _ := a.HasPermissionToChannel(rctx, userID, channel.Id, model.PermissionReadChannelContent); !hasPermission {
 		return model.NewAppError("ValidateIncomingWebhookUserChannelAccess", "api.webhook.incoming.user_membership.app_error", nil, "user_id="+userID+", channel_id="+channel.Id, http.StatusForbidden)
+	}
+
+	return nil
+}
+
+// ValidateOutgoingWebhookUser ensures a user being assigned as an outgoing webhook's owner
+// does not hold privileges the requester lacks. When the hook is bound to a channel the user
+// must be able to read it; when ChannelId is empty they must be a member of the team.
+func (a *App) ValidateOutgoingWebhookUser(rctx request.CTX, session model.Session, user *model.User, teamID string, channel *model.Channel) *model.AppError {
+	if user.IsSystemAdmin() && !a.SessionHasPermissionTo(session, model.PermissionManageSystem) {
+		return model.NewAppError("ValidateOutgoingWebhookUser", "api.webhook.incoming.user_role.app_error", nil, "user_id="+user.Id, http.StatusForbidden)
+	}
+
+	if channel != nil {
+		return a.ValidateOutgoingWebhookUserChannelAccess(rctx, user.Id, channel)
+	}
+
+	return a.ValidateOutgoingWebhookUserTeamAccess(rctx, user.Id, teamID)
+}
+
+// ValidateOutgoingWebhookUserChannelAccess ensures the outgoing webhook owner can read the channel
+// the hook is bound to.
+func (a *App) ValidateOutgoingWebhookUserChannelAccess(rctx request.CTX, userID string, channel *model.Channel) *model.AppError {
+	if hasPermission, _ := a.HasPermissionToChannel(rctx, userID, channel.Id, model.PermissionReadChannelContent); !hasPermission {
+		return model.NewAppError("ValidateOutgoingWebhookUserChannelAccess", "api.webhook.incoming.user_membership.app_error", nil, "user_id="+userID+", channel_id="+channel.Id, http.StatusForbidden)
+	}
+
+	return nil
+}
+
+// ValidateOutgoingWebhookUserTeamAccess ensures the outgoing webhook owner can access the team
+// when the hook is not bound to a channel.
+func (a *App) ValidateOutgoingWebhookUserTeamAccess(rctx request.CTX, userID string, teamID string) *model.AppError {
+	if teamID != "" && !a.HasPermissionToTeam(rctx, userID, teamID, model.PermissionViewTeam) {
+		return model.NewAppError("ValidateOutgoingWebhookUserTeamAccess", "api.webhook.incoming.user_membership.app_error", nil, "user_id="+userID+", team_id="+teamID, http.StatusForbidden)
 	}
 
 	return nil


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
Tighten authorization on `POST /api/v4/hooks/outgoing` when assigning another user as the webhook creator, and on `PUT` when moving an outgoing webhook to a different channel.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-69946

#### Screenshots
<!-- Include screenshots or GIFs for UI changes. -->

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Authorization changes affect outgoing webhook creation and updates. Automated tests cover the affected access paths, but unauthorized assignments could alter existing behavior.

**QA Recommendation:** Manual QA can be skipped. Run the automated webhook authorization tests.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->