### PR TITLE
fix(auth): normalize passwords to Unicode NFC before hashing and comparing

### DIFF
--- a/server/channels/app/authentication.go
+++ b/server/channels/app/authentication.go
@@ -67,6 +67,13 @@ func (a *App) checkUserPassword(user *model.User, password string) *model.AppErr
 		return model.NewAppError("checkUserPassword", "api.user.check_user_password.invalid.app_error", nil, "user_id="+user.Id, http.StatusUnauthorized)
 	}
 
+	// Normalize to the same Unicode form used when the password was hashed
+	// (see PreSave/UpdatePassword), so a password typed with a different
+	// but canonically-equivalent Unicode composition on another device
+	// still verifies correctly. This also affects the plaintext password
+	// forwarded to migratePassword below, which re-hashes it.
+	password = utils.NormalizePassword(password)
+
 	// Get the hasher and parsed PHC
 	hasher, phc, err := hashers.GetHasherFromPHCString(user.Password)
 	if err != nil {

--- a/server/channels/app/authentication_test.go
+++ b/server/channels/app/authentication_test.go
@@ -775,6 +775,47 @@ func TestCheckUserPassword(t *testing.T) {
 	})
 }
 
+// TestCheckUserPasswordUnicodeNormalization exercises the fix for a
+// password containing a character with two different but canonically
+// equivalent Unicode representations: a precomposed codepoint (e.g. "e"
+// with an acute accent as the single rune U+00E9) vs a base letter
+// followed by a combining mark (plain "e" + the combining acute accent
+// U+0301). Before the fix, a password hashed from one form would fail to
+// verify against the other, even though it is the same password typed on
+// a different device/input method. See
+// https://github.com/mattermost/mattermost/issues/36877.
+//
+// This intentionally does not use Setup(t)/InitBasic(t): checkUserPassword
+// only touches a.Srv()/the database when migrating away from a non-latest
+// hasher, which never happens here because both hashes below are created
+// with the current hashers.GetLatestHasher(). That keeps this test fast
+// and independent of Postgres, unlike TestCheckUserPassword above.
+func TestCheckUserPasswordUnicodeNormalization(t *testing.T) {
+	const (
+		passwordNFC = "Sunrise-café-42"  // e-acute as one precomposed codepoint (U+00E9)
+		passwordNFD = "Sunrise-café-42" // "e" + combining acute accent (U+0301)
+	)
+	require.NotEqual(t, passwordNFC, passwordNFD, "the two forms must differ at the byte level for this test to be meaningful")
+
+	a := &App{}
+
+	t.Run("password set with NFC form, verified with NFD form", func(t *testing.T) {
+		user := &model.User{Id: model.NewId(), Password: passwordNFC}
+		require.Nil(t, user.PreSave(hashers.GetLatestHasher()))
+
+		appErr := a.checkUserPassword(user, passwordNFD)
+		require.Nil(t, appErr, "logging in with the NFD form of the same password must succeed")
+	})
+
+	t.Run("password set with NFD form, verified with NFC form", func(t *testing.T) {
+		user := &model.User{Id: model.NewId(), Password: passwordNFD}
+		require.Nil(t, user.PreSave(hashers.GetLatestHasher()))
+
+		appErr := a.checkUserPassword(user, passwordNFC)
+		require.Nil(t, appErr, "logging in with the NFC form of the same password must succeed")
+	})
+}
+
 func TestMigratePassword(t *testing.T) {
 	th := Setup(t).InitBasic(t)
 

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -28,6 +28,7 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/app/password/hashers"
 	"github.com/mattermost/mattermost/server/v8/channels/app/users"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
+	"github.com/mattermost/mattermost/server/v8/channels/utils"
 	"github.com/mattermost/mattermost/server/v8/einterfaces"
 	"github.com/mattermost/mattermost/server/v8/platform/shared/mfa"
 )
@@ -1768,6 +1769,11 @@ func (a *App) UpdatePassword(rctx request.CTX, user *model.User, newPassword str
 	if user.IsMagicLinkEnabled() {
 		return model.NewAppError("UpdatePassword", "api.user.update_password.magic_link.app_error", nil, "", http.StatusBadRequest)
 	}
+
+	// Normalize Unicode to NFC before hashing, matching model.User.PreSave
+	// and checkUserPassword, so the stored hash verifies consistently
+	// regardless of which Unicode form the client's input method produces.
+	newPassword = utils.NormalizePassword(newPassword)
 
 	hashedPassword, err := hashers.Hash(newPassword)
 	if err != nil {

--- a/server/channels/utils/unicode.go
+++ b/server/channels/utils/unicode.go
@@ -13,3 +13,14 @@ import "golang.org/x/text/unicode/norm"
 func NormalizeFilename(name string) string {
 	return norm.NFC.String(name)
 }
+
+// NormalizePassword normalizes a password to NFC (composed) form before it
+// is hashed or compared against a stored hash. Without this, a password
+// containing a character that has both a precomposed and a combining-mark
+// representation (e.g. "é" as U+00E9 vs "e"+U+0301) hashes differently
+// depending on which Unicode form the input method produced, so the same
+// password can fail to verify when typed on a different device/OS/input
+// method than the one used when it was set.
+func NormalizePassword(password string) string {
+	return norm.NFC.String(password)
+}

--- a/server/public/model/user.go
+++ b/server/public/model/user.go
@@ -17,6 +17,7 @@ import (
 	"unicode/utf8"
 
 	"golang.org/x/text/language"
+	"golang.org/x/text/unicode/norm"
 
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/public/shared/timezones"
@@ -530,6 +531,14 @@ func (u *User) PreSave(hasher UserPasswordHasher) *AppError {
 	}
 
 	if u.Password != "" {
+		// Normalize to NFC before hashing so that a password containing a
+		// character with both a precomposed and a combining-mark Unicode
+		// representation (e.g. "é" as U+00E9 vs "e"+U+0301) always hashes
+		// the same way, regardless of which form the client's input
+		// method produced. checkUserPassword performs the same
+		// normalization before comparing, so this keeps hash creation and
+		// verification consistent. See PreSave doc comment.
+		u.Password = norm.NFC.String(u.Password)
 		hashed, err := hasher.Hash(u.Password)
 		if errors.Is(err, ErrPasswordTooLong) {
 			return NewAppError("User.PreSave", "model.user.pre_save.password_too_long.app_error",

--- a/server/public/model/user_test.go
+++ b/server/public/model/user_test.go
@@ -225,6 +225,33 @@ func TestUserPreSave(t *testing.T) {
 	}
 }
 
+func TestUserPreSaveNormalizesPasswordToNFC(t *testing.T) {
+	var received string
+	hasher := stubHasherFunc(func(password string) (string, error) {
+		received = password
+		return "hashed_" + password, nil
+	})
+
+	// The same visual password "café", typed two different ways:
+	//   nfc: "é" as the single precomposed codepoint U+00E9.
+	//   nfd: "e" followed by the combining acute accent U+0301, which is
+	//        what some input methods/OSes (e.g. macOS/HFS+ for filenames)
+	//        produce for the same visual character.
+	nfc := "café"
+	nfd := "café"
+	require.NotEqual(t, nfc, nfd, "the two forms must differ at the byte level for this test to be meaningful")
+
+	user := User{Password: nfd}
+	err := user.PreSave(hasher)
+	require.Nil(t, err)
+
+	// PreSave must normalize to NFC before handing the password to the
+	// hasher, so the stored hash always corresponds to the same canonical
+	// form regardless of which Unicode composition the client sent.
+	assert.Equal(t, nfc, received, "hasher should receive the NFC-normalized password")
+	assert.Equal(t, "hashed_"+nfc, user.Password)
+}
+
 func TestUserPreSavePwdTooLong(t *testing.T) {
 	hasher := stubHasherFunc(func(password string) (string, error) {
 		return "", ErrPasswordTooLong


### PR DESCRIPTION
#### Summary

Passwords are never Unicode-normalized before hashing or comparison. A character that has both a precomposed form (e.g. "é" as the single codepoint U+00E9) and a decomposed form (base letter + combining mark, e.g. "e" + U+0301) hashes to different bytes depending on which form the client's OS/input method produced. So a password set on one device can fail to verify on another device that produces the other Unicode form of the same visual password, even though the user typed exactly the same thing. Reported in #36877.

This normalizes all password hash-creation and comparison call sites to NFC:
- `model.User.PreSave` (server/public/model/user.go) — hashing at initial user creation.
- `App.UpdatePassword` (server/channels/app/user.go) — hashing on password change/reset (also covers `ResetPasswordFromToken`, which calls into this).
- `App.checkUserPassword` (server/channels/app/authentication.go) — the login-time comparison. Normalizing here also fixes `migratePassword`, which reuses this same (now-normalized) plaintext to re-hash with the latest hasher.

`golang.org/x/text/unicode/norm` is already a dependency used elsewhere in the codebase for the identical purpose on filenames (`server/channels/utils/unicode.go`'s `NormalizeFilename`, `server/public/model/file_info.go`'s `SanitizeFilename`), so this adds no new dependency. A sibling `NormalizePassword` helper was added next to `NormalizeFilename`.

**How I verified this**: traced every place a password is hashed (`hashers.Hash(...)` / `hasher.Hash(...)`) or compared (`hasher.CompareHashAndPassword(...)`) in `server/channels/app` and `server/public/model` to confirm these are the complete and only call sites — 3 hash-creation sites, 1 comparison site.

Added two tests and ran both against the unpatched code first, then against the fix:
1. `TestUserPreSaveNormalizesPasswordToNFC` (server/public/model/user_test.go) — pure logic, no DB, using the existing `stubHasherFunc` test pattern already in this file. Confirmed it fails on unpatched `PreSave` (asserts equal but gets two byte-different, visually-identical strings) and passes after the fix.
2. `TestCheckUserPasswordUnicodeNormalization` (server/channels/app/authentication_test.go) — exercises the real, unexported `checkUserPassword` method directly (not a reimplementation), covering both directions (password set with NFC/verified with NFD, and vice versa). This one does need the package's `TestMain`, which unconditionally sets up a Postgres-backed store even though `checkUserPassword` itself never touches the DB in this code path (only `migratePassword`, for legacy-hasher upgrades, does — not triggered here since both hashes are created with the current `hashers.GetLatestHasher()`). I stood up a local Postgres role/db matching `server/public/model/config.go`'s `SqlSettingsDefaultDataSource` to actually run it for real rather than skip it: confirmed it fails on unpatched code (both hash-creation and comparison reverted) and passes after the fix, then re-confirmed the fix still passes after restoring.

`go build`, `go vet`, and `gofmt -l` are clean for all touched packages.

Not run: the broader `channels/app` test suite (e.g. `TestCheckUserPassword`, `TestMigratePassword`) — only the new test was targeted via `-run`, since a full-suite run wasn't necessary to verify this specific change and is expensive in this environment.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/36877

#### Release Note

```release-note
Passwords are now normalized to Unicode NFC before being hashed or checked. Previously, a password containing a character with more than one valid Unicode representation (e.g. an accented letter typed as a single precomposed codepoint vs. a base letter plus a combining accent mark) could fail to log in from a device or input method that produced a different, but visually identical, encoding of the same password.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🔴 High

**Regression Risk:** The changes affect password creation, password updates, login verification, and password migration. Automated tests cover NFC/NFD handling and existing authentication flows, but authentication remains a critical path.

**QA Recommendation:** Run targeted manual tests for password creation, login, password changes, and password resets with NFC and NFD inputs.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->