### PR TITLE
Log an error instead of refusing to start on unsupported Postgres, Elasticsearch, and OpenSearch versions (#37929)

### DIFF
--- a/server/channels/store/sqlstore/migrate.go
+++ b/server/channels/store/sqlstore/migrate.go
@@ -47,8 +47,7 @@ func NewMigrator(settings model.SqlSettings, logger mlog.LoggerIFace, dryRun boo
 		return nil, fmt.Errorf("error while getting DB version: %w", err)
 	}
 
-	ok, err := ss.ensureMinimumDBVersion(ver)
-	if !ok {
+	if err = ss.checkVersion(ver); err != nil {
 		return nil, fmt.Errorf("error while checking DB version: %w", err)
 	}
 

--- a/server/channels/store/sqlstore/store.go
+++ b/server/channels/store/sqlstore/store.go
@@ -224,8 +224,7 @@ func New(settings model.SqlSettings, logger mlog.LoggerIFace, metrics einterface
 		return nil, errors.Wrap(err, "error while getting DB version")
 	}
 
-	ok, err := store.ensureMinimumDBVersion(ver)
-	if !ok {
+	if err = store.checkVersion(ver); err != nil {
 		return nil, errors.Wrap(err, "error while checking DB version")
 	}
 
@@ -989,27 +988,38 @@ func IsDuplicate(err error) bool {
 	return false
 }
 
-// ensureMinimumDBVersion gets the DB version and ensures it is
-// above the required minimum version requirements.
-func (ss *SqlStore) ensureMinimumDBVersion(ver string) (bool, error) {
+// checkVersion returns an error if the given Postgres version cannot be
+// determined. An unsupported version is only logged: running one is discouraged,
+// but not prevented.
+func (ss *SqlStore) checkVersion(ver string) error {
 	intVer, err := strconv.Atoi(ver)
 	if err != nil {
-		return false, fmt.Errorf("cannot parse DB version: %v", err)
+		return fmt.Errorf("cannot parse DB version: %v", err)
 	}
+
 	if intVer < minimumRequiredPostgresVersion {
-		return false, fmt.Errorf("minimum Postgres version requirements not met. Found: %s, Wanted: %s", versionString(intVer), versionString(minimumRequiredPostgresVersion))
+		ss.logger.Error("Unsupported Postgres version. Running an unsupported version may lead to unexpected behaviour.",
+			mlog.String("version", versionString(intVer)),
+			mlog.String("min_version", versionString(minimumRequiredPostgresVersion)),
+		)
 	}
-	return true, nil
+
+	return nil
 }
 
 // versionString converts an integer representation of a Postgres DB version
 // to a pretty-printed string.
-// Postgres doesn't follow three-part version numbers from 10.0 onwards:
+// From 10.0 onwards, the version is the major version multiplied by 10000 plus
+// the minor version, e.g. 10.1 is 100001. Prior to 10, the version used two
+// digits for each of the three parts, e.g. 9.1.5 is 90105:
 // https://www.postgresql.org/docs/13/libpq-status.html#LIBPQ-PQSERVERVERSION.
 func versionString(v int) string {
-	minor := v % 10000
 	major := v / 10000
-	return strconv.Itoa(major) + "." + strconv.Itoa(minor)
+	if major < 10 {
+		return fmt.Sprintf("%d.%d.%d", major, (v/100)%100, v%100)
+	}
+
+	return fmt.Sprintf("%d.%d", major, v%10000)
 }
 
 func (ss *SqlStore) toReserveCase(str string) string {

--- a/server/channels/store/sqlstore/store_test.go
+++ b/server/channels/store/sqlstore/store_test.go
@@ -525,58 +525,48 @@ func TestGetDbVersion(t *testing.T) {
 	}
 }
 
-func TestEnsureMinimumDBVersion(t *testing.T) {
+func TestCheckVersion(t *testing.T) {
 	if enableFullyParallelTests {
 		t.Parallel()
 	}
 
 	tests := []struct {
-		driver string
-		ver    string
-		ok     bool
-		err    string
+		ver            string
+		wantErr        string
+		wantLog        string
+		wantVersion    string
+		wantMinVersion string
 	}{
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "110001",
-			ok:     false,
-			err:    "",
+			ver:            "110001",
+			wantLog:        "Unsupported Postgres version",
+			wantVersion:    "11.1",
+			wantMinVersion: "14.0",
 		},
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "130001",
-			ok:     false,
-			err:    "",
+			ver:            "130001",
+			wantLog:        "Unsupported Postgres version",
+			wantVersion:    "13.1",
+			wantMinVersion: "14.0",
 		},
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "140000",
-			ok:     true,
-			err:    "",
+			ver: "140000",
 		},
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "141900",
-			ok:     true,
-			err:    "",
+			ver: "140019",
 		},
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "150000",
-			ok:     true,
-			err:    "",
+			ver: "150000",
 		},
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "90603",
-			ok:     false,
-			err:    "minimum Postgres version requirements not met",
+			ver:            "90603",
+			wantLog:        "Unsupported Postgres version",
+			wantVersion:    "9.6.3",
+			wantMinVersion: "14.0",
 		},
 		{
-			driver: model.DatabaseDriverPostgres,
-			ver:    "12.34.1",
-			ok:     false,
-			err:    "cannot parse DB version",
+			ver:     "12.34.1",
+			wantErr: "cannot parse DB version",
 		},
 	}
 
@@ -585,13 +575,36 @@ func TestEnsureMinimumDBVersion(t *testing.T) {
 		DriverName: &pg,
 	}
 	for _, tc := range tests {
-		store := &SqlStore{}
-		store.settings = pgSettings
-		ok, err := store.ensureMinimumDBVersion(tc.ver)
-		assert.Equal(t, tc.ok, ok, "driver: %s, version: %s", tc.driver, tc.ver)
-		if tc.err != "" {
-			assert.Contains(t, err.Error(), tc.err)
-		}
+		t.Run(tc.ver, func(t *testing.T) {
+			logger := mlog.CreateConsoleTestLogger(t)
+			var buf mlog.Buffer
+			require.NoError(t, mlog.AddWriterTarget(logger, &buf, true, mlog.LvlError))
+
+			store := &SqlStore{}
+			store.settings = pgSettings
+			store.logger = logger
+
+			err := store.checkVersion(tc.ver)
+			require.NoError(t, logger.Flush())
+
+			if tc.wantErr != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tc.wantErr)
+				return
+			}
+			require.NoError(t, err)
+
+			if tc.wantLog == "" {
+				assert.Empty(t, buf.String())
+				return
+			}
+
+			assert.Contains(t, buf.String(), tc.wantLog)
+			assert.Contains(t, buf.String(), fmt.Sprintf(`"version":%q`, tc.wantVersion))
+			if tc.wantMinVersion != "" {
+				assert.Contains(t, buf.String(), fmt.Sprintf(`"min_version":%q`, tc.wantMinVersion))
+			}
+		})
 	}
 }
 
@@ -773,17 +786,38 @@ func TestVersionString(t *testing.T) {
 		},
 		{
 			input:  90603,
-			output: "9.603",
+			output: "9.6.3",
 		},
 		{
 			input:  120005,
 			output: "12.5",
 		},
+		// Examples given by the PQserverVersion documentation.
+		{
+			input:  100001,
+			output: "10.1",
+		},
+		{
+			input:  110000,
+			output: "11.0",
+		},
+		{
+			input:  90105,
+			output: "9.1.5",
+		},
+		{
+			input:  90200,
+			output: "9.2.0",
+		},
+		{
+			input:  140019,
+			output: "14.19",
+		},
 	}
 
 	for _, v := range versions {
 		out := versionString(v.input)
-		assert.Equal(t, v.output, out)
+		assert.Equal(t, v.output, out, "input: %d", v.input)
 	}
 }
 

--- a/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
+++ b/server/enterprise/elasticsearch/elasticsearch/elasticsearch.go
@@ -147,7 +147,7 @@ func (es *ElasticsearchInterfaceImpl) IsIndexingSync() bool {
 
 // fetchServerInfo retrieves and stores the server version and plugins from the given client.
 func (es *ElasticsearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *elastic.TypedClient) *model.AppError {
-	version, major, appErr := checkVersion(ctx, client)
+	version, major, appErr := checkVersion(ctx, client, es.Platform.Log())
 	if appErr != nil {
 		return appErr
 	}
@@ -2240,7 +2240,10 @@ func (es *ElasticsearchInterfaceImpl) DeleteFilesBatch(rctx request.CTX, endTime
 	return nil
 }
 
-func checkVersion(ctx context.Context, client *elastic.TypedClient) (string, int, *model.AppError) {
+// checkVersion returns the version of the connected Elasticsearch server. An
+// unsupported version is logged but not treated as fatal, allowing the server to
+// start regardless.
+func checkVersion(ctx context.Context, client *elastic.TypedClient, logger mlog.LoggerIFace) (string, int, *model.AppError) {
 	resp, err := client.API.Core.Info().Do(ctx)
 	if err != nil {
 		return "", 0, model.NewAppError("Elasticsearch.checkVersion", "ent.elasticsearch.start.get_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError).Wrap(err)
@@ -2251,11 +2254,13 @@ func checkVersion(ctx context.Context, client *elastic.TypedClient) (string, int
 		return "", 0, model.NewAppError("Elasticsearch.checkVersion", "ent.elasticsearch.start.parse_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusInternalServerError).Wrap(esErr)
 	}
 
-	if major < elasticsearchMinVersion {
-		return "", 0, model.NewAppError("Elasticsearch.checkVersion", "ent.elasticsearch.min_version.app_error", map[string]any{"Version": major, "MinVersion": elasticsearchMinVersion, "Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusBadRequest)
+	if major < elasticsearchMinVersion || major > elasticsearchMaxVersion {
+		logger.Error("Unsupported Elasticsearch version. Running an unsupported version may lead to unexpected behaviour.",
+			mlog.String("version", resp.Version.Int),
+			mlog.Int("min_version", elasticsearchMinVersion),
+			mlog.Int("max_version", elasticsearchMaxVersion),
+		)
 	}
-	if major > elasticsearchMaxVersion {
-		return "", 0, model.NewAppError("Elasticsearch.checkVersion", "ent.elasticsearch.max_version.app_error", map[string]any{"Version": major, "MaxVersion": elasticsearchMaxVersion, "Backend": model.ElasticsearchSettingsESBackend}, "", http.StatusBadRequest)
-	}
+
 	return resp.Version.Int, major, nil
 }

--- a/server/enterprise/elasticsearch/opensearch/check_version_test.go
+++ b/server/enterprise/elasticsearch/opensearch/check_version_test.go
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.enterprise for license information.
 
-package elasticsearch
+package opensearch
 
 import (
 	"context"
@@ -10,20 +10,24 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	elastic "github.com/elastic/go-elasticsearch/v8"
+	"github.com/opensearch-project/opensearch-go/v4"
+	"github.com/opensearch-project/opensearch-go/v4/opensearchapi"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
-func newTestClient(t *testing.T, handler http.Handler) *elastic.TypedClient {
+func newTestClient(t *testing.T, handler http.Handler) *opensearchapi.Client {
 	t.Helper()
 	ts := httptest.NewServer(handler)
 	t.Cleanup(ts.Close)
 
-	client, err := elastic.NewTypedClient(elastic.Config{
-		Addresses: []string{ts.URL},
+	client, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: opensearch.Config{
+			Addresses:  []string{ts.URL},
+			MaxRetries: 0,
+		},
 	})
 	require.NoError(t, err)
 	return client
@@ -32,8 +36,7 @@ func newTestClient(t *testing.T, handler http.Handler) *elastic.TypedClient {
 func infoHandler(version string) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.Header().Set("X-Elastic-Product", "Elasticsearch")
-		fmt.Fprintf(w, `{"cluster_name":"test","version":{"number":%q,"build_flavor":"default","build_hash":"abc","build_date":"2024-01-01","build_snapshot":false,"build_type":"docker","lucene_version":"9.0.0","minimum_wire_compatibility_version":"7.0.0","minimum_index_compatibility_version":"7.0.0"}}`, version)
+		fmt.Fprintf(w, `{"name":"node","cluster_name":"test","cluster_uuid":"abc","version":{"distribution":"opensearch","number":%q,"build_type":"tar","build_hash":"abc","build_date":"2024-01-01","build_snapshot":false,"lucene_version":"9.7.0","minimum_wire_compatibility_version":"7.10.0","minimum_index_compatibility_version":"7.0.0"},"tagline":"The OpenSearch Project: https://opensearch.org/"}`, version)
 	}
 }
 
@@ -47,29 +50,22 @@ func TestCheckVersion(t *testing.T) {
 		wantUnsupported bool
 	}{
 		{
-			name:        "ES 8 is supported",
-			version:     "8.9.0",
-			wantVersion: "8.9.0",
-			wantMajor:   8,
+			name:        "OpenSearch 2 is supported",
+			version:     "2.11.0",
+			wantVersion: "2.11.0",
+			wantMajor:   2,
 		},
 		{
-			name:        "ES 9 is supported",
-			version:     "9.0.0",
-			wantVersion: "9.0.0",
-			wantMajor:   9,
+			name:        "OpenSearch 3 is supported",
+			version:     "3.0.0",
+			wantVersion: "3.0.0",
+			wantMajor:   3,
 		},
 		{
-			name:            "ES 7 is too old, but allowed",
-			version:         "7.17.0",
-			wantVersion:     "7.17.0",
-			wantMajor:       7,
-			wantUnsupported: true,
-		},
-		{
-			name:            "ES 10 is too new, but allowed",
-			version:         "10.0.0",
-			wantVersion:     "10.0.0",
-			wantMajor:       10,
+			name:            "OpenSearch 4 is too new, but allowed",
+			version:         "4.0.0",
+			wantVersion:     "4.0.0",
+			wantMajor:       4,
 			wantUnsupported: true,
 		},
 		{
@@ -99,10 +95,9 @@ func TestCheckVersion(t *testing.T) {
 			assert.Equal(t, tc.wantVersion, version)
 			assert.Equal(t, tc.wantMajor, major)
 			if tc.wantUnsupported {
-				assert.Contains(t, buf.String(), "Unsupported Elasticsearch version")
+				assert.Contains(t, buf.String(), "Unsupported OpenSearch version")
 				assert.Contains(t, buf.String(), fmt.Sprintf(`"version":%q`, tc.wantVersion))
-				assert.Contains(t, buf.String(), `"min_version":8`)
-				assert.Contains(t, buf.String(), `"max_version":9`)
+				assert.Contains(t, buf.String(), `"max_version":3`)
 			} else {
 				assert.Empty(t, buf.String())
 			}
@@ -114,9 +109,11 @@ func TestCheckVersionConnectionError(t *testing.T) {
 	ts := httptest.NewServer(http.NotFoundHandler())
 	ts.Close() // close immediately to force connection error
 
-	client, err := elastic.NewTypedClient(elastic.Config{
-		Addresses:  []string{ts.URL},
-		MaxRetries: 0,
+	client, err := opensearchapi.NewClient(opensearchapi.Config{
+		Client: opensearch.Config{
+			Addresses:  []string{ts.URL},
+			MaxRetries: 0,
+		},
 	})
 	require.NoError(t, err)
 

--- a/server/enterprise/elasticsearch/opensearch/check_version_test.go
+++ b/server/enterprise/elasticsearch/opensearch/check_version_test.go
@@ -56,10 +56,11 @@ func TestCheckVersion(t *testing.T) {
 			wantMajor:   2,
 		},
 		{
-			name:        "OpenSearch 3 is supported",
-			version:     "3.0.0",
-			wantVersion: "3.0.0",
-			wantMajor:   3,
+			name:            "OpenSearch 3 is too new, but allowed",
+			version:         "3.0.0",
+			wantVersion:     "3.0.0",
+			wantMajor:       3,
+			wantUnsupported: true,
 		},
 		{
 			name:            "OpenSearch 4 is too new, but allowed",
@@ -97,7 +98,7 @@ func TestCheckVersion(t *testing.T) {
 			if tc.wantUnsupported {
 				assert.Contains(t, buf.String(), "Unsupported OpenSearch version")
 				assert.Contains(t, buf.String(), fmt.Sprintf(`"version":%q`, tc.wantVersion))
-				assert.Contains(t, buf.String(), `"max_version":3`)
+				assert.Contains(t, buf.String(), fmt.Sprintf(`"max_version":%d`, opensearchMaxVersion))
 			} else {
 				assert.Empty(t, buf.String())
 			}

--- a/server/enterprise/elasticsearch/opensearch/opensearch.go
+++ b/server/enterprise/elasticsearch/opensearch/opensearch.go
@@ -108,7 +108,7 @@ func (os *OpensearchInterfaceImpl) IsIndexingSync() bool {
 
 // fetchServerInfo retrieves and stores the server version and plugins from the given client.
 func (os *OpensearchInterfaceImpl) fetchServerInfo(ctx context.Context, client *opensearchapi.Client) *model.AppError {
-	version, major, appErr := checkMaxVersion(ctx, client)
+	version, major, appErr := checkVersion(ctx, client, os.Platform.Log())
 	if appErr != nil {
 		return appErr
 	}
@@ -2322,19 +2322,26 @@ func (os *OpensearchInterfaceImpl) DeleteFilesBatch(rctx request.CTX, endTime, l
 	return nil
 }
 
-func checkMaxVersion(ctx context.Context, client *opensearchapi.Client) (string, int, *model.AppError) {
+// checkVersion returns the version of the connected OpenSearch server. An
+// unsupported version is logged but not treated as fatal, allowing the server to
+// start regardless.
+func checkVersion(ctx context.Context, client *opensearchapi.Client, logger mlog.LoggerIFace) (string, int, *model.AppError) {
 	resp, err := client.Info(ctx, nil)
 	if err != nil {
-		return "", 0, model.NewAppError("Opensearch.checkMaxVersion", "ent.elasticsearch.start.get_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
+		return "", 0, model.NewAppError("Opensearch.checkVersion", "ent.elasticsearch.start.get_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	major, _, _, esErr := common.GetVersionComponents(resp.Version.Number)
 	if esErr != nil {
-		return "", 0, model.NewAppError("Opensearch.checkMaxVersion", "ent.elasticsearch.start.parse_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(err)
+		return "", 0, model.NewAppError("Opensearch.checkVersion", "ent.elasticsearch.start.parse_server_version.app_error", map[string]any{"Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusInternalServerError).Wrap(esErr)
 	}
 
 	if major > opensearchMaxVersion {
-		return "", 0, model.NewAppError("Opensearch.checkMaxVersion", "ent.elasticsearch.max_version.app_error", map[string]any{"Version": major, "MaxVersion": opensearchMaxVersion, "Backend": model.ElasticsearchSettingsOSBackend}, "", http.StatusBadRequest)
+		logger.Error("Unsupported OpenSearch version. Running an unsupported version may lead to unexpected behaviour.",
+			mlog.String("version", resp.Version.Number),
+			mlog.Int("max_version", opensearchMaxVersion),
+		)
 	}
+
 	return resp.Version.Number, major, nil
 }

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -9521,14 +9521,6 @@
     "translation": "Trying to index a new batch when all the entities are completed"
   },
   {
-    "id": "ent.elasticsearch.max_version.app_error",
-    "translation": "{{.Backend}} version {{.Version}} is higher than max supported version of {{.MaxVersion}}"
-  },
-  {
-    "id": "ent.elasticsearch.min_version.app_error",
-    "translation": "{{.Backend}} version {{.Version}} is lower than min supported version of {{.MinVersion}}"
-  },
-  {
     "id": "ent.elasticsearch.not_started.error",
     "translation": "{{.Backend}} is not started"
   },


### PR DESCRIPTION
#### Summary

Cherry-pick of #37929 into `release-11.7`.

Unsupported Postgres, Elasticsearch and OpenSearch versions used to abort startup. Now they log an `ERROR` and the server starts anyway, leaving the decision to run an unsupported configuration to the administrator.

Example logs:
```
Unsupported Postgres version. Running an unsupported version may lead to unexpected behaviour.  version=11.1 min_version=14.0
Unsupported Elasticsearch version. Running an unsupported version may lead to unexpected behaviour.  version=7.17.0 min_version=8 max_version=9
Unsupported OpenSearch version. Running an unsupported version may lead to unexpected behaviour.  version=4.0.0 max_version=2
```

Two adjustments were needed relative to master:
* Conflict in `server/enterprise/elasticsearch/opensearch/opensearch.go`: took the master side, which also wraps `esErr` (not `err`) when the version string fails to parse.
* Separate commit adapting the new OpenSearch `checkVersion` test: `release-11.7` supports OpenSearch up to major version 2 (master supports 3), so OpenSearch 3 is now an unsupported-but-allowed case and the assertion reads `opensearchMaxVersion` instead of hardcoding it.

#### Ticket Link

Cherry-pick of https://github.com/mattermost/mattermost/pull/37929

#### Release Note

```release-note
The server now logs an error and continues to start when connected to an unsupported Postgres, Elasticsearch, or OpenSearch version, instead of refusing to start.
```
