### PR TITLE
fix(search): include "last first" order in user name search suggestions

### DIFF
--- a/webapp/channels/src/packages/mattermost-redux/src/utils/user_utils.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/utils/user_utils.test.ts
@@ -79,7 +79,7 @@ describe('user utils', () => {
             const suggestions = nameSuggestionsForUser(userObj);
             const expectedSuggestions = [
                 'test.user', '.user', 'user',
-                'test', 'user name', 'test user name', 'tester',
+                'test', 'user name', 'test user name', 'user name test', 'tester',
                 'software engineer at mattermost', 'engineer at mattermost', 'at mattermost', 'mattermost',
                 'test.user_name',
             ];
@@ -90,12 +90,24 @@ describe('user utils', () => {
             const suggestions = nameSuggestionsForUser(userObj, true);
             const expectedSuggestions = [
                 'test.user', '.user', 'user',
-                'test', 'user name', 'test user name', 'tester',
+                'test', 'user name', 'test user name', 'user name test', 'tester',
                 'software engineer at mattermost', 'engineer at mattermost', 'at mattermost', 'mattermost',
                 'test.user_name',
                 'test.user_name@example.com',
             ];
             expect(suggestions).toEqual(expectedSuggestions);
+        });
+
+        it('should include "last first" order so server-order-independent search results are not dropped client-side', () => {
+            // Regression test for https://github.com/mattermost/mattermost/issues/37865:
+            // the server matches search tokens across first/last name in
+            // either order, but the client-side suggestion list only had
+            // "first last", so a "Last First" search that the server
+            // returned a match for could still show "Nothing found" in the
+            // UI once filtered client-side.
+            const suggestions = nameSuggestionsForUser(userObj);
+            expect(suggestions).toContain('test user name'); // first + ' ' + last
+            expect(suggestions).toContain('user name test'); // last + ' ' + first
         });
 
         it('should not include full email when includeFullEmail is true but email has no @ symbol', () => {
@@ -338,6 +350,16 @@ describe('user utils', () => {
 
         it('should match by fullname fully', () => {
             expect(filterProfilesMatchingWithTerm(users, 'First Last1')).toEqual([userA]);
+        });
+
+        it('should match by fullname fully in "last first" order', () => {
+            // https://github.com/mattermost/mattermost/issues/37865: the
+            // server already matches "Last First" the same as "First Last"
+            // (see generateSearchQuery in
+            // server/channels/store/sqlstore/user_store.go), so the client
+            // filter must not drop a "Last First" query the server would
+            // have returned a match for.
+            expect(filterProfilesMatchingWithTerm(users, 'Last1 First')).toEqual([userA]);
         });
 
         it('should match by fullname case-insensitive', () => {

--- a/webapp/channels/src/packages/mattermost-redux/src/utils/user_utils.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/utils/user_utils.ts
@@ -157,7 +157,18 @@ export function nameSuggestionsForUser(user: UserProfile, includeFullEmail = fal
     const first = (user.first_name || '').toLowerCase();
     const last = (user.last_name || '').toLowerCase();
     const full = first + ' ' + last;
-    profileSuggestions.push(first, last, full);
+
+    // Also suggest "last first" order, not just "first last". The server
+    // already matches name tokens regardless of order (generateSearchQuery
+    // in server/channels/store/sqlstore/user_store.go ANDs each
+    // whitespace-split search token against an OR across username/first
+    // name/last name/nickname, so which field matches which token doesn't
+    // matter), so the client-side suggestion list should too, otherwise a
+    // successful server search can still show "Nothing found" in the UI
+    // for locales/habits where people search by surname first (e.g. "Иванов
+    // Иван" instead of "Иван Иванов").
+    const fullReversed = last + ' ' + first;
+    profileSuggestions.push(first, last, full, fullReversed);
     profileSuggestions.push((user.nickname || '').toLowerCase());
     const positionSuggestions = getSuggestionsSplitBy((user.position || '').toLowerCase(), ' ');
     profileSuggestions.push(...positionSuggestions);


### PR DESCRIPTION
#### Summary

`nameSuggestionsForUser` (in `mattermost-redux/utils/user_utils.ts`, used by the DM/people picker's client-side filtering) only ever built `first`, `last`, and `first + ' ' + last` as name suggestions. The server's own search doesn't have this limitation: `generateSearchQuery` in `server/channels/store/sqlstore/user_store.go` ANDs each whitespace-split search token against an OR across username/first name/last name/nickname, so it matches "Last First" exactly as well as "First Last" — which field matches which token doesn't matter.

That mismatch meant a query like "Иванов Иван" (surname first, as is customary in some locales) could get a real match back from `POST /api/v4/users/search`, only for the web client to filter it back out client-side and show "Nothing found", because none of the suggestion strings contained that word order as a substring.

Fixes #37865, which also correctly identified the fix location (I independently confirmed this by reading the current source of both `nameSuggestionsForUser` and the server's `generateSearchQuery` before making any change, rather than trusting the report at face value).

This adds `last + ' ' + first` as a fourth suggestion alongside the existing three.

**How I verified this**: ran the file's Jest suite (`npx jest src/packages/mattermost-redux/src/utils/user_utils.test.ts` from `webapp/channels`, after `npm install`). Added a `nameSuggestionsForUser` unit test and a `filterProfilesMatchingWithTerm` integration test that reproduces the exact reported symptom (a "Last First" query that should match a known user), and updated the two pre-existing exact-array-match tests to include the new suggestion at the position it's pushed. Ran the suite against the unpatched code first: 4 tests failed, including the new "Last1 First" search resolving to an empty array — the exact "Nothing found" symptom from the issue. Applied the fix and confirmed all 69 tests in the file pass, with no regressions in the other 65. `npx eslint` on both changed files reports no issues. Did not run a full `tsc -b` typecheck across the monorepo or the broader webapp test suite — only this file's Jest suite and lint were targeted, since that's what verifies this specific change.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/37865

#### Release Note

```release-note
Fixed the Direct Message "Find people" search so that typing a name as "Last First" (surname first) returns the same results as "First Last", matching how server-side search already worked.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change affects a shared people-search utility and a user-facing picker. Targeted tests pass, but broader webapp tests were not run.
**QA Recommendation:** Manual QA is recommended for surname-first and standard name searches in the people picker.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->