### PR TITLE
Cherry pick #36364 to release-11.7

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/notifications/at_mentions_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/notifications/at_mentions_spec.js
@@ -57,18 +57,19 @@ describe('Notifications', () => {
         const message = `@${receiver.username} I'm messaging you! ${Date.now()}`;
 
         // # Use another account to post a message @-mentioning our receiver
-        cy.postMessageAs({sender, message, channelId: otherChannel.id});
+        cy.postMessageAs({sender, message, channelId: otherChannel.id}).then(({id: postId}) => {
+            const body = `@${sender.username}: ${message}`;
 
-        const body = `@${sender.username}: ${message}`;
+            cy.get('@notifySpy').should('have.been.calledWithMatch', otherChannel.display_name, (args) => {
+                expect(args.body, `Notification body: "${args.body}" should match: "${body}"`).to.equal(body);
+                expect(args.tag, `Notification tag: "${args.tag}" should match the post id`).to.equal(postId);
+                expect(args.tag, `Notification tag: "${args.tag}" should not contain notification text`).not.to.equal(body);
+                return true;
+            });
 
-        cy.get('@notifySpy').should('have.been.calledWithMatch', otherChannel.display_name, (args) => {
-            expect(args.body, `Notification body: "${args.body}" should match: "${body}"`).to.equal(body);
-            expect(args.tag, `Notification tag: "${args.tag}" should match: "${body}"`).to.equal(body);
-            return true;
+            cy.get('@notifySpy').should('have.been.calledWithMatch',
+                otherChannel.display_name, {body, tag: postId, requireInteraction: false, silent: false});
         });
-
-        cy.get('@notifySpy').should('have.been.calledWithMatch',
-            otherChannel.display_name, {body, tag: body, requireInteraction: false, silent: false});
 
         // * Verify unread mentions badge
         cy.get(`#sidebarItem_${otherChannel.name}`).

--- a/webapp/channels/src/actions/notification_actions.test.js
+++ b/webapp/channels/src/actions/notification_actions.test.js
@@ -211,6 +211,7 @@ describe('notification_actions', () => {
                     body: '@username: Where is Jessica Hyde?',
                     requireInteraction: false,
                     silent: false,
+                    tag: 'post_id',
                     title: 'Utopia',
                     onClick: expect.any(Function),
                 });
@@ -358,6 +359,7 @@ describe('notification_actions', () => {
                     body: '@username: Where is Jessica Hyde?',
                     requireInteraction: false,
                     silent: false,
+                    tag: 'post_id',
                     title: 'Muted Channel',
                     onClick: expect.any(Function),
                 });
@@ -459,6 +461,7 @@ describe('notification_actions', () => {
                         body: '@username: Where is Jessica Hyde?',
                         requireInteraction: false,
                         silent: false,
+                        tag: 'post_id',
                         title: 'Reply in Utopia',
                         onClick: expect.any(Function),
                     });

--- a/webapp/channels/src/actions/notification_actions.tsx
+++ b/webapp/channels/src/actions/notification_actions.tsx
@@ -163,7 +163,7 @@ export function sendDesktopNotification(post: Post, msgProps: NewPostMessageProp
             return {data: {status: 'not_sent', reason: 'desktop_notification_hook', data: String(hookResult)}};
         }
 
-        const result = dispatch(notifyMe(argsAfterHooks.title, argsAfterHooks.body, channel.id, teamId, argsAfterHooks.silent, argsAfterHooks.soundName, argsAfterHooks.url));
+        const result = dispatch(notifyMe(argsAfterHooks.title, argsAfterHooks.body, channel.id, teamId, argsAfterHooks.silent, argsAfterHooks.soundName, argsAfterHooks.url, post.id));
 
         //Don't add extra sounds on native desktop clients
         if (desktopSoundEnabled && !isDesktopApp() && !isMobileApp()) {
@@ -420,10 +420,12 @@ function shouldSkipNotification(
     return undefined;
 }
 
-export function notifyMe(title: string, body: string, channelId: string, teamId: string, silent: boolean, soundName: string, url: string): ActionFuncAsync<NotificationResult> {
+export function notifyMe(title: string, body: string, channelId: string, teamId: string, silent: boolean, soundName: string, url: string, postId: string): ActionFuncAsync<NotificationResult> {
     return async (dispatch) => {
         // handle notifications in desktop app
         if (isDesktopApp()) {
+            // The notification-tag leak only affects Chromium-based browser notifications,
+            // so the desktop app path does not need the opaque post id.
             const result = await DesktopApp.dispatchNotification(title, body, channelId, teamId, silent, soundName, url);
             return {data: result};
         }
@@ -432,6 +434,8 @@ export function notifyMe(title: string, body: string, channelId: string, teamId:
             const result = await dispatch(showNotification({
                 title,
                 body,
+
+                tag: postId,
                 requireInteraction: false,
                 silent,
                 onClick: () => {

--- a/webapp/channels/src/utils/notifications.test.ts
+++ b/webapp/channels/src/utils/notifications.test.ts
@@ -93,7 +93,7 @@ describe('Notifications.showNotification', () => {
         const call = window.Notification.mock.calls[0];
         expect(call[1]).toEqual({
             body: 'body',
-            tag: 'body',
+            tag: '',
             icon: '',
             requireInteraction: true,
             silent: false,
@@ -119,11 +119,65 @@ describe('Notifications.showNotification', () => {
         const call = window.Notification.mock.calls[0];
         expect(call[1]).toEqual({
             body: 'body',
-            tag: 'body',
+            tag: '',
             icon: '',
             requireInteraction: true,
             silent: false,
         });
+    });
+
+    it('should not leak notification text via the Notifications API tag when no tag is provided', async () => {
+        // The Notifications API tag is serialised into the activation command line on Chromium
+        // and captured by EDR / SIEM tooling. The tag must therefore never carry message content.
+        window.Notification.permission = 'granted';
+        jest.resetModules();
+        Notifications = require('utils/notifications');
+
+        const sensitiveBody = '@alice: token=AKIA-SECRET-VALUE confidential incident details';
+        const visibleTitle = '@alice posted in Town Square';
+
+        await store.dispatch(Notifications.showNotification({
+            title: visibleTitle,
+            body: sensitiveBody,
+            requireInteraction: false,
+            silent: false,
+        }));
+
+        expect(window.Notification).toHaveBeenCalledTimes(1);
+        const options = window.Notification.mock.calls[0][1];
+        expect(options.body).toBe(sensitiveBody);
+        expect(options.tag).not.toContain('AKIA-SECRET-VALUE');
+        expect(options.tag).not.toContain('token=');
+        expect(options.tag).not.toContain(visibleTitle);
+        expect(options.tag).toBe('');
+    });
+
+    it('should use the explicit tag identifier when the caller provides one', async () => {
+        // When a stable opaque id is passed, it must be used verbatim so that
+        // subsequent updates to the same message replace the previous notification, and
+        // so that no user-visible text leaks into the tag field at all.
+        window.Notification.permission = 'granted';
+        jest.resetModules();
+        Notifications = require('utils/notifications');
+
+        const sensitiveBody = '@bob: AWS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY';
+        const visibleTitle = '@bob posted in #incident-response';
+        const postId = 'post-9bg7p4dyitggimxtxctt7gwp4y';
+
+        await store.dispatch(Notifications.showNotification({
+            title: visibleTitle,
+            body: sensitiveBody,
+            tag: postId,
+            requireInteraction: false,
+            silent: false,
+        }));
+
+        expect(window.Notification).toHaveBeenCalledTimes(1);
+        const options = window.Notification.mock.calls[0][1];
+        expect(options.tag).toBe(postId);
+        expect(options.tag).not.toContain('AWS_SECRET_ACCESS_KEY');
+        expect(options.tag).not.toContain(visibleTitle);
+        expect(options.body).toBe(sensitiveBody);
     });
 
     it('should do nothing if permissions previously requested but not granted', async () => {

--- a/webapp/channels/src/utils/notifications.ts
+++ b/webapp/channels/src/utils/notifications.ts
@@ -25,6 +25,14 @@ let requestedNotificationPermission = Boolean('Notification' in window && Notifi
 export interface ShowNotificationParams {
     title: string;
     body: string;
+
+    /**
+     * Opaque, non-content identifier used as the Web Notifications API tag.
+     * Callers may pass a stable id when they need replacement semantics. When
+     * omitted, the tag is left empty so no user-visible notification text reaches
+     * the tag field (see #36297 / MM-68537).
+     */
+    tag?: string;
     requireInteraction: boolean;
     silent: boolean;
     onClick?: (this: Notification, e: Event) => any | null;
@@ -34,6 +42,7 @@ export function showNotification(
     {
         title,
         body,
+        tag,
         requireInteraction,
         silent,
         onClick,
@@ -78,7 +87,15 @@ export function showNotification(
 
         const notification = new Notification(title, {
             body,
-            tag: body,
+
+            // Use the explicit opaque tag when the caller provides one; otherwise keep it empty.
+            // Notification text must never reach the tag field:
+            // Chromium-based browsers serialise tag into the notification
+            // activation command line via --notification-launch-id
+            // (https://notifications.spec.whatwg.org/#dom-notification-tag), where endpoint
+            // detection tools log it and ship it to customer SIEM pipelines that were never in
+            // scope to receive chat content. See #36297 / MM-68537.
+            tag: tag ?? '',
             icon,
             requireInteraction,
             silent,


### PR DESCRIPTION
#### Summary

Cherry-pick of https://github.com/mattermost/mattermost/pull/36364 onto `release-11.7`.

`showNotification` was passing rendered chat text into the Web Notifications API `tag` option. Chromium-based browsers serialize `tag` into the notification activation command line, where endpoint tooling can capture it.

This change keeps user-visible text in `options.body`, but uses an opaque post id as the browser notification tag when a post is available. Calls that do not pass an explicit tag keep the tag empty, so notification text is not copied into the tag field.

Conflict resolution on this branch: kept the release-11.7 Edge-specific notification icon path while applying the opaque `tag` fix.

##### Verification

- `npm test --workspace=channels -- src/actions/notification_actions.test.js --runInBand`
- `npm test --workspace=channels -- src/utils/notifications.test.ts --runInBand`
- Confirm browser notifications still show expected title/body, and `tag` is either empty or the post id (not message text)

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/36297
Fixes: https://mattermost.atlassian.net/browse/MM-68537

#### Screenshots

N/A

#### Release Note

```release-note
Fixed a webapp issue that caused private chat message content to be copied into the Web Notifications API `tag` option, where Chromium-based browsers can expose it through notification activation metadata.
```