### PR TITLE
Automated cherry pick of #37749

### DIFF
--- a/server/channels/store/sqlstore/team_store.go
+++ b/server/channels/store/sqlstore/team_store.go
@@ -541,7 +541,7 @@ func (s SqlTeamStore) teamSearchQuery(opts *model.TeamSearch, countQuery bool) s
 		if teamFilters == nil {
 			teamFilters = groupConstrainedFilter
 		} else {
-			teamFilters = sq.Or{teamFilters, groupConstrainedFilter}
+			teamFilters = sq.And{teamFilters, groupConstrainedFilter}
 		}
 	}
 
@@ -615,6 +615,10 @@ func (s SqlTeamStore) SearchAllPaged(opts *model.TeamSearch) ([]*model.Team, int
 func (s SqlTeamStore) SearchOpen(opts *model.TeamSearch) ([]*model.Team, error) {
 	opts.TeamType = new("O")
 	opts.AllowOpenInvite = new(true)
+	// GroupConstrained is caller-controlled and must never be allowed to
+	// widen this mandatory public-only restriction, so reset it here
+	// regardless of what the caller passed in.
+	opts.GroupConstrained = nil
 	return s.SearchAll(opts)
 }
 
@@ -623,6 +627,10 @@ func (s SqlTeamStore) SearchOpen(opts *model.TeamSearch) ([]*model.Team, error) 
 func (s SqlTeamStore) SearchPrivate(opts *model.TeamSearch) ([]*model.Team, error) {
 	opts.TeamType = new("O")
 	opts.AllowOpenInvite = new(false)
+	// GroupConstrained is caller-controlled and must never be allowed to
+	// widen this mandatory private-only restriction, so reset it here
+	// regardless of what the caller passed in.
+	opts.GroupConstrained = nil
 	return s.SearchAll(opts)
 }
 

--- a/server/channels/store/storetest/team_store.go
+++ b/server/channels/store/storetest/team_store.go
@@ -502,28 +502,28 @@ func testTeamStoreSearchAll(t *testing.T, rctx request.CTX, ss store.Store) {
 			[]string{o.Id, p.Id},
 		},
 		{
-			"Search for all 3 teams filter by allow open invite and include group constrained",
+			"Search for all 3 teams filter by allow open invite and group constrained must intersect, not union",
 			&model.TeamSearch{Term: "searchterm", AllowOpenInvite: new(true), GroupConstrained: new(true)},
-			2,
-			[]string{o.Id, g.Id},
+			0,
+			[]string{},
 		},
 		{
-			"Search for all 3 teams filter by group constrained and not open invite",
+			"Search for all 3 teams filter by group constrained and not open invite must intersect, not union",
 			&model.TeamSearch{Term: "searchterm", GroupConstrained: new(true), AllowOpenInvite: new(false)},
-			2,
-			[]string{g.Id, p.Id},
+			0,
+			[]string{},
 		},
 		{
-			"Search for all 3 teams filter by group constrained false and open invite",
+			"Search for all 3 teams filter by group constrained false and open invite must intersect, not union",
 			&model.TeamSearch{Term: "searchterm", GroupConstrained: new(false), AllowOpenInvite: new(true)},
-			2,
-			[]string{o.Id, p.Id},
+			1,
+			[]string{o.Id},
 		},
 		{
-			"Search for all 3 teams filter by group constrained false and open invite false",
+			"Search for all 3 teams filter by group constrained false and open invite false must intersect, not union",
 			&model.TeamSearch{Term: "searchterm", GroupConstrained: new(false), AllowOpenInvite: new(false)},
-			2,
-			[]string{p.Id, o.Id},
+			1,
+			[]string{p.Id},
 		},
 		{
 			"Search for teams which are not part of a data retention policy",
@@ -651,6 +651,19 @@ func testTeamStoreSearchOpen(t *testing.T, rctx request.CTX, ss store.Store) {
 			}
 		})
 	}
+
+	t.Run("Search for a private team with GroupConstrained explicitly false must not bypass the open-invite restriction", func(t *testing.T) {
+		r1, err := ss.Team().SearchOpen(&model.TeamSearch{Term: p.DisplayName, GroupConstrained: new(false)})
+		require.NoError(t, err)
+		require.Empty(t, r1)
+	})
+
+	t.Run("Search for an open team with GroupConstrained explicitly set must still return it, proving GroupConstrained is reset rather than merely intersected", func(t *testing.T) {
+		r1, err := ss.Team().SearchOpen(&model.TeamSearch{Term: o.DisplayName, GroupConstrained: new(true)})
+		require.NoError(t, err)
+		require.Len(t, r1, 1)
+		assert.Equal(t, o.Id, r1[0].Id)
+	})
 }
 
 func testTeamStoreSearchPrivate(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -757,6 +770,19 @@ func testTeamStoreSearchPrivate(t *testing.T, rctx request.CTX, ss store.Store) 
 			}
 		})
 	}
+
+	t.Run("Search for an open team with GroupConstrained explicitly set must not bypass the private-only restriction", func(t *testing.T) {
+		r1, err := ss.Team().SearchPrivate(&model.TeamSearch{Term: o.DisplayName, GroupConstrained: new(false)})
+		require.NoError(t, err)
+		require.Empty(t, r1)
+	})
+
+	t.Run("Search for a private team with GroupConstrained explicitly set must still return it, proving GroupConstrained is reset rather than merely intersected", func(t *testing.T) {
+		r1, err := ss.Team().SearchPrivate(&model.TeamSearch{Term: p.DisplayName, GroupConstrained: new(true)})
+		require.NoError(t, err)
+		require.Len(t, r1, 1)
+		assert.Equal(t, p.Id, r1[0].Id)
+	})
 }
 
 func testTeamStoreGetByInviteId(t *testing.T, rctx request.CTX, ss store.Store) {


### PR DESCRIPTION
Cherry pick of #37749 on release-11.9.

/cc  @edgarbellot

```release-note
NONE
```