### PR TITLE
[MM-70287] Add user_created to SAML/OAuth SSO audit events

### DIFF
--- a/docs/main/administration-guide/comply/embedded-json-audit-log-schema.mdx
+++ b/docs/main/administration-guide/comply/embedded-json-audit-log-schema.mdx
@@ -600,7 +600,7 @@ From Mattermost v11.5.0, audit log entries for posts and content access events i
 </tr>
 <tr>
 <td><code>completeSaml</code></td>
-<td>Completing SAML authentication</td>
+<td>Completing SAML authentication. <code>meta.user_created</code> is true when the login provisioned a new account via JIT.</td>
 </tr>
 <tr>
 <td><code>extendSessionExpiry</code></td>
@@ -819,7 +819,7 @@ From Mattermost v11.5.0, audit log entries for posts and content access events i
 </tr>
 <tr>
 <td><code>completeOAuth</code></td>
-<td>Completing OAuth flow</td>
+<td>Completing OAuth/OIDC authentication. <code>meta.user_created</code> is true when the login provisioned a new account via JIT.</td>
 </tr>
 <tr>
 <td><code>createOAuthApp</code></td>

--- a/server/channels/app/oauth.go
+++ b/server/channels/app/oauth.go
@@ -732,8 +732,7 @@ func (a *App) RevokeAccessToken(rctx request.CTX, token string) *model.AppError 
 }
 
 // CompleteOAuth finishes an OAuth/OIDC login or signup.
-// The bool is true when this call provisioned a new Mattermost account via JIT.
-func (a *App) CompleteOAuth(rctx request.CTX, service string, body io.ReadCloser, props map[string]string, tokenUser *model.User) (*model.User, bool, *model.AppError) {
+func (a *App) CompleteOAuth(rctx request.CTX, service string, body io.ReadCloser, props map[string]string, tokenUser *model.User) (user *model.User, userWasCreated bool, err *model.AppError) {
 	defer body.Close()
 
 	action := props["action"]
@@ -748,7 +747,7 @@ func (a *App) CompleteOAuth(rctx request.CTX, service string, body io.ReadCloser
 	case model.OAuthActionLogin:
 		return a.LoginByOAuth(rctx, service, body, inviteToken, inviteId, tokenUser)
 	case model.OAuthActionEmailToSSO:
-		user, err := a.CompleteSwitchWithOAuth(rctx, service, body, props["email"], tokenUser)
+		user, err = a.CompleteSwitchWithOAuth(rctx, service, body, props["email"], tokenUser)
 		return user, false, err
 	case model.OAuthActionSSOToEmail:
 		return a.LoginByOAuth(rctx, service, body, inviteToken, inviteId, tokenUser)
@@ -775,28 +774,28 @@ func (a *App) getSSOProvider(service string) (einterfaces.OAuthProvider, *model.
 }
 
 // TODO: merge conflict, needs teamID string
-func (a *App) LoginByOAuth(rctx request.CTX, service string, userData io.Reader, inviteToken string, inviteId string, tokenUser *model.User) (*model.User, bool, *model.AppError) {
+func (a *App) LoginByOAuth(rctx request.CTX, service string, userData io.Reader, inviteToken string, inviteId string, tokenUser *model.User) (user *model.User, userWasCreated bool, err *model.AppError) {
 	provider, e := a.getSSOProvider(service)
 	if e != nil {
 		return nil, false, e
 	}
 
 	buf := bytes.Buffer{}
-	if _, err := buf.ReadFrom(userData); err != nil {
+	if _, readErr := buf.ReadFrom(userData); readErr != nil {
 		return nil, false, model.NewAppError("LoginByOAuth2", "api.user.login_by_oauth.parse.app_error",
 			map[string]any{"Service": service}, "", http.StatusBadRequest)
 	}
 
-	settings, err := provider.GetSSOSettings(rctx, a.Config(), service)
-	if err != nil {
+	settings, err2 := provider.GetSSOSettings(rctx, a.Config(), service)
+	if err2 != nil {
 		return nil, false, model.NewAppError("LoginByOAuth", "api.user.oauth.get_settings.app_error",
-			map[string]any{"Service": service}, "", http.StatusBadRequest).Wrap(err)
+			map[string]any{"Service": service}, "", http.StatusBadRequest).Wrap(err2)
 	}
 
-	authUser, err := provider.GetUserFromJSON(rctx, bytes.NewReader(buf.Bytes()), tokenUser, settings)
-	if err != nil {
+	authUser, err2 := provider.GetUserFromJSON(rctx, bytes.NewReader(buf.Bytes()), tokenUser, settings)
+	if err2 != nil {
 		return nil, false, model.NewAppError("LoginByOAuth", "api.user.login_by_oauth.parse.app_error",
-			map[string]any{"Service": service}, "", http.StatusBadRequest).Wrap(err)
+			map[string]any{"Service": service}, "", http.StatusBadRequest).Wrap(err2)
 	}
 
 	if *authUser.AuthData == "" {
@@ -805,10 +804,9 @@ func (a *App) LoginByOAuth(rctx request.CTX, service string, userData io.Reader,
 	}
 
 	user, appErr := a.GetUserByAuth(new(*authUser.AuthData), service)
-	userCreated := false
 	if appErr != nil {
 		if appErr.Id == MissingAuthAccountError {
-			user, userCreated, appErr = a.CreateOAuthUser(rctx, service, bytes.NewReader(buf.Bytes()), inviteToken, inviteId, tokenUser)
+			user, userWasCreated, appErr = a.CreateOAuthUser(rctx, service, bytes.NewReader(buf.Bytes()), inviteToken, inviteId, tokenUser)
 		} else {
 			return nil, false, appErr
 		}
@@ -833,7 +831,7 @@ func (a *App) LoginByOAuth(rctx request.CTX, service string, userData io.Reader,
 		return nil, false, appErr
 	}
 
-	return user, userCreated, nil
+	return user, userWasCreated, nil
 }
 
 // LoginByIntune authenticates a user using a Microsoft Entra ID access_token from MSAL

--- a/server/channels/app/oauth.go
+++ b/server/channels/app/oauth.go
@@ -745,9 +745,13 @@ func (a *App) CompleteOAuth(rctx request.CTX, service string, body io.ReadCloser
 	switch action {
 	case model.OAuthActionSignup:
 		return a.CreateOAuthUser(rctx, service, body, inviteToken, inviteId, tokenUser)
+	case model.OAuthActionLogin:
+		return a.LoginByOAuth(rctx, service, body, inviteToken, inviteId, tokenUser)
 	case model.OAuthActionEmailToSSO:
 		user, err := a.CompleteSwitchWithOAuth(rctx, service, body, props["email"], tokenUser)
 		return user, false, err
+	case model.OAuthActionSSOToEmail:
+		return a.LoginByOAuth(rctx, service, body, inviteToken, inviteId, tokenUser)
 	default:
 		return a.LoginByOAuth(rctx, service, body, inviteToken, inviteId, tokenUser)
 	}

--- a/server/channels/app/oauth.go
+++ b/server/channels/app/oauth.go
@@ -731,7 +731,9 @@ func (a *App) RevokeAccessToken(rctx request.CTX, token string) *model.AppError 
 	return nil
 }
 
-func (a *App) CompleteOAuth(rctx request.CTX, service string, body io.ReadCloser, props map[string]string, tokenUser *model.User) (*model.User, *model.AppError) {
+// CompleteOAuth finishes an OAuth/OIDC login or signup.
+// The bool is true when this call provisioned a new Mattermost account via JIT.
+func (a *App) CompleteOAuth(rctx request.CTX, service string, body io.ReadCloser, props map[string]string, tokenUser *model.User) (*model.User, bool, *model.AppError) {
 	defer body.Close()
 
 	action := props["action"]
@@ -743,12 +745,9 @@ func (a *App) CompleteOAuth(rctx request.CTX, service string, body io.ReadCloser
 	switch action {
 	case model.OAuthActionSignup:
 		return a.CreateOAuthUser(rctx, service, body, inviteToken, inviteId, tokenUser)
-	case model.OAuthActionLogin:
-		return a.LoginByOAuth(rctx, service, body, inviteToken, inviteId, tokenUser)
 	case model.OAuthActionEmailToSSO:
-		return a.CompleteSwitchWithOAuth(rctx, service, body, props["email"], tokenUser)
-	case model.OAuthActionSSOToEmail:
-		return a.LoginByOAuth(rctx, service, body, inviteToken, inviteId, tokenUser)
+		user, err := a.CompleteSwitchWithOAuth(rctx, service, body, props["email"], tokenUser)
+		return user, false, err
 	default:
 		return a.LoginByOAuth(rctx, service, body, inviteToken, inviteId, tokenUser)
 	}
@@ -772,52 +771,53 @@ func (a *App) getSSOProvider(service string) (einterfaces.OAuthProvider, *model.
 }
 
 // TODO: merge conflict, needs teamID string
-func (a *App) LoginByOAuth(rctx request.CTX, service string, userData io.Reader, inviteToken string, inviteId string, tokenUser *model.User) (*model.User, *model.AppError) {
+func (a *App) LoginByOAuth(rctx request.CTX, service string, userData io.Reader, inviteToken string, inviteId string, tokenUser *model.User) (*model.User, bool, *model.AppError) {
 	provider, e := a.getSSOProvider(service)
 	if e != nil {
-		return nil, e
+		return nil, false, e
 	}
 
 	buf := bytes.Buffer{}
 	if _, err := buf.ReadFrom(userData); err != nil {
-		return nil, model.NewAppError("LoginByOAuth2", "api.user.login_by_oauth.parse.app_error",
+		return nil, false, model.NewAppError("LoginByOAuth2", "api.user.login_by_oauth.parse.app_error",
 			map[string]any{"Service": service}, "", http.StatusBadRequest)
 	}
 
 	settings, err := provider.GetSSOSettings(rctx, a.Config(), service)
 	if err != nil {
-		return nil, model.NewAppError("LoginByOAuth", "api.user.oauth.get_settings.app_error",
+		return nil, false, model.NewAppError("LoginByOAuth", "api.user.oauth.get_settings.app_error",
 			map[string]any{"Service": service}, "", http.StatusBadRequest).Wrap(err)
 	}
 
 	authUser, err := provider.GetUserFromJSON(rctx, bytes.NewReader(buf.Bytes()), tokenUser, settings)
 	if err != nil {
-		return nil, model.NewAppError("LoginByOAuth", "api.user.login_by_oauth.parse.app_error",
+		return nil, false, model.NewAppError("LoginByOAuth", "api.user.login_by_oauth.parse.app_error",
 			map[string]any{"Service": service}, "", http.StatusBadRequest).Wrap(err)
 	}
 
 	if *authUser.AuthData == "" {
-		return nil, model.NewAppError("LoginByOAuth3", "api.user.login_by_oauth.parse.app_error",
+		return nil, false, model.NewAppError("LoginByOAuth3", "api.user.login_by_oauth.parse.app_error",
 			map[string]any{"Service": service}, "", http.StatusBadRequest)
 	}
 
 	user, appErr := a.GetUserByAuth(new(*authUser.AuthData), service)
+	userCreated := false
 	if appErr != nil {
 		if appErr.Id == MissingAuthAccountError {
-			user, appErr = a.CreateOAuthUser(rctx, service, bytes.NewReader(buf.Bytes()), inviteToken, inviteId, tokenUser)
+			user, userCreated, appErr = a.CreateOAuthUser(rctx, service, bytes.NewReader(buf.Bytes()), inviteToken, inviteId, tokenUser)
 		} else {
-			return nil, appErr
+			return nil, false, appErr
 		}
 	} else {
 		// OAuth doesn't run through CheckUserPreflightAuthenticationCriteria, so prevent bot login
 		// here manually. Technically, the auth data above will fail to match a bot in the first
 		// place, but explicit is always better.
 		if user.IsBot {
-			return nil, model.NewAppError("loginByOAuth", "api.user.login_by_oauth.bot_login_forbidden.app_error", nil, "", http.StatusForbidden)
+			return nil, false, model.NewAppError("loginByOAuth", "api.user.login_by_oauth.bot_login_forbidden.app_error", nil, "", http.StatusForbidden)
 		}
 
 		if appErr = a.UpdateOAuthUserAttrs(rctx, bytes.NewReader(buf.Bytes()), user, provider, service, tokenUser); appErr != nil {
-			return nil, appErr
+			return nil, false, appErr
 		}
 
 		if appErr = a.AddUserToTeamByInviteIfNeeded(rctx, user, inviteToken, inviteId); appErr != nil {
@@ -826,10 +826,10 @@ func (a *App) LoginByOAuth(rctx request.CTX, service string, userData io.Reader,
 	}
 
 	if appErr != nil {
-		return nil, appErr
+		return nil, false, appErr
 	}
 
-	return user, nil
+	return user, userCreated, nil
 }
 
 // LoginByIntune authenticates a user using a Microsoft Entra ID access_token from MSAL

--- a/server/channels/app/oauth.go
+++ b/server/channels/app/oauth.go
@@ -773,7 +773,6 @@ func (a *App) getSSOProvider(service string) (einterfaces.OAuthProvider, *model.
 	return provider, nil
 }
 
-// TODO: merge conflict, needs teamID string
 func (a *App) LoginByOAuth(rctx request.CTX, service string, userData io.Reader, inviteToken string, inviteId string, tokenUser *model.User) (user *model.User, userWasCreated bool, err *model.AppError) {
 	provider, e := a.getSSOProvider(service)
 	if e != nil {
@@ -822,8 +821,8 @@ func (a *App) LoginByOAuth(rctx request.CTX, service string, userData io.Reader,
 			return nil, false, appErr
 		}
 
-		if appErr = a.AddUserToTeamByInviteIfNeeded(rctx, user, inviteToken, inviteId); appErr != nil {
-			rctx.Logger().Warn("Failed to add user to team", mlog.Err(appErr))
+		if inviteErr := a.AddUserToTeamByInviteIfNeeded(rctx, user, inviteToken, inviteId); inviteErr != nil {
+			rctx.Logger().Warn("Failed to add user to team", mlog.Err(inviteErr))
 		}
 	}
 

--- a/server/channels/app/oauth_test.go
+++ b/server/channels/app/oauth_test.go
@@ -2341,7 +2341,7 @@ func TestCompleteOAuthUserCreated(t *testing.T) {
 	}
 
 	t.Run("login JIT-creates then subsequent login does not", func(t *testing.T) {
-		id := int64(model.GetMillis())
+		id := model.GetMillis()
 		username := "o" + model.NewId()
 		email := model.NewId() + "@simulator.amazonses.com"
 		props := map[string]string{"action": model.OAuthActionLogin}
@@ -2358,7 +2358,7 @@ func TestCompleteOAuthUserCreated(t *testing.T) {
 	})
 
 	t.Run("signup reports user created", func(t *testing.T) {
-		id := int64(model.GetMillis())
+		id := model.GetMillis()
 		username := "o" + model.NewId()
 		email := model.NewId() + "@simulator.amazonses.com"
 
@@ -2370,7 +2370,7 @@ func TestCompleteOAuthUserCreated(t *testing.T) {
 
 	t.Run("email-to-sso does not report user created", func(t *testing.T) {
 		existing := th.CreateUser(t)
-		id := int64(model.GetMillis())
+		id := model.GetMillis()
 		username := "o" + model.NewId()
 		email := model.NewId() + "@simulator.amazonses.com"
 		props := map[string]string{

--- a/server/channels/app/oauth_test.go
+++ b/server/channels/app/oauth_test.go
@@ -4,6 +4,7 @@
 package app
 
 import (
+	"bytes"
 	"encoding/base64"
 	"encoding/json"
 	"errors"
@@ -19,6 +20,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin/plugintest/mock"
+	oauthgitlab "github.com/mattermost/mattermost/server/v8/channels/app/oauthproviders/gitlab"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 	"github.com/mattermost/mattermost/server/v8/einterfaces"
 	"github.com/mattermost/mattermost/server/v8/einterfaces/mocks"
@@ -2321,5 +2323,65 @@ func TestRedactOAuthTokenResponse(t *testing.T) {
 			assert.NotContains(t, actual, "abc")
 			assert.NotContains(t, actual, "def")
 		}
+	})
+}
+
+func TestCompleteOAuthUserCreated(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		*cfg.GitLabSettings.Enable = true
+	})
+
+	gitlabBody := func(id int64, username, email string) io.ReadCloser {
+		js, err := json.Marshal(oauthgitlab.GitLabUser{Id: id, Username: username, Email: email, Name: "Test User"})
+		require.NoError(t, err)
+		return io.NopCloser(bytes.NewReader(js))
+	}
+
+	t.Run("login JIT-creates then subsequent login does not", func(t *testing.T) {
+		id := int64(model.GetMillis())
+		username := "o" + model.NewId()
+		email := model.NewId() + "@simulator.amazonses.com"
+		props := map[string]string{"action": model.OAuthActionLogin}
+
+		user, userCreated, appErr := th.App.CompleteOAuth(th.Context, model.UserAuthServiceGitlab, gitlabBody(id, username, email), props, nil)
+		require.Nil(t, appErr)
+		require.NotNil(t, user)
+		assert.True(t, userCreated)
+
+		user2, userCreated, appErr := th.App.CompleteOAuth(th.Context, model.UserAuthServiceGitlab, gitlabBody(id, username, email), props, nil)
+		require.Nil(t, appErr)
+		assert.False(t, userCreated)
+		assert.Equal(t, user.Id, user2.Id)
+	})
+
+	t.Run("signup reports user created", func(t *testing.T) {
+		id := int64(model.GetMillis())
+		username := "o" + model.NewId()
+		email := model.NewId() + "@simulator.amazonses.com"
+
+		user, userCreated, appErr := th.App.CompleteOAuth(th.Context, model.UserAuthServiceGitlab, gitlabBody(id, username, email), map[string]string{"action": model.OAuthActionSignup}, nil)
+		require.Nil(t, appErr)
+		require.NotNil(t, user)
+		assert.True(t, userCreated)
+	})
+
+	t.Run("email-to-sso does not report user created", func(t *testing.T) {
+		existing := th.CreateUser(t)
+		id := int64(model.GetMillis())
+		username := "o" + model.NewId()
+		email := model.NewId() + "@simulator.amazonses.com"
+		props := map[string]string{
+			"action": model.OAuthActionEmailToSSO,
+			"email":  existing.Email,
+		}
+
+		user, userCreated, appErr := th.App.CompleteOAuth(th.Context, model.UserAuthServiceGitlab, gitlabBody(id, username, email), props, nil)
+		require.Nil(t, appErr)
+		require.NotNil(t, user)
+		assert.Equal(t, existing.Id, user.Id)
+		assert.False(t, userCreated)
 	})
 }

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -444,24 +444,26 @@ func (a *App) createUserOrGuest(rctx request.CTX, user *model.User, guest bool) 
 	return ruser, nil
 }
 
-func (a *App) CreateOAuthUser(rctx request.CTX, service string, userData io.Reader, inviteToken string, inviteId string, tokenUser *model.User) (*model.User, *model.AppError) {
+// CreateOAuthUser creates a user from OAuth/OIDC identity data.
+// The bool is true when this call provisioned a new Mattermost account via JIT.
+func (a *App) CreateOAuthUser(rctx request.CTX, service string, userData io.Reader, inviteToken string, inviteId string, tokenUser *model.User) (*model.User, bool, *model.AppError) {
 	if !*a.Config().TeamSettings.EnableUserCreation {
-		return nil, model.NewAppError("CreateOAuthUser", "api.user.create_user.disabled.app_error", nil, "", http.StatusNotImplemented)
+		return nil, false, model.NewAppError("CreateOAuthUser", "api.user.create_user.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
 
 	provider, e := a.getSSOProvider(service)
 	if e != nil {
-		return nil, e
+		return nil, false, e
 	}
 
 	settings, err := provider.GetSSOSettings(rctx, a.Config(), service)
 	if err != nil {
-		return nil, model.NewAppError("CreateOAuthUser", "api.user.oauth.get_settings.app_error", map[string]any{"Service": service}, "", http.StatusInternalServerError).Wrap(err)
+		return nil, false, model.NewAppError("CreateOAuthUser", "api.user.oauth.get_settings.app_error", map[string]any{"Service": service}, "", http.StatusInternalServerError).Wrap(err)
 	}
 
 	user, err := provider.GetUserFromJSON(rctx, userData, tokenUser, settings)
 	if err != nil {
-		return nil, model.NewAppError("CreateOAuthUser", "api.user.create_oauth_user.create.app_error", map[string]any{"Service": service}, "", http.StatusInternalServerError).Wrap(err)
+		return nil, false, model.NewAppError("CreateOAuthUser", "api.user.create_oauth_user.create.app_error", map[string]any{"Service": service}, "", http.StatusInternalServerError).Wrap(err)
 	}
 	if user.AuthService == "" {
 		user.AuthService = service
@@ -478,36 +480,36 @@ func (a *App) CreateOAuthUser(rctx request.CTX, service string, userData io.Read
 
 	userByAuth, _ := a.ch.srv.userService.GetUserByAuth(user.AuthData, service)
 	if userByAuth != nil {
-		return userByAuth, nil
+		return userByAuth, false, nil
 	}
 
 	userByEmail, _ := a.ch.srv.userService.GetUserByEmail(user.Email)
 	if userByEmail != nil {
 		if userByEmail.AuthService == "" {
-			return nil, model.NewAppError("CreateOAuthUser", "api.user.create_oauth_user.already_attached.app_error", map[string]any{"Service": service, "Auth": model.UserAuthServiceEmail}, "email="+user.Email, http.StatusBadRequest)
+			return nil, false, model.NewAppError("CreateOAuthUser", "api.user.create_oauth_user.already_attached.app_error", map[string]any{"Service": service, "Auth": model.UserAuthServiceEmail}, "email="+user.Email, http.StatusBadRequest)
 		}
 		if provider.IsSameUser(rctx, userByEmail, user) {
 			if _, err = a.Srv().Store().User().UpdateAuthData(userByEmail.Id, user.AuthService, user.AuthData, "", false); err != nil {
 				// if the user is not updated, write a warning to the log, but don't prevent user login
 				rctx.Logger().Warn("Error attempting to update user AuthData", mlog.Err(err))
 			}
-			return userByEmail, nil
+			return userByEmail, false, nil
 		}
-		return nil, model.NewAppError("CreateOAuthUser", "api.user.create_oauth_user.already_attached.app_error", map[string]any{"Service": service, "Auth": userByEmail.AuthService}, "email="+user.Email+" authData="+*user.AuthData, http.StatusBadRequest)
+		return nil, false, model.NewAppError("CreateOAuthUser", "api.user.create_oauth_user.already_attached.app_error", map[string]any{"Service": service, "Auth": userByEmail.AuthService}, "email="+user.Email+" authData="+*user.AuthData, http.StatusBadRequest)
 	}
 
 	user.EmailVerified = true
 
 	ruser, appErr := a.CreateUser(rctx, user)
 	if appErr != nil {
-		return nil, appErr
+		return nil, false, appErr
 	}
 
 	if appErr = a.AddUserToTeamByInviteIfNeeded(rctx, ruser, inviteToken, inviteId); appErr != nil {
 		rctx.Logger().Warn("Failed to add user to team", mlog.Err(appErr))
 	}
 
-	return ruser, nil
+	return ruser, true, nil
 }
 
 func (a *App) AddUserToTeamByInviteIfNeeded(rctx request.CTX, user *model.User, inviteToken string, inviteId string) *model.AppError {

--- a/server/channels/app/user.go
+++ b/server/channels/app/user.go
@@ -445,8 +445,7 @@ func (a *App) createUserOrGuest(rctx request.CTX, user *model.User, guest bool) 
 }
 
 // CreateOAuthUser creates a user from OAuth/OIDC identity data.
-// The bool is true when this call provisioned a new Mattermost account via JIT.
-func (a *App) CreateOAuthUser(rctx request.CTX, service string, userData io.Reader, inviteToken string, inviteId string, tokenUser *model.User) (*model.User, bool, *model.AppError) {
+func (a *App) CreateOAuthUser(rctx request.CTX, service string, userData io.Reader, inviteToken string, inviteId string, tokenUser *model.User) (user *model.User, userWasCreated bool, err *model.AppError) {
 	if !*a.Config().TeamSettings.EnableUserCreation {
 		return nil, false, model.NewAppError("CreateOAuthUser", "api.user.create_user.disabled.app_error", nil, "", http.StatusNotImplemented)
 	}
@@ -456,14 +455,14 @@ func (a *App) CreateOAuthUser(rctx request.CTX, service string, userData io.Read
 		return nil, false, e
 	}
 
-	settings, err := provider.GetSSOSettings(rctx, a.Config(), service)
-	if err != nil {
-		return nil, false, model.NewAppError("CreateOAuthUser", "api.user.oauth.get_settings.app_error", map[string]any{"Service": service}, "", http.StatusInternalServerError).Wrap(err)
+	settings, getErr := provider.GetSSOSettings(rctx, a.Config(), service)
+	if getErr != nil {
+		return nil, false, model.NewAppError("CreateOAuthUser", "api.user.oauth.get_settings.app_error", map[string]any{"Service": service}, "", http.StatusInternalServerError).Wrap(getErr)
 	}
 
-	user, err := provider.GetUserFromJSON(rctx, userData, tokenUser, settings)
-	if err != nil {
-		return nil, false, model.NewAppError("CreateOAuthUser", "api.user.create_oauth_user.create.app_error", map[string]any{"Service": service}, "", http.StatusInternalServerError).Wrap(err)
+	user, getErr = provider.GetUserFromJSON(rctx, userData, tokenUser, settings)
+	if getErr != nil {
+		return nil, false, model.NewAppError("CreateOAuthUser", "api.user.create_oauth_user.create.app_error", map[string]any{"Service": service}, "", http.StatusInternalServerError).Wrap(getErr)
 	}
 	if user.AuthService == "" {
 		user.AuthService = service
@@ -489,9 +488,9 @@ func (a *App) CreateOAuthUser(rctx request.CTX, service string, userData io.Read
 			return nil, false, model.NewAppError("CreateOAuthUser", "api.user.create_oauth_user.already_attached.app_error", map[string]any{"Service": service, "Auth": model.UserAuthServiceEmail}, "email="+user.Email, http.StatusBadRequest)
 		}
 		if provider.IsSameUser(rctx, userByEmail, user) {
-			if _, err = a.Srv().Store().User().UpdateAuthData(userByEmail.Id, user.AuthService, user.AuthData, "", false); err != nil {
+			if _, updateErr := a.Srv().Store().User().UpdateAuthData(userByEmail.Id, user.AuthService, user.AuthData, "", false); updateErr != nil {
 				// if the user is not updated, write a warning to the log, but don't prevent user login
-				rctx.Logger().Warn("Error attempting to update user AuthData", mlog.Err(err))
+				rctx.Logger().Warn("Error attempting to update user AuthData", mlog.Err(updateErr))
 			}
 			return userByEmail, false, nil
 		}

--- a/server/channels/app/user_test.go
+++ b/server/channels/app/user_test.go
@@ -56,8 +56,9 @@ func TestCreateOAuthUser(t *testing.T) {
 		js, jsonErr := json.Marshal(glUser)
 		require.NoError(t, jsonErr)
 
-		user, err := th.App.CreateOAuthUser(th.Context, model.UserAuthServiceGitlab, bytes.NewReader(js), "", "", nil)
+		user, userCreated, err := th.App.CreateOAuthUser(th.Context, model.UserAuthServiceGitlab, bytes.NewReader(js), "", "", nil)
 		require.Nil(t, err)
+		assert.True(t, userCreated)
 
 		require.Equal(t, glUser.Username, user.Username, "usernames didn't match")
 
@@ -87,8 +88,9 @@ func TestCreateOAuthUser(t *testing.T) {
 		assert.Equal(t, dbUser.Id, s)
 
 		// data passed doesn't matter as return is mocked
-		_, err := th.App.CreateOAuthUser(th.Context, model.ServiceOffice365, strings.NewReader("{}"), "", "", nil)
+		_, userCreated, err := th.App.CreateOAuthUser(th.Context, model.ServiceOffice365, strings.NewReader("{}"), "", "", nil)
 		assert.Nil(t, err)
+		assert.False(t, userCreated)
 		u, er := th.App.Srv().Store().User().GetByEmail(dbUser.Email)
 		assert.NoError(t, er)
 		// make sure authdata is updated
@@ -97,7 +99,7 @@ func TestCreateOAuthUser(t *testing.T) {
 
 	t.Run("user creation disabled", func(t *testing.T) {
 		*th.App.Config().TeamSettings.EnableUserCreation = false
-		_, err := th.App.CreateOAuthUser(th.Context, model.UserAuthServiceGitlab, strings.NewReader("{}"), "", "", nil)
+		_, _, err := th.App.CreateOAuthUser(th.Context, model.UserAuthServiceGitlab, strings.NewReader("{}"), "", "", nil)
 		require.NotNil(t, err, "should have failed - user creation disabled")
 	})
 }
@@ -868,7 +870,7 @@ func createGitlabUser(t *testing.T, a *App, rctx request.CTX, id int64, username
 	var user *model.User
 	var err *model.AppError
 
-	user, err = a.CreateOAuthUser(rctx, "gitlab", bytes.NewReader(gitlabUser), "", "", nil)
+	user, _, err = a.CreateOAuthUser(rctx, "gitlab", bytes.NewReader(gitlabUser), "", "", nil)
 	require.Nil(t, err, "unable to create the user", err)
 
 	return user, gitlabUserObj

--- a/server/channels/web/oauth.go
+++ b/server/channels/web/oauth.go
@@ -367,13 +367,15 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, err := c.App.CompleteOAuth(c.AppContext, service, body, props, tokenUser)
+	user, userCreated, err := c.App.CompleteOAuth(c.AppContext, service, body, props, tokenUser)
 	if err != nil {
 		err.Translate(c.AppContext.T)
 		c.LogErrorByCode(err)
 		renderError(err)
 		return
 	}
+
+	auditRec.AddMeta("user_created", userCreated)
 
 	if action == model.OAuthActionEmailToSSO {
 		redirectURL = c.GetSiteURLHeader() + "/login?extra=signin_change"

--- a/server/channels/web/oauth.go
+++ b/server/channels/web/oauth.go
@@ -368,14 +368,13 @@ func completeOAuth(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	user, userCreated, err := c.App.CompleteOAuth(c.AppContext, service, body, props, tokenUser)
+	auditRec.AddMeta("user_created", userCreated)
 	if err != nil {
 		err.Translate(c.AppContext.T)
 		c.LogErrorByCode(err)
 		renderError(err)
 		return
 	}
-
-	auditRec.AddMeta("user_created", userCreated)
 
 	if action == model.OAuthActionEmailToSSO {
 		redirectURL = c.GetSiteURLHeader() + "/login?extra=signin_change"

--- a/server/channels/web/saml.go
+++ b/server/channels/web/saml.go
@@ -161,7 +161,7 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	user, assertion, err := samlInterface.DoLogin(c.AppContext, encodedXML, relayProps)
+	user, assertion, userCreated, err := samlInterface.DoLogin(c.AppContext, encodedXML, relayProps)
 	if err != nil {
 		c.LogAudit("fail")
 		handleError(err)
@@ -218,6 +218,7 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	auditRec.AddMeta("obtained_user_id", user.Id)
 	auditRec.AddMeta("obtained_user_email", user.Email)
+	auditRec.AddMeta("user_created", userCreated)
 	c.LogAuditWithUserId(user.Id, "obtained user")
 
 	desktopToken := relayProps["desktop_token"]

--- a/server/channels/web/saml.go
+++ b/server/channels/web/saml.go
@@ -162,6 +162,11 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 	}
 
 	user, assertion, userCreated, err := samlInterface.DoLogin(c.AppContext, encodedXML, relayProps)
+	if user != nil {
+		auditRec.AddMeta("obtained_user_id", user.Id)
+		auditRec.AddMeta("obtained_user_email", user.Email)
+	}
+	auditRec.AddMeta("user_created", userCreated)
 	if err != nil {
 		c.LogAudit("fail")
 		handleError(err)
@@ -216,9 +221,6 @@ func completeSaml(c *Context, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	auditRec.AddMeta("obtained_user_id", user.Id)
-	auditRec.AddMeta("obtained_user_email", user.Email)
-	auditRec.AddMeta("user_created", userCreated)
 	c.LogAuditWithUserId(user.Id, "obtained user")
 
 	desktopToken := relayProps["desktop_token"]

--- a/server/channels/web/saml_test.go
+++ b/server/channels/web/saml_test.go
@@ -233,7 +233,7 @@ func TestCompleteSamlUserCreatedAudit(t *testing.T) {
 		require.NoError(t, readErr)
 
 		var last map[string]any
-		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
 			var rec map[string]any
 			require.NoError(t, json.Unmarshal([]byte(line), &rec))
 			if rec[model.AuditKeyEventName] == model.AuditEventCompleteSaml {

--- a/server/channels/web/saml_test.go
+++ b/server/channels/web/saml_test.go
@@ -5,9 +5,12 @@ package web
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -18,6 +21,7 @@ import (
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/channels/app"
+	"github.com/mattermost/mattermost/server/v8/config"
 	"github.com/mattermost/mattermost/server/v8/einterfaces"
 	"github.com/mattermost/mattermost/server/v8/einterfaces/mocks"
 )
@@ -186,7 +190,7 @@ func TestCompleteSamlRelayStateSignedRoundTrip(t *testing.T) {
 	var capturedRelayProps map[string]string
 	fakeSaml.On("DoLogin", mock.Anything, mock.Anything, mock.AnythingOfType("map[string]string")).
 		Run(func(args mock.Arguments) { capturedRelayProps = args.Get(2).(map[string]string) }).
-		Return(th.BasicUser, (*saml2.AssertionInfo)(nil), nil)
+		Return(th.BasicUser, (*saml2.AssertionInfo)(nil), false, nil)
 
 	res = postCompleteSaml(t, th, "dummy-encoded-xml", capturedRelayState)
 	assert.Equal(t, http.StatusFound, res.Code)
@@ -204,4 +208,57 @@ func TestCompleteSamlRelayStateSignedRoundTrip(t *testing.T) {
 	res = postCompleteSaml(t, th, "dummy-encoded-xml", capturedRelayState)
 	assert.Equal(t, http.StatusFound, res.Code)
 	fakeSaml.AssertNumberOfCalls(t, "DoLogin", 2)
+}
+
+func TestCompleteSamlUserCreatedAudit(t *testing.T) {
+	fakeSaml := registerFakeSamlInterface(t)
+	th := Setup(t).InitBasic(t)
+
+	path := filepath.Join(t.TempDir(), "audit.log")
+	cfg, err := config.MloggerConfigFromAuditConfig(model.ExperimentalAuditSettings{
+		FileEnabled: model.NewPointer(true),
+		FileName:    model.NewPointer(path),
+	}, nil)
+	require.NoError(t, err)
+	require.NoError(t, th.App.Srv().Audit.Configure(cfg))
+
+	relayState := model.SignSamlRelayState(th.App.SamlRelayStateSigningKey(), map[string]string{
+		"action": model.OAuthActionLogin,
+	})
+
+	lastUserCreated := func() any {
+		t.Helper()
+		require.NoError(t, th.App.Srv().Audit.Flush())
+		data, readErr := os.ReadFile(path)
+		require.NoError(t, readErr)
+
+		var last map[string]any
+		for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+			var rec map[string]any
+			require.NoError(t, json.Unmarshal([]byte(line), &rec))
+			if rec[model.AuditKeyEventName] == model.AuditEventCompleteSaml {
+				last = rec
+			}
+		}
+		require.NotNil(t, last, "expected a completeSaml audit record")
+
+		metaMap := last[model.AuditKeyMeta].(map[string]any)
+		if params, ok := last[model.AuditKeyEvent].(map[string]any)["parameters"].(map[string]any); ok {
+			_, inParams := params["user_created"]
+			assert.False(t, inParams)
+		}
+		return metaMap["user_created"]
+	}
+
+	fakeSaml.On("DoLogin", mock.Anything, mock.Anything, mock.Anything).
+		Return(th.BasicUser, (*saml2.AssertionInfo)(nil), true, nil).Once()
+	res := postCompleteSaml(t, th, "dummy-encoded-xml", relayState)
+	assert.Equal(t, http.StatusFound, res.Code)
+	assert.Equal(t, true, lastUserCreated())
+
+	fakeSaml.On("DoLogin", mock.Anything, mock.Anything, mock.Anything).
+		Return(th.BasicUser, (*saml2.AssertionInfo)(nil), false, nil).Once()
+	res = postCompleteSaml(t, th, "dummy-encoded-xml", relayState)
+	assert.Equal(t, http.StatusFound, res.Code)
+	assert.Equal(t, false, lastUserCreated())
 }

--- a/server/channels/web/saml_test.go
+++ b/server/channels/web/saml_test.go
@@ -261,4 +261,11 @@ func TestCompleteSamlUserCreatedAudit(t *testing.T) {
 	res = postCompleteSaml(t, th, "dummy-encoded-xml", relayState)
 	assert.Equal(t, http.StatusFound, res.Code)
 	assert.Equal(t, false, lastUserCreated())
+
+	// Post-create failure (e.g. FirstLoginSync) still records user_created on the FAIL audit.
+	fakeSaml.On("DoLogin", mock.Anything, mock.Anything, mock.Anything).
+		Return(th.BasicUser, (*saml2.AssertionInfo)(nil), true, model.NewAppError("DoLogin", "ent.ldap.syncronize.populate_syncables", nil, "", http.StatusInternalServerError)).Once()
+	res = postCompleteSaml(t, th, "dummy-encoded-xml", relayState)
+	assert.Equal(t, http.StatusFound, res.Code)
+	assert.Equal(t, true, lastUserCreated())
 }

--- a/server/einterfaces/mocks/SamlInterface.go
+++ b/server/einterfaces/mocks/SamlInterface.go
@@ -85,7 +85,7 @@ func (_m *SamlInterface) ConfigureSP(rctx request.CTX) error {
 }
 
 // DoLogin provides a mock function with given fields: rctx, encodedXML, relayState
-func (_m *SamlInterface) DoLogin(rctx request.CTX, encodedXML string, relayState map[string]string) (*model.User, *saml2.AssertionInfo, *model.AppError) {
+func (_m *SamlInterface) DoLogin(rctx request.CTX, encodedXML string, relayState map[string]string) (*model.User, *saml2.AssertionInfo, bool, *model.AppError) {
 	ret := _m.Called(rctx, encodedXML, relayState)
 
 	if len(ret) == 0 {
@@ -94,8 +94,9 @@ func (_m *SamlInterface) DoLogin(rctx request.CTX, encodedXML string, relayState
 
 	var r0 *model.User
 	var r1 *saml2.AssertionInfo
-	var r2 *model.AppError
-	if rf, ok := ret.Get(0).(func(request.CTX, string, map[string]string) (*model.User, *saml2.AssertionInfo, *model.AppError)); ok {
+	var r2 bool
+	var r3 *model.AppError
+	if rf, ok := ret.Get(0).(func(request.CTX, string, map[string]string) (*model.User, *saml2.AssertionInfo, bool, *model.AppError)); ok {
 		return rf(rctx, encodedXML, relayState)
 	}
 	if rf, ok := ret.Get(0).(func(request.CTX, string, map[string]string) *model.User); ok {
@@ -114,15 +115,21 @@ func (_m *SamlInterface) DoLogin(rctx request.CTX, encodedXML string, relayState
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(request.CTX, string, map[string]string) *model.AppError); ok {
+	if rf, ok := ret.Get(2).(func(request.CTX, string, map[string]string) bool); ok {
 		r2 = rf(rctx, encodedXML, relayState)
 	} else {
-		if ret.Get(2) != nil {
-			r2 = ret.Get(2).(*model.AppError)
+		r2 = ret.Get(2).(bool)
+	}
+
+	if rf, ok := ret.Get(3).(func(request.CTX, string, map[string]string) *model.AppError); ok {
+		r3 = rf(rctx, encodedXML, relayState)
+	} else {
+		if ret.Get(3) != nil {
+			r3 = ret.Get(3).(*model.AppError)
 		}
 	}
 
-	return r0, r1, r2
+	return r0, r1, r2, r3
 }
 
 // GetMetadata provides a mock function with given fields: rctx

--- a/server/einterfaces/saml.go
+++ b/server/einterfaces/saml.go
@@ -12,6 +12,8 @@ import (
 type SamlInterface interface {
 	ConfigureSP(rctx request.CTX) error
 	BuildRequest(rctx request.CTX, relayState string) (*model.SamlAuthRequest, *model.AppError)
+	// DoLogin may return a non-nil user with a non-nil err when the account was provisioned
+	// but a post-create step failed (e.g. LDAP FirstLoginSync or admin role assignment).
 	DoLogin(rctx request.CTX, encodedXML string, relayState map[string]string) (user *model.User, assertion *saml2.AssertionInfo, userWasCreated bool, err *model.AppError)
 	GetMetadata(rctx request.CTX) (string, *model.AppError)
 	CheckProviderAttributes(rctx request.CTX, SS *model.SamlSettings, ouser *model.User, patch *model.UserPatch) string

--- a/server/einterfaces/saml.go
+++ b/server/einterfaces/saml.go
@@ -12,7 +12,8 @@ import (
 type SamlInterface interface {
 	ConfigureSP(rctx request.CTX) error
 	BuildRequest(rctx request.CTX, relayState string) (*model.SamlAuthRequest, *model.AppError)
-	DoLogin(rctx request.CTX, encodedXML string, relayState map[string]string) (*model.User, *saml2.AssertionInfo, *model.AppError)
+	// The bool is true when this login provisioned a new account via JIT.
+	DoLogin(rctx request.CTX, encodedXML string, relayState map[string]string) (*model.User, *saml2.AssertionInfo, bool, *model.AppError)
 	GetMetadata(rctx request.CTX) (string, *model.AppError)
 	CheckProviderAttributes(rctx request.CTX, SS *model.SamlSettings, ouser *model.User, patch *model.UserPatch) string
 }

--- a/server/einterfaces/saml.go
+++ b/server/einterfaces/saml.go
@@ -12,8 +12,7 @@ import (
 type SamlInterface interface {
 	ConfigureSP(rctx request.CTX) error
 	BuildRequest(rctx request.CTX, relayState string) (*model.SamlAuthRequest, *model.AppError)
-	// The bool is true when this login provisioned a new account via JIT.
-	DoLogin(rctx request.CTX, encodedXML string, relayState map[string]string) (*model.User, *saml2.AssertionInfo, bool, *model.AppError)
+	DoLogin(rctx request.CTX, encodedXML string, relayState map[string]string) (user *model.User, assertion *saml2.AssertionInfo, userWasCreated bool, err *model.AppError)
 	GetMetadata(rctx request.CTX) (string, *model.AppError)
 	CheckProviderAttributes(rctx request.CTX, SS *model.SamlSettings, ouser *model.User, patch *model.UserPatch) string
 }


### PR DESCRIPTION
#### Summary
Adds `meta.user_created` on successful `completeSaml` and `completeOAuth` audit events so compliance teams can tell JIT account provisioning apart from returning SSO logins. SAML JIT still does not emit `createUser`; this flag is the intended signal.

Requires the companion enterprise PR that updates `SamlInterface.DoLogin` to report whether the login created the user.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-70287

#### Release Note
```release-note
Added meta.user_created to completeSaml and completeOAuth audit events to indicate JIT account provisioning.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** Changes affect SAML and OAuth authentication flows and shared API contracts. Automated tests cover new-user and returning-user paths, but integration regressions remain possible.

**QA Recommendation:** Skip manual QA if the full automated test suite passes.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->