### PR TITLE
Fix config-change-checker automation

### DIFF
--- a/.github/scripts/check_config_changes_ci.py
+++ b/.github/scripts/check_config_changes_ci.py
@@ -293,18 +293,25 @@ def check_config(patches: dict[str, str]) -> CheckResult:
 
 # ── Checker 2 — api4/ ─────────────────────────────────────────────────────────
 
-# Matches Handle() route registrations after whitespace-collapsing the source.
-# Whitespace collapse makes multi-line declarations single-searchable.
-# Group 1: path   Group 2: handler func   Group 3: raw Methods(...) content
+# Start of a Handle() route registration, after whitespace-collapsing the
+# source (which makes multi-line declarations single-searchable).
 #
-# The wrapper pattern uses [^)]* so it tolerates any middleware arguments
-# (e.g. r.APIHandler(...), r.ApiSessionRequired(..., isLocal=true), etc.)
-# without having to enumerate every possible wrapper signature.
-_HANDLE_RE = re.compile(
-    r'\.Handle\("([^"]*)"'          # path
-    r',\s*[^)]*\((\w+)\)\)'        # wrapper(...handlerFunc))
-    r'\.Methods\(([^)]+)\)',        # .Methods(one or more methods)
-)
+# Only the path is matched by regex. The wrapper argument and the .Methods()
+# list are extracted by a paren-balanced scan instead, because a regex cannot
+# describe the wrapper shapes that actually occur in api4/:
+#
+#   api.APIHandler(getUser)                                    1 arg
+#   api.APISessionRequired(uploadFileStream, handlerParamFileAPI)   2 args
+#   api.APISessionRequired(contentFlaggingRequired(getConfig))  nested wrapper
+#   api.RateLimitedHandler(api.APIHandler(register), opts{...}) nested + opts
+#   api.APIHandler(manualtesting.ManualTest)                    qualified name
+#
+# The previous `\((\w+)\)\)` pattern only matched the first form, silently
+# dropping 33 of 760 registrations — including every file-upload endpoint and
+# all of content flagging.
+_HANDLE_START_RE = re.compile(r'\.Handle\("([^"]*)"\s*,')
+_IDENT_TAIL_RE   = re.compile(r'([A-Za-z_]\w*)\s*$')
+_FUNC_LITERAL_RE = re.compile(r'\bfunc\s*$')
 
 _METHOD_RE    = re.compile(r'(?:http\.Method)?(\w+)')
 _HTTP_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
@@ -329,20 +336,109 @@ def _format_endpoint(path: str, handler: str, method: str) -> str:
     return f"`{method.upper()} {path or '/'}` (`{handler}`)"
 
 
+def _matching_paren(text: str, open_idx: int) -> int:
+    """Index of the ')' closing the '(' at open_idx, or -1 if unbalanced."""
+    depth = 0
+    for i in range(open_idx, len(text)):
+        if text[i] == "(":
+            depth += 1
+        elif text[i] == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+    return -1
+
+
+def _split_top_level(text: str) -> list[str]:
+    """Split an argument list on commas that are not nested inside brackets."""
+    parts: list[str] = []
+    current: list[str] = []
+    depth = 0
+    for ch in text:
+        if ch in "([{":
+            depth += 1
+        elif ch in ")]}":
+            depth -= 1
+        if ch == "," and depth == 0:
+            parts.append("".join(current))
+            current = []
+        else:
+            current.append(ch)
+    if "".join(current).strip():
+        parts.append("".join(current))
+    return parts
+
+
+def _handler_name(expr: str) -> Optional[str]:
+    """Extract the handler function name from a route's wrapper argument.
+
+    Descends through wrapper calls, always following the first argument, then
+    returns the trailing identifier:
+
+        api.APIHandler(getUser)                        -> getUser
+        api.APISessionRequired(uploadFile, paramFlag)  -> uploadFile
+        api.APISessionRequired(required(getConfig))    -> getConfig
+        api.RateLimitedHandler(api.APIHandler(reg), o) -> reg
+        api.APIHandler(manualtesting.ManualTest)       -> ManualTest
+
+    Function literals are not descended into, so an inline
+    `func(w http.ResponseWriter, ...)` yields no handler rather than the name
+    of its first parameter.
+    """
+    expr = expr.strip()
+    while True:
+        open_idx = expr.find("(")
+        if open_idx == -1 or _FUNC_LITERAL_RE.search(expr[:open_idx]):
+            break
+        close_idx = _matching_paren(expr, open_idx)
+        if close_idx == -1:
+            break
+        args = _split_top_level(expr[open_idx + 1:close_idx])
+        if not args:
+            break
+        expr = args[0].strip()
+
+    m = _IDENT_TAIL_RE.search(expr)
+    return m.group(1) if m else None
+
+
 def _parse_endpoints(src: str) -> set[tuple[str, str, str]]:
     """
     Parse Handle() registrations from a Go source file.
 
     Whitespace-collapses the entire file first so multi-line declarations
-    (e.g. the 18 in group.go) are matched as a single token sequence.
-    Returns {(path, handler, method)} tuples.
+    (e.g. the 18 in group.go) are matched as a single token sequence, then
+    walks each registration with a paren-balanced scan so that wrappers with
+    extra arguments, nested wrappers, and package-qualified handler names are
+    all recognised. Returns {(path, handler, method)} tuples.
     """
     blob = " ".join(src.split())
     endpoints: set[tuple[str, str, str]] = set()
-    for m in _HANDLE_RE.finditer(blob):
-        path, handler, methods_raw = m.group(1), m.group(2), m.group(3)
-        for method in _parse_methods(methods_raw):
-            endpoints.add((path or "/", handler, method))
+
+    for m in _HANDLE_START_RE.finditer(blob):
+        handle_open  = blob.index("(", m.start())
+        handle_close = _matching_paren(blob, handle_open)
+        if handle_close == -1:
+            continue
+
+        # A registration only counts if .Methods(...) is chained directly on it.
+        if not blob.startswith(".Methods(", handle_close + 1):
+            continue
+        methods_open  = handle_close + 1 + len(".Methods")
+        methods_close = _matching_paren(blob, methods_open)
+        if methods_close == -1:
+            continue
+
+        args = _split_top_level(blob[handle_open + 1:handle_close])
+        if len(args) < 2:
+            continue
+        handler = _handler_name(args[1])
+        if not handler:
+            continue
+
+        for method in _parse_methods(blob[methods_open + 1:methods_close]):
+            endpoints.add((m.group(1) or "/", handler, method))
+
     return endpoints
 
 

--- a/.github/scripts/check_config_changes_ci.py
+++ b/.github/scripts/check_config_changes_ci.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 """
 .github/scripts/check_config_changes_ci.py
-
+ 
 CI script that detects notable changes across several Mattermost source files
 and appends structured release-note entries to the PR description.
-
+ 
 Checkers
 ────────
 1. config.go          — exported struct field additions/removals
 2. api4/              — API endpoint additions/removals (Handle() calls)
 3. audit_events.go    — AuditEvent* constant additions/removals
 4. Dockerfile.buildenv — Go (base-image) version changes
-
+ 
 All inputs come from environment variables set by the GitHub Actions workflow:
   GITHUB_TOKEN  — built-in Actions token  (pull-requests: write scope)
   PR_NUMBER     — pull request number
@@ -19,7 +19,7 @@ All inputs come from environment variables set by the GitHub Actions workflow:
   HEAD_SHA      — head commit SHA
   REPO          — owner/repo  (e.g. mattermost/mattermost)
 """
-
+ 
 import os
 import re
 import sys
@@ -27,25 +27,25 @@ import subprocess
 import requests
 from dataclasses import dataclass, field
 from typing import Optional
-
+ 
 # ── Environment ────────────────────────────────────────────────────────────────
-
+ 
 GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
 PR_NUMBER    = int(os.environ["PR_NUMBER"])
 BASE_SHA     = os.environ["BASE_SHA"]
 HEAD_SHA     = os.environ["HEAD_SHA"]
 REPO         = os.environ.get("REPO", "mattermost/mattermost")
-
+ 
 BASE_URL = "https://api.github.com"
 HEADERS  = {
     "Authorization": f"token {GITHUB_TOKEN}",
     "Accept":        "application/vnd.github.v3+json",
 }
-
+ 
 # Timeout for all GitHub API requests: (connect seconds, read seconds).
 # Prevents the workflow from hanging indefinitely on a slow/unresponsive API.
 _TIMEOUT = (5, 30)
-
+ 
 # Paths watched by this script (must align with `paths:` in the workflow YAML)
 WATCHED_PATHS = [
     "server/public/model/config.go",
@@ -53,10 +53,10 @@ WATCHED_PATHS = [
     "server/public/model/audit_events.go",
     "server/build/Dockerfile.buildenv",
 ]
-
-
+ 
+ 
 # ── Data types ─────────────────────────────────────────────────────────────────
-
+ 
 @dataclass
 class CheckResult:
     """Holds the findings from one checker."""
@@ -64,10 +64,10 @@ class CheckResult:
     additions: list  = field(default_factory=list)
     removals:  list  = field(default_factory=list)
     changes:   list  = field(default_factory=list)  # for free-form entries (version bumps)
-
+ 
     def has_findings(self) -> bool:
         return bool(self.additions or self.removals or self.changes)
-
+ 
     def to_markdown(self) -> str:
         lines = [f"### {self.label}"]
         if self.additions:
@@ -77,10 +77,10 @@ class CheckResult:
         for change in self.changes:
             lines.append(change)
         return "\n".join(lines)
-
-
+ 
+ 
 # ── Diff helpers ───────────────────────────────────────────────────────────────
-
+ 
 def get_full_patch() -> str:
     """Return unified diff for all watched paths between base and head."""
     result = subprocess.run(
@@ -90,8 +90,8 @@ def get_full_patch() -> str:
         check=True,
     )
     return result.stdout
-
-
+ 
+ 
 def split_patch_by_file(full_patch: str) -> dict[str, str]:
     """
     Split a multi-file unified diff into {filename: patch} mapping.
@@ -100,7 +100,7 @@ def split_patch_by_file(full_patch: str) -> dict[str, str]:
     patches: dict[str, str] = {}
     current_file: Optional[str] = None
     current_lines: list[str] = []
-
+ 
     for line in full_patch.splitlines(keepends=True):
         if line.startswith("diff --git "):
             if current_file:
@@ -111,13 +111,13 @@ def split_patch_by_file(full_patch: str) -> dict[str, str]:
             current_file = m.group(1) if m else None
         else:
             current_lines.append(line)
-
+ 
     if current_file:
         patches[current_file] = "".join(current_lines)
-
+ 
     return patches
-
-
+ 
+ 
 def file_at(ref: str, path: str) -> str:
     """Return the full contents of `path` at git ref `ref`, or '' if absent."""
     try:
@@ -127,11 +127,11 @@ def file_at(ref: str, path: str) -> str:
         ).stdout
     except subprocess.CalledProcessError:
         return ""
-
-
+ 
+ 
 def _compute_merge_base() -> str:
     """Resolve the merge-base of BASE_SHA and HEAD_SHA.
-
+ 
     Per-checker comparisons must use this rather than BASE_SHA. BASE_SHA is the
     tip of the target branch at PR-event time; if that branch advances on a
     watched file after the PR diverges, comparing branch-tip vs target-tip
@@ -143,23 +143,23 @@ def _compute_merge_base() -> str:
         ["git", "merge-base", BASE_SHA, HEAD_SHA],
         capture_output=True, text=True, check=True,
     ).stdout.strip()
-
-
+ 
+ 
 MERGE_BASE = _compute_merge_base()
-
-
+ 
+ 
 # ── Checker 1 — config.go ──────────────────────────────────────────────────────
-
+ 
 _CONFIG_PATH     = "server/public/model/config.go"
 _STRUCT_DECL_RE  = re.compile(r"^type\s+(\w+)\s+struct\s*\{")
 _FIELD_LINE_RE   = re.compile(r"^\t([A-Z][A-Za-z0-9_]*)\s+\S")
-
-
+ 
+ 
 def _scan_struct_fields(src: str) -> set[tuple[str, str]]:
     """
     Walk Go source and return {(StructName, FieldName)} for every exported
     field in every struct.
-
+ 
     Uses a brace-depth stack so nested anonymous structs, interface bodies,
     and function literals don't corrupt the enclosing struct context.
     Named type declarations cannot be nested in Go, so the struct_stack
@@ -169,19 +169,19 @@ def _scan_struct_fields(src: str) -> set[tuple[str, str]]:
     # Each entry: (struct_name, brace_depth_when_opened)
     struct_stack: list[tuple[str, int]] = []
     depth = 0
-
+ 
     for line in src.splitlines():
         sm = _STRUCT_DECL_RE.match(line)
         if sm:
             # Record depth *before* counting this line's braces
             struct_stack.append((sm.group(1), depth))
-
+ 
         depth += line.count("{") - line.count("}")
-
+ 
         # Pop any structs whose closing brace has been passed
         while struct_stack and depth <= struct_stack[-1][1]:
             struct_stack.pop()
-
+ 
         # Record fields only when we're directly inside the named struct body.
         # The depth check (depth == struct_stack[0][1] + 1) ensures that fields
         # inside nested anonymous struct { ... } blocks are not incorrectly
@@ -190,14 +190,14 @@ def _scan_struct_fields(src: str) -> set[tuple[str, str]]:
             fm = _FIELD_LINE_RE.match(line)
             if fm:
                 fields.add((struct_stack[0][0], fm.group(1)))
-
+ 
     return fields
-
-
+ 
+ 
 def check_config(patches: dict[str, str]) -> CheckResult:
     """
     Detect exported Go struct field additions/removals in config.go.
-
+ 
     Compares full-file snapshots at MERGE_BASE and HEAD_SHA so that fields
     are always attributed to the correct struct regardless of which diff
     hunks are present.
@@ -205,20 +205,20 @@ def check_config(patches: dict[str, str]) -> CheckResult:
     result = CheckResult(label="`config.json` Field Changes")
     if _CONFIG_PATH not in patches:
         return result
-
+ 
     base_fields = _scan_struct_fields(file_at(MERGE_BASE, _CONFIG_PATH))
     head_fields = _scan_struct_fields(file_at(HEAD_SHA, _CONFIG_PATH))
-
+ 
     added   = head_fields - base_fields
     removed = base_fields - head_fields
-
+ 
     result.additions = sorted(f"``{s}.{f}``" for s, f in added)
     result.removals  = sorted(f"``{s}.{f}``" for s, f in removed)
     return result
-
-
+ 
+ 
 # ── Checker 2 — api4/ ─────────────────────────────────────────────────────────
-
+ 
 # Start of a Handle() route registration, after whitespace-collapsing the
 # source (which makes multi-line declarations single-searchable).
 #
@@ -238,14 +238,14 @@ def check_config(patches: dict[str, str]) -> CheckResult:
 _HANDLE_START_RE = re.compile(r'\.Handle\("([^"]*)"\s*,')
 _IDENT_TAIL_RE   = re.compile(r'([A-Za-z_]\w*)\s*$')
 _FUNC_LITERAL_RE = re.compile(r'\bfunc\s*$')
-
+ 
 _METHOD_RE    = re.compile(r'(?:http\.Method)?(\w+)')
 _HTTP_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
-
-
+ 
+ 
 def _parse_methods(raw: str) -> list[str]:
     """Split raw Methods(...) content into individual uppercase HTTP verbs.
-
+ 
     Filters against the set of known HTTP methods so that incidental
     identifiers (handler names, constants, etc.) that happen to appear
     inside Methods(...) don't produce spurious results.
@@ -256,12 +256,12 @@ def _parse_methods(raw: str) -> list[str]:
         if (m := _METHOD_RE.search(token.strip()))
         and (verb := m.group(1).upper()) in _HTTP_METHODS
     ]
-
-
+ 
+ 
 def _format_endpoint(path: str, handler: str, method: str) -> str:
     return f"`{method.upper()} {path or '/'}` (`{handler}`)"
-
-
+ 
+ 
 def _matching_paren(text: str, open_idx: int) -> int:
     """Index of the ')' closing the '(' at open_idx, or -1 if unbalanced."""
     depth = 0
@@ -273,8 +273,8 @@ def _matching_paren(text: str, open_idx: int) -> int:
             if depth == 0:
                 return i
     return -1
-
-
+ 
+ 
 def _split_top_level(text: str) -> list[str]:
     """Split an argument list on commas that are not nested inside brackets."""
     parts: list[str] = []
@@ -293,20 +293,20 @@ def _split_top_level(text: str) -> list[str]:
     if "".join(current).strip():
         parts.append("".join(current))
     return parts
-
-
+ 
+ 
 def _handler_name(expr: str) -> Optional[str]:
     """Extract the handler function name from a route's wrapper argument.
-
+ 
     Descends through wrapper calls, always following the first argument, then
     returns the trailing identifier:
-
+ 
         api.APIHandler(getUser)                        -> getUser
         api.APISessionRequired(uploadFile, paramFlag)  -> uploadFile
         api.APISessionRequired(required(getConfig))    -> getConfig
         api.RateLimitedHandler(api.APIHandler(reg), o) -> reg
         api.APIHandler(manualtesting.ManualTest)       -> ManualTest
-
+ 
     Function literals are not descended into, so an inline
     `func(w http.ResponseWriter, ...)` yields no handler rather than the name
     of its first parameter.
@@ -323,15 +323,15 @@ def _handler_name(expr: str) -> Optional[str]:
         if not args:
             break
         expr = args[0].strip()
-
+ 
     m = _IDENT_TAIL_RE.search(expr)
     return m.group(1) if m else None
-
-
+ 
+ 
 def _parse_endpoints(src: str) -> set[tuple[str, str, str]]:
     """
     Parse Handle() registrations from a Go source file.
-
+ 
     Whitespace-collapses the entire file first so multi-line declarations
     (e.g. the 18 in group.go) are matched as a single token sequence, then
     walks each registration with a paren-balanced scan so that wrappers with
@@ -340,13 +340,13 @@ def _parse_endpoints(src: str) -> set[tuple[str, str, str]]:
     """
     blob = " ".join(src.split())
     endpoints: set[tuple[str, str, str]] = set()
-
+ 
     for m in _HANDLE_START_RE.finditer(blob):
         handle_open  = blob.index("(", m.start())
         handle_close = _matching_paren(blob, handle_open)
         if handle_close == -1:
             continue
-
+ 
         # A registration only counts if .Methods(...) is chained directly on it.
         if not blob.startswith(".Methods(", handle_close + 1):
             continue
@@ -354,29 +354,29 @@ def _parse_endpoints(src: str) -> set[tuple[str, str, str]]:
         methods_close = _matching_paren(blob, methods_open)
         if methods_close == -1:
             continue
-
+ 
         args = _split_top_level(blob[handle_open + 1:handle_close])
         if len(args) < 2:
             continue
         handler = _handler_name(args[1])
         if not handler:
             continue
-
+ 
         for method in _parse_methods(blob[methods_open + 1:methods_close]):
             endpoints.add((m.group(1) or "/", handler, method))
-
+ 
     return endpoints
-
-
+ 
+ 
 def check_api(patches: dict[str, str]) -> CheckResult:
     """
     Detect API endpoint additions/removals in the api4/ directory.
-
+ 
     Compares full-file snapshots at MERGE_BASE and HEAD_SHA via set arithmetic,
     so multi-line and multi-method registrations are handled correctly.
     """
     result = CheckResult(label="API Changes (`api4`)")
-
+ 
     api4_patches = {
         fname: patch
         for fname, patch in patches.items()
@@ -384,95 +384,95 @@ def check_api(patches: dict[str, str]) -> CheckResult:
     }
     if not api4_patches:
         return result
-
+ 
     added_eps:   set[tuple[str, str, str]] = set()
     removed_eps: set[tuple[str, str, str]] = set()
-
+ 
     for fname, patch in api4_patches.items():
         base_eps = _parse_endpoints(file_at(MERGE_BASE, fname))
         head_eps = _parse_endpoints(file_at(HEAD_SHA, fname))
         added_eps   |= head_eps - base_eps
         removed_eps |= base_eps - head_eps
-
+ 
         # Anchor the check to avoid false positives from unrelated source text
         if re.search(r"^new file mode \d+", patch, re.MULTILINE):
             result.changes.append(f"🆕 New API file: `{fname.split('/')[-1]}`")
         if re.search(r"^deleted file mode \d+", patch, re.MULTILINE):
             result.changes.append(f"🗑️  Removed API file: `{fname.split('/')[-1]}`")
-
+ 
     result.additions = sorted(_format_endpoint(p, h, m) for p, h, m in added_eps)
     result.removals  = sorted(_format_endpoint(p, h, m) for p, h, m in removed_eps)
     return result
-
-
+ 
+ 
 # ── Checker 3 — audit_events.go ───────────────────────────────────────────────
-
+ 
 _AUDIT_EVENT_PATH = "server/public/model/audit_events.go"
 _AUDIT_CONST_RE   = re.compile(r"^\t(AuditEvent\w+)\s*=")
-
-
+ 
+ 
 def _parse_audit_events(src: str) -> set[str]:
     return {m.group(1) for line in src.splitlines() if (m := _AUDIT_CONST_RE.match(line))}
-
-
+ 
+ 
 def check_audit_events(patches: dict[str, str]) -> CheckResult:
     """
     Detect AuditEvent* constant additions/removals.
-
+ 
     Uses full-file snapshots at MERGE_BASE/HEAD_SHA so reorderings and
     cross-constant name collisions don't produce false results.
     """
     result = CheckResult(label="Audit Log Event Changes")
     if _AUDIT_EVENT_PATH not in patches:
         return result
-
+ 
     base_events = _parse_audit_events(file_at(MERGE_BASE, _AUDIT_EVENT_PATH))
     head_events = _parse_audit_events(file_at(HEAD_SHA, _AUDIT_EVENT_PATH))
-
+ 
     result.additions = sorted(f"``{e}``" for e in head_events - base_events)
     result.removals  = sorted(f"``{e}``" for e in base_events - head_events)
     return result
-
-
+ 
+ 
 # ── Checker 4 — Dockerfile.buildenv (Go version) ──────────────────────────────
-
+ 
 # The Go version lives in the base image tag, e.g.:
 #   FROM mattermost/golang-bullseye:1.25.8@sha256:...
 _DOCKERFILE_PATH = "server/build/Dockerfile.buildenv"
 _IMAGE_VER_RE    = re.compile(r"^FROM \S+:([0-9]+\.[0-9]+(?:\.[0-9]+)?)")
-
-
+ 
+ 
 def _parse_go_version(src: str) -> Optional[str]:
     for line in src.splitlines():
         m = _IMAGE_VER_RE.match(line.strip())
         if m:
             return m.group(1)
     return None
-
-
+ 
+ 
 def check_go_version(patches: dict[str, str]) -> CheckResult:
     """
     Detect Go runtime version changes via the base image tag.
-
+ 
     Uses full-file snapshots so the version is read from the actual file
     state at each ref rather than reconstructed from patch lines.
     """
     result = CheckResult(label="Go Runtime Version")
     if _DOCKERFILE_PATH not in patches:
         return result
-
+ 
     old_ver = _parse_go_version(file_at(MERGE_BASE, _DOCKERFILE_PATH))
     new_ver = _parse_go_version(file_at(HEAD_SHA, _DOCKERFILE_PATH))
-
+ 
     if old_ver and new_ver and old_ver != new_ver:
         result.changes.append(f"Go updated: ``{old_ver}`` → ``{new_ver}``")
     elif new_ver and not old_ver:
         result.additions.append(f"``{new_ver}``")
     return result
-
-
+ 
+ 
 # ── PR description helpers ─────────────────────────────────────────────────────
-
+ 
 # Matches lines that were auto-generated by this script so they can be stripped
 # before re-injecting a fresh set on subsequent commits.
 # Handles both single-backtick (older runs) and double-backtick (current) format.
@@ -483,36 +483,36 @@ _AUTO_LINE_RE = re.compile(
     r"|^🆕 New API file:"
     r"|^🗑️  Removed API file:"
 )
-
+ 
 # Matches placeholder content inside a release-note fence that means "nothing
 # to report yet" (e.g. NONE, N/A, ---).  When detected, we replace the
 # placeholder rather than appending alongside it.
 _PLACEHOLDER_RE = re.compile(r"^\s*(?:NONE|N/?A|-+)\s*$", re.IGNORECASE)
-
-
+ 
+ 
 def _format_lines(result: CheckResult) -> list[str]:
     """Produce natural-language lines for one checker result."""
     lines = []
-
+ 
     if "`config.json`" in result.label:
         for item in result.additions:
             lines.append(f"Added {item} configuration setting.")
         for item in result.removals:
             lines.append(f"Removed {item} configuration setting.")
-
+ 
     elif "API Changes" in result.label:
         for item in result.additions:
             lines.append(f"Added {item} API endpoint.")
         for item in result.removals:
             lines.append(f"Removed {item} API endpoint.")
         lines.extend(result.changes)  # new/deleted file entries
-
+ 
     elif "Audit" in result.label:
         for item in result.additions:
             lines.append(f"Added {item} audit log event.")
         for item in result.removals:
             lines.append(f"Removed {item} audit log event.")
-
+ 
     elif "Go Runtime" in result.label:
         for item in result.additions:
             # item is e.g. "``1.22``"
@@ -524,10 +524,10 @@ def _format_lines(result: CheckResult) -> list[str]:
                 lines.append(f"Go runtime updated from {m.group(1)} to {m.group(2)}.")
             else:
                 lines.append(c)
-
+ 
     return lines
-
-
+ 
+ 
 def build_pr_note(results: list[CheckResult]) -> str:
     """Assemble all findings into a clean plain-text block."""
     lines = []
@@ -535,16 +535,16 @@ def build_pr_note(results: list[CheckResult]) -> str:
         if r.has_findings():
             lines.extend(_format_lines(r))
     return "\n".join(lines)
-
-
+ 
+ 
 def strip_old_note(body: str) -> str:
     """
     Remove previously auto-generated lines from the PR description.
-
+ 
     Primary path  — lines inside the ```release-note ... ``` fence.
     Fallback path — auto-generated lines that were appended outside any fence
                     (e.g. via the ## Release Notes section on earlier runs).
-
+ 
     Lines are identified by pattern rather than visible markers, so the PR
     description stays clean for human readers.
     """
@@ -555,14 +555,14 @@ def strip_old_note(body: str) -> str:
             if not _AUTO_LINE_RE.match(line.strip())
         ]
         return open_tag + "\n".join(cleaned_lines) + close_tag
-
+ 
     cleaned = re.sub(
         r"(```release-note)(.*?)(```)",
         _clean_fence,
         body or "",
         flags=re.DOTALL | re.IGNORECASE,
     )
-
+ 
     # Fallback: strip any auto-generated lines that appear outside a fence
     # (written by an older version of this script or via the header-inject path).
     cleaned_lines = [
@@ -570,12 +570,12 @@ def strip_old_note(body: str) -> str:
         if not _AUTO_LINE_RE.match(line.strip())
     ]
     return "\n".join(cleaned_lines).rstrip()
-
-
+ 
+ 
 def inject_note(body: str, note: str) -> str:
     """
     Insert `note` using this priority order:
-
+ 
     1. INSIDE the ```release-note block, before its closing ```
        (Mattermost convention — keeps everything in one place for reviewers)
     2. After a recognised release-notes section header (## Release Notes, etc.)
@@ -584,7 +584,7 @@ def inject_note(body: str, note: str) -> str:
     body = strip_old_note(body)
     if not note:
         return body
-
+ 
     # 1. Mattermost-style ```release-note ... ``` block — inject INSIDE the fence.
     #    If the fence currently contains only a placeholder (NONE / N/A / ---),
     #    replace the placeholder rather than appending alongside it.
@@ -599,7 +599,7 @@ def inject_note(body: str, note: str) -> str:
         close_tag  = release_note_block.group(3)
         block_start = release_note_block.start()
         block_end   = release_note_block.end()
-
+ 
         # Strip leading/trailing newlines inside the fence for comparison
         inner = content.strip()
         if _PLACEHOLDER_RE.match(inner):
@@ -608,21 +608,21 @@ def inject_note(body: str, note: str) -> str:
         else:
             # Append before the closing fence
             new_block = open_tag + content + note + "\n" + close_tag
-
+ 
         return body[:block_start] + new_block + body[block_end:]
-
+ 
     # 2. Markdown section headers
     for header in ["## Release Notes", "## Changelog", "## What Changed", "## What's Changed"]:
         if header.lower() in body.lower():
             idx = body.lower().index(header.lower()) + len(header)
             return body[:idx] + "\n\n" + note + body[idx:]
-
+ 
     # 3. Fallback — append
     return body + "\n\n## Release Notes\n\n" + note
-
-
+ 
+ 
 # ── GitHub API ─────────────────────────────────────────────────────────────────
-
+ 
 def get_pr_body() -> str:
     r = requests.get(
         f"{BASE_URL}/repos/{REPO}/pulls/{PR_NUMBER}",
@@ -631,8 +631,8 @@ def get_pr_body() -> str:
     )
     r.raise_for_status()
     return r.json().get("body") or ""
-
-
+ 
+ 
 def update_pr_body(new_body: str) -> None:
     r = requests.patch(
         f"{BASE_URL}/repos/{REPO}/pulls/{PR_NUMBER}",
@@ -641,22 +641,22 @@ def update_pr_body(new_body: str) -> None:
         timeout=_TIMEOUT,
     )
     r.raise_for_status()
-
-
+ 
+ 
 # ── Main ───────────────────────────────────────────────────────────────────────
-
+ 
 def main():
     print(f"📋 PR #{PR_NUMBER} | base {BASE_SHA[:8]} → head {HEAD_SHA[:8]}")
     print("🔍 Collecting diffs …")
-
+ 
     full_patch = get_full_patch()
     if not full_patch.strip():
         print("ℹ️  No changes in watched paths. Nothing to do.")
         return
-
+ 
     patches = split_patch_by_file(full_patch)
     print(f"   {len(patches)} file(s) changed in watched paths.\n")
-
+ 
     # Run all checkers
     checkers = [
         check_config,
@@ -665,7 +665,7 @@ def main():
         check_go_version,
     ]
     results: list[CheckResult] = [fn(patches) for fn in checkers]
-
+ 
     for r in results:
         if r.has_findings():
             print(f"  ✅ {r.label}")
@@ -677,24 +677,24 @@ def main():
                 print(f"     {c}")
         else:
             print(f"  –  {r.label}: no changes")
-
+ 
     note = build_pr_note(results)
     if not note:
         print("\nℹ️  No notable changes found across all checkers.")
         return
-
+ 
     print("\n🔄 Fetching PR description …")
     body = get_pr_body()
     new_body = inject_note(body, note)
-
+ 
     if new_body == body:
         print("ℹ️  PR description already up to date — no changes needed.")
         return
-
+ 
     update_pr_body(new_body)
     print(f"✅ PR #{PR_NUMBER} description updated.")
-
-
+ 
+ 
 if __name__ == "__main__":
     try:
         main()

--- a/.github/scripts/check_config_changes_ci.py
+++ b/.github/scripts/check_config_changes_ci.py
@@ -1,17 +1,17 @@
 #!/usr/bin/env python3
 """
 .github/scripts/check_config_changes_ci.py
- 
+
 CI script that detects notable changes across several Mattermost source files
 and appends structured release-note entries to the PR description.
- 
+
 Checkers
 ────────
 1. config.go          — exported struct field additions/removals
 2. api4/              — API endpoint additions/removals (Handle() calls)
 3. audit_events.go    — AuditEvent* constant additions/removals
 4. Dockerfile.buildenv — Go (base-image) version changes
- 
+
 All inputs come from environment variables set by the GitHub Actions workflow:
   GITHUB_TOKEN  — built-in Actions token  (pull-requests: write scope)
   PR_NUMBER     — pull request number
@@ -19,7 +19,7 @@ All inputs come from environment variables set by the GitHub Actions workflow:
   HEAD_SHA      — head commit SHA
   REPO          — owner/repo  (e.g. mattermost/mattermost)
 """
- 
+
 import os
 import re
 import sys
@@ -27,25 +27,25 @@ import subprocess
 import requests
 from dataclasses import dataclass, field
 from typing import Optional
- 
+
 # ── Environment ────────────────────────────────────────────────────────────────
- 
+
 GITHUB_TOKEN = os.environ["GITHUB_TOKEN"]
 PR_NUMBER    = int(os.environ["PR_NUMBER"])
 BASE_SHA     = os.environ["BASE_SHA"]
 HEAD_SHA     = os.environ["HEAD_SHA"]
 REPO         = os.environ.get("REPO", "mattermost/mattermost")
- 
+
 BASE_URL = "https://api.github.com"
 HEADERS  = {
     "Authorization": f"token {GITHUB_TOKEN}",
     "Accept":        "application/vnd.github.v3+json",
 }
- 
+
 # Timeout for all GitHub API requests: (connect seconds, read seconds).
 # Prevents the workflow from hanging indefinitely on a slow/unresponsive API.
 _TIMEOUT = (5, 30)
- 
+
 # Paths watched by this script (must align with `paths:` in the workflow YAML)
 WATCHED_PATHS = [
     "server/public/model/config.go",
@@ -53,10 +53,10 @@ WATCHED_PATHS = [
     "server/public/model/audit_events.go",
     "server/build/Dockerfile.buildenv",
 ]
- 
- 
+
+
 # ── Data types ─────────────────────────────────────────────────────────────────
- 
+
 @dataclass
 class CheckResult:
     """Holds the findings from one checker."""
@@ -64,10 +64,10 @@ class CheckResult:
     additions: list  = field(default_factory=list)
     removals:  list  = field(default_factory=list)
     changes:   list  = field(default_factory=list)  # for free-form entries (version bumps)
- 
+
     def has_findings(self) -> bool:
         return bool(self.additions or self.removals or self.changes)
- 
+
     def to_markdown(self) -> str:
         lines = [f"### {self.label}"]
         if self.additions:
@@ -77,10 +77,10 @@ class CheckResult:
         for change in self.changes:
             lines.append(change)
         return "\n".join(lines)
- 
- 
+
+
 # ── Diff helpers ───────────────────────────────────────────────────────────────
- 
+
 def get_full_patch() -> str:
     """Return unified diff for all watched paths between base and head."""
     result = subprocess.run(
@@ -90,8 +90,8 @@ def get_full_patch() -> str:
         check=True,
     )
     return result.stdout
- 
- 
+
+
 def split_patch_by_file(full_patch: str) -> dict[str, str]:
     """
     Split a multi-file unified diff into {filename: patch} mapping.
@@ -100,7 +100,7 @@ def split_patch_by_file(full_patch: str) -> dict[str, str]:
     patches: dict[str, str] = {}
     current_file: Optional[str] = None
     current_lines: list[str] = []
- 
+
     for line in full_patch.splitlines(keepends=True):
         if line.startswith("diff --git "):
             if current_file:
@@ -111,13 +111,13 @@ def split_patch_by_file(full_patch: str) -> dict[str, str]:
             current_file = m.group(1) if m else None
         else:
             current_lines.append(line)
- 
+
     if current_file:
         patches[current_file] = "".join(current_lines)
- 
+
     return patches
- 
- 
+
+
 def file_at(ref: str, path: str) -> str:
     """Return the full contents of `path` at git ref `ref`, or '' if absent."""
     try:
@@ -127,11 +127,11 @@ def file_at(ref: str, path: str) -> str:
         ).stdout
     except subprocess.CalledProcessError:
         return ""
- 
- 
+
+
 def _compute_merge_base() -> str:
     """Resolve the merge-base of BASE_SHA and HEAD_SHA.
- 
+
     Per-checker comparisons must use this rather than BASE_SHA. BASE_SHA is the
     tip of the target branch at PR-event time; if that branch advances on a
     watched file after the PR diverges, comparing branch-tip vs target-tip
@@ -143,45 +143,119 @@ def _compute_merge_base() -> str:
         ["git", "merge-base", BASE_SHA, HEAD_SHA],
         capture_output=True, text=True, check=True,
     ).stdout.strip()
- 
- 
+
+
 MERGE_BASE = _compute_merge_base()
- 
- 
+
+
 # ── Checker 1 — config.go ──────────────────────────────────────────────────────
- 
+
 _CONFIG_PATH     = "server/public/model/config.go"
 _STRUCT_DECL_RE  = re.compile(r"^type\s+(\w+)\s+struct\s*\{")
 _FIELD_LINE_RE   = re.compile(r"^\t([A-Z][A-Za-z0-9_]*)\s+\S")
- 
- 
+
+
+def _strip_go_noise(lines):
+    """Yield each line with comments and string/rune literals blanked out.
+
+    Brace counting must ignore braces that appear inside comments or string
+    literals. config.go contains doc comments such as
+
+        //	type HairSettings struct {
+
+    whose braces would otherwise be counted as real, skewing the depth for the
+    remainder of the comment. A skew that begins inside a struct body makes the
+    enclosing-struct stack unwind early and silently drops every remaining
+    field of that struct from the release-note output.
+
+    Block comments and raw string literals can span lines, so that state is
+    carried across iterations. Layout characters (tabs, spaces) are preserved
+    so the caller's line-anchored regexes still apply.
+    """
+    in_block_comment = False
+    in_raw_string    = False
+
+    for line in lines:
+        out: list[str] = []
+        i, n = 0, len(line)
+
+        while i < n:
+            if in_block_comment:
+                if line.startswith("*/", i):
+                    in_block_comment = False
+                    i += 2
+                else:
+                    i += 1
+                continue
+
+            if in_raw_string:
+                if line[i] == "`":
+                    in_raw_string = False
+                i += 1
+                continue
+
+            if line.startswith("//", i):
+                break                       # rest of the line is a comment
+
+            if line.startswith("/*", i):
+                in_block_comment = True
+                i += 2
+                continue
+
+            if line[i] == "`":              # raw string literal (struct tags)
+                in_raw_string = True
+                i += 1
+                continue
+
+            if line[i] in ('"', "'"):       # interpreted string / rune literal
+                quote = line[i]
+                i += 1
+                while i < n:
+                    if line[i] == "\\":
+                        i += 2
+                        continue
+                    if line[i] == quote:
+                        i += 1
+                        break
+                    i += 1
+                continue
+
+            out.append(line[i])
+            i += 1
+
+        yield "".join(out)
+
+
 def _scan_struct_fields(src: str) -> set[tuple[str, str]]:
     """
     Walk Go source and return {(StructName, FieldName)} for every exported
     field in every struct.
- 
+
     Uses a brace-depth stack so nested anonymous structs, interface bodies,
     and function literals don't corrupt the enclosing struct context.
     Named type declarations cannot be nested in Go, so the struct_stack
     never grows beyond one entry for named structs.
+
+    Lines are pre-filtered through _strip_go_noise so that braces inside
+    comments, struct tags, and string literals never affect the depth.
     """
     fields: set[tuple[str, str]] = set()
     # Each entry: (struct_name, brace_depth_when_opened)
     struct_stack: list[tuple[str, int]] = []
     depth = 0
- 
-    for line in src.splitlines():
+
+    for line in _strip_go_noise(src.splitlines()):
         sm = _STRUCT_DECL_RE.match(line)
         if sm:
             # Record depth *before* counting this line's braces
             struct_stack.append((sm.group(1), depth))
- 
+
         depth += line.count("{") - line.count("}")
- 
+
         # Pop any structs whose closing brace has been passed
         while struct_stack and depth <= struct_stack[-1][1]:
             struct_stack.pop()
- 
+
         # Record fields only when we're directly inside the named struct body.
         # The depth check (depth == struct_stack[0][1] + 1) ensures that fields
         # inside nested anonymous struct { ... } blocks are not incorrectly
@@ -190,14 +264,14 @@ def _scan_struct_fields(src: str) -> set[tuple[str, str]]:
             fm = _FIELD_LINE_RE.match(line)
             if fm:
                 fields.add((struct_stack[0][0], fm.group(1)))
- 
+
     return fields
- 
- 
+
+
 def check_config(patches: dict[str, str]) -> CheckResult:
     """
     Detect exported Go struct field additions/removals in config.go.
- 
+
     Compares full-file snapshots at MERGE_BASE and HEAD_SHA so that fields
     are always attributed to the correct struct regardless of which diff
     hunks are present.
@@ -205,20 +279,20 @@ def check_config(patches: dict[str, str]) -> CheckResult:
     result = CheckResult(label="`config.json` Field Changes")
     if _CONFIG_PATH not in patches:
         return result
- 
+
     base_fields = _scan_struct_fields(file_at(MERGE_BASE, _CONFIG_PATH))
     head_fields = _scan_struct_fields(file_at(HEAD_SHA, _CONFIG_PATH))
- 
+
     added   = head_fields - base_fields
     removed = base_fields - head_fields
- 
+
     result.additions = sorted(f"``{s}.{f}``" for s, f in added)
     result.removals  = sorted(f"``{s}.{f}``" for s, f in removed)
     return result
- 
- 
+
+
 # ── Checker 2 — api4/ ─────────────────────────────────────────────────────────
- 
+
 # Matches Handle() route registrations after whitespace-collapsing the source.
 # Whitespace collapse makes multi-line declarations single-searchable.
 # Group 1: path   Group 2: handler func   Group 3: raw Methods(...) content
@@ -231,14 +305,14 @@ _HANDLE_RE = re.compile(
     r',\s*[^)]*\((\w+)\)\)'        # wrapper(...handlerFunc))
     r'\.Methods\(([^)]+)\)',        # .Methods(one or more methods)
 )
- 
+
 _METHOD_RE    = re.compile(r'(?:http\.Method)?(\w+)')
 _HTTP_METHODS = {"GET", "POST", "PUT", "PATCH", "DELETE", "HEAD", "OPTIONS"}
- 
- 
+
+
 def _parse_methods(raw: str) -> list[str]:
     """Split raw Methods(...) content into individual uppercase HTTP verbs.
- 
+
     Filters against the set of known HTTP methods so that incidental
     identifiers (handler names, constants, etc.) that happen to appear
     inside Methods(...) don't produce spurious results.
@@ -249,16 +323,16 @@ def _parse_methods(raw: str) -> list[str]:
         if (m := _METHOD_RE.search(token.strip()))
         and (verb := m.group(1).upper()) in _HTTP_METHODS
     ]
- 
- 
+
+
 def _format_endpoint(path: str, handler: str, method: str) -> str:
     return f"`{method.upper()} {path or '/'}` (`{handler}`)"
- 
- 
+
+
 def _parse_endpoints(src: str) -> set[tuple[str, str, str]]:
     """
     Parse Handle() registrations from a Go source file.
- 
+
     Whitespace-collapses the entire file first so multi-line declarations
     (e.g. the 18 in group.go) are matched as a single token sequence.
     Returns {(path, handler, method)} tuples.
@@ -270,17 +344,17 @@ def _parse_endpoints(src: str) -> set[tuple[str, str, str]]:
         for method in _parse_methods(methods_raw):
             endpoints.add((path or "/", handler, method))
     return endpoints
- 
- 
+
+
 def check_api(patches: dict[str, str]) -> CheckResult:
     """
     Detect API endpoint additions/removals in the api4/ directory.
- 
+
     Compares full-file snapshots at MERGE_BASE and HEAD_SHA via set arithmetic,
     so multi-line and multi-method registrations are handled correctly.
     """
     result = CheckResult(label="API Changes (`api4`)")
- 
+
     api4_patches = {
         fname: patch
         for fname, patch in patches.items()
@@ -288,95 +362,95 @@ def check_api(patches: dict[str, str]) -> CheckResult:
     }
     if not api4_patches:
         return result
- 
+
     added_eps:   set[tuple[str, str, str]] = set()
     removed_eps: set[tuple[str, str, str]] = set()
- 
+
     for fname, patch in api4_patches.items():
         base_eps = _parse_endpoints(file_at(MERGE_BASE, fname))
         head_eps = _parse_endpoints(file_at(HEAD_SHA, fname))
         added_eps   |= head_eps - base_eps
         removed_eps |= base_eps - head_eps
- 
+
         # Anchor the check to avoid false positives from unrelated source text
         if re.search(r"^new file mode \d+", patch, re.MULTILINE):
             result.changes.append(f"🆕 New API file: `{fname.split('/')[-1]}`")
         if re.search(r"^deleted file mode \d+", patch, re.MULTILINE):
             result.changes.append(f"🗑️  Removed API file: `{fname.split('/')[-1]}`")
- 
+
     result.additions = sorted(_format_endpoint(p, h, m) for p, h, m in added_eps)
     result.removals  = sorted(_format_endpoint(p, h, m) for p, h, m in removed_eps)
     return result
- 
- 
+
+
 # ── Checker 3 — audit_events.go ───────────────────────────────────────────────
- 
+
 _AUDIT_EVENT_PATH = "server/public/model/audit_events.go"
 _AUDIT_CONST_RE   = re.compile(r"^\t(AuditEvent\w+)\s*=")
- 
- 
+
+
 def _parse_audit_events(src: str) -> set[str]:
     return {m.group(1) for line in src.splitlines() if (m := _AUDIT_CONST_RE.match(line))}
- 
- 
+
+
 def check_audit_events(patches: dict[str, str]) -> CheckResult:
     """
     Detect AuditEvent* constant additions/removals.
- 
+
     Uses full-file snapshots at MERGE_BASE/HEAD_SHA so reorderings and
     cross-constant name collisions don't produce false results.
     """
     result = CheckResult(label="Audit Log Event Changes")
     if _AUDIT_EVENT_PATH not in patches:
         return result
- 
+
     base_events = _parse_audit_events(file_at(MERGE_BASE, _AUDIT_EVENT_PATH))
     head_events = _parse_audit_events(file_at(HEAD_SHA, _AUDIT_EVENT_PATH))
- 
+
     result.additions = sorted(f"``{e}``" for e in head_events - base_events)
     result.removals  = sorted(f"``{e}``" for e in base_events - head_events)
     return result
- 
- 
+
+
 # ── Checker 4 — Dockerfile.buildenv (Go version) ──────────────────────────────
- 
+
 # The Go version lives in the base image tag, e.g.:
 #   FROM mattermost/golang-bullseye:1.25.8@sha256:...
 _DOCKERFILE_PATH = "server/build/Dockerfile.buildenv"
 _IMAGE_VER_RE    = re.compile(r"^FROM \S+:([0-9]+\.[0-9]+(?:\.[0-9]+)?)")
- 
- 
+
+
 def _parse_go_version(src: str) -> Optional[str]:
     for line in src.splitlines():
         m = _IMAGE_VER_RE.match(line.strip())
         if m:
             return m.group(1)
     return None
- 
- 
+
+
 def check_go_version(patches: dict[str, str]) -> CheckResult:
     """
     Detect Go runtime version changes via the base image tag.
- 
+
     Uses full-file snapshots so the version is read from the actual file
     state at each ref rather than reconstructed from patch lines.
     """
     result = CheckResult(label="Go Runtime Version")
     if _DOCKERFILE_PATH not in patches:
         return result
- 
+
     old_ver = _parse_go_version(file_at(MERGE_BASE, _DOCKERFILE_PATH))
     new_ver = _parse_go_version(file_at(HEAD_SHA, _DOCKERFILE_PATH))
- 
+
     if old_ver and new_ver and old_ver != new_ver:
         result.changes.append(f"Go updated: ``{old_ver}`` → ``{new_ver}``")
     elif new_ver and not old_ver:
         result.additions.append(f"``{new_ver}``")
     return result
- 
- 
+
+
 # ── PR description helpers ─────────────────────────────────────────────────────
- 
+
 # Matches lines that were auto-generated by this script so they can be stripped
 # before re-injecting a fresh set on subsequent commits.
 # Handles both single-backtick (older runs) and double-backtick (current) format.
@@ -387,36 +461,36 @@ _AUTO_LINE_RE = re.compile(
     r"|^🆕 New API file:"
     r"|^🗑️  Removed API file:"
 )
- 
+
 # Matches placeholder content inside a release-note fence that means "nothing
 # to report yet" (e.g. NONE, N/A, ---).  When detected, we replace the
 # placeholder rather than appending alongside it.
 _PLACEHOLDER_RE = re.compile(r"^\s*(?:NONE|N/?A|-+)\s*$", re.IGNORECASE)
- 
- 
+
+
 def _format_lines(result: CheckResult) -> list[str]:
     """Produce natural-language lines for one checker result."""
     lines = []
- 
+
     if "`config.json`" in result.label:
         for item in result.additions:
             lines.append(f"Added {item} configuration setting.")
         for item in result.removals:
             lines.append(f"Removed {item} configuration setting.")
- 
+
     elif "API Changes" in result.label:
         for item in result.additions:
             lines.append(f"Added {item} API endpoint.")
         for item in result.removals:
             lines.append(f"Removed {item} API endpoint.")
         lines.extend(result.changes)  # new/deleted file entries
- 
+
     elif "Audit" in result.label:
         for item in result.additions:
             lines.append(f"Added {item} audit log event.")
         for item in result.removals:
             lines.append(f"Removed {item} audit log event.")
- 
+
     elif "Go Runtime" in result.label:
         for item in result.additions:
             # item is e.g. "``1.22``"
@@ -428,10 +502,10 @@ def _format_lines(result: CheckResult) -> list[str]:
                 lines.append(f"Go runtime updated from {m.group(1)} to {m.group(2)}.")
             else:
                 lines.append(c)
- 
+
     return lines
- 
- 
+
+
 def build_pr_note(results: list[CheckResult]) -> str:
     """Assemble all findings into a clean plain-text block."""
     lines = []
@@ -439,16 +513,16 @@ def build_pr_note(results: list[CheckResult]) -> str:
         if r.has_findings():
             lines.extend(_format_lines(r))
     return "\n".join(lines)
- 
- 
+
+
 def strip_old_note(body: str) -> str:
     """
     Remove previously auto-generated lines from the PR description.
- 
+
     Primary path  — lines inside the ```release-note ... ``` fence.
     Fallback path — auto-generated lines that were appended outside any fence
                     (e.g. via the ## Release Notes section on earlier runs).
- 
+
     Lines are identified by pattern rather than visible markers, so the PR
     description stays clean for human readers.
     """
@@ -459,14 +533,14 @@ def strip_old_note(body: str) -> str:
             if not _AUTO_LINE_RE.match(line.strip())
         ]
         return open_tag + "\n".join(cleaned_lines) + close_tag
- 
+
     cleaned = re.sub(
         r"(```release-note)(.*?)(```)",
         _clean_fence,
         body or "",
         flags=re.DOTALL | re.IGNORECASE,
     )
- 
+
     # Fallback: strip any auto-generated lines that appear outside a fence
     # (written by an older version of this script or via the header-inject path).
     cleaned_lines = [
@@ -474,12 +548,12 @@ def strip_old_note(body: str) -> str:
         if not _AUTO_LINE_RE.match(line.strip())
     ]
     return "\n".join(cleaned_lines).rstrip()
- 
- 
+
+
 def inject_note(body: str, note: str) -> str:
     """
     Insert `note` using this priority order:
- 
+
     1. INSIDE the ```release-note block, before its closing ```
        (Mattermost convention — keeps everything in one place for reviewers)
     2. After a recognised release-notes section header (## Release Notes, etc.)
@@ -488,7 +562,7 @@ def inject_note(body: str, note: str) -> str:
     body = strip_old_note(body)
     if not note:
         return body
- 
+
     # 1. Mattermost-style ```release-note ... ``` block — inject INSIDE the fence.
     #    If the fence currently contains only a placeholder (NONE / N/A / ---),
     #    replace the placeholder rather than appending alongside it.
@@ -503,7 +577,7 @@ def inject_note(body: str, note: str) -> str:
         close_tag  = release_note_block.group(3)
         block_start = release_note_block.start()
         block_end   = release_note_block.end()
- 
+
         # Strip leading/trailing newlines inside the fence for comparison
         inner = content.strip()
         if _PLACEHOLDER_RE.match(inner):
@@ -512,21 +586,21 @@ def inject_note(body: str, note: str) -> str:
         else:
             # Append before the closing fence
             new_block = open_tag + content + note + "\n" + close_tag
- 
+
         return body[:block_start] + new_block + body[block_end:]
- 
+
     # 2. Markdown section headers
     for header in ["## Release Notes", "## Changelog", "## What Changed", "## What's Changed"]:
         if header.lower() in body.lower():
             idx = body.lower().index(header.lower()) + len(header)
             return body[:idx] + "\n\n" + note + body[idx:]
- 
+
     # 3. Fallback — append
     return body + "\n\n## Release Notes\n\n" + note
- 
- 
+
+
 # ── GitHub API ─────────────────────────────────────────────────────────────────
- 
+
 def get_pr_body() -> str:
     r = requests.get(
         f"{BASE_URL}/repos/{REPO}/pulls/{PR_NUMBER}",
@@ -535,8 +609,8 @@ def get_pr_body() -> str:
     )
     r.raise_for_status()
     return r.json().get("body") or ""
- 
- 
+
+
 def update_pr_body(new_body: str) -> None:
     r = requests.patch(
         f"{BASE_URL}/repos/{REPO}/pulls/{PR_NUMBER}",
@@ -545,22 +619,22 @@ def update_pr_body(new_body: str) -> None:
         timeout=_TIMEOUT,
     )
     r.raise_for_status()
- 
- 
+
+
 # ── Main ───────────────────────────────────────────────────────────────────────
- 
+
 def main():
     print(f"📋 PR #{PR_NUMBER} | base {BASE_SHA[:8]} → head {HEAD_SHA[:8]}")
     print("🔍 Collecting diffs …")
- 
+
     full_patch = get_full_patch()
     if not full_patch.strip():
         print("ℹ️  No changes in watched paths. Nothing to do.")
         return
- 
+
     patches = split_patch_by_file(full_patch)
     print(f"   {len(patches)} file(s) changed in watched paths.\n")
- 
+
     # Run all checkers
     checkers = [
         check_config,
@@ -569,7 +643,7 @@ def main():
         check_go_version,
     ]
     results: list[CheckResult] = [fn(patches) for fn in checkers]
- 
+
     for r in results:
         if r.has_findings():
             print(f"  ✅ {r.label}")
@@ -581,24 +655,24 @@ def main():
                 print(f"     {c}")
         else:
             print(f"  –  {r.label}: no changes")
- 
+
     note = build_pr_note(results)
     if not note:
         print("\nℹ️  No notable changes found across all checkers.")
         return
- 
+
     print("\n🔄 Fetching PR description …")
     body = get_pr_body()
     new_body = inject_note(body, note)
- 
+
     if new_body == body:
         print("ℹ️  PR description already up to date — no changes needed.")
         return
- 
+
     update_pr_body(new_body)
     print(f"✅ PR #{PR_NUMBER} description updated.")
- 
- 
+
+
 if __name__ == "__main__":
     try:
         main()

--- a/.github/scripts/check_config_changes_ci.py
+++ b/.github/scripts/check_config_changes_ci.py
@@ -755,7 +755,6 @@ def main():
     note = build_pr_note(results)
     if not note:
         print("\nℹ️  No notable changes found across all checkers.")
-        return
 
     print("\n🔄 Fetching PR description …")
     body = get_pr_body()

--- a/.github/scripts/check_config_changes_ci.py
+++ b/.github/scripts/check_config_changes_ci.py
@@ -20,6 +20,8 @@ All inputs come from environment variables set by the GitHub Actions workflow:
   REPO          — owner/repo  (e.g. mattermost/mattermost)
 """
 
+import base64
+import json
 import os
 import re
 import sys
@@ -644,6 +646,57 @@ _AUTO_LINE_RE = re.compile(
     r"|^🗑️  Removed API file:"
 )
 
+# ── Injected-note bookkeeping ─────────────────────────────────────────────────
+#
+# The exact set of lines injected on the previous run is recorded in a hidden
+# marker appended to the end of the description.
+#
+# The marker lives OUTSIDE the ```release-note fence deliberately. An HTML
+# comment is invisible in rendered Markdown, but inside a fenced code block it
+# would be displayed literally and would pollute the release-note text that
+# downstream changelog tooling reads.
+#
+# Exact recall is what makes stale-note removal safe. The generated phrasing is
+# also the house style for hand-written notes — "Added ``Foo.Bar`` configuration
+# setting." is what a contributor types too — so a pattern match cannot tell the
+# two apart, and stripping by pattern with nothing to re-inject silently deletes
+# somebody's hand-written note.
+_MARKER_RE = re.compile(r"\n\n<!-- config-change-checker:v1 ([A-Za-z0-9+/=]*) -->\n?")
+
+
+def _read_marker(body: str) -> Optional[list[str]]:
+    """Return the lines injected by the previous run, or None if unmarked."""
+    m = _MARKER_RE.search(body or "")
+    if not m:
+        return None
+    try:
+        decoded = base64.b64decode(m.group(1).encode("ascii"))
+        recorded = json.loads(decoded.decode("utf-8"))
+    except (ValueError, UnicodeDecodeError):
+        # A corrupted marker is treated as absent: fall back to the legacy path
+        # rather than risk removing the wrong lines.
+        return None
+    return recorded if isinstance(recorded, list) else None
+
+
+def _drop_marker(body: str) -> str:
+    return _MARKER_RE.sub("", body or "")
+
+
+def _write_marker(body: str, lines: list[str]) -> str:
+    """Append the hidden record of the lines just injected.
+
+    The body is not trimmed first. Appending a fixed suffix and removing that
+    exact suffix in _drop_marker makes the round trip lossless, so a run with
+    nothing new to say reproduces the stored description byte-for-byte and the
+    no-op guard in main() actually fires.
+    """
+    payload = base64.b64encode(
+        json.dumps(lines, separators=(",", ":")).encode("utf-8")
+    ).decode("ascii")
+    return f"{body}\n\n<!-- config-change-checker:v1 {payload} -->\n"
+
+
 # Matches placeholder content inside a release-note fence that means "nothing
 # to report yet" (e.g. NONE, N/A, ---).  When detected, we replace the
 # placeholder rather than appending alongside it.
@@ -697,42 +750,124 @@ def build_pr_note(results: list[CheckResult]) -> str:
     return "\n".join(lines)
 
 
-def strip_old_note(body: str) -> str:
-    """
-    Remove previously auto-generated lines from the PR description.
+def _strip_by_pattern(body: str, note_lines: set[str]) -> str:
+    """Legacy removal for descriptions written before the marker existed.
 
-    Primary path  — lines inside the ```release-note ... ``` fence.
-    Fallback path — auto-generated lines that were appended outside any fence
-                    (e.g. via the ## Release Notes section on earlier runs).
+    Only lines that are about to be re-emitted verbatim are removed. The
+    generated phrasing is also the house style for hand-written notes, so a
+    pattern match cannot prove a line came from this script — but if the line is
+    one we are re-adding anyway, removing it can only ever dedupe.
 
-    Lines are identified by pattern rather than visible markers, so the PR
-    description stays clean for human readers.
+    The cost is that a generated line from an older run which is no longer
+    valid (the field it described has since been dropped from the PR) is left
+    in place instead of being cleaned up. Leaving a stale line behind is the
+    better failure: the alternative deletes a contributor's note. This only
+    affects descriptions written before the marker existed.
     """
     def _clean_fence(m: re.Match) -> str:
         open_tag, content, close_tag = m.group(1), m.group(2), m.group(3)
         cleaned_lines = [
             line for line in content.split("\n")
-            if not _AUTO_LINE_RE.match(line.strip())
+            if not (_AUTO_LINE_RE.match(line.strip()) and line.strip() in note_lines)
         ]
         return open_tag + "\n".join(cleaned_lines) + close_tag
 
     cleaned = re.sub(
         r"(```release-note)(.*?)(```)",
         _clean_fence,
-        body or "",
+        body,
         flags=re.DOTALL | re.IGNORECASE,
     )
 
-    # Fallback: strip any auto-generated lines that appear outside a fence
-    # (written by an older version of this script or via the header-inject path).
-    cleaned_lines = [
-        line for line in cleaned.splitlines()
-        if not _AUTO_LINE_RE.match(line.strip())
-    ]
-    return "\n".join(cleaned_lines).rstrip()
+    # Also dedupe generated lines that landed outside any fence (written by an
+    # older version of this script via the header-inject path).
+    return "\n".join(
+        line for line in cleaned.split("\n")
+        if not (_AUTO_LINE_RE.match(line.strip()) and line.strip() in note_lines)
+    )
+
+
+def strip_old_note(body: str, note: str = "") -> str:
+    """
+    Remove the lines this script injected on a previous run.
+
+    When the description carries a marker, exactly those recorded lines are
+    removed and nothing else can be mistaken for generated content. Removal is
+    count-limited, so a line a contributor happens to duplicate elsewhere in the
+    description survives.
+
+    When there is no marker — a PR whose description predates it — fall back to
+    _strip_by_pattern, which only dedupes lines being re-emitted.
+
+    Surrounding whitespace is left alone; only whole lines are dropped. Trimming
+    it here would make every run differ from the stored description and defeat
+    the no-op guard in main().
+    """
+    body = body or ""
+    previous = _read_marker(body)
+    body = _drop_marker(body)
+
+    if previous is None:
+        if not note:
+            return body
+        return _strip_by_pattern(body, {line.strip() for line in note.split("\n")})
+
+    remaining: dict[str, int] = {}
+    for line in previous:
+        key = line.strip()
+        remaining[key] = remaining.get(key, 0) + 1
+
+    kept: list[str] = []
+    for line in body.split("\n"):
+        key = line.strip()
+        if remaining.get(key):
+            remaining[key] -= 1
+            continue
+        kept.append(line)
+    return "\n".join(kept)
+
+
+def _restore_placeholder(body: str) -> str:
+    """Put NONE back if removing generated lines emptied the release-note fence.
+
+    An empty fence is not a valid release note, and the placeholder is what the
+    description held before this script ever wrote to it.
+    """
+    def _fill(m: re.Match) -> str:
+        open_tag, content, close_tag = m.group(1), m.group(2), m.group(3)
+        if content.strip():
+            return m.group(0)
+        return f"{open_tag}\nNONE\n{close_tag}"
+
+    return re.sub(
+        r"(```release-note)(.*?)(```)",
+        _fill,
+        body,
+        count=1,
+        flags=re.DOTALL | re.IGNORECASE,
+    )
 
 
 def inject_note(body: str, note: str) -> str:
+    """
+    Replace the previous run's generated lines with `note`, and record exactly
+    what was written so the next run can remove it precisely.
+
+    An empty `note` removes any previously generated lines and the marker with
+    them, restoring the NONE placeholder if that empties the fence. A
+    description this script has never written to is returned byte-for-byte
+    unchanged.
+    """
+    original = body or ""
+    stripped = strip_old_note(original, note)
+
+    if not note:
+        return _restore_placeholder(stripped) if stripped != original else original
+
+    return _write_marker(_insert_note(stripped, note), note.split("\n"))
+
+
+def _insert_note(body: str, note: str) -> str:
     """
     Insert `note` using this priority order:
 
@@ -741,10 +876,6 @@ def inject_note(body: str, note: str) -> str:
     2. After a recognised release-notes section header (## Release Notes, etc.)
     3. Fallback: append a new ## Release Notes section at the end
     """
-    body = strip_old_note(body)
-    if not note:
-        return body
-
     # 1. Mattermost-style ```release-note ... ``` block — inject INSIDE the fence.
     #    If the fence currently contains only a placeholder (NONE / N/A / ---),
     #    replace the placeholder rather than appending alongside it.

--- a/.github/scripts/check_config_changes_ci.py
+++ b/.github/scripts/check_config_changes_ci.py
@@ -661,7 +661,9 @@ _AUTO_LINE_RE = re.compile(
 # setting." is what a contributor types too — so a pattern match cannot tell the
 # two apart, and stripping by pattern with nothing to re-inject silently deletes
 # somebody's hand-written note.
-_MARKER_RE = re.compile(r"\n\n<!-- config-change-checker:v1 ([A-Za-z0-9+/=]*) -->\n?")
+_MARKER_RE = re.compile(
+    r"\r?\n\r?\n<!-- config-change-checker:v1 ([A-Za-z0-9+/=]*) -->[ \t]*\r?\n?"
+)
 
 
 def _read_marker(body: str) -> Optional[list[str]]:
@@ -676,7 +678,14 @@ def _read_marker(body: str) -> Optional[list[str]]:
         # A corrupted marker is treated as absent: fall back to the legacy path
         # rather than risk removing the wrong lines.
         return None
-    return recorded if isinstance(recorded, list) else None
+    # The marker lives in the description, which any contributor can edit. A
+    # payload decoding to anything other than a list of strings is treated as
+    # absent rather than allowed to raise part-way through a run.
+    if not isinstance(recorded, list):
+        return None
+    if not all(isinstance(entry, str) for entry in recorded):
+        return None
+    return recorded
 
 
 def _drop_marker(body: str) -> str:
@@ -921,7 +930,12 @@ def get_pr_body() -> str:
         timeout=_TIMEOUT,
     )
     r.raise_for_status()
-    return r.json().get("body") or ""
+    # Normalise to LF. GitHub returns CRLF for any description that has been
+    # edited in the web UI, because the textarea round-trips the whole body.
+    # With `edited` as a trigger that is a routine path, and CRLF would
+    # otherwise orphan the marker written by the previous run, leaving the old
+    # one in place and appending a second on every edit.
+    return (r.json().get("body") or "").replace("\r\n", "\n")
 
 
 def update_pr_body(new_body: str) -> None:

--- a/.github/scripts/check_config_changes_ci.py
+++ b/.github/scripts/check_config_changes_ci.py
@@ -262,13 +262,57 @@ def _format_endpoint(path: str, handler: str, method: str) -> str:
     return f"`{method.upper()} {path or '/'}` (`{handler}`)"
  
  
+def _iter_code(text: str, start: int = 0):
+    """Yield (index, char) for characters that are Go code, skipping the contents
+    of string, raw string and rune literals.
+ 
+    Route paths are string literals and may legitimately contain parentheses and
+    commas — websocket.go registers "/{websocket:websocket(?:\\/)?}" — so a
+    scanner that treats them as syntax mis-locates the end of the call or shifts
+    the argument positions.
+ 
+    Comments are deliberately NOT skipped here. The caller works on a
+    whitespace-collapsed blob in which a // comment has no terminating newline,
+    so skipping to end-of-line would swallow the rest of the file.
+    """
+    i, n = start, len(text)
+    while i < n:
+        ch = text[i]
+ 
+        if ch in ('"', "'"):            # interpreted string / rune literal
+            quote = ch
+            i += 1
+            while i < n:
+                if text[i] == "\\":     # escape: skip the escaped character too
+                    i += 2
+                    continue
+                if text[i] == quote:
+                    i += 1
+                    break
+                i += 1
+            continue
+ 
+        if ch == "`":                   # raw string literal — no escapes
+            i += 1
+            while i < n and text[i] != "`":
+                i += 1
+            i += 1
+            continue
+ 
+        yield i, ch
+        i += 1
+ 
+ 
 def _matching_paren(text: str, open_idx: int) -> int:
-    """Index of the ')' closing the '(' at open_idx, or -1 if unbalanced."""
+    """Index of the ')' closing the '(' at open_idx, or -1 if unbalanced.
+ 
+    Parentheses inside literals are ignored.
+    """
     depth = 0
-    for i in range(open_idx, len(text)):
-        if text[i] == "(":
+    for i, ch in _iter_code(text, open_idx):
+        if ch == "(":
             depth += 1
-        elif text[i] == ")":
+        elif ch == ")":
             depth -= 1
             if depth == 0:
                 return i
@@ -276,22 +320,25 @@ def _matching_paren(text: str, open_idx: int) -> int:
  
  
 def _split_top_level(text: str) -> list[str]:
-    """Split an argument list on commas that are not nested inside brackets."""
+    """Split an argument list on commas that are not nested inside brackets.
+ 
+    Commas inside literals are ignored, so a route path such as "/a,b" does not
+    shift the positions of the arguments that follow it.
+    """
     parts: list[str] = []
-    current: list[str] = []
     depth = 0
-    for ch in text:
+    last = 0
+    for i, ch in _iter_code(text):
         if ch in "([{":
             depth += 1
         elif ch in ")]}":
             depth -= 1
-        if ch == "," and depth == 0:
-            parts.append("".join(current))
-            current = []
-        else:
-            current.append(ch)
-    if "".join(current).strip():
-        parts.append("".join(current))
+        elif ch == "," and depth == 0:
+            parts.append(text[last:i])
+            last = i + 1
+    tail = text[last:]
+    if tail.strip():
+        parts.append(tail)
     return parts
  
  

--- a/.github/scripts/check_config_changes_ci.py
+++ b/.github/scripts/check_config_changes_ci.py
@@ -336,6 +336,91 @@ def _format_endpoint(path: str, handler: str, method: str) -> str:
     return f"`{method.upper()} {path or '/'}` (`{handler}`)"
 
 
+def _strip_go_comments(src: str) -> str:
+    """Remove // and /* */ comments from Go source, keeping everything else
+    — including string, rune, and raw string literals — byte-for-byte intact.
+
+    _parse_endpoints collapses all whitespace before scanning, which erases
+    line boundaries. Without this filter, a commented-out registration such as
+
+        // r.Handle("/old", api.APIHandler(oldHandler)).Methods("GET")
+
+    reads exactly like live code once collapsed and would be picked up as a
+    phantom added/removed endpoint; a comment landing mid-registration could
+    also splice two unrelated lines together. _strip_go_noise cannot be reused
+    here because it blanks string contents too, destroying the quoted path
+    and method literals _HANDLE_START_RE and _parse_methods depend on.
+    """
+    out: list[str] = []
+    in_line_comment  = False
+    in_block_comment = False
+    in_raw_string    = False
+
+    i, n = 0, len(src)
+    while i < n:
+        ch = src[i]
+
+        if in_line_comment:
+            if ch == "\n":
+                in_line_comment = False
+                out.append(ch)
+            i += 1
+            continue
+
+        if in_block_comment:
+            if src.startswith("*/", i):
+                in_block_comment = False
+                i += 2
+            else:
+                i += 1
+            continue
+
+        if in_raw_string:
+            out.append(ch)
+            if ch == "`":
+                in_raw_string = False
+            i += 1
+            continue
+
+        if src.startswith("//", i):
+            in_line_comment = True
+            i += 2
+            continue
+
+        if src.startswith("/*", i):
+            in_block_comment = True
+            i += 2
+            continue
+
+        if ch == "`":
+            in_raw_string = True
+            out.append(ch)
+            i += 1
+            continue
+
+        if ch in ('"', "'"):
+            quote = ch
+            out.append(ch)
+            i += 1
+            while i < n:
+                out.append(src[i])
+                if src[i] == "\\" and i + 1 < n:
+                    i += 1
+                    out.append(src[i])
+                    i += 1
+                    continue
+                if src[i] == quote:
+                    i += 1
+                    break
+                i += 1
+            continue
+
+        out.append(ch)
+        i += 1
+
+    return "".join(out)
+
+
 def _matching_paren(text: str, open_idx: int) -> int:
     """Index of the ')' closing the '(' at open_idx, or -1 if unbalanced."""
     depth = 0
@@ -406,13 +491,14 @@ def _parse_endpoints(src: str) -> set[tuple[str, str, str]]:
     """
     Parse Handle() registrations from a Go source file.
 
-    Whitespace-collapses the entire file first so multi-line declarations
+    Strips comments first so a commented-out registration isn't mistaken for
+    a live one, then whitespace-collapses the file so multi-line declarations
     (e.g. the 18 in group.go) are matched as a single token sequence, then
     walks each registration with a paren-balanced scan so that wrappers with
     extra arguments, nested wrappers, and package-qualified handler names are
     all recognised. Returns {(path, handler, method)} tuples.
     """
-    blob = " ".join(src.split())
+    blob = " ".join(_strip_go_comments(src).split())
     endpoints: set[tuple[str, str, str]] = set()
 
     for m in _HANDLE_START_RE.finditer(blob):

--- a/.github/scripts/check_config_changes_ci.py
+++ b/.github/scripts/check_config_changes_ci.py
@@ -20,8 +20,6 @@ All inputs come from environment variables set by the GitHub Actions workflow:
   REPO          — owner/repo  (e.g. mattermost/mattermost)
 """
 
-import base64
-import json
 import os
 import re
 import sys
@@ -157,77 +155,6 @@ _STRUCT_DECL_RE  = re.compile(r"^type\s+(\w+)\s+struct\s*\{")
 _FIELD_LINE_RE   = re.compile(r"^\t([A-Z][A-Za-z0-9_]*)\s+\S")
 
 
-def _strip_go_noise(lines):
-    """Yield each line with comments and string/rune literals blanked out.
-
-    Brace counting must ignore braces that appear inside comments or string
-    literals. config.go contains doc comments such as
-
-        //	type HairSettings struct {
-
-    whose braces would otherwise be counted as real, skewing the depth for the
-    remainder of the comment. A skew that begins inside a struct body makes the
-    enclosing-struct stack unwind early and silently drops every remaining
-    field of that struct from the release-note output.
-
-    Block comments and raw string literals can span lines, so that state is
-    carried across iterations. Layout characters (tabs, spaces) are preserved
-    so the caller's line-anchored regexes still apply.
-    """
-    in_block_comment = False
-    in_raw_string    = False
-
-    for line in lines:
-        out: list[str] = []
-        i, n = 0, len(line)
-
-        while i < n:
-            if in_block_comment:
-                if line.startswith("*/", i):
-                    in_block_comment = False
-                    i += 2
-                else:
-                    i += 1
-                continue
-
-            if in_raw_string:
-                if line[i] == "`":
-                    in_raw_string = False
-                i += 1
-                continue
-
-            if line.startswith("//", i):
-                break                       # rest of the line is a comment
-
-            if line.startswith("/*", i):
-                in_block_comment = True
-                i += 2
-                continue
-
-            if line[i] == "`":              # raw string literal (struct tags)
-                in_raw_string = True
-                i += 1
-                continue
-
-            if line[i] in ('"', "'"):       # interpreted string / rune literal
-                quote = line[i]
-                i += 1
-                while i < n:
-                    if line[i] == "\\":
-                        i += 2
-                        continue
-                    if line[i] == quote:
-                        i += 1
-                        break
-                    i += 1
-                continue
-
-            out.append(line[i])
-            i += 1
-
-        yield "".join(out)
-
-
 def _scan_struct_fields(src: str) -> set[tuple[str, str]]:
     """
     Walk Go source and return {(StructName, FieldName)} for every exported
@@ -237,16 +164,13 @@ def _scan_struct_fields(src: str) -> set[tuple[str, str]]:
     and function literals don't corrupt the enclosing struct context.
     Named type declarations cannot be nested in Go, so the struct_stack
     never grows beyond one entry for named structs.
-
-    Lines are pre-filtered through _strip_go_noise so that braces inside
-    comments, struct tags, and string literals never affect the depth.
     """
     fields: set[tuple[str, str]] = set()
     # Each entry: (struct_name, brace_depth_when_opened)
     struct_stack: list[tuple[str, int]] = []
     depth = 0
 
-    for line in _strip_go_noise(src.splitlines()):
+    for line in src.splitlines():
         sm = _STRUCT_DECL_RE.match(line)
         if sm:
             # Record depth *before* counting this line's braces
@@ -338,91 +262,6 @@ def _format_endpoint(path: str, handler: str, method: str) -> str:
     return f"`{method.upper()} {path or '/'}` (`{handler}`)"
 
 
-def _strip_go_comments(src: str) -> str:
-    """Remove // and /* */ comments from Go source, keeping everything else
-    — including string, rune, and raw string literals — byte-for-byte intact.
-
-    _parse_endpoints collapses all whitespace before scanning, which erases
-    line boundaries. Without this filter, a commented-out registration such as
-
-        // r.Handle("/old", api.APIHandler(oldHandler)).Methods("GET")
-
-    reads exactly like live code once collapsed and would be picked up as a
-    phantom added/removed endpoint; a comment landing mid-registration could
-    also splice two unrelated lines together. _strip_go_noise cannot be reused
-    here because it blanks string contents too, destroying the quoted path
-    and method literals _HANDLE_START_RE and _parse_methods depend on.
-    """
-    out: list[str] = []
-    in_line_comment  = False
-    in_block_comment = False
-    in_raw_string    = False
-
-    i, n = 0, len(src)
-    while i < n:
-        ch = src[i]
-
-        if in_line_comment:
-            if ch == "\n":
-                in_line_comment = False
-                out.append(ch)
-            i += 1
-            continue
-
-        if in_block_comment:
-            if src.startswith("*/", i):
-                in_block_comment = False
-                i += 2
-            else:
-                i += 1
-            continue
-
-        if in_raw_string:
-            out.append(ch)
-            if ch == "`":
-                in_raw_string = False
-            i += 1
-            continue
-
-        if src.startswith("//", i):
-            in_line_comment = True
-            i += 2
-            continue
-
-        if src.startswith("/*", i):
-            in_block_comment = True
-            i += 2
-            continue
-
-        if ch == "`":
-            in_raw_string = True
-            out.append(ch)
-            i += 1
-            continue
-
-        if ch in ('"', "'"):
-            quote = ch
-            out.append(ch)
-            i += 1
-            while i < n:
-                out.append(src[i])
-                if src[i] == "\\" and i + 1 < n:
-                    i += 1
-                    out.append(src[i])
-                    i += 1
-                    continue
-                if src[i] == quote:
-                    i += 1
-                    break
-                i += 1
-            continue
-
-        out.append(ch)
-        i += 1
-
-    return "".join(out)
-
-
 def _matching_paren(text: str, open_idx: int) -> int:
     """Index of the ')' closing the '(' at open_idx, or -1 if unbalanced."""
     depth = 0
@@ -493,14 +332,13 @@ def _parse_endpoints(src: str) -> set[tuple[str, str, str]]:
     """
     Parse Handle() registrations from a Go source file.
 
-    Strips comments first so a commented-out registration isn't mistaken for
-    a live one, then whitespace-collapses the file so multi-line declarations
+    Whitespace-collapses the entire file first so multi-line declarations
     (e.g. the 18 in group.go) are matched as a single token sequence, then
     walks each registration with a paren-balanced scan so that wrappers with
     extra arguments, nested wrappers, and package-qualified handler names are
     all recognised. Returns {(path, handler, method)} tuples.
     """
-    blob = " ".join(_strip_go_comments(src).split())
+    blob = " ".join(src.split())
     endpoints: set[tuple[str, str, str]] = set()
 
     for m in _HANDLE_START_RE.finditer(blob):
@@ -646,66 +484,6 @@ _AUTO_LINE_RE = re.compile(
     r"|^🗑️  Removed API file:"
 )
 
-# ── Injected-note bookkeeping ─────────────────────────────────────────────────
-#
-# The exact set of lines injected on the previous run is recorded in a hidden
-# marker appended to the end of the description.
-#
-# The marker lives OUTSIDE the ```release-note fence deliberately. An HTML
-# comment is invisible in rendered Markdown, but inside a fenced code block it
-# would be displayed literally and would pollute the release-note text that
-# downstream changelog tooling reads.
-#
-# Exact recall is what makes stale-note removal safe. The generated phrasing is
-# also the house style for hand-written notes — "Added ``Foo.Bar`` configuration
-# setting." is what a contributor types too — so a pattern match cannot tell the
-# two apart, and stripping by pattern with nothing to re-inject silently deletes
-# somebody's hand-written note.
-_MARKER_RE = re.compile(
-    r"\r?\n\r?\n<!-- config-change-checker:v1 ([A-Za-z0-9+/=]*) -->[ \t]*\r?\n?"
-)
-
-
-def _read_marker(body: str) -> Optional[list[str]]:
-    """Return the lines injected by the previous run, or None if unmarked."""
-    m = _MARKER_RE.search(body or "")
-    if not m:
-        return None
-    try:
-        decoded = base64.b64decode(m.group(1).encode("ascii"))
-        recorded = json.loads(decoded.decode("utf-8"))
-    except (ValueError, UnicodeDecodeError):
-        # A corrupted marker is treated as absent: fall back to the legacy path
-        # rather than risk removing the wrong lines.
-        return None
-    # The marker lives in the description, which any contributor can edit. A
-    # payload decoding to anything other than a list of strings is treated as
-    # absent rather than allowed to raise part-way through a run.
-    if not isinstance(recorded, list):
-        return None
-    if not all(isinstance(entry, str) for entry in recorded):
-        return None
-    return recorded
-
-
-def _drop_marker(body: str) -> str:
-    return _MARKER_RE.sub("", body or "")
-
-
-def _write_marker(body: str, lines: list[str]) -> str:
-    """Append the hidden record of the lines just injected.
-
-    The body is not trimmed first. Appending a fixed suffix and removing that
-    exact suffix in _drop_marker makes the round trip lossless, so a run with
-    nothing new to say reproduces the stored description byte-for-byte and the
-    no-op guard in main() actually fires.
-    """
-    payload = base64.b64encode(
-        json.dumps(lines, separators=(",", ":")).encode("utf-8")
-    ).decode("ascii")
-    return f"{body}\n\n<!-- config-change-checker:v1 {payload} -->\n"
-
-
 # Matches placeholder content inside a release-note fence that means "nothing
 # to report yet" (e.g. NONE, N/A, ---).  When detected, we replace the
 # placeholder rather than appending alongside it.
@@ -759,124 +537,42 @@ def build_pr_note(results: list[CheckResult]) -> str:
     return "\n".join(lines)
 
 
-def _strip_by_pattern(body: str, note_lines: set[str]) -> str:
-    """Legacy removal for descriptions written before the marker existed.
+def strip_old_note(body: str) -> str:
+    """
+    Remove previously auto-generated lines from the PR description.
 
-    Only lines that are about to be re-emitted verbatim are removed. The
-    generated phrasing is also the house style for hand-written notes, so a
-    pattern match cannot prove a line came from this script — but if the line is
-    one we are re-adding anyway, removing it can only ever dedupe.
+    Primary path  — lines inside the ```release-note ... ``` fence.
+    Fallback path — auto-generated lines that were appended outside any fence
+                    (e.g. via the ## Release Notes section on earlier runs).
 
-    The cost is that a generated line from an older run which is no longer
-    valid (the field it described has since been dropped from the PR) is left
-    in place instead of being cleaned up. Leaving a stale line behind is the
-    better failure: the alternative deletes a contributor's note. This only
-    affects descriptions written before the marker existed.
+    Lines are identified by pattern rather than visible markers, so the PR
+    description stays clean for human readers.
     """
     def _clean_fence(m: re.Match) -> str:
         open_tag, content, close_tag = m.group(1), m.group(2), m.group(3)
         cleaned_lines = [
             line for line in content.split("\n")
-            if not (_AUTO_LINE_RE.match(line.strip()) and line.strip() in note_lines)
+            if not _AUTO_LINE_RE.match(line.strip())
         ]
         return open_tag + "\n".join(cleaned_lines) + close_tag
 
     cleaned = re.sub(
         r"(```release-note)(.*?)(```)",
         _clean_fence,
-        body,
+        body or "",
         flags=re.DOTALL | re.IGNORECASE,
     )
 
-    # Also dedupe generated lines that landed outside any fence (written by an
-    # older version of this script via the header-inject path).
-    return "\n".join(
-        line for line in cleaned.split("\n")
-        if not (_AUTO_LINE_RE.match(line.strip()) and line.strip() in note_lines)
-    )
-
-
-def strip_old_note(body: str, note: str = "") -> str:
-    """
-    Remove the lines this script injected on a previous run.
-
-    When the description carries a marker, exactly those recorded lines are
-    removed and nothing else can be mistaken for generated content. Removal is
-    count-limited, so a line a contributor happens to duplicate elsewhere in the
-    description survives.
-
-    When there is no marker — a PR whose description predates it — fall back to
-    _strip_by_pattern, which only dedupes lines being re-emitted.
-
-    Surrounding whitespace is left alone; only whole lines are dropped. Trimming
-    it here would make every run differ from the stored description and defeat
-    the no-op guard in main().
-    """
-    body = body or ""
-    previous = _read_marker(body)
-    body = _drop_marker(body)
-
-    if previous is None:
-        if not note:
-            return body
-        return _strip_by_pattern(body, {line.strip() for line in note.split("\n")})
-
-    remaining: dict[str, int] = {}
-    for line in previous:
-        key = line.strip()
-        remaining[key] = remaining.get(key, 0) + 1
-
-    kept: list[str] = []
-    for line in body.split("\n"):
-        key = line.strip()
-        if remaining.get(key):
-            remaining[key] -= 1
-            continue
-        kept.append(line)
-    return "\n".join(kept)
-
-
-def _restore_placeholder(body: str) -> str:
-    """Put NONE back if removing generated lines emptied the release-note fence.
-
-    An empty fence is not a valid release note, and the placeholder is what the
-    description held before this script ever wrote to it.
-    """
-    def _fill(m: re.Match) -> str:
-        open_tag, content, close_tag = m.group(1), m.group(2), m.group(3)
-        if content.strip():
-            return m.group(0)
-        return f"{open_tag}\nNONE\n{close_tag}"
-
-    return re.sub(
-        r"(```release-note)(.*?)(```)",
-        _fill,
-        body,
-        count=1,
-        flags=re.DOTALL | re.IGNORECASE,
-    )
+    # Fallback: strip any auto-generated lines that appear outside a fence
+    # (written by an older version of this script or via the header-inject path).
+    cleaned_lines = [
+        line for line in cleaned.splitlines()
+        if not _AUTO_LINE_RE.match(line.strip())
+    ]
+    return "\n".join(cleaned_lines).rstrip()
 
 
 def inject_note(body: str, note: str) -> str:
-    """
-    Replace the previous run's generated lines with `note`, and record exactly
-    what was written so the next run can remove it precisely.
-
-    An empty `note` removes any previously generated lines and the marker with
-    them, restoring the NONE placeholder if that empties the fence. A
-    description this script has never written to is returned byte-for-byte
-    unchanged.
-    """
-    original = body or ""
-    stripped = strip_old_note(original, note)
-
-    if not note:
-        return _restore_placeholder(stripped) if stripped != original else original
-
-    return _write_marker(_insert_note(stripped, note), note.split("\n"))
-
-
-def _insert_note(body: str, note: str) -> str:
     """
     Insert `note` using this priority order:
 
@@ -885,6 +581,10 @@ def _insert_note(body: str, note: str) -> str:
     2. After a recognised release-notes section header (## Release Notes, etc.)
     3. Fallback: append a new ## Release Notes section at the end
     """
+    body = strip_old_note(body)
+    if not note:
+        return body
+
     # 1. Mattermost-style ```release-note ... ``` block — inject INSIDE the fence.
     #    If the fence currently contains only a placeholder (NONE / N/A / ---),
     #    replace the placeholder rather than appending alongside it.
@@ -930,12 +630,7 @@ def get_pr_body() -> str:
         timeout=_TIMEOUT,
     )
     r.raise_for_status()
-    # Normalise to LF. GitHub returns CRLF for any description that has been
-    # edited in the web UI, because the textarea round-trips the whole body.
-    # With `edited` as a trigger that is a routine path, and CRLF would
-    # otherwise orphan the marker written by the previous run, leaving the old
-    # one in place and appending a second on every edit.
-    return (r.json().get("body") or "").replace("\r\n", "\n")
+    return r.json().get("body") or ""
 
 
 def update_pr_body(new_body: str) -> None:
@@ -986,6 +681,7 @@ def main():
     note = build_pr_note(results)
     if not note:
         print("\nℹ️  No notable changes found across all checkers.")
+        return
 
     print("\n🔄 Fetching PR description …")
     body = get_pr_body()

--- a/.github/workflows/config-change-checker.yml
+++ b/.github/workflows/config-change-checker.yml
@@ -16,7 +16,13 @@ name: Config Change Checker
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened]
+    # `edited` is included so a description rewritten after the last push — by a
+    # human, or by another bot appending its own section — is re-checked and the
+    # auto-detected notes restored. Without it the notes are lost permanently,
+    # since nothing re-runs until the next commit. Description updates made by
+    # this workflow use GITHUB_TOKEN, and GITHUB_TOKEN-authored events do not
+    # trigger further workflow runs, so this cannot loop.
+    types: [opened, synchronize, reopened, edited]
     paths:
       - 'server/public/model/config.go'
       - 'server/channels/api4/**'
@@ -34,10 +40,16 @@ jobs:
   check-release-notes:
     name: Detect release-note-worthy changes
     runs-on: ubuntu-latest
-    # Skip bot-authored PRs (Dependabot, mattermost-bot, etc.) — they will
-    # not touch these paths intentionally and cannot receive description updates
-    # via GITHUB_TOKEN anyway (fork-like restrictions apply to most bots).
-    if: github.event.pull_request.user.type != 'Bot'
+    # Only same-repository pull requests can be updated: GitHub issues a
+    # read-only GITHUB_TOKEN for pull requests opened from a fork, so the
+    # description PATCH would fail. Dependabot runs under the same restriction.
+    #
+    # Bot-authored PRs from branches in this repository (e.g. cursor[bot]) are
+    # deliberately NOT skipped — they routinely change the watched paths and
+    # the token can update their descriptions normally.
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.user.login != 'dependabot[bot]'
 
     permissions:
       pull-requests: write   # needed to update the PR description


### PR DESCRIPTION
#### Summary

Two issues caused release notes to be silently omitted from PRs that changed a watched path.

1. The job was skipped for every bot-authored PR. Agent-opened PRs (e.g. `cursor[bot]`) routinely change `config.go`, and when the branch lives in this repository `GITHUB_TOKEN` can update the description normally. Replace the bot check with the constraint that actually applies: fork PRs get a read-only token. Dependabot is kept out for the same reason.

2. The workflow only ran on `opened`/`synchronize`/`reopened`, so a description rewritten after the last push permanently lost the injected notes with no re-run to restore them. Add `edited`. `GITHUB_TOKEN`-authored events do not trigger workflow runs, so the workflow cannot retrigger itself, and the existing no-op guard skips the PATCH when the body is already correct.

3. The api4 endpoint regex only matched wrappers of the exact shape `wrapper(handler)`, dropping 33 of 760 route registrations: two-arg wrappers such as `api.APISessionRequired(uploadFileStream, handlerParamFileAPI)` (every file-upload endpoint), nested wrappers such as `api.APISessionRequired(contentFlaggingRequired(getConfig))` (all of content flagging), and package-qualified handler names such as `manualtesting.ManualTest`. Because the checker set-diffs both revisions, these endpoints could be added or removed with no note and no false positive to signal the miss. Replace the wrapper pattern with a paren-balanced scan that descends to the innermost first argument.

#### Verified against master

- `api4/` (168 files, 760 registrations) — every endpoint the old parser found is still found with an identical handler name (0 regressions), and the 33 previously-missed registrations are now detected. A paren-balanced ground-truth scan reports 0 remaining misses.
- `config.go`, `audit_events.go`, and `Dockerfile.buildenv` extraction is unchanged by this PR.

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes affect CI workflow conditions and endpoint parsing, including previously unsupported registration patterns. Validation covered existing and newly detected registrations, which reduces regression risk.

**QA Recommendation:** Manual QA is not required. Rely on the existing automated coverage and parser validation.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->