### PR TITLE
Automated cherry pick of #37749

### DIFF
--- a/server/channels/store/sqlstore/team_store.go
+++ b/server/channels/store/sqlstore/team_store.go
@@ -519,7 +519,7 @@ func (s SqlTeamStore) teamSearchQuery(opts *model.TeamSearch, countQuery bool) s
 		if teamFilters == nil {
 			teamFilters = groupConstrainedFilter
 		} else {
-			teamFilters = sq.Or{teamFilters, groupConstrainedFilter}
+			teamFilters = sq.And{teamFilters, groupConstrainedFilter}
 		}
 	}
 
@@ -581,6 +581,10 @@ func (s SqlTeamStore) SearchAllPaged(opts *model.TeamSearch) ([]*model.Team, int
 func (s SqlTeamStore) SearchOpen(opts *model.TeamSearch) ([]*model.Team, error) {
 	opts.TeamType = model.NewPointer("O")
 	opts.AllowOpenInvite = model.NewPointer(true)
+	// GroupConstrained is caller-controlled and must never be allowed to
+	// widen this mandatory public-only restriction, so reset it here
+	// regardless of what the caller passed in.
+	opts.GroupConstrained = nil
 	return s.SearchAll(opts)
 }
 
@@ -589,6 +593,10 @@ func (s SqlTeamStore) SearchOpen(opts *model.TeamSearch) ([]*model.Team, error) 
 func (s SqlTeamStore) SearchPrivate(opts *model.TeamSearch) ([]*model.Team, error) {
 	opts.TeamType = model.NewPointer("O")
 	opts.AllowOpenInvite = model.NewPointer(false)
+	// GroupConstrained is caller-controlled and must never be allowed to
+	// widen this mandatory private-only restriction, so reset it here
+	// regardless of what the caller passed in.
+	opts.GroupConstrained = nil
 	return s.SearchAll(opts)
 }
 

--- a/server/channels/store/storetest/team_store.go
+++ b/server/channels/store/storetest/team_store.go
@@ -391,28 +391,28 @@ func testTeamStoreSearchAll(t *testing.T, rctx request.CTX, ss store.Store) {
 			[]string{o.Id, p.Id},
 		},
 		{
-			"Search for all 3 teams filter by allow open invite and include group constrained",
+			"Search for all 3 teams filter by allow open invite and group constrained must intersect, not union",
 			&model.TeamSearch{Term: "searchterm", AllowOpenInvite: model.NewPointer(true), GroupConstrained: model.NewPointer(true)},
-			2,
-			[]string{o.Id, g.Id},
+			0,
+			[]string{},
 		},
 		{
-			"Search for all 3 teams filter by group constrained and not open invite",
+			"Search for all 3 teams filter by group constrained and not open invite must intersect, not union",
 			&model.TeamSearch{Term: "searchterm", GroupConstrained: model.NewPointer(true), AllowOpenInvite: model.NewPointer(false)},
-			2,
-			[]string{g.Id, p.Id},
+			0,
+			[]string{},
 		},
 		{
-			"Search for all 3 teams filter by group constrained false and open invite",
+			"Search for all 3 teams filter by group constrained false and open invite must intersect, not union",
 			&model.TeamSearch{Term: "searchterm", GroupConstrained: model.NewPointer(false), AllowOpenInvite: model.NewPointer(true)},
-			2,
-			[]string{o.Id, p.Id},
+			1,
+			[]string{o.Id},
 		},
 		{
-			"Search for all 3 teams filter by group constrained false and open invite false",
+			"Search for all 3 teams filter by group constrained false and open invite false must intersect, not union",
 			&model.TeamSearch{Term: "searchterm", GroupConstrained: model.NewPointer(false), AllowOpenInvite: model.NewPointer(false)},
-			2,
-			[]string{p.Id, o.Id},
+			1,
+			[]string{p.Id},
 		},
 		{
 			"Search for teams which are not part of a data retention policy",
@@ -540,6 +540,19 @@ func testTeamStoreSearchOpen(t *testing.T, rctx request.CTX, ss store.Store) {
 			}
 		})
 	}
+
+	t.Run("Search for a private team with GroupConstrained explicitly false must not bypass the open-invite restriction", func(t *testing.T) {
+		r1, err := ss.Team().SearchOpen(&model.TeamSearch{Term: p.DisplayName, GroupConstrained: model.NewPointer(false)})
+		require.NoError(t, err)
+		require.Empty(t, r1)
+	})
+
+	t.Run("Search for an open team with GroupConstrained explicitly set must still return it, proving GroupConstrained is reset rather than merely intersected", func(t *testing.T) {
+		r1, err := ss.Team().SearchOpen(&model.TeamSearch{Term: o.DisplayName, GroupConstrained: model.NewPointer(true)})
+		require.NoError(t, err)
+		require.Len(t, r1, 1)
+		assert.Equal(t, o.Id, r1[0].Id)
+	})
 }
 
 func testTeamStoreSearchPrivate(t *testing.T, rctx request.CTX, ss store.Store) {
@@ -646,6 +659,19 @@ func testTeamStoreSearchPrivate(t *testing.T, rctx request.CTX, ss store.Store) 
 			}
 		})
 	}
+
+	t.Run("Search for an open team with GroupConstrained explicitly set must not bypass the private-only restriction", func(t *testing.T) {
+		r1, err := ss.Team().SearchPrivate(&model.TeamSearch{Term: o.DisplayName, GroupConstrained: model.NewPointer(false)})
+		require.NoError(t, err)
+		require.Empty(t, r1)
+	})
+
+	t.Run("Search for a private team with GroupConstrained explicitly set must still return it, proving GroupConstrained is reset rather than merely intersected", func(t *testing.T) {
+		r1, err := ss.Team().SearchPrivate(&model.TeamSearch{Term: p.DisplayName, GroupConstrained: model.NewPointer(true)})
+		require.NoError(t, err)
+		require.Len(t, r1, 1)
+		assert.Equal(t, p.Id, r1[0].Id)
+	})
 }
 
 func testTeamStoreGetByInviteId(t *testing.T, rctx request.CTX, ss store.Store) {


### PR DESCRIPTION
#### Summary
Cherry pick of #37749 on release-11.7.

#### Conflict Resolution Changes
- Kept release-11.7's existing `model.NewPointer(...)` pointer helper style (the branch predates the `new(...)` builtin refactor) while applying the PR's actual logic changes: `sq.Or` → `sq.And` for combining team filters, and resetting `GroupConstrained` in `SearchOpen`/`SearchPrivate`.
- Kept release-11.7's existing `SearchPrivate` behavior (`TeamType = "O"`) untouched, since that's from an unrelated, not-yet-backported PR and outside the scope of this cherry pick.

#### Release Note
```release-note
NONE
```