### PR TITLE
[MM-69816] Update prepackaged Calls to v1.12.3

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -156,7 +156,7 @@ TEMPLATES_DIR=templates
 
 # Plugins Packages
 PLUGIN_PACKAGES ?= $(PLUGIN_PACKAGES:)
-PLUGIN_PACKAGES += mattermost-plugin-calls-v1.12.2
+PLUGIN_PACKAGES += mattermost-plugin-calls-v1.12.3
 PLUGIN_PACKAGES += mattermost-plugin-github-v2.8.0
 PLUGIN_PACKAGES += mattermost-plugin-gitlab-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-jira-v4.8.0


### PR DESCRIPTION
#### Summary
- Update prepackaged Calls to v1.12.3

#### Ticket Link
- https://mattermost.atlassian.net/browse/MM-69816

#### Release Note
```release-note
Mattermost Calls was updated to v1.12.3.
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The update affects user-facing call sessions and exit behavior. The change is isolated to the bundled plugin, but session recovery and call termination paths require regression coverage.
**QA Recommendation:** Skip manual QA because automated testing provides full coverage and rollback is straightforward.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->