### PR TITLE
[M-70285] Fix plugin settings section handling

### DIFF
--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
@@ -103,6 +103,93 @@ describe('custom plugin sections and settings', () => {
         expect(screen.getByText('This is the footer')).toBeInTheDocument();
     });
 
+    it('renders top-level settings together with sections', () => {
+        const state = {
+            ...baseState,
+            entities: {
+                admin: {
+                    plugins: {
+                        testplugin: {
+                            ...plugin,
+                            settings_schema: {
+                                ...plugin.settings_schema,
+                                settings: [{
+                                    key: 'topLevelSetting',
+                                    display_name: 'Top-level Setting',
+                                    type: 'text' as const,
+                                    help_text: 'Top-level setting help text',
+                                    placeholder: '',
+                                    default: '',
+                                }],
+                                sections: [{
+                                    key: 'section1',
+                                    title: 'Section 1',
+                                    settings: [{
+                                        key: 'sectionSetting',
+                                        display_name: 'Section Setting',
+                                        type: 'text' as const,
+                                        help_text: 'Section setting help text',
+                                        placeholder: '',
+                                        default: '',
+                                    }],
+                                }],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        renderWithContext(
+            <CustomPluginSettings
+                {...baseProps}
+                patchConfig={jest.fn()}
+            />,
+            state,
+        );
+
+        expect(screen.getByText('Top-level Setting')).toBeInTheDocument();
+        expect(screen.getByText('Section 1')).toBeInTheDocument();
+        expect(screen.getByText('Section Setting')).toBeInTheDocument();
+    });
+
+    it('renders top-level settings when sections is empty', () => {
+        const state = {
+            ...baseState,
+            entities: {
+                admin: {
+                    plugins: {
+                        testplugin: {
+                            ...plugin,
+                            settings_schema: {
+                                ...plugin.settings_schema,
+                                settings: [{
+                                    key: 'topLevelSetting',
+                                    display_name: 'Top-level Setting',
+                                    type: 'text' as const,
+                                    help_text: 'Top-level setting help text',
+                                    placeholder: '',
+                                    default: '',
+                                }],
+                                sections: [],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        renderWithContext(
+            <CustomPluginSettings
+                {...baseProps}
+                patchConfig={jest.fn()}
+            />,
+            state,
+        );
+
+        expect(screen.getByText('Top-level Setting')).toBeInTheDocument();
+    });
+
     it('renders plugin metadata with distinct display name and id', () => {
         const pluginId = 'com.mattermost.fl3xx';
         const pluginName = 'FL3XX';

--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
@@ -153,6 +153,67 @@ describe('custom plugin sections and settings', () => {
         expect(screen.getByText('Section Setting')).toBeInTheDocument();
     });
 
+    it('renders warnings for top-level custom settings when plugin activation failed', () => {
+        const state = {
+            ...baseState,
+            entities: {
+                admin: {
+                    plugins: {
+                        testplugin: {
+                            ...plugin,
+                            active: false,
+                            settings_schema: {
+                                ...plugin.settings_schema,
+                                settings: [
+                                    {
+                                        key: 'customSetting1',
+                                        display_name: 'Custom Setting 1',
+                                        type: 'custom' as const,
+                                        help_text: '',
+                                    },
+                                    {
+                                        key: 'customSetting2',
+                                        display_name: 'Custom Setting 2',
+                                        type: 'custom' as const,
+                                        help_text: '',
+                                    },
+                                ],
+                                sections: [{
+                                    key: 'section1',
+                                    title: 'Section 1',
+                                    settings: [],
+                                }],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        renderWithContext(
+            <CustomPluginSettings
+                {...baseProps}
+                config={{
+                    PluginSettings: {
+                        PluginStates: {
+                            testplugin: {
+                                Enable: true,
+                            },
+                        },
+                        Plugins: {
+                            testplugin: {},
+                        },
+                    } as unknown as PluginSettings,
+                }}
+                patchConfig={jest.fn()}
+            />,
+            state,
+        );
+
+        expect(screen.getAllByText('In order to view this setting, enable the plugin and click Save.')).toHaveLength(2);
+        expect(screen.getByText('Section 1')).toBeInTheDocument();
+    });
+
     it('renders top-level settings when sections is empty', () => {
         const state = {
             ...baseState,

--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.ts
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.ts
@@ -82,7 +82,7 @@ function makeGetPluginSchema() {
                         banner_type: bannerType,
                         component,
                         showTitle: customComponents[key] ? customComponents[key].options.showTitle : false,
-                    } as Partial<AdminDefinitionSetting>;
+                    } as AdminDefinitionSetting;
                 });
             };
 
@@ -90,7 +90,7 @@ function makeGetPluginSchema() {
                 return sections.map((section) => {
                     const key = section.key.toLowerCase();
                     let component;
-                    let settings: Array<Partial<AdminDefinitionSetting>> = [];
+                    let settings: AdminDefinitionSetting[] = [];
                     if (section.custom) {
                         if (customSections[key]) {
                             component = customSections[key]?.component;
@@ -126,10 +126,11 @@ function makeGetPluginSchema() {
             };
 
             let sections: AdminDefinitionConfigSchemaSection[] = [];
-            let settings: Array<Partial<AdminDefinitionSetting>> = [];
-            if (plugin.settings_schema && plugin.settings_schema.sections) {
+            let settings: AdminDefinitionSetting[] = [];
+            if (plugin.settings_schema?.sections?.length) {
                 sections = parsePluginSettingSections(plugin.settings_schema.sections);
-            } else if (plugin.settings_schema && plugin.settings_schema.settings) {
+            }
+            if (plugin.settings_schema?.settings?.length) {
                 settings = parsePluginSettings(plugin.settings_schema.settings);
             }
 
@@ -150,22 +151,28 @@ function makeGetPluginSchema() {
 
                     sections = [{
                         key: pluginEnabledConfigKey + '.Section',
-                        header: plugin.settings_schema?.header,
-                        footer: plugin.settings_schema?.footer,
-                        settings: [pluginEnableSetting, warningBanner],
+                        settings: [pluginEnableSetting, ...settings, warningBanner],
                     }];
+                    settings = [];
                 } else if (sections.length > 0) {
                     // Have a separate section on top with the plugin enable/disable setting.
                     sections.unshift({
                         key: pluginEnabledConfigKey + '.Section',
-                        header: plugin.settings_schema?.header,
-                        footer: plugin.settings_schema?.footer,
-                        settings: [pluginEnableSetting],
+                        settings: [pluginEnableSetting, ...settings],
                     });
+                    settings = [];
                 } else {
                     // Otherwise we retain existing behaviour and add the setting in front.
                     settings.unshift(pluginEnableSetting);
                 }
+            }
+
+            if (sections.length > 0 && settings.length > 0) {
+                sections.unshift({
+                    key: pluginEnabledConfigKey + '.Section',
+                    settings,
+                });
+                settings = [];
             }
 
             const checkDisableSetting = (s: Partial<AdminDefinitionSetting>) => {

--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.ts
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.ts
@@ -62,7 +62,10 @@ function makeGetPluginSchema() {
                         type = Constants.SettingsTypes.TYPE_BANNER;
                         displayName = defineMessage({id: 'admin.plugin.customSetting.pluginDisabledWarning', defaultMessage: 'In order to view this setting, enable the plugin and click Save.'});
                         bannerType = 'warning';
-                        isDisabled = it.any(it.stateIsTrue(pluginEnabledConfigKey), it.not(it.userHasWritePermissionOnResource('plugins')));
+                        isDisabled = it.any(
+                            it.all(Boolean(plugin.active), it.stateIsTrue(pluginEnabledConfigKey)),
+                            it.not(it.userHasWritePermissionOnResource('plugins')),
+                        );
                     }
 
                     const isHidden = () => {

--- a/webapp/channels/src/components/admin_console/plugin_management/plugin_management.test.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_management/plugin_management.test.tsx
@@ -9,7 +9,7 @@ import PluginState from 'mattermost-redux/constants/plugins';
 import {PluginManagement} from 'components/admin_console/plugin_management/plugin_management';
 
 import {defaultIntl} from 'tests/helpers/intl-test-helper';
-import {renderWithContext} from 'tests/react_testing_utils';
+import {renderWithContext, screen} from 'tests/react_testing_utils';
 
 describe('components/PluginManagement', () => {
     const defaultProps = {
@@ -575,5 +575,37 @@ describe('components/PluginManagement', () => {
             ref.current!.setState({loading: false} as any);
         });
         expect(container).toMatchSnapshot();
+    });
+
+    test('should show the settings link for a plugin with sections only', () => {
+        const props = {
+            ...defaultProps,
+            pluginStatuses: {
+                plugin_0: defaultProps.pluginStatuses.plugin_0,
+            },
+            plugins: {
+                plugin_0: {
+                    ...defaultProps.plugins.plugin_0,
+                    settings_schema: {
+                        sections: [{
+                            key: 'section',
+                            settings: [],
+                        }],
+                    },
+                },
+            },
+        };
+        const ref = React.createRef<InstanceType<typeof PluginManagement>>();
+        renderWithContext(
+            <PluginManagement
+                {...props}
+                ref={ref}
+            />,
+        );
+        act(() => {
+            ref.current!.setState({loading: false} as any);
+        });
+
+        expect(screen.getByText('Settings')).toBeInTheDocument();
     });
 });

--- a/webapp/channels/src/components/admin_console/plugin_management/plugin_management.tsx
+++ b/webapp/channels/src/components/admin_console/plugin_management/plugin_management.tsx
@@ -174,6 +174,7 @@ type PluginStatus = {
         header: string;
         footer: string;
         settings?: unknown[];
+        sections?: unknown[];
     };
 };
 
@@ -997,7 +998,12 @@ export class PluginManagement extends OLDAdminSettings<Props, State> {
             });
             pluginsList = plugins.map((pluginStatus: PluginStatus) => {
                 const p = this.props.plugins[pluginStatus.id];
-                const hasSettings = Boolean(p && p.settings_schema && (p.settings_schema.header || p.settings_schema.footer || (p.settings_schema.settings && p.settings_schema.settings.length > 0)));
+                const hasSettings = Boolean(p?.settings_schema && (
+                    p.settings_schema.header ||
+                    p.settings_schema.footer ||
+                    p.settings_schema.settings?.length ||
+                    p.settings_schema.sections?.length
+                ));
                 return (
                     <PluginItem
                         key={pluginStatus.id}

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.test.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.test.tsx
@@ -287,6 +287,27 @@ describe('components/admin_console/SchemaAdminSettings', () => {
         expect(screen.getByText('Test')).toBeInTheDocument();
     });
 
+    test('should render a component-only section without settings', () => {
+        renderWithContext(
+            <SchemaAdminSettings
+                {...DefaultProps}
+                config={config}
+                environmentConfig={environmentConfig}
+                schema={{
+                    id: 'Config',
+                    name: 'config',
+                    sections: [{
+                        key: 'component-only',
+                        component: () => <p>{'Component-only section'}</p>,
+                    }],
+                } as unknown as AdminDefinitionSubSectionSchema}
+                patchConfig={jest.fn()}
+            />,
+        );
+
+        expect(screen.getByText('Component-only section')).toBeInTheDocument();
+    });
+
     test('should render header text with markdown links', () => {
         const headerText = 'This is [a link](!https://example.com) in the header';
         const props = {
@@ -361,6 +382,45 @@ describe('components/admin_console/SchemaAdminSettings', () => {
 
         expect(text.indexOf('Schema header')).toBeLessThan(text.indexOf('Plugin section'));
         expect(text.indexOf('Plugin section')).toBeLessThan(text.indexOf('Schema footer'));
+    });
+
+    test('should render top-level settings and sections between the schema header and footer', () => {
+        const props = {
+            ...DefaultProps,
+            config,
+            environmentConfig,
+            schema: {
+                id: 'Config',
+                name: 'config',
+                header: 'Schema header',
+                footer: 'Schema footer',
+                settings: [{
+                    key: 'ServiceSettings.SiteURL',
+                    label: 'Top-level Setting',
+                    type: 'text' as const,
+                }],
+                sections: [{
+                    key: 'section',
+                    title: 'Plugin section',
+                    settings: [{
+                        key: 'ServiceSettings.ConnectionURL',
+                        label: 'Section Setting',
+                        type: 'text' as const,
+                    }],
+                }],
+            } as AdminDefinitionSubSectionSchema,
+            patchConfig: jest.fn(),
+        };
+
+        const {container} = renderWithContext(<SchemaAdminSettings {...props}/>);
+        const text = container.textContent || '';
+
+        expect(screen.getByText('Top-level Setting')).toBeInTheDocument();
+        expect(screen.getByText('Section Setting')).toBeInTheDocument();
+        expect(text.indexOf('Schema header')).toBeLessThan(text.indexOf('Top-level Setting'));
+        expect(text.indexOf('Top-level Setting')).toBeLessThan(text.indexOf('Plugin section'));
+        expect(text.indexOf('Plugin section')).toBeLessThan(text.indexOf('Section Setting'));
+        expect(text.indexOf('Section Setting')).toBeLessThan(text.indexOf('Schema footer'));
     });
 
     test('should render page not found', () => {

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.test.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.test.tsx
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
+import {act} from 'react-dom/test-utils';
 import {defineMessage} from 'react-intl';
 
 import type {CloudState} from '@mattermost/types/cloud';
@@ -446,6 +447,102 @@ describe('components/admin_console/SchemaAdminSettings', () => {
 
         expect(ref.current?.canSave()).toBe(true);
         expect(mockValidate).toHaveBeenCalled();
+    });
+
+    test('should persist permissions from sections in a mixed schema', async () => {
+        const permissionKey = 'Permissions.enableTeamCreation';
+        const editRole = jest.fn().mockResolvedValue({});
+        const roles = {
+            system_user: {
+                name: 'system_user',
+                permissions: [],
+            },
+        };
+        const mixedSchema = {
+            id: 'Config',
+            name: 'config',
+            settings: [{
+                key: 'ServiceSettings.SiteURL',
+                label: 'Site URL',
+                type: 'text' as const,
+            }],
+            sections: [{
+                key: 'permissions',
+                settings: [{
+                    key: permissionKey,
+                    label: 'Enable Team Creation',
+                    type: 'permission' as const,
+                    permissions_mapping_name: 'enableTeamCreation' as const,
+                }],
+            }],
+        };
+        const ref = React.createRef<SchemaAdminSettingsClass>();
+        renderWithContext(
+            <SchemaAdminSettingsClass
+                ref={ref}
+                {...DefaultProps}
+                config={config}
+                editRole={editRole}
+                environmentConfig={environmentConfig}
+                roles={roles as any}
+                schema={mixedSchema}
+                patchConfig={jest.fn()}
+                intl={defaultIntl}
+            />,
+        );
+
+        act(() => {
+            ref.current!.setState({
+                [permissionKey]: true,
+                saveNeeded: 'permissions',
+            } as any);
+        });
+        await ref.current!.handleSubmit({preventDefault: jest.fn()} as any);
+
+        expect(editRole).toHaveBeenCalledWith(expect.objectContaining({
+            name: 'system_user',
+            permissions: ['create_team'],
+        }));
+    });
+
+    test('should validate top-level and section settings in a mixed schema', () => {
+        const topLevelValidate = jest.fn(() => new ValidationResult(true, ''));
+        const sectionValidate = jest.fn(() => new ValidationResult(false, 'Invalid section setting'));
+        const mixedSchema = {
+            id: 'Config',
+            name: 'config',
+            settings: [{
+                key: 'ServiceSettings.SiteURL',
+                label: 'Site URL',
+                type: 'text' as const,
+                validate: topLevelValidate,
+            }],
+            sections: [{
+                key: 'connection',
+                settings: [{
+                    key: 'ServiceSettings.ConnectionURL',
+                    label: 'Connection URL',
+                    type: 'text' as const,
+                    validate: sectionValidate,
+                }],
+            }],
+        };
+        const ref = React.createRef<SchemaAdminSettingsClass>();
+        renderWithContext(
+            <SchemaAdminSettingsClass
+                ref={ref}
+                {...DefaultProps}
+                config={config}
+                environmentConfig={environmentConfig}
+                schema={mixedSchema}
+                patchConfig={jest.fn()}
+                intl={defaultIntl}
+            />,
+        );
+
+        expect(ref.current?.canSave()).toBe(false);
+        expect(topLevelValidate).toHaveBeenCalled();
+        expect(sectionValidate).toHaveBeenCalled();
     });
 
     test('should handle changing text input values', async () => {

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.test.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.test.tsx
@@ -336,6 +336,32 @@ describe('components/admin_console/SchemaAdminSettings', () => {
         expect(container.textContent).toContain('in the footer');
     });
 
+    test('should render a schema footer after all sections', () => {
+        const props = {
+            ...DefaultProps,
+            config,
+            environmentConfig,
+            schema: {
+                id: 'Config',
+                name: 'config',
+                header: 'Schema header',
+                footer: 'Schema footer',
+                sections: [{
+                    key: 'section',
+                    title: 'Plugin section',
+                    settings: [],
+                }],
+            } as AdminDefinitionSubSectionSchema,
+            patchConfig: jest.fn(),
+        };
+
+        const {container} = renderWithContext(<SchemaAdminSettings {...props}/>);
+        const text = container.textContent || '';
+
+        expect(text.indexOf('Schema header')).toBeLessThan(text.indexOf('Plugin section'));
+        expect(text.indexOf('Plugin section')).toBeLessThan(text.indexOf('Schema footer'));
+    });
+
     test('should render page not found', () => {
         const props = {
             ...DefaultProps,

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.test.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.test.tsx
@@ -415,6 +415,8 @@ describe('components/admin_console/SchemaAdminSettings', () => {
         const {container} = renderWithContext(<SchemaAdminSettings {...props}/>);
         const text = container.textContent || '';
 
+        expect(screen.getByText('Schema header')).toBeInTheDocument();
+        expect(screen.getByText('Schema footer')).toBeInTheDocument();
         expect(screen.getByText('Top-level Setting')).toBeInTheDocument();
         expect(screen.getByText('Section Setting')).toBeInTheDocument();
         expect(text.indexOf('Schema header')).toBeLessThan(text.indexOf('Top-level Setting'));

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -119,6 +119,19 @@ export function descriptorOrStringToString(text: string | MessageDescriptor | un
     return typeof text === 'string' ? text : intl.formatMessage(text, values);
 }
 
+function getSchemaSettings(schema: AdminDefinitionSubSectionSchema | null): AdminDefinitionSetting[] {
+    if (!schema || !('settings' in schema || 'sections' in schema)) {
+        return [];
+    }
+
+    const settings = 'settings' in schema && schema.settings ? [...schema.settings] : [];
+    if ('sections' in schema && schema.sections) {
+        schema.sections.forEach((section) => settings.push(...section.settings));
+    }
+
+    return settings;
+}
+
 export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettingsProps, State> {
     private isPlugin: boolean;
     private saveActions: Array<() => Promise<{error?: {message?: string}}>>;
@@ -189,7 +202,7 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
         });
 
         if (this.state.saveNeeded === 'both' || this.state.saveNeeded === 'permissions') {
-            const settings = (this.props.schema && 'settings' in this.props.schema && this.props.schema.settings) || [];
+            const settings = getSchemaSettings(this.props.schema);
             const rolesBinding = settings.reduce<Record<string, string>>((acc, val) => {
                 if (val.type === Constants.SettingsTypes.TYPE_PERMISSION) {
                     acc[val.permissions_mapping_name] = this.state[val.key].toString();
@@ -233,13 +246,7 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
         let state: Partial<State> = {};
 
         if (schema) {
-            let settings: AdminDefinitionSetting[] = [];
-
-            if ('settings' in schema && schema.settings) {
-                settings = schema.settings;
-            } else if ('sections' in schema && schema.sections) {
-                schema.sections.map((section) => section.settings).forEach((sectionSettings) => settings.push(...sectionSettings));
-            }
+            const settings = getSchemaSettings(schema);
 
             // Recursively collect settings from expandable settings
             const collectSettingsRecursively = (settingsArray: AdminDefinitionSetting[]): AdminDefinitionSetting[] => {
@@ -1337,11 +1344,7 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
     };
 
     canSave = () => {
-        if (!this.props.schema || !('settings' in this.props.schema) || !this.props.schema.settings) {
-            return true;
-        }
-
-        for (const setting of this.props.schema.settings) {
+        for (const setting of getSchemaSettings(this.props.schema)) {
             // Some settings are actually not settings (banner)
             // and don't have a key, skip those ones
             if (!('key' in setting) || !setting.key) {
@@ -1586,13 +1589,7 @@ export const getConfigFromState = (
     isDisabled: (setting: AdminDefinitionSetting) => boolean,
 ) => {
     if (schema) {
-        let settings: AdminDefinitionSetting[] = [];
-
-        if ('settings' in schema && schema.settings) {
-            settings = schema.settings;
-        } else if ('sections' in schema && schema.sections) {
-            schema.sections.map((section) => section.settings).forEach((sectionSettings) => settings.push(...sectionSettings));
-        }
+        const settings = getSchemaSettings(schema);
 
         // Recursively collect settings from expandable settings
         const collectSettingsRecursively = (settingsArray: AdminDefinitionSetting[]): AdminDefinitionSetting[] => {

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -126,7 +126,11 @@ function getSchemaSettings(schema: AdminDefinitionSubSectionSchema | null): Admi
 
     const settings = 'settings' in schema && schema.settings ? [...schema.settings] : [];
     if ('sections' in schema && schema.sections) {
-        schema.sections.forEach((section) => settings.push(...section.settings));
+        schema.sections.forEach((section) => {
+            if (section.settings) {
+                settings.push(...section.settings);
+            }
+        });
     }
 
     return settings;
@@ -1076,86 +1080,61 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
             return null;
         }
 
-        if ('settings' in schema && schema.settings) {
+        const buildSettingsList = (settings: AdminDefinitionSetting[] | undefined) => {
             const settingsList: React.ReactNode[] = [];
-            if (schema.settings) {
-                schema.settings.forEach((setting) => {
+            if (settings) {
+                settings.forEach((setting) => {
                     if (this.buildSettingFunctions[setting.type] && !this.isHidden(setting)) {
                         settingsList.push(this.buildSettingFunctions[setting.type](setting));
                     }
                 });
             }
 
-            let header;
-            if (schema.header) {
-                header = (
-                    <div className='banner'>
-                        <SchemaText
-                            text={schema.header}
-                            isMarkdown={true}
-                        />
-                    </div>
-                );
-            }
+            return settingsList;
+        };
 
-            let footer;
-            if (schema.footer) {
-                footer = (
-                    <div className='banner'>
-                        <SchemaText
-                            text={schema.footer}
-                            isMarkdown={true}
-                        />
-                    </div>
-                );
-            }
+        let header;
+        if ('header' in schema && schema.header) {
+            header = (
+                <div className='banner'>
+                    <SchemaText
+                        text={schema.header}
+                        isMarkdown={true}
+                    />
+                </div>
+            );
+        }
 
+        let footer;
+        if ('footer' in schema && schema.footer) {
+            footer = (
+                <div className='banner'>
+                    <SchemaText
+                        text={schema.footer}
+                        isMarkdown={true}
+                    />
+                </div>
+            );
+        }
+
+        const schemaSections = 'sections' in schema ? schema.sections : undefined;
+        if ('settings' in schema && schema.settings && !schemaSections) {
             return (
                 <SettingsGroup container={false}>
                     {header}
-                    {settingsList}
+                    {buildSettingsList(schema.settings)}
                     {footer}
                 </SettingsGroup>
             );
-        } else if ('sections' in schema && schema.sections) {
+        } else if (schemaSections) {
             const sections: React.ReactNode[] = [];
-            let header;
-            if (schema.header) {
-                header = (
-                    <div className='banner'>
-                        <SchemaText
-                            text={schema.header}
-                            isMarkdown={true}
-                        />
-                    </div>
-                );
-            }
 
-            let footer;
-            if (schema.footer) {
-                footer = (
-                    <div className='banner'>
-                        <SchemaText
-                            text={schema.footer}
-                            isMarkdown={true}
-                        />
-                    </div>
-                );
-            }
-
-            schema.sections.forEach((section) => {
+            schemaSections.forEach((section) => {
                 if (this.isSectionHidden(section)) {
                     return;
                 }
 
-                const settingsList: React.ReactNode[] = [];
-                if (section.settings) {
-                    section.settings.forEach((setting) => {
-                        if (this.buildSettingFunctions[setting.type] && !this.isHidden(setting)) {
-                            settingsList.push(this.buildSettingFunctions[setting.type](setting));
-                        }
-                    });
-                }
+                const settingsList = buildSettingsList(section.settings);
 
                 if (section.component) {
                     const CustomComponent = section.component;
@@ -1259,6 +1238,11 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
             return (
                 <div>
                     {header}
+                    {'settings' in schema && schema.settings && schema.settings.length > 0 && (
+                        <SettingsGroup container={false}>
+                            {buildSettingsList(schema.settings)}
+                        </SettingsGroup>
+                    )}
                     {sections}
                     {footer}
                 </div>

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -1112,6 +1112,29 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
             );
         } else if ('sections' in schema && schema.sections) {
             const sections: React.ReactNode[] = [];
+            let header;
+            if (schema.header) {
+                header = (
+                    <div className='banner'>
+                        <SchemaText
+                            text={schema.header}
+                            isMarkdown={true}
+                        />
+                    </div>
+                );
+            }
+
+            let footer;
+            if (schema.footer) {
+                footer = (
+                    <div className='banner'>
+                        <SchemaText
+                            text={schema.footer}
+                            isMarkdown={true}
+                        />
+                    </div>
+                );
+            }
 
             schema.sections.forEach((section) => {
                 if (this.isSectionHidden(section)) {
@@ -1228,7 +1251,9 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
 
             return (
                 <div>
+                    {header}
                     {sections}
+                    {footer}
                 </div>
             );
         }

--- a/webapp/channels/src/utils/admin_console_plugin_index.test.ts
+++ b/webapp/channels/src/utils/admin_console_plugin_index.test.ts
@@ -67,4 +67,42 @@ describe('AdminConsolePluginsIndex.getPluginEntries', () => {
         expect(entries['plugin_plugin-without-settings']).toContain('Enable Plugin: ');
         expect(entries['plugin_plugin-without-settings']).toContain('PluginSettings.PluginStates.plugin-without-settings.Enable');
     });
+
+    it('should index plugin section content and nested settings', () => {
+        const plugin = {
+            ...samplePlugin4,
+            settings_schema: {
+                ...samplePlugin4.settings_schema,
+                sections: [{
+                    key: 'connection',
+                    title: 'Connection Settings',
+                    subtitle: 'Configure the service connection',
+                    header: 'Read the [connection guide](https://example.com/header)',
+                    footer: 'Restart after [saving](https://example.com/footer)',
+                    settings: [{
+                        key: 'ServiceURL',
+                        display_name: 'Service URL',
+                        type: 'text',
+                        help_text: 'Address of the [external service](https://example.com/service)',
+                        placeholder: '',
+                        default: '',
+                    }],
+                }],
+            },
+        };
+
+        const entries = getPluginEntries({[plugin.id]: plugin}, intl)[`plugin_${plugin.id}`];
+
+        expect(entries).toEqual(expect.arrayContaining([
+            'connection',
+            'Connection Settings',
+            'Configure the service connection',
+            'Read the connection guide',
+            'Restart after saving',
+            'ServiceURL',
+            'Service URL',
+            'Address of the external service',
+        ]));
+        expect(entries.join(' ')).not.toContain('https://example.com');
+    });
 });

--- a/webapp/channels/src/utils/admin_console_plugin_index.ts
+++ b/webapp/channels/src/utils/admin_console_plugin_index.ts
@@ -34,6 +34,21 @@ function extractTextsFromPlugin(plugin: PluginRedux, intl: IntlShape) {
                 texts.push(...settingsTexts);
             }
         }
+
+        if (plugin.settings_schema.sections) {
+            for (const section of plugin.settings_schema.sections) {
+                pushString(texts, section.key, intl);
+                pushString(texts, section.title, intl);
+                pushString(texts, section.subtitle, intl);
+                pushString(texts, section.header, intl, true);
+                pushString(texts, section.footer, intl, true);
+
+                for (const setting of section.settings || []) {
+                    const settingsTexts = extractTextFromSetting(setting as Partial<AdminDefinitionSetting & PluginSetting>, intl);
+                    texts.push(...settingsTexts);
+                }
+            }
+        }
     }
     return texts;
 }


### PR DESCRIPTION

#### Summary
Fixed plugin settings section handling in the System Console:
- show the Settings link for sections-only plugins
- render top-level settings alongside sections, including when `sections` is empty
- support component-only sections without a settings list
- process permission persistence and validation across top-level and section settings
- show custom-setting warnings when configured activation fails at runtime
- place schema footers after all settings and sections
- include section metadata and nested settings in Admin Console search

The mixed custom-section fallback behavior remains tracked separately in MM-70283.

QA:
1. Upload a plugin with sections but no schema header, footer, or top-level settings and verify its Settings link appears.
2. Open a plugin with both top-level settings and sections; verify the schema header and footer are visible and surround both content groups in the correct order.
3. Verify a component-only section renders without defining `settings`.
4. Verify permission changes and validation execute for settings normalized into sections.
5. Configure a plugin as enabled while forcing activation to fail and verify unavailable custom settings show warning banners.
6. Search the Admin Console by a section title or nested setting label and verify the plugin appears.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-70285

#### Screenshots
[fixed_plugin_section_settings_v2.mp4](https://cursor.com/agents/bc-3028ee67-92a4-48d5-a1cd-d6961d35cbd7/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ffixed_plugin_section_settings_v2.mp4)

#### Release Note
```release-note
Fixed rendering, navigation, validation, and search for section-based plugin settings.
```

[Open in Web](https://cursor.com/agents/bc-3028ee67-92a4-48d5-a1cd-d6961d35cbd7?cursor_ref=pr_footer&cursor_cta=open_in_web) | [Open in Cursor](https://cursor.com/background-agent?bcId=bc-3028ee67-92a4-48d5-a1cd-d6961d35cbd7&cursor_ref=pr_footer&cursor_cta=open_in_cursor)

## Change Impact: 🟡 Medium

**Regression Risk:** Changes span multiple Admin Console components and shared plugin indexing logic. Tests cover the affected settings, rendering, activation, and search paths.

**QA Recommendation:** Manual QA can be skipped. Automated test coverage is sufficient.

*Generated by CodeRabbitAI*
