### PR TITLE
MM-69962: Fix inline media flickering between sizes near the 480px container threshold

### DIFF
--- a/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.test.tsx
+++ b/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.test.tsx
@@ -111,6 +111,30 @@ describe('MediaGallery', () => {
         expect(onToggle).toHaveBeenCalledWith('p1');
     });
 
+    it('keeps the row height stable in a narrow container so a toggling scrollbar cannot resize tiles in a loop', () => {
+        const rectSpy = jest.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
+            width: 470,
+            height: 216,
+        } as DOMRect);
+
+        try {
+            const {container} = renderWithContext(
+                <MediaGallery
+                    fileInfos={[fileInfo({id: 'v', name: 'clip.mp4', extension: 'mp4', mime_type: 'video/mp4'})]}
+                    postId='p1'
+                    onItemClick={jest.fn()}
+                />,
+                baseState,
+            );
+
+            const row = container.querySelector<HTMLElement>('.MediaGallery__row');
+            expect(row).not.toBeNull();
+            expect(row!.style.height).toBe('216px');
+        } finally {
+            rectSpy.mockRestore();
+        }
+    });
+
     it('marks the tile container as hidden when isEmbedVisible is false', () => {
         const {container} = renderWithContext(
             <MediaGallery

--- a/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.test.tsx
+++ b/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.test.tsx
@@ -9,7 +9,7 @@ import type {FileInfo} from '@mattermost/types/files';
 
 import {renderWithContext} from 'tests/react_testing_utils';
 
-import MediaGallery from './media_gallery';
+import MediaGallery, {nextNarrowState} from './media_gallery';
 
 function fileInfo(overrides: Partial<FileInfo>): FileInfo {
     return {
@@ -31,6 +31,37 @@ function fileInfo(overrides: Partial<FileInfo>): FileInfo {
         ...overrides,
     };
 }
+
+describe('nextNarrowState', () => {
+    const SCROLLBAR_WIDTH = 15;
+
+    it('switches to compact rows below the enter threshold', () => {
+        expect(nextNarrowState(false, 479)).toBe(true);
+        expect(nextNarrowState(false, 480)).toBe(false);
+    });
+
+    it('stays compact until well past the enter threshold so a vanishing scrollbar cannot flip it back', () => {
+        expect(nextNarrowState(true, 479 + SCROLLBAR_WIDTH)).toBe(true);
+        expect(nextNarrowState(true, 511)).toBe(true);
+        expect(nextNarrowState(true, 512)).toBe(false);
+    });
+
+    it('settles at every width in the worst case, where tall rows scroll and compact rows do not', () => {
+        for (let unscrolledWidth = 400; unscrolledWidth <= 600; unscrolledWidth++) {
+            const scrolledWidth = unscrolledWidth - SCROLLBAR_WIDTH;
+
+            // Going compact hides the scrollbar, which widens the container back out.
+            if (nextNarrowState(false, scrolledWidth)) {
+                expect(nextNarrowState(true, unscrolledWidth)).toBe(true);
+            }
+
+            // Going tall shows the scrollbar, which narrows the container again.
+            if (!nextNarrowState(true, unscrolledWidth)) {
+                expect(nextNarrowState(false, scrolledWidth)).toBe(false);
+            }
+        }
+    });
+});
 
 describe('MediaGallery', () => {
     const baseState = {
@@ -111,10 +142,10 @@ describe('MediaGallery', () => {
         expect(onToggle).toHaveBeenCalledWith('p1');
     });
 
-    it('keeps the row height stable in a narrow container so a toggling scrollbar cannot resize tiles in a loop', () => {
+    it('uses compact rows in a narrow container', () => {
         const rectSpy = jest.spyOn(Element.prototype, 'getBoundingClientRect').mockReturnValue({
-            width: 470,
-            height: 216,
+            width: 400,
+            height: 144,
         } as DOMRect);
 
         try {
@@ -129,7 +160,7 @@ describe('MediaGallery', () => {
 
             const row = container.querySelector<HTMLElement>('.MediaGallery__row');
             expect(row).not.toBeNull();
-            expect(row!.style.height).toBe('216px');
+            expect(row!.style.height).toBe('144px');
         } finally {
             rectSpy.mockRestore();
         }

--- a/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.tsx
+++ b/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import classNames from 'classnames';
-import React, {useCallback, useMemo, useRef} from 'react';
+import React, {useCallback, useEffect, useMemo, useRef, useState} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useSelector} from 'react-redux';
 
@@ -41,6 +41,13 @@ const MAX_TILE_WIDTH = 500;
 const GAP = 8;
 const FALLBACK_WIDTH = 700;
 
+const NARROW_ENTER_WIDTH = 480;
+const NARROW_EXIT_WIDTH = 512;
+
+export function nextNarrowState(isNarrow: boolean, width: number): boolean {
+    return isNarrow ? width < NARROW_EXIT_WIDTH : width < NARROW_ENTER_WIDTH;
+}
+
 function tileKindFor(fileInfo: FileInfo): TileKind | null {
     const type = getFileType(fileInfo.extension);
     if (type === FileTypes.IMAGE) {
@@ -59,6 +66,13 @@ const MediaGallery = ({fileInfos, postId, compactDisplay, isEmbedVisible = true,
     const containerRef = useRef<HTMLDivElement | null>(null);
     const {width: containerWidth} = useContainerDimensions(containerRef);
 
+    const effectiveWidth = containerWidth > 0 ? containerWidth : FALLBACK_WIDTH;
+    const [isNarrow, setIsNarrow] = useState(false);
+
+    useEffect(() => {
+        setIsNarrow((prev) => nextNarrowState(prev, effectiveWidth));
+    }, [effectiveWidth]);
+
     const tiles: ClassifiedFile[] = useMemo(() => {
         const out: ClassifiedFile[] = [];
         for (const file of fileInfos) {
@@ -71,15 +85,14 @@ const MediaGallery = ({fileInfos, postId, compactDisplay, isEmbedVisible = true,
     }, [fileInfos]);
 
     const rows = useMemo(() => {
-        const effectiveWidth = containerWidth > 0 ? containerWidth : FALLBACK_WIDTH;
         return packRows(tiles, {
             containerWidth: effectiveWidth,
-            rowHeight: compactDisplay ? COMPACT_ROW_HEIGHT : ROW_HEIGHT,
+            rowHeight: (compactDisplay || isNarrow) ? COMPACT_ROW_HEIGHT : ROW_HEIGHT,
             minTileWidth: MIN_TILE_WIDTH,
             maxTileWidth: MAX_TILE_WIDTH,
             gap: GAP,
         });
-    }, [tiles, containerWidth, compactDisplay]);
+    }, [tiles, effectiveWidth, isNarrow, compactDisplay]);
 
     const handleClick = useCallback((index: number) => {
         const file = tiles[index]?.file;

--- a/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.tsx
+++ b/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.tsx
@@ -40,7 +40,6 @@ const MIN_TILE_WIDTH = 50;
 const MAX_TILE_WIDTH = 500;
 const GAP = 8;
 const FALLBACK_WIDTH = 700;
-const NARROW_CONTAINER_WIDTH = 480;
 
 function tileKindFor(fileInfo: FileInfo): TileKind | null {
     const type = getFileType(fileInfo.extension);
@@ -73,10 +72,9 @@ const MediaGallery = ({fileInfos, postId, compactDisplay, isEmbedVisible = true,
 
     const rows = useMemo(() => {
         const effectiveWidth = containerWidth > 0 ? containerWidth : FALLBACK_WIDTH;
-        const isNarrow = effectiveWidth < NARROW_CONTAINER_WIDTH;
         return packRows(tiles, {
             containerWidth: effectiveWidth,
-            rowHeight: (compactDisplay || isNarrow) ? COMPACT_ROW_HEIGHT : ROW_HEIGHT,
+            rowHeight: compactDisplay ? COMPACT_ROW_HEIGHT : ROW_HEIGHT,
             minTileWidth: MIN_TILE_WIDTH,
             maxTileWidth: MAX_TILE_WIDTH,
             gap: GAP,


### PR DESCRIPTION
#### Summary
`MediaGallery` chose its row height based on whether the measured container was narrower than 480px switching between a 216px and a 144px row. That creates a feedback loop if the 216px row overflows, the scrollbar appears, the scrollbar narrows the container below 480px, the row drops to 144px, the overflow goes away, the scrollbar disappears, and the container widens again. this removes `isNarrow` entirely as suggested in the ticket.

Tiles still adapt to narrow containers: `pack_rows.ts` clamps each tile to `Math.min(maxTileWidth, containerWidth)` so they shrink horizontally as before.

QA steps:
1. Post a video and reply to it, then open that thread in the Threads view.
2. Resize the window so `div.MediaGallery__row` is just over 480px wide.
3. Add posts until the thread is almost tall enough to scroll.
4. Shrink the window slightly so the row drops just under 480px.
5. The video should hold a single stable size instead of flickering between two sizes.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-69962

#### Release Note
```release-note
Fixed an issue where inline images and videos could flicker between two sizes when a media gallery was near the width at which a scrollbar appears.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to `MediaGallery` row sizing and narrow-width state. Unit tests cover threshold behavior, scrollbar hysteresis, and narrow-container rendering.

**QA Recommendation:** Manual QA is not required. Automated testing provides sufficient coverage.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->