### PR TITLE
fix(import): don't panic when os.Stat fails with something other than ErrNotExist

### DIFF
--- a/server/channels/jobs/import_process/worker.go
+++ b/server/channels/jobs/import_process/worker.go
@@ -54,14 +54,8 @@ func MakeWorker(jobServer *jobs.JobServer, app AppIface) *jobs.SimpleWorker {
 		var importFile filestore.ReadCloseSeeker
 		if job.Data["local_mode"] == "true" {
 			// We simply read the file from the local filesystem.
-			info, err := os.Stat(importFileName)
-			if errors.Is(err, os.ErrNotExist) {
-				return fmt.Errorf("file %s doesn't exist.", importFileName)
-			}
-
-			importFileSize = info.Size()
-
-			importFile, err = os.Open(importFileName)
+			var err error
+			importFile, importFileSize, err = resolveLocalImportFile(importFileName)
 			if err != nil {
 				return err
 			}
@@ -150,4 +144,29 @@ func MakeWorker(jobServer *jobs.JobServer, app AppIface) *jobs.SimpleWorker {
 	}
 	worker := jobs.NewSimpleWorker(workerName, jobServer, execute, isEnabled)
 	return worker
+}
+
+// resolveLocalImportFile stats and opens the import archive directly from
+// the local filesystem. It is used when the import job is run in local mode
+// (e.g. `mmctl --local import process ... --bypass-upload`), bypassing the
+// upload/FileBackend path entirely.
+func resolveLocalImportFile(importFileName string) (filestore.ReadCloseSeeker, int64, error) {
+	info, err := os.Stat(importFileName)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, 0, fmt.Errorf("file %s doesn't exist.", importFileName)
+		}
+		// Any other Stat error (e.g. permission denied, or a path
+		// component that isn't a directory) is not "file doesn't exist",
+		// and info is nil here, so it must be returned instead of
+		// falling through to a nil-pointer dereference on info.Size().
+		return nil, 0, fmt.Errorf("unable to stat file %s: %w", importFileName, err)
+	}
+
+	file, err := os.Open(importFileName)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	return file, info.Size(), nil
 }

--- a/server/channels/jobs/import_process/worker_test.go
+++ b/server/channels/jobs/import_process/worker_test.go
@@ -1,0 +1,69 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package import_process
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestResolveLocalImportFile_MissingFile verifies the well-understood case
+// still returns the friendly "doesn't exist" error.
+func TestResolveLocalImportFile_MissingFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	missing := filepath.Join(tmpDir, "does-not-exist.zip")
+
+	file, size, err := resolveLocalImportFile(missing)
+	require.Error(t, err)
+	assert.Nil(t, file)
+	assert.Zero(t, size)
+	assert.Contains(t, err.Error(), "doesn't exist")
+}
+
+// TestResolveLocalImportFile_StatErrorOtherThanNotExist reproduces the panic
+// reported in https://github.com/mattermost/mattermost/issues/37492: a
+// Stat() error that is NOT os.ErrNotExist (e.g. because the mattermost
+// process doesn't have permission to traverse a directory in the path, or -
+// as simulated here - a path component exists but is not a directory, which
+// fails with ENOTDIR rather than ENOENT) must still be reported as an error
+// rather than falling through to a nil `info` and panicking on
+// `info.Size()`.
+func TestResolveLocalImportFile_StatErrorOtherThanNotExist(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a regular file, then build a path that uses it as if it were
+	// a directory. On every OS this repo supports, stat-ing a path with a
+	// non-directory intermediate component fails with ENOTDIR, which is a
+	// distinct error from ENOENT/os.ErrNotExist.
+	regularFile := filepath.Join(tmpDir, "not-a-directory")
+	require.NoError(t, os.WriteFile(regularFile, []byte("x"), 0600))
+	badPath := filepath.Join(regularFile, "archive.zip")
+
+	file, size, err := resolveLocalImportFile(badPath)
+	require.Error(t, err, "a Stat error other than ErrNotExist must be returned, not silently ignored")
+	assert.False(t, errors.Is(err, os.ErrNotExist), "ENOTDIR must not be reported as the file-doesn't-exist case")
+	assert.Nil(t, file)
+	assert.Zero(t, size)
+}
+
+// TestResolveLocalImportFile_Success is the happy path: an existing,
+// readable file is stat'd and opened correctly.
+func TestResolveLocalImportFile_Success(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "archive.zip")
+	contents := []byte("fake archive contents")
+	require.NoError(t, os.WriteFile(path, contents, 0600))
+
+	file, size, err := resolveLocalImportFile(path)
+	require.NoError(t, err)
+	require.NotNil(t, file)
+	defer file.Close()
+
+	assert.EqualValues(t, len(contents), size)
+}


### PR DESCRIPTION
#### Summary

`import_process`'s local-mode path (`mmctl --local import process ... --bypass-upload`) only checked `errors.Is(err, os.ErrNotExist)` after `os.Stat`. Any other `Stat` error — permission denied, or a path with a non-directory intermediate component (`ENOTDIR`) — left `info` as `nil` and fell through to `info.Size()`, panicking with "invalid memory address or nil pointer dereference" inside the job worker goroutine, exactly as reported in #37492.

This extracts the local-mode stat+open logic into `resolveLocalImportFile` (no behavior change from the extraction itself) and fixes it to check `err != nil` generally, returning a real error for any `Stat` failure while keeping the existing friendly message for the `ErrNotExist` case.

**How I verified this**: read the current source at the exact line the issue's permalink points to and confirmed the bug is still present. Wrote `worker_test.go` and ran the new `TestResolveLocalImportFile_StatErrorOtherThanNotExist` test (using a path with a non-directory intermediate component, which fails with `ENOTDIR` rather than `ENOENT`) against the original unpatched logic first — it panicked with the exact same "invalid memory address or nil pointer dereference" signature from the issue. Then applied the fix and confirmed all three new tests pass (missing-file, stat-error-other-than-not-exist, success path), plus `go build`, `go vet`, and `gofmt -l` are clean for the package. I did not run the full server test suite or any DB-backed integration test — this fix and its tests are self-contained filesystem logic with no server/store dependency, so none was needed.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/37492

#### Release Note

```release-note
Fixed a panic ("invalid memory address or nil pointer dereference") in the bulk import job worker when running `mmctl --local import process` and the import archive could not be stat'd for a reason other than not existing (e.g. a permissions problem). The job now fails with a descriptive error instead of crashing.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to local import file resolution. Tests cover missing files, stat errors, and successful resolution.

**QA Recommendation:** Manual QA is not required. Automated tests and package checks provide sufficient coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->