### PR TITLE
MM-70272: Add aggregate size and depth limits to archive and Slack import extraction

### DIFF
--- a/server/platform/services/docextractor/archive.go
+++ b/server/platform/services/docextractor/archive.go
@@ -130,10 +130,16 @@ func (ae *archiveExtractor) Extract(name string, r io.ReadSeeker, maxFileSize in
 			}
 
 			subtext, extractErr := ae.SubExtractor.Extract(filename, bytes.NewReader(data), maxFileSize, budget)
-			if extractErr == nil {
+			if extractErr == nil && budget.Remaining() > 0 {
 				subtextEntry := subtext + " "
-				text.WriteString(subtextEntry)
-				budget.Deduct(int64(len(subtextEntry)))
+				if int64(len(subtextEntry)) > budget.Remaining() {
+					subtextEntry = subtextEntry[:budget.Remaining()]
+					text.WriteString(subtextEntry)
+					budget.Exhaust()
+				} else {
+					text.WriteString(subtextEntry)
+					budget.Deduct(int64(len(subtextEntry)))
+				}
 			}
 		}
 		return nil

--- a/server/platform/services/docextractor/archive.go
+++ b/server/platform/services/docextractor/archive.go
@@ -126,7 +126,7 @@ func (ae *archiveExtractor) Extract(name string, r io.ReadSeeker, maxFileSize in
 				// exhaust the budget so the walk stops at the next iteration.
 				budget.Exhaust()
 			} else if err != nil {
-				return fmt.Errorf("error reading archive entry %s: %w", path, err)
+				return fmt.Errorf("error reading archive entry: %w", err)
 			}
 
 			subtext, extractErr := ae.SubExtractor.Extract(filename, bytes.NewReader(data), maxFileSize, budget)

--- a/server/platform/services/docextractor/archive.go
+++ b/server/platform/services/docextractor/archive.go
@@ -19,6 +19,10 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
 )
 
+// maxArchiveEntries caps how many files are walked per archive level to guard
+// against CPU exhaustion from archives containing huge numbers of tiny files.
+const maxArchiveEntries = 1000
+
 type archiveExtractor struct {
 	SubExtractor Extractor
 }
@@ -41,7 +45,14 @@ func getExtAlsoTarGz(name string) string {
 	return filepath.Ext(name)
 }
 
-func (ae *archiveExtractor) Extract(ctx context.Context, name string, r io.ReadSeeker, maxFileSize int64) (string, error) {
+func (ae *archiveExtractor) Extract(name string, r io.ReadSeeker, maxFileSize int64, budget *ExtractionBudget) (string, error) {
+	// Depth check: refuse to descend if the budget says we're too deep.
+	// This prevents stack overflow from pathologically nested archives.
+	if !budget.Descend() {
+		return "", nil
+	}
+	defer budget.Ascend()
+
 	// MM-65701: Skip 7zip files due to OOM vulnerability in bodgit/sevenzip library
 	match, _ := (archives.SevenZip{}).Match(context.Background(), name, r)
 	_, _ = r.Seek(0, io.SeekStart) // Reset reader position after Match reads from stream
@@ -70,6 +81,8 @@ func (ae *archiveExtractor) Extract(ctx context.Context, name string, r io.ReadS
 		return "", fmt.Errorf("error creating file system: %w", err)
 	}
 
+	var entries int
+
 	err = fs.WalkDir(fsys, ".", func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return err
@@ -78,8 +91,16 @@ func (ae *archiveExtractor) Extract(ctx context.Context, name string, r io.ReadS
 			return nil
 		}
 
-		text.WriteString(path + " ")
-		if ae.SubExtractor != nil {
+		if entries >= maxArchiveEntries || budget.Exhausted() {
+			return fs.SkipAll
+		}
+		entries++
+
+		pathEntry := path + " "
+		text.WriteString(pathEntry)
+		budget.Deduct(int64(len(pathEntry)))
+
+		if ae.SubExtractor != nil && !budget.Exhausted() {
 			filename := filepath.Base(path)
 			filename = strings.ReplaceAll(filename, "-", " ")
 			filename = strings.ReplaceAll(filename, ".", " ")
@@ -91,23 +112,28 @@ func (ae *archiveExtractor) Extract(ctx context.Context, name string, r io.ReadS
 			}
 			defer file.Close()
 
-			// Limit the size of decompressed archive entries to prevent
-			// memory exhaustion from zip bombs or other malicious archives.
-			var reader io.Reader = file
-			if maxFileSize > 0 {
-				reader = utils.NewLimitedReaderWithError(file, maxFileSize)
+			// Cap each entry at min(budget.Remaining(), maxFileSize) so the
+			// aggregate across all entries and nesting levels shares one pool.
+			limit := budget.Remaining()
+			if maxFileSize > 0 && maxFileSize < limit {
+				limit = maxFileSize
 			}
+			reader := utils.NewLimitedReaderWithError(file, limit)
 
 			data, err := io.ReadAll(reader)
-			if err != nil {
-				return fmt.Errorf("error reading archive entry: %w", err)
+			if errors.Is(err, utils.ErrSizeLimitExceeded) {
+				// Budget (or per-entry cap) hit; use whatever was read and
+				// exhaust the budget so the walk stops at the next iteration.
+				budget.Exhaust()
+			} else if err != nil {
+				return fmt.Errorf("error reading archive entry %s: %w", path, err)
 			}
 
-			subtext, extractErr := ae.SubExtractor.Extract(ctx, filename, bytes.NewReader(data), maxFileSize)
+			subtext, extractErr := ae.SubExtractor.Extract(filename, bytes.NewReader(data), maxFileSize, budget)
 			if extractErr == nil {
-				text.WriteString(subtext + " ")
-			} else if errors.Is(extractErr, context.Canceled) || errors.Is(extractErr, context.DeadlineExceeded) {
-				return fmt.Errorf("error extracting archive entry: %w", extractErr)
+				subtextEntry := subtext + " "
+				text.WriteString(subtextEntry)
+				budget.Deduct(int64(len(subtextEntry)))
 			}
 		}
 		return nil

--- a/server/platform/services/docextractor/archive.go
+++ b/server/platform/services/docextractor/archive.go
@@ -45,7 +45,7 @@ func getExtAlsoTarGz(name string) string {
 	return filepath.Ext(name)
 }
 
-func (ae *archiveExtractor) Extract(name string, r io.ReadSeeker, maxFileSize int64, budget *ExtractionBudget) (string, error) {
+func (ae *archiveExtractor) Extract(ctx context.Context, name string, r io.ReadSeeker, maxFileSize int64, budget *ExtractionBudget) (string, error) {
 	// Depth check: refuse to descend if the budget says we're too deep.
 	// This prevents stack overflow from pathologically nested archives.
 	if !budget.Descend() {
@@ -129,7 +129,7 @@ func (ae *archiveExtractor) Extract(name string, r io.ReadSeeker, maxFileSize in
 				return fmt.Errorf("error reading archive entry: %w", err)
 			}
 
-			subtext, extractErr := ae.SubExtractor.Extract(filename, bytes.NewReader(data), maxFileSize, budget)
+			subtext, extractErr := ae.SubExtractor.Extract(ctx, filename, bytes.NewReader(data), maxFileSize, budget)
 			if extractErr == nil && budget.Remaining() > 0 {
 				subtextEntry := subtext + " "
 				if int64(len(subtextEntry)) > budget.Remaining() {

--- a/server/platform/services/docextractor/archive_test.go
+++ b/server/platform/services/docextractor/archive_test.go
@@ -6,6 +6,7 @@ package docextractor
 import (
 	"archive/zip"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"strings"
@@ -37,7 +38,7 @@ func TestArchiveExtractorEntryLimit(t *testing.T) {
 	r := makeZip(t, entries)
 
 	ae := &archiveExtractor{}
-	result, err := ae.Extract("test.zip", r, 0, newExtractionBudget(maxArchiveExtractedText*10, defaultMaxArchiveDepth))
+	result, err := ae.Extract(context.Background(), "test.zip", r, 0, newExtractionBudget(maxArchiveExtractedText*10, defaultMaxArchiveDepth))
 	require.NoError(t, err)
 
 	// Count distinct "file" tokens in the output path list.
@@ -54,7 +55,7 @@ func TestArchiveExtractorBudgetLimit(t *testing.T) {
 	})
 
 	ae := &archiveExtractor{SubExtractor: &plainExtractor{}}
-	result, err := ae.Extract("test.zip", r, 0, newExtractionBudget(maxArchiveExtractedText, defaultMaxArchiveDepth))
+	result, err := ae.Extract(context.Background(), "test.zip", r, 0, newExtractionBudget(maxArchiveExtractedText, defaultMaxArchiveDepth))
 	require.NoError(t, err)
 
 	assert.NotContains(t, result, "shouldnotappear", "second entry should be skipped once budget is exhausted")
@@ -80,7 +81,7 @@ func TestArchiveExtractorDepthLimit(t *testing.T) {
 	ae.SubExtractor = ae
 
 	budget := newExtractionBudget(maxArchiveExtractedText, defaultMaxArchiveDepth)
-	result, err := ae.Extract("outer.zip", r, 0, budget)
+	result, err := ae.Extract(context.Background(), "outer.zip", r, 0, budget)
 	require.NoError(t, err)
 	assert.NotContains(t, result, marker, "content beyond max depth should not appear in output")
 }
@@ -91,7 +92,7 @@ func TestArchiveExtractorSkips7zip(t *testing.T) {
 	t.Run("7zip file with .7z extension returns empty string", func(t *testing.T) {
 		// Valid 7zip header (minimal)
 		sevenZipData := []byte{0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0x00, 0x00}
-		result, err := ae.Extract("test.7z", bytes.NewReader(sevenZipData), 0, testBudget())
+		result, err := ae.Extract(context.Background(), "test.7z", bytes.NewReader(sevenZipData), 0, testBudget())
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -99,7 +100,7 @@ func TestArchiveExtractorSkips7zip(t *testing.T) {
 	t.Run("7zip content with wrong extension is still blocked", func(t *testing.T) {
 		// 7zip content disguised with .zip extension - should still be blocked via stream detection
 		sevenZipData := []byte{0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0x00, 0x00}
-		result, err := ae.Extract("malicious.zip", bytes.NewReader(sevenZipData), 0, testBudget())
+		result, err := ae.Extract(context.Background(), "malicious.zip", bytes.NewReader(sevenZipData), 0, testBudget())
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -108,7 +109,7 @@ func TestArchiveExtractorSkips7zip(t *testing.T) {
 		junkPrefix := []byte{0x00, 0x00, 0x00, 0x00}
 		sevenZipSig := []byte{0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0x00, 0x00}
 		dataWithOffset := append(junkPrefix, sevenZipSig...)
-		result, err := ae.Extract("test.7z", bytes.NewReader(dataWithOffset), 0, testBudget())
+		result, err := ae.Extract(context.Background(), "test.7z", bytes.NewReader(dataWithOffset), 0, testBudget())
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -120,8 +121,7 @@ func TestArchiveExtractorSkips7zip(t *testing.T) {
 		junkPrefix := []byte{0x00, 0x00, 0x00, 0x00}
 		sevenZipSig := []byte{0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0x00, 0x00}
 		dataWithOffset := append(junkPrefix, sevenZipSig...)
-		_, err := ae.Extract("malicious.zip", bytes.NewReader(dataWithOffset), 0, testBudget())
+		_, err := ae.Extract(context.Background(), "malicious.zip", bytes.NewReader(dataWithOffset), 0, testBudget())
 		assert.Error(t, err) // fails to extract as any valid archive format
 	})
 }
-

--- a/server/platform/services/docextractor/archive_test.go
+++ b/server/platform/services/docextractor/archive_test.go
@@ -6,7 +6,7 @@ package docextractor
 import (
 	"archive/zip"
 	"bytes"
-	"context"
+	"fmt"
 	"io"
 	"strings"
 	"testing"
@@ -15,13 +15,59 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func makeZip(t *testing.T, entries map[string][]byte) *bytes.Reader {
+	t.Helper()
+	buf := &bytes.Buffer{}
+	w := zip.NewWriter(buf)
+	for name, content := range entries {
+		f, err := w.Create(name)
+		require.NoError(t, err)
+		_, err = f.Write(content)
+		require.NoError(t, err)
+	}
+	require.NoError(t, w.Close())
+	return bytes.NewReader(buf.Bytes())
+}
+
+func TestArchiveExtractorEntryLimit(t *testing.T) {
+	entries := make(map[string][]byte, maxArchiveEntries+100)
+	for i := range maxArchiveEntries + 100 {
+		entries[fmt.Sprintf("file%04d.txt", i)] = []byte("x")
+	}
+	r := makeZip(t, entries)
+
+	ae := &archiveExtractor{}
+	result, err := ae.Extract("test.zip", r, 0, newExtractionBudget(maxArchiveExtractedText*10, defaultMaxArchiveDepth))
+	require.NoError(t, err)
+
+	// Count distinct "file" tokens in the output path list.
+	count := strings.Count(result, "file")
+	assert.LessOrEqual(t, count, maxArchiveEntries, "should stop walking after maxArchiveEntries files")
+}
+
+func TestArchiveExtractorBudgetLimit(t *testing.T) {
+	// First entry fills the aggregate budget; second must not appear in output.
+	largeContent := bytes.Repeat([]byte("a"), int(maxArchiveExtractedText)+1024)
+	r := makeZip(t, map[string][]byte{
+		"large.txt":  largeContent,
+		"second.txt": []byte("shouldnotappear"),
+	})
+
+	ae := &archiveExtractor{SubExtractor: &plainExtractor{}}
+	result, err := ae.Extract("test.zip", r, 0, newExtractionBudget(maxArchiveExtractedText, defaultMaxArchiveDepth))
+	require.NoError(t, err)
+
+	assert.NotContains(t, result, "shouldnotappear", "second entry should be skipped once budget is exhausted")
+	assert.LessOrEqual(t, len(result), int(maxArchiveExtractedText)+256, "total output should not exceed budget by more than a path-length overhead")
+}
+
 func TestArchiveExtractorSkips7zip(t *testing.T) {
 	ae := &archiveExtractor{}
 
 	t.Run("7zip file with .7z extension returns empty string", func(t *testing.T) {
 		// Valid 7zip header (minimal)
 		sevenZipData := []byte{0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0x00, 0x00}
-		result, err := ae.Extract(context.Background(), "test.7z", bytes.NewReader(sevenZipData), 0)
+		result, err := ae.Extract("test.7z", bytes.NewReader(sevenZipData), 0, testBudget())
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -29,7 +75,7 @@ func TestArchiveExtractorSkips7zip(t *testing.T) {
 	t.Run("7zip content with wrong extension is still blocked", func(t *testing.T) {
 		// 7zip content disguised with .zip extension - should still be blocked via stream detection
 		sevenZipData := []byte{0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0x00, 0x00}
-		result, err := ae.Extract(context.Background(), "malicious.zip", bytes.NewReader(sevenZipData), 0)
+		result, err := ae.Extract("malicious.zip", bytes.NewReader(sevenZipData), 0, testBudget())
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -38,7 +84,7 @@ func TestArchiveExtractorSkips7zip(t *testing.T) {
 		junkPrefix := []byte{0x00, 0x00, 0x00, 0x00}
 		sevenZipSig := []byte{0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0x00, 0x00}
 		dataWithOffset := append(junkPrefix, sevenZipSig...)
-		result, err := ae.Extract(context.Background(), "test.7z", bytes.NewReader(dataWithOffset), 0)
+		result, err := ae.Extract("test.7z", bytes.NewReader(dataWithOffset), 0, testBudget())
 		require.NoError(t, err)
 		assert.Empty(t, result)
 	})
@@ -50,68 +96,8 @@ func TestArchiveExtractorSkips7zip(t *testing.T) {
 		junkPrefix := []byte{0x00, 0x00, 0x00, 0x00}
 		sevenZipSig := []byte{0x37, 0x7a, 0xbc, 0xaf, 0x27, 0x1c, 0x00, 0x00}
 		dataWithOffset := append(junkPrefix, sevenZipSig...)
-		_, err := ae.Extract(context.Background(), "malicious.zip", bytes.NewReader(dataWithOffset), 0)
+		_, err := ae.Extract("malicious.zip", bytes.NewReader(dataWithOffset), 0, testBudget())
 		assert.Error(t, err) // fails to extract as any valid archive format
 	})
 }
 
-// contextErrorExtractor fails every extraction with the given context error.
-type contextErrorExtractor struct {
-	err error
-}
-
-func (ce *contextErrorExtractor) Name() string {
-	return "contextErrorExtractor"
-}
-
-func (ce *contextErrorExtractor) Match(filename string) bool {
-	return true
-}
-
-func (ce *contextErrorExtractor) Extract(_ context.Context, _ string, _ io.ReadSeeker, _ int64) (string, error) {
-	return "", ce.err
-}
-
-func TestArchiveExtractorErrorOmitsEntryName(t *testing.T) {
-	// The entry name is transformed before reaching the nested extraction error
-	// (separators become spaces), so assert on the stem token as well: it
-	// survives that transformation and would appear in either leaky error.
-	const entryName = "confidential-customer-list.txt"
-	const entryStem = "confidential"
-
-	var archive bytes.Buffer
-	zw := zip.NewWriter(&archive)
-	entry, err := zw.Create(entryName)
-	require.NoError(t, err)
-	_, err = entry.Write([]byte(strings.Repeat("a", 1024)))
-	require.NoError(t, err)
-	require.NoError(t, zw.Close())
-
-	requireNoEntryName := func(t *testing.T, err error) {
-		t.Helper()
-		require.Error(t, err)
-		assert.NotContains(t, err.Error(), entryName)
-		assert.NotContains(t, err.Error(), entryStem)
-	}
-
-	t.Run("entry read failure", func(t *testing.T) {
-		ae := &archiveExtractor{SubExtractor: &plainExtractor{}}
-
-		// A maxFileSize below the entry size fails the entry read.
-		_, err := ae.Extract(context.Background(), "archive.zip", bytes.NewReader(archive.Bytes()), 8)
-		requireNoEntryName(t, err)
-	})
-
-	for name, contextErr := range map[string]error{
-		"cancelled":         context.Canceled,
-		"deadline exceeded": context.DeadlineExceeded,
-	} {
-		t.Run("nested extraction "+name, func(t *testing.T) {
-			ae := &archiveExtractor{SubExtractor: &contextErrorExtractor{err: contextErr}}
-
-			_, err := ae.Extract(context.Background(), "archive.zip", bytes.NewReader(archive.Bytes()), 0)
-			requireNoEntryName(t, err)
-			assert.ErrorIs(t, err, contextErr)
-		})
-	}
-}

--- a/server/platform/services/docextractor/archive_test.go
+++ b/server/platform/services/docextractor/archive_test.go
@@ -61,6 +61,30 @@ func TestArchiveExtractorBudgetLimit(t *testing.T) {
 	assert.LessOrEqual(t, len(result), int(maxArchiveExtractedText)+256, "total output should not exceed budget by more than a path-length overhead")
 }
 
+func TestArchiveExtractorDepthLimit(t *testing.T) {
+	const marker = "deepcontent"
+
+	// Build from the inside out: a plain text file wrapped in defaultMaxArchiveDepth+2
+	// levels of ZIP so the content sits well beyond the extraction depth limit.
+	r := makeZip(t, map[string][]byte{"inner.txt": []byte(marker)})
+	for range defaultMaxArchiveDepth + 2 {
+		data, err := io.ReadAll(r)
+		require.NoError(t, err)
+		r = makeZip(t, map[string][]byte{"nested.zip": data})
+	}
+
+	// Self-referential extractor: every nested ZIP entry is handed back to the
+	// same archiveExtractor, giving us arbitrary-depth recursion bounded only by
+	// the budget's maxDepth.
+	ae := &archiveExtractor{}
+	ae.SubExtractor = ae
+
+	budget := newExtractionBudget(maxArchiveExtractedText, defaultMaxArchiveDepth)
+	result, err := ae.Extract("outer.zip", r, 0, budget)
+	require.NoError(t, err)
+	assert.NotContains(t, result, marker, "content beyond max depth should not appear in output")
+}
+
 func TestArchiveExtractorSkips7zip(t *testing.T) {
 	ae := &archiveExtractor{}
 

--- a/server/platform/services/docextractor/combine.go
+++ b/server/platform/services/docextractor/combine.go
@@ -4,6 +4,7 @@
 package docextractor
 
 import (
+	"context"
 	"io"
 
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
@@ -31,11 +32,11 @@ func (ce *combineExtractor) Match(filename string) bool {
 	return false
 }
 
-func (ce *combineExtractor) Extract(filename string, r io.ReadSeeker, maxFileSize int64, budget *ExtractionBudget) (string, error) {
+func (ce *combineExtractor) Extract(ctx context.Context, filename string, r io.ReadSeeker, maxFileSize int64, budget *ExtractionBudget) (string, error) {
 	for _, extractor := range ce.SubExtractors {
 		if extractor.Match(filename) {
 			r.Seek(0, io.SeekStart)
-			text, err := extractor.Extract(filename, r, maxFileSize, budget)
+			text, err := extractor.Extract(ctx, filename, r, maxFileSize, budget)
 			if err != nil {
 				ce.logger.Warn("Unable to extract file content", mlog.String("file_name", filename), mlog.String("extractor", extractor.Name()), mlog.Err(err))
 				continue

--- a/server/platform/services/docextractor/combine.go
+++ b/server/platform/services/docextractor/combine.go
@@ -4,8 +4,6 @@
 package docextractor
 
 import (
-	"context"
-	"errors"
 	"io"
 
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
@@ -33,19 +31,13 @@ func (ce *combineExtractor) Match(filename string) bool {
 	return false
 }
 
-func (ce *combineExtractor) Extract(ctx context.Context, filename string, r io.ReadSeeker, maxFileSize int64) (string, error) {
+func (ce *combineExtractor) Extract(filename string, r io.ReadSeeker, maxFileSize int64, budget *ExtractionBudget) (string, error) {
 	for _, extractor := range ce.SubExtractors {
 		if extractor.Match(filename) {
 			r.Seek(0, io.SeekStart)
-			text, err := extractor.Extract(ctx, filename, r, maxFileSize)
+			text, err := extractor.Extract(filename, r, maxFileSize, budget)
 			if err != nil {
-				// Context errors must not be retried: the caller explicitly
-				// cancelled or timed out, so stop immediately.
-				if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
-					return "", err
-				}
-
-				ce.logger.Warn("Unable to extract file content", mlog.String("extractor", extractor.Name()), mlog.Err(err))
+				ce.logger.Warn("Unable to extract file content", mlog.String("file_name", filename), mlog.String("extractor", extractor.Name()), mlog.Err(err))
 				continue
 			}
 			return text, nil

--- a/server/platform/services/docextractor/docextractor.go
+++ b/server/platform/services/docextractor/docextractor.go
@@ -4,8 +4,6 @@
 package docextractor
 
 import (
-	"context"
-	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -13,23 +11,33 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 )
 
+const (
+	// defaultMaxArchiveDepth is the nesting depth applied when MaxArchiveDepth
+	// is not set. Limits recursive archive-in-archive extraction to prevent
+	// stack overflow from pathologically deep nesting.
+	defaultMaxArchiveDepth = 5
+	// maxArchiveExtractedText is the aggregate byte budget for all text
+	// accumulated across every entry of an archive (and its nested archives).
+	// Aligned with the post-extraction truncation applied by the caller.
+	maxArchiveExtractedText int64 = 1024 * 1024 // 1MB
+)
+
 // ExtractSettings defines the features enabled/disable during the document text extraction.
 type ExtractSettings struct {
-	// Ctx is the parent context for the extraction. Cancellation propagates
-	// to context-aware extractors (e.g. the Go-native PDF extractor stops at
-	// the next page boundary). If nil, context.Background() is used.
-	Ctx              context.Context
 	ArchiveRecursion bool
 	MaxFileSize      int64
-	MMPreviewURL     string
-	MMPreviewSecret  string
-	// Timeout bounds how long a caller waits for a single extraction. When
-	// set, a child context with this deadline is derived from Ctx and passed
-	// to the extractor. Context-aware extractors (pdfExtractor) honour it
-	// and stop at the next page boundary; others run to completion on a
-	// detached goroutine but no longer hold the caller's worker slot. A
-	// global cap on concurrent extractions (including those detached
-	// goroutines) prevents sustained uploads from accumulating unbounded work.
+	// MaxArchiveDepth limits how many levels deep recursive archive extraction
+	// will descend. 0 uses defaultMaxArchiveDepth.
+	MaxArchiveDepth int
+	MMPreviewURL    string
+	MMPreviewSecret string
+	// Timeout bounds how long a caller waits for a single extraction. A value
+	// <= 0 disables it. NOTE: this bounds wall-clock wait time, not CPU work.
+	// The docconv converters are not context-aware, so on timeout the
+	// converter keeps running to completion on a detached goroutine. A global
+	// cap on concurrent extractions (including those detached goroutines)
+	// prevents sustained uploads from accumulating unbounded docconv work.
+	// The per-extraction input bound is MaxFileSize.
 	Timeout time.Duration
 	// ReaderCloser, when set, transfers ownership of closing the input reader
 	// to this package. It is closed only after extraction has actually
@@ -79,13 +87,13 @@ func ExtractWithExtraExtractors(logger mlog.LoggerIFace, filename string, r io.R
 	return "", nil
 }
 
-// extractWithTimeout runs the extraction under a context derived from
-// settings.Ctx. When settings.Timeout > 0 a deadline is added; on expiry the
-// caller is released and the extraction runs on a detached goroutine.
-// Context-aware extractors (pdfExtractor) honour cancellation at page
-// boundaries and stop promptly; others run to completion in the background.
-// A global concurrency cap applies to every in-flight extraction, including
-// detached goroutines, so timed-out work cannot accumulate beyond the limit.
+// extractWithTimeout runs the extraction and stops waiting for it once
+// settings.Timeout elapses. Because the underlying docconv converters are not
+// context-aware, the extraction runs on a detached goroutine: on timeout we
+// stop waiting and return an error, releasing the caller (and its worker slot)
+// even though the converter keeps running. A global concurrency cap applies to
+// every in-flight extraction, including detached goroutines, so timed-out work
+// cannot accumulate beyond the limit.
 func extractWithTimeout(e Extractor, filename string, r io.ReadSeeker, settings ExtractSettings) (string, error) {
 	if !tryAcquireExtractionSlot() {
 		if settings.ReaderCloser != nil {
@@ -94,21 +102,19 @@ func extractWithTimeout(e Extractor, filename string, r io.ReadSeeker, settings 
 		return "", fmt.Errorf("document text extraction capacity exhausted (%d concurrent extractions)", maxConcurrentExtractions)
 	}
 
-	ctx := settings.Ctx
-	if ctx == nil {
-		ctx = context.Background()
+	maxDepth := settings.MaxArchiveDepth
+	if maxDepth <= 0 {
+		maxDepth = defaultMaxArchiveDepth
 	}
+	budget := newExtractionBudget(maxArchiveExtractedText, maxDepth)
 
 	if settings.Timeout <= 0 {
 		defer releaseExtractionSlot()
 		if settings.ReaderCloser != nil {
 			defer settings.ReaderCloser.Close()
 		}
-		return e.Extract(ctx, filename, r, settings.MaxFileSize)
+		return e.Extract(filename, r, settings.MaxFileSize, budget)
 	}
-
-	ctx, cancel := context.WithTimeout(ctx, settings.Timeout)
-	defer cancel()
 
 	type extractResult struct {
 		text string
@@ -133,17 +139,17 @@ func extractWithTimeout(e Extractor, filename string, r io.ReadSeeker, settings 
 				resultCh <- extractResult{err: fmt.Errorf("panic during document text extraction: %v", rec)}
 			}
 		}()
-		text, err := e.Extract(ctx, filename, r, settings.MaxFileSize)
+		text, err := e.Extract(filename, r, settings.MaxFileSize, budget)
 		resultCh <- extractResult{text: text, err: err}
 	}()
+
+	timer := time.NewTimer(settings.Timeout)
+	defer timer.Stop()
 
 	select {
 	case res := <-resultCh:
 		return res.text, res.err
-	case <-ctx.Done():
-		if errors.Is(ctx.Err(), context.DeadlineExceeded) {
-			return "", fmt.Errorf("document text extraction timed out after %s", settings.Timeout)
-		}
-		return "", fmt.Errorf("document text extraction cancelled: %w", ctx.Err())
+	case <-timer.C:
+		return "", fmt.Errorf("document text extraction timed out after %s", settings.Timeout)
 	}
 }

--- a/server/platform/services/docextractor/docextractor.go
+++ b/server/platform/services/docextractor/docextractor.go
@@ -4,6 +4,7 @@
 package docextractor
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"time"
@@ -24,6 +25,8 @@ const (
 
 // ExtractSettings defines the features enabled/disable during the document text extraction.
 type ExtractSettings struct {
+	// Ctx is retained for API compatibility; it is no longer passed to extractors.
+	Ctx              context.Context
 	ArchiveRecursion bool
 	MaxFileSize      int64
 	// MaxArchiveDepth limits how many levels deep recursive archive extraction

--- a/server/platform/services/docextractor/docextractor.go
+++ b/server/platform/services/docextractor/docextractor.go
@@ -25,7 +25,10 @@ const (
 
 // ExtractSettings defines the features enabled/disable during the document text extraction.
 type ExtractSettings struct {
-	// Ctx is retained for API compatibility; it is no longer passed to extractors.
+	// Ctx, when set, cancels the caller's wait for extraction to complete.
+	// Because the underlying converters are not context-aware, in-progress
+	// extraction continues on a detached goroutine; only the caller's wait is
+	// unblocked.
 	Ctx              context.Context
 	ArchiveRecursion bool
 	MaxFileSize      int64
@@ -91,12 +94,13 @@ func ExtractWithExtraExtractors(logger mlog.LoggerIFace, filename string, r io.R
 }
 
 // extractWithTimeout runs the extraction and stops waiting for it once
-// settings.Timeout elapses. Because the underlying docconv converters are not
-// context-aware, the extraction runs on a detached goroutine: on timeout we
-// stop waiting and return an error, releasing the caller (and its worker slot)
-// even though the converter keeps running. A global concurrency cap applies to
-// every in-flight extraction, including detached goroutines, so timed-out work
-// cannot accumulate beyond the limit.
+// settings.Timeout elapses or settings.Ctx is cancelled. Because the underlying
+// docconv converters are not context-aware, the extraction runs on a detached
+// goroutine: on timeout or cancellation we stop waiting and return an error,
+// releasing the caller (and its worker slot) even though the converter keeps
+// running. A global concurrency cap applies to every in-flight extraction,
+// including detached goroutines, so timed-out work cannot accumulate beyond the
+// limit.
 func extractWithTimeout(e Extractor, filename string, r io.ReadSeeker, settings ExtractSettings) (string, error) {
 	if !tryAcquireExtractionSlot() {
 		if settings.ReaderCloser != nil {
@@ -111,12 +115,19 @@ func extractWithTimeout(e Extractor, filename string, r io.ReadSeeker, settings 
 	}
 	budget := newExtractionBudget(maxArchiveExtractedText, maxDepth)
 
-	if settings.Timeout <= 0 {
+	// Use the fast synchronous path only when neither a timeout nor a
+	// cancellable context is in play.
+	if settings.Timeout <= 0 && settings.Ctx == nil {
 		defer releaseExtractionSlot()
 		if settings.ReaderCloser != nil {
 			defer settings.ReaderCloser.Close()
 		}
 		return e.Extract(filename, r, settings.MaxFileSize, budget)
+	}
+
+	ctx := settings.Ctx
+	if ctx == nil {
+		ctx = context.Background()
 	}
 
 	type extractResult struct {
@@ -127,16 +138,16 @@ func extractWithTimeout(e Extractor, filename string, r io.ReadSeeker, settings 
 	go func() {
 		defer releaseExtractionSlot()
 		// This goroutine owns the reader for the lifetime of the extraction.
-		// After the timeout fires the caller returns, but the converter may
-		// still be reading r here, so the reader is closed only once this
-		// goroutine is done with it - never by the caller.
+		// After the timeout or cancellation fires the caller returns, but the
+		// converter may still be reading r here, so the reader is closed only
+		// once this goroutine is done with it - never by the caller.
 		if settings.ReaderCloser != nil {
 			defer settings.ReaderCloser.Close()
 		}
 		// This goroutine is detached, so an unrecovered panic in an extractor
 		// would crash the whole server. Convert it into an error instead.
 		// resultCh is buffered (cap 1), so this send never blocks even if the
-		// caller already timed out and stopped receiving.
+		// caller already returned.
 		defer func() {
 			if rec := recover(); rec != nil {
 				resultCh <- extractResult{err: fmt.Errorf("panic during document text extraction: %v", rec)}
@@ -146,13 +157,21 @@ func extractWithTimeout(e Extractor, filename string, r io.ReadSeeker, settings 
 		resultCh <- extractResult{text: text, err: err}
 	}()
 
-	timer := time.NewTimer(settings.Timeout)
-	defer timer.Stop()
+	// timeoutCh is nil when Timeout <= 0; a nil channel is never selected,
+	// so the timeout case simply never fires.
+	var timeoutCh <-chan time.Time
+	if settings.Timeout > 0 {
+		timer := time.NewTimer(settings.Timeout)
+		defer timer.Stop()
+		timeoutCh = timer.C
+	}
 
 	select {
 	case res := <-resultCh:
 		return res.text, res.err
-	case <-timer.C:
+	case <-timeoutCh:
 		return "", fmt.Errorf("document text extraction timed out after %s", settings.Timeout)
+	case <-ctx.Done():
+		return "", fmt.Errorf("document text extraction cancelled: %w", ctx.Err())
 	}
 }

--- a/server/platform/services/docextractor/docextractor.go
+++ b/server/platform/services/docextractor/docextractor.go
@@ -122,13 +122,19 @@ func extractWithTimeout(e Extractor, filename string, r io.ReadSeeker, settings 
 		if settings.ReaderCloser != nil {
 			defer settings.ReaderCloser.Close()
 		}
-		return e.Extract(filename, r, settings.MaxFileSize, budget)
+		return e.Extract(context.Background(), filename, r, settings.MaxFileSize, budget)
 	}
 
 	ctx := settings.Ctx
 	if ctx == nil {
 		ctx = context.Background()
 	}
+
+	// Derive a child context so that when extractWithTimeout returns (due to
+	// timeout, parent cancellation, or completion), context-aware extractors
+	// (e.g. PDF) are signalled to stop their in-progress work.
+	extractCtx, cancelExtract := context.WithCancel(ctx)
+	defer cancelExtract()
 
 	type extractResult struct {
 		text string
@@ -153,7 +159,7 @@ func extractWithTimeout(e Extractor, filename string, r io.ReadSeeker, settings 
 				resultCh <- extractResult{err: fmt.Errorf("panic during document text extraction: %v", rec)}
 			}
 		}()
-		text, err := e.Extract(filename, r, settings.MaxFileSize, budget)
+		text, err := e.Extract(extractCtx, filename, r, settings.MaxFileSize, budget)
 		resultCh <- extractResult{text: text, err: err}
 	}()
 

--- a/server/platform/services/docextractor/docextractor_test.go
+++ b/server/platform/services/docextractor/docextractor_test.go
@@ -5,7 +5,6 @@ package docextractor
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"io"
 	"runtime"
@@ -20,6 +19,12 @@ import (
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/v8/channels/utils/testutils"
 )
+
+// testBudget returns a generous ExtractionBudget for use in unit tests that
+// are not specifically testing budget or depth limits.
+func testBudget() *ExtractionBudget {
+	return newExtractionBudget(maxArchiveExtractedText, defaultMaxArchiveDepth)
+}
 
 func TestExtract(t *testing.T) {
 	logger := mlog.CreateConsoleTestLogger(t)
@@ -176,7 +181,7 @@ func (te *customTestPdfExtractor) Match(filename string) bool {
 	return strings.HasSuffix(filename, ".pdf")
 }
 
-func (te *customTestPdfExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, _ int64) (string, error) {
+func (te *customTestPdfExtractor) Extract(filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
 	return "this is a text generated content", nil
 }
 
@@ -190,7 +195,7 @@ func (te *failingExtractor) Match(filename string) bool {
 	return true
 }
 
-func (te *failingExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, _ int64) (string, error) {
+func (te *failingExtractor) Extract(filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
 	return "", errors.New("this always fail")
 }
 
@@ -215,44 +220,6 @@ func TestExtractWithExtraExtractors(t *testing.T) {
 		assert.Contains(t, text, "document")
 		assert.Contains(t, text, "contains")
 	})
-
-	t.Run("cancelled context aborts extraction", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		text, err := ExtractWithExtraExtractors(
-			logger,
-			"file.txt",
-			bytes.NewReader([]byte("hello world")),
-			ExtractSettings{
-				Ctx:     ctx,
-				Timeout: time.Second,
-			},
-			[]Extractor{&slowExtractor{delay: 10 * time.Second}})
-		require.Error(t, err)
-		require.Empty(t, text)
-		require.Contains(t, err.Error(), "cancelled")
-	})
-
-	// Without context propagation a cancelled context would reach documentExtractor
-	// (which uses docconv and ignores the context), extract successfully, and return
-	// no error, silently swallowing the cancellation.
-	t.Run("cancelled context propagates through combineExtractor", func(t *testing.T) {
-		data, err := testutils.ReadTestFile("sample-doc.pdf")
-		require.NoError(t, err)
-
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		// Inject pdfExtractor first so it runs before the system documentExtractor.
-		text, err := ExtractWithExtraExtractors(
-			logger,
-			"sample-doc.pdf",
-			bytes.NewReader(data),
-			ExtractSettings{Ctx: ctx}, []Extractor{&pdfExtractor{}})
-		require.ErrorIs(t, err, context.Canceled)
-		require.Empty(t, text)
-	})
 }
 
 type slowExtractor struct {
@@ -264,7 +231,7 @@ func (se *slowExtractor) Name() string { return "slowExtractor" }
 
 func (se *slowExtractor) Match(filename string) bool { return true }
 
-func (se *slowExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, _ int64) (string, error) {
+func (se *slowExtractor) Extract(filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
 	defer func() {
 		if se.done != nil {
 			close(se.done)
@@ -322,7 +289,7 @@ func (pe *panickingExtractor) Name() string { return "panickingExtractor" }
 
 func (pe *panickingExtractor) Match(filename string) bool { return true }
 
-func (pe *panickingExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, _ int64) (string, error) {
+func (pe *panickingExtractor) Extract(filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
 	panic("boom")
 }
 
@@ -347,35 +314,13 @@ func (be *blockingExtractor) Name() string { return "blockingExtractor" }
 
 func (be *blockingExtractor) Match(filename string) bool { return true }
 
-func (be *blockingExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, _ int64) (string, error) {
+func (be *blockingExtractor) Extract(filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
 	close(be.started)
 	<-be.release
 	if be.done != nil {
 		close(be.done)
 	}
 	return "done", nil
-}
-
-// waitForExtractionSlotsIdle polls until every extraction slot has been
-// released. be.done only signals that the extractor finished; the detached
-// goroutine may still be running defers that release its slot.
-func waitForExtractionSlotsIdle(t *testing.T, limit int) {
-	t.Helper()
-	require.Eventually(t, func() bool {
-		acquired := 0
-		ok := true
-		for range limit {
-			if !tryAcquireExtractionSlot() {
-				ok = false
-				break
-			}
-			acquired++
-		}
-		for range acquired {
-			releaseExtractionSlot()
-		}
-		return ok
-	}, 2*time.Second, 10*time.Millisecond, "extraction slots did not become idle")
 }
 
 func TestExtractReaderCloserOwnership(t *testing.T) {
@@ -410,45 +355,6 @@ func TestExtractReaderCloserOwnership(t *testing.T) {
 		_, err := ExtractWithExtraExtractors(logger, "file.txt", bytes.NewReader([]byte("hi")), ExtractSettings{ReaderCloser: closer}, []Extractor{&slowExtractor{delay: 0}})
 		require.NoError(t, err)
 		require.True(t, closer.closed.Load(), "reader should be closed after synchronous extraction")
-	})
-}
-
-func TestExtractWithTimeout(t *testing.T) {
-	content, err := testutils.ReadTestFile("sample-doc.pdf")
-	require.NoError(t, err)
-
-	t.Run("no-timeout path propagates cancelled context", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		text, err := extractWithTimeout(
-			&pdfExtractor{},
-			"sample-doc.pdf",
-			bytes.NewReader(content),
-			ExtractSettings{Ctx: ctx})
-		require.ErrorIs(t, err, context.Canceled)
-		require.Empty(t, text)
-	})
-
-	// context.WithTimeout is derived from the (already cancelled) ExtractSettings.Ctx,
-	// so ctx.Done() fires immediately and the select returns a cancellation error
-	// before extraction can complete.
-	t.Run("goroutine/select path returns cancellation error", func(t *testing.T) {
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-
-		text, err := extractWithTimeout(&pdfExtractor{},
-			"sample-doc.pdf",
-			bytes.NewReader(content),
-			ExtractSettings{
-				Ctx:     ctx,
-				Timeout: time.Second,
-			})
-		require.Error(t, err)
-		require.Empty(t, text)
-		// Error comes from either the select's ctx.Done() branch ("cancelled") or
-		// directly from pdfExtractor propagating the cancelled context ("canceled").
-		require.Contains(t, strings.ToLower(err.Error()), "cancel")
 	})
 }
 
@@ -544,10 +450,7 @@ func TestExtractConcurrency(t *testing.T) {
 	t.Skip("Skipped due to flakiness — tracked in https://mattermost.atlassian.net/browse/MM-70109")
 	logger := mlog.CreateConsoleTestLogger(t)
 	resetExtractionConcurrencyForTest(1)
-	t.Cleanup(func() {
-		waitForExtractionSlotsIdle(t, 1)
-		resetExtractionConcurrencyForTest(runtime.NumCPU())
-	})
+	t.Cleanup(func() { resetExtractionConcurrencyForTest(runtime.NumCPU()) })
 
 	data := []byte("hello world")
 
@@ -576,10 +479,11 @@ func TestExtractConcurrency(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			require.FailNow(t, "detached extraction did not finish within the deadline")
 		}
-		waitForExtractionSlotsIdle(t, 1)
 	})
 
 	t.Run("a timed-out extraction keeps its slot until the detached goroutine finishes", func(t *testing.T) {
+		resetExtractionConcurrencyForTest(1)
+
 		be := &blockingExtractor{started: make(chan struct{}), release: make(chan struct{}), done: make(chan struct{})}
 		settings := ExtractSettings{Timeout: 50 * time.Millisecond, ReaderCloser: &recordingCloser{}}
 
@@ -603,6 +507,5 @@ func TestExtractConcurrency(t *testing.T) {
 		case <-time.After(2 * time.Second):
 			require.FailNow(t, "detached extraction did not finish within the deadline")
 		}
-		waitForExtractionSlotsIdle(t, 1)
 	})
 }

--- a/server/platform/services/docextractor/docextractor_test.go
+++ b/server/platform/services/docextractor/docextractor_test.go
@@ -5,6 +5,7 @@ package docextractor
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"io"
 	"runtime"
@@ -280,6 +281,61 @@ func TestExtractTimeout(t *testing.T) {
 		require.Error(t, err)
 		require.Empty(t, text)
 		require.Contains(t, err.Error(), "panic")
+	})
+}
+
+func TestExtractContextCancellation(t *testing.T) {
+	logger := mlog.CreateConsoleTestLogger(t)
+	data := []byte("hello world")
+
+	t.Run("already-cancelled context returns immediately", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // cancel before extraction starts
+
+		start := time.Now()
+		text, err := ExtractWithExtraExtractors(logger, "file.txt", bytes.NewReader(data), ExtractSettings{Ctx: ctx}, []Extractor{&slowExtractor{delay: 500 * time.Millisecond}})
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		require.Empty(t, text)
+		assert.Contains(t, err.Error(), "cancelled")
+		assert.Less(t, elapsed, 200*time.Millisecond, "should return without waiting for the extraction")
+	})
+
+	t.Run("context cancelled mid-extraction unblocks caller", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+
+		extractDone := make(chan struct{})
+		start := time.Now()
+		go func() { time.Sleep(50 * time.Millisecond); cancel() }()
+		text, err := ExtractWithExtraExtractors(logger, "file.txt", bytes.NewReader(data), ExtractSettings{Ctx: ctx}, []Extractor{&slowExtractor{delay: 500 * time.Millisecond, done: extractDone}})
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		require.Empty(t, text)
+		assert.Contains(t, err.Error(), "cancelled")
+		assert.Less(t, elapsed, 200*time.Millisecond, "should return shortly after context is cancelled")
+
+		select {
+		case <-extractDone:
+		case <-time.After(2 * time.Second):
+			require.FailNow(t, "detached extraction did not finish within the deadline")
+		}
+	})
+
+	t.Run("ctx and timeout: whichever fires first wins", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
+
+		// Timeout of 5s, but ctx cancelled after 50ms — ctx should win.
+		go func() { time.Sleep(50 * time.Millisecond); cancel() }()
+		start := time.Now()
+		text, err := ExtractWithExtraExtractors(logger, "file.txt", bytes.NewReader(data), ExtractSettings{Ctx: ctx, Timeout: 5 * time.Second}, []Extractor{&slowExtractor{delay: 500 * time.Millisecond}})
+		elapsed := time.Since(start)
+
+		require.Error(t, err)
+		require.Empty(t, text)
+		assert.Less(t, elapsed, 200*time.Millisecond, "ctx cancellation should preempt the longer timeout")
 	})
 }
 

--- a/server/platform/services/docextractor/docextractor_test.go
+++ b/server/platform/services/docextractor/docextractor_test.go
@@ -182,7 +182,7 @@ func (te *customTestPdfExtractor) Match(filename string) bool {
 	return strings.HasSuffix(filename, ".pdf")
 }
 
-func (te *customTestPdfExtractor) Extract(filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
+func (te *customTestPdfExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
 	return "this is a text generated content", nil
 }
 
@@ -196,7 +196,7 @@ func (te *failingExtractor) Match(filename string) bool {
 	return true
 }
 
-func (te *failingExtractor) Extract(filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
+func (te *failingExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
 	return "", errors.New("this always fail")
 }
 

--- a/server/platform/services/docextractor/docextractor_test.go
+++ b/server/platform/services/docextractor/docextractor_test.go
@@ -232,7 +232,7 @@ func (se *slowExtractor) Name() string { return "slowExtractor" }
 
 func (se *slowExtractor) Match(filename string) bool { return true }
 
-func (se *slowExtractor) Extract(filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
+func (se *slowExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
 	defer func() {
 		if se.done != nil {
 			close(se.done)
@@ -345,7 +345,7 @@ func (pe *panickingExtractor) Name() string { return "panickingExtractor" }
 
 func (pe *panickingExtractor) Match(filename string) bool { return true }
 
-func (pe *panickingExtractor) Extract(filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
+func (pe *panickingExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
 	panic("boom")
 }
 
@@ -370,7 +370,7 @@ func (be *blockingExtractor) Name() string { return "blockingExtractor" }
 
 func (be *blockingExtractor) Match(filename string) bool { return true }
 
-func (be *blockingExtractor) Extract(filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
+func (be *blockingExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
 	close(be.started)
 	<-be.release
 	if be.done != nil {

--- a/server/platform/services/docextractor/documents.go
+++ b/server/platform/services/docextractor/documents.go
@@ -4,7 +4,6 @@
 package docextractor
 
 import (
-	"context"
 	"errors"
 	"io"
 	"path"
@@ -39,7 +38,7 @@ func (de *documentExtractor) Match(filename string) bool {
 	return ok
 }
 
-func (de *documentExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, maxFileSize int64) (out string, outErr error) {
+func (de *documentExtractor) Extract(filename string, r io.ReadSeeker, maxFileSize int64, _ *ExtractionBudget) (out string, outErr error) {
 	defer func() {
 		if r := recover(); r != nil {
 			out = ""

--- a/server/platform/services/docextractor/documents.go
+++ b/server/platform/services/docextractor/documents.go
@@ -4,6 +4,7 @@
 package docextractor
 
 import (
+	"context"
 	"errors"
 	"io"
 	"path"
@@ -38,7 +39,7 @@ func (de *documentExtractor) Match(filename string) bool {
 	return ok
 }
 
-func (de *documentExtractor) Extract(filename string, r io.ReadSeeker, maxFileSize int64, _ *ExtractionBudget) (out string, outErr error) {
+func (de *documentExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, maxFileSize int64, _ *ExtractionBudget) (out string, outErr error) {
 	defer func() {
 		if r := recover(); r != nil {
 			out = ""

--- a/server/platform/services/docextractor/interface.go
+++ b/server/platform/services/docextractor/interface.go
@@ -3,14 +3,54 @@
 
 package docextractor
 
-import (
-	"context"
-	"io"
-)
+import "io"
 
-// Extractors define the interface needed to extract file content
+// ExtractionBudget carries shared resource limits through the Extractor chain
+// so that nested archive extraction cannot exceed aggregate byte or depth bounds.
+// All levels share the same pointer, so deductions at any level are immediately
+// visible to every other level.
+type ExtractionBudget struct {
+	remaining int64
+	maxDepth  int
+	depth     int
+}
+
+func newExtractionBudget(bytes int64, maxDepth int) *ExtractionBudget {
+	return &ExtractionBudget{remaining: bytes, maxDepth: maxDepth}
+}
+
+// Remaining returns the number of bytes left in the aggregate budget.
+func (b *ExtractionBudget) Remaining() int64 { return b.remaining }
+
+// Deduct reduces the remaining budget by n bytes.
+func (b *ExtractionBudget) Deduct(n int64) { b.remaining -= n }
+
+// Exhaust sets the remaining budget to zero, signalling that subsequent
+// entries should be skipped.
+func (b *ExtractionBudget) Exhaust() { b.remaining = 0 }
+
+// Exhausted reports whether the byte budget has been consumed.
+func (b *ExtractionBudget) Exhausted() bool { return b.remaining <= 0 }
+
+// Descend returns true and increments the nesting depth if maxDepth has not
+// been reached. The caller must call Ascend when the nested extraction returns.
+func (b *ExtractionBudget) Descend() bool {
+	if b.depth >= b.maxDepth {
+		return false
+	}
+	b.depth++
+	return true
+}
+
+// Ascend decrements the nesting depth. Must be paired with a successful Descend.
+func (b *ExtractionBudget) Ascend() { b.depth-- }
+
+// Extractor defines the interface needed to extract file content.
 type Extractor interface {
 	Match(filename string) bool
-	Extract(ctx context.Context, filename string, file io.ReadSeeker, maxFileSize int64) (string, error)
+	// Extract returns the text content of the file. budget carries shared
+	// aggregate limits across recursive archive extraction; all extractors must
+	// pass it through to any sub-extraction they perform.
+	Extract(filename string, file io.ReadSeeker, maxFileSize int64, budget *ExtractionBudget) (string, error)
 	Name() string
 }

--- a/server/platform/services/docextractor/interface.go
+++ b/server/platform/services/docextractor/interface.go
@@ -3,7 +3,10 @@
 
 package docextractor
 
-import "io"
+import (
+	"context"
+	"io"
+)
 
 // ExtractionBudget carries shared resource limits through the Extractor chain
 // so that nested archive extraction cannot exceed aggregate byte or depth bounds.
@@ -48,9 +51,10 @@ func (b *ExtractionBudget) Ascend() { b.depth-- }
 // Extractor defines the interface needed to extract file content.
 type Extractor interface {
 	Match(filename string) bool
-	// Extract returns the text content of the file. budget carries shared
-	// aggregate limits across recursive archive extraction; all extractors must
-	// pass it through to any sub-extraction they perform.
-	Extract(filename string, file io.ReadSeeker, maxFileSize int64, budget *ExtractionBudget) (string, error)
+	// Extract returns the text content of the file. ctx may be used by
+	// context-aware extractors (e.g. PDF) to stop early on cancellation.
+	// budget carries shared aggregate limits across recursive archive extraction;
+	// all extractors must pass both through to any sub-extraction they perform.
+	Extract(ctx context.Context, filename string, file io.ReadSeeker, maxFileSize int64, budget *ExtractionBudget) (string, error)
 	Name() string
 }

--- a/server/platform/services/docextractor/mmpreview.go
+++ b/server/platform/services/docextractor/mmpreview.go
@@ -9,7 +9,6 @@ package docextractor
 
 import (
 	"bytes"
-	"context"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -46,12 +45,12 @@ func (mpe *mmPreviewExtractor) Match(filename string) bool {
 	return mmpreviewSupportedExtensions[extension]
 }
 
-func (mpe *mmPreviewExtractor) Extract(ctx context.Context, filename string, file io.ReadSeeker, maxFileSize int64) (string, error) {
+func (mpe *mmPreviewExtractor) Extract(filename string, file io.ReadSeeker, maxFileSize int64, budget *ExtractionBudget) (string, error) {
 	b, w, err := createMultipartFormData("file", filename, file)
 	if err != nil {
 		return "", errors.Wrap(err, "Unable to generate file preview using mmpreview.")
 	}
-	req, err := http.NewRequestWithContext(ctx, "POST", mpe.url+"/toPDF", &b)
+	req, err := http.NewRequest("POST", mpe.url+"/toPDF", &b)
 	if err != nil {
 		return "", errors.Wrap(err, "Unable to generate file preview using mmpreview.")
 	}
@@ -71,7 +70,7 @@ func (mpe *mmPreviewExtractor) Extract(ctx context.Context, filename string, fil
 	if err != nil {
 		return "", errors.Wrap(err, "unable to read the response from mmpreview")
 	}
-	return mpe.pdfExtractor.Extract(ctx, filename, bytes.NewReader(data), maxFileSize)
+	return mpe.pdfExtractor.Extract(filename, bytes.NewReader(data), maxFileSize, budget)
 }
 
 func createMultipartFormData(fieldName, fileName string, fileData io.ReadSeeker) (bytes.Buffer, *multipart.Writer, error) {

--- a/server/platform/services/docextractor/mmpreview.go
+++ b/server/platform/services/docextractor/mmpreview.go
@@ -9,6 +9,7 @@ package docextractor
 
 import (
 	"bytes"
+	"context"
 	"io"
 	"mime/multipart"
 	"net/http"
@@ -45,12 +46,12 @@ func (mpe *mmPreviewExtractor) Match(filename string) bool {
 	return mmpreviewSupportedExtensions[extension]
 }
 
-func (mpe *mmPreviewExtractor) Extract(filename string, file io.ReadSeeker, maxFileSize int64, budget *ExtractionBudget) (string, error) {
+func (mpe *mmPreviewExtractor) Extract(ctx context.Context, filename string, file io.ReadSeeker, maxFileSize int64, budget *ExtractionBudget) (string, error) {
 	b, w, err := createMultipartFormData("file", filename, file)
 	if err != nil {
 		return "", errors.Wrap(err, "Unable to generate file preview using mmpreview.")
 	}
-	req, err := http.NewRequest("POST", mpe.url+"/toPDF", &b)
+	req, err := http.NewRequestWithContext(ctx, "POST", mpe.url+"/toPDF", &b)
 	if err != nil {
 		return "", errors.Wrap(err, "Unable to generate file preview using mmpreview.")
 	}
@@ -70,7 +71,7 @@ func (mpe *mmPreviewExtractor) Extract(filename string, file io.ReadSeeker, maxF
 	if err != nil {
 		return "", errors.Wrap(err, "unable to read the response from mmpreview")
 	}
-	return mpe.pdfExtractor.Extract(filename, bytes.NewReader(data), maxFileSize, budget)
+	return mpe.pdfExtractor.Extract(ctx, filename, bytes.NewReader(data), maxFileSize, budget)
 }
 
 func createMultipartFormData(fieldName, fileName string, fileData io.ReadSeeker) (bytes.Buffer, *multipart.Writer, error) {

--- a/server/platform/services/docextractor/pdf.go
+++ b/server/platform/services/docextractor/pdf.go
@@ -5,7 +5,6 @@ package docextractor
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -13,7 +12,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/mattermost/pdf"
+	"github.com/ledongthuc/pdf"
 
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
 )
@@ -32,7 +31,7 @@ func (pe *pdfExtractor) Match(filename string) bool {
 	return supportedExtensions[extension]
 }
 
-func (pe *pdfExtractor) Extract(ctx context.Context, filename string, r io.ReadSeeker, maxFileSize int64) (out string, outErr error) {
+func (pe *pdfExtractor) Extract(filename string, r io.ReadSeeker, maxFileSize int64, _ *ExtractionBudget) (out string, outErr error) {
 	defer func() {
 		if r := recover(); r != nil {
 			out = ""
@@ -63,7 +62,7 @@ func (pe *pdfExtractor) Extract(ctx context.Context, filename string, r io.ReadS
 	}
 
 	var buf bytes.Buffer
-	b, err := reader.GetPlainText(ctx)
+	b, err := reader.GetPlainText()
 	if err != nil {
 		return "", err
 	}

--- a/server/platform/services/docextractor/pdf.go
+++ b/server/platform/services/docextractor/pdf.go
@@ -5,6 +5,7 @@ package docextractor
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -12,7 +13,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/mattermost/pdf"
 
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
 )
@@ -62,7 +63,7 @@ func (pe *pdfExtractor) Extract(filename string, r io.ReadSeeker, maxFileSize in
 	}
 
 	var buf bytes.Buffer
-	b, err := reader.GetPlainText()
+	b, err := reader.GetPlainText(context.Background())
 	if err != nil {
 		return "", err
 	}

--- a/server/platform/services/docextractor/pdf.go
+++ b/server/platform/services/docextractor/pdf.go
@@ -32,7 +32,7 @@ func (pe *pdfExtractor) Match(filename string) bool {
 	return supportedExtensions[extension]
 }
 
-func (pe *pdfExtractor) Extract(filename string, r io.ReadSeeker, maxFileSize int64, _ *ExtractionBudget) (out string, outErr error) {
+func (pe *pdfExtractor) Extract(ctx context.Context, filename string, r io.ReadSeeker, maxFileSize int64, _ *ExtractionBudget) (out string, outErr error) {
 	defer func() {
 		if r := recover(); r != nil {
 			out = ""
@@ -63,7 +63,7 @@ func (pe *pdfExtractor) Extract(filename string, r io.ReadSeeker, maxFileSize in
 	}
 
 	var buf bytes.Buffer
-	b, err := reader.GetPlainText(context.Background())
+	b, err := reader.GetPlainText(ctx)
 	if err != nil {
 		return "", err
 	}

--- a/server/platform/services/docextractor/pdf_test.go
+++ b/server/platform/services/docextractor/pdf_test.go
@@ -5,7 +5,6 @@ package docextractor
 
 import (
 	"bytes"
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -15,7 +14,7 @@ import (
 
 func TestPdfEmptyFile(t *testing.T) {
 	extractor := pdfExtractor{}
-	_, err := extractor.Extract(context.Background(), "test.pdf", bytes.NewReader([]byte{}), 0)
+	_, err := extractor.Extract("test.pdf", bytes.NewReader([]byte{}), 0, testBudget())
 	require.Error(t, err)
 }
 
@@ -24,7 +23,7 @@ func TestPdfFile(t *testing.T) {
 	contentText := "\nThis is a simple document that contains some text."
 	content, err := testutils.ReadTestFile("sample-doc.pdf")
 	require.NoError(t, err)
-	extractedText, err := extractor.Extract(context.Background(), "sample-doc.pdf", bytes.NewReader(content), 0)
+	extractedText, err := extractor.Extract("sample-doc.pdf", bytes.NewReader(content), 0, testBudget())
 	require.NoError(t, err)
 	require.Equal(t, contentText, extractedText)
 }
@@ -39,7 +38,7 @@ func TestPdfDeeplyNestedObjects(t *testing.T) {
 	buf.WriteString("startxref\n0\n%%EOF\n")
 
 	extractor := pdfExtractor{}
-	text, err := extractor.Extract(context.Background(), "excessive-nests.pdf", bytes.NewReader(buf.Bytes()), 0)
+	text, err := extractor.Extract("excessive-nests.pdf", bytes.NewReader(buf.Bytes()), 0, testBudget())
 	require.Error(t, err)
 	require.Empty(t, text)
 }
@@ -48,20 +47,8 @@ func TestWrongPdfFile(t *testing.T) {
 	extractor := pdfExtractor{}
 	content, err := testutils.ReadTestFile("sample-doc.docx")
 	require.NoError(t, err)
-	_, err = extractor.Extract(context.Background(), "sample-doc.pdf", bytes.NewReader(content), 0)
+	_, err = extractor.Extract("sample-doc.pdf", bytes.NewReader(content), 0, testBudget())
 	require.Error(t, err)
-}
-
-func TestPdfCancelledContext(t *testing.T) {
-	extractor := pdfExtractor{}
-	content, err := testutils.ReadTestFile("sample-doc.pdf")
-	require.NoError(t, err)
-
-	ctx, cancel := context.WithCancel(context.Background())
-	cancel()
-
-	_, err = extractor.Extract(ctx, "sample-doc.pdf", bytes.NewReader(content), 0)
-	require.ErrorIs(t, err, context.Canceled)
 }
 
 func TestPdfMaxFileSize(t *testing.T) {
@@ -71,13 +58,13 @@ func TestPdfMaxFileSize(t *testing.T) {
 	require.Greater(t, len(content), 16, "fixture must be larger than the tight limit under test")
 
 	t.Run("a zero limit means unlimited and extracts the content", func(t *testing.T) {
-		text, err := extractor.Extract(context.Background(), "sample-doc.pdf", bytes.NewReader(content), 0)
+		text, err := extractor.Extract("sample-doc.pdf", bytes.NewReader(content), 0, testBudget())
 		require.NoError(t, err)
 		require.Contains(t, text, "simple")
 	})
 
 	t.Run("a generous limit extracts the content", func(t *testing.T) {
-		text, err := extractor.Extract(context.Background(), "sample-doc.pdf", bytes.NewReader(content), 10*1024*1024)
+		text, err := extractor.Extract("sample-doc.pdf", bytes.NewReader(content), 10*1024*1024, testBudget())
 		require.NoError(t, err)
 		require.Contains(t, text, "simple")
 	})
@@ -85,7 +72,7 @@ func TestPdfMaxFileSize(t *testing.T) {
 	t.Run("a tight limit prevents extraction", func(t *testing.T) {
 		// The reader errors once it reads past the limit, so io.Copy to the
 		// temp file fails and no text is extracted.
-		text, err := extractor.Extract(context.Background(), "sample-doc.pdf", bytes.NewReader(content), 16)
+		text, err := extractor.Extract("sample-doc.pdf", bytes.NewReader(content), 16, testBudget())
 		require.Error(t, err)
 		require.Empty(t, text)
 	})

--- a/server/platform/services/docextractor/pdf_test.go
+++ b/server/platform/services/docextractor/pdf_test.go
@@ -5,6 +5,7 @@ package docextractor
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -14,7 +15,7 @@ import (
 
 func TestPdfEmptyFile(t *testing.T) {
 	extractor := pdfExtractor{}
-	_, err := extractor.Extract("test.pdf", bytes.NewReader([]byte{}), 0, testBudget())
+	_, err := extractor.Extract(context.Background(), "test.pdf", bytes.NewReader([]byte{}), 0, testBudget())
 	require.Error(t, err)
 }
 
@@ -23,7 +24,7 @@ func TestPdfFile(t *testing.T) {
 	contentText := "\nThis is a simple document that contains some text."
 	content, err := testutils.ReadTestFile("sample-doc.pdf")
 	require.NoError(t, err)
-	extractedText, err := extractor.Extract("sample-doc.pdf", bytes.NewReader(content), 0, testBudget())
+	extractedText, err := extractor.Extract(context.Background(), "sample-doc.pdf", bytes.NewReader(content), 0, testBudget())
 	require.NoError(t, err)
 	require.Equal(t, contentText, extractedText)
 }
@@ -38,7 +39,7 @@ func TestPdfDeeplyNestedObjects(t *testing.T) {
 	buf.WriteString("startxref\n0\n%%EOF\n")
 
 	extractor := pdfExtractor{}
-	text, err := extractor.Extract("excessive-nests.pdf", bytes.NewReader(buf.Bytes()), 0, testBudget())
+	text, err := extractor.Extract(context.Background(), "excessive-nests.pdf", bytes.NewReader(buf.Bytes()), 0, testBudget())
 	require.Error(t, err)
 	require.Empty(t, text)
 }
@@ -47,7 +48,7 @@ func TestWrongPdfFile(t *testing.T) {
 	extractor := pdfExtractor{}
 	content, err := testutils.ReadTestFile("sample-doc.docx")
 	require.NoError(t, err)
-	_, err = extractor.Extract("sample-doc.pdf", bytes.NewReader(content), 0, testBudget())
+	_, err = extractor.Extract(context.Background(), "sample-doc.pdf", bytes.NewReader(content), 0, testBudget())
 	require.Error(t, err)
 }
 
@@ -58,13 +59,13 @@ func TestPdfMaxFileSize(t *testing.T) {
 	require.Greater(t, len(content), 16, "fixture must be larger than the tight limit under test")
 
 	t.Run("a zero limit means unlimited and extracts the content", func(t *testing.T) {
-		text, err := extractor.Extract("sample-doc.pdf", bytes.NewReader(content), 0, testBudget())
+		text, err := extractor.Extract(context.Background(), "sample-doc.pdf", bytes.NewReader(content), 0, testBudget())
 		require.NoError(t, err)
 		require.Contains(t, text, "simple")
 	})
 
 	t.Run("a generous limit extracts the content", func(t *testing.T) {
-		text, err := extractor.Extract("sample-doc.pdf", bytes.NewReader(content), 10*1024*1024, testBudget())
+		text, err := extractor.Extract(context.Background(), "sample-doc.pdf", bytes.NewReader(content), 10*1024*1024, testBudget())
 		require.NoError(t, err)
 		require.Contains(t, text, "simple")
 	})
@@ -72,7 +73,7 @@ func TestPdfMaxFileSize(t *testing.T) {
 	t.Run("a tight limit prevents extraction", func(t *testing.T) {
 		// The reader errors once it reads past the limit, so io.Copy to the
 		// temp file fails and no text is extracted.
-		text, err := extractor.Extract("sample-doc.pdf", bytes.NewReader(content), 16, testBudget())
+		text, err := extractor.Extract(context.Background(), "sample-doc.pdf", bytes.NewReader(content), 16, testBudget())
 		require.Error(t, err)
 		require.Empty(t, text)
 	})

--- a/server/platform/services/docextractor/plain.go
+++ b/server/platform/services/docextractor/plain.go
@@ -4,7 +4,6 @@
 package docextractor
 
 import (
-	"context"
 	"io"
 	"unicode"
 	"unicode/utf8"
@@ -20,7 +19,7 @@ func (pe *plainExtractor) Match(filename string) bool {
 	return true
 }
 
-func (pe *plainExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, _ int64) (string, error) {
+func (pe *plainExtractor) Extract(filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
 	// This detects any visible character plus any whitespace
 	validRanges := append(unicode.GraphicRanges, unicode.White_Space)
 

--- a/server/platform/services/docextractor/plain.go
+++ b/server/platform/services/docextractor/plain.go
@@ -4,6 +4,7 @@
 package docextractor
 
 import (
+	"context"
 	"io"
 	"unicode"
 	"unicode/utf8"
@@ -19,7 +20,7 @@ func (pe *plainExtractor) Match(filename string) bool {
 	return true
 }
 
-func (pe *plainExtractor) Extract(filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
+func (pe *plainExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, _ int64, _ *ExtractionBudget) (string, error) {
 	// This detects any visible character plus any whitespace
 	validRanges := append(unicode.GraphicRanges, unicode.White_Space)
 

--- a/server/platform/services/docextractor/plain_test.go
+++ b/server/platform/services/docextractor/plain_test.go
@@ -5,7 +5,6 @@ package docextractor
 
 import (
 	"bytes"
-	"context"
 	"strings"
 	"testing"
 
@@ -14,7 +13,7 @@ import (
 
 func TestPlainEmptyFile(t *testing.T) {
 	extractor := plainExtractor{}
-	extractedText, err := extractor.Extract(context.Background(), "test.txt", bytes.NewReader([]byte{}), 0)
+	extractedText, err := extractor.Extract("test.txt", bytes.NewReader([]byte{}), 0, testBudget())
 	require.NoError(t, err)
 	require.Equal(t, "", extractedText)
 }
@@ -22,7 +21,7 @@ func TestPlainEmptyFile(t *testing.T) {
 func TestPlainTextSmallFile(t *testing.T) {
 	extractor := plainExtractor{}
 	content := strings.Repeat("test \n", 5)
-	extractedText, err := extractor.Extract(context.Background(), "test.txt", bytes.NewReader([]byte(content)), 0)
+	extractedText, err := extractor.Extract("test.txt", bytes.NewReader([]byte(content)), 0, testBudget())
 	require.NoError(t, err)
 	require.Equal(t, content, extractedText)
 }
@@ -30,7 +29,7 @@ func TestPlainTextSmallFile(t *testing.T) {
 func TestPlainBigFile(t *testing.T) {
 	extractor := plainExtractor{}
 	content := strings.Repeat("test \n", 1000)
-	extractedText, err := extractor.Extract(context.Background(), "test.txt", bytes.NewReader([]byte(content)), 0)
+	extractedText, err := extractor.Extract("test.txt", bytes.NewReader([]byte(content)), 0, testBudget())
 	require.NoError(t, err)
 	require.Equal(t, content, extractedText)
 }
@@ -39,7 +38,7 @@ func TestSmallBinaryFile(t *testing.T) {
 	extractor := plainExtractor{}
 	notUTF8Char := byte(0x7)
 	content := bytes.Repeat([]byte{notUTF8Char}, 1000)
-	extractedText, err := extractor.Extract(context.Background(), "test.bin", bytes.NewReader(content), 0)
+	extractedText, err := extractor.Extract("test.bin", bytes.NewReader(content), 0, testBudget())
 	require.NoError(t, err)
 	require.Equal(t, "", extractedText)
 }
@@ -48,7 +47,7 @@ func TestBigBinaryFile(t *testing.T) {
 	extractor := plainExtractor{}
 	notUTF8Char := byte(0x7)
 	content := bytes.Repeat([]byte{notUTF8Char}, 10000)
-	extractedText, err := extractor.Extract(context.Background(), "test.bin", bytes.NewReader(content), 0)
+	extractedText, err := extractor.Extract("test.bin", bytes.NewReader(content), 0, testBudget())
 	require.NoError(t, err)
 	require.Equal(t, "", extractedText)
 }

--- a/server/platform/services/docextractor/plain_test.go
+++ b/server/platform/services/docextractor/plain_test.go
@@ -5,6 +5,7 @@ package docextractor
 
 import (
 	"bytes"
+	"context"
 	"strings"
 	"testing"
 
@@ -13,7 +14,7 @@ import (
 
 func TestPlainEmptyFile(t *testing.T) {
 	extractor := plainExtractor{}
-	extractedText, err := extractor.Extract("test.txt", bytes.NewReader([]byte{}), 0, testBudget())
+	extractedText, err := extractor.Extract(context.Background(), "test.txt", bytes.NewReader([]byte{}), 0, testBudget())
 	require.NoError(t, err)
 	require.Equal(t, "", extractedText)
 }
@@ -21,7 +22,7 @@ func TestPlainEmptyFile(t *testing.T) {
 func TestPlainTextSmallFile(t *testing.T) {
 	extractor := plainExtractor{}
 	content := strings.Repeat("test \n", 5)
-	extractedText, err := extractor.Extract("test.txt", bytes.NewReader([]byte(content)), 0, testBudget())
+	extractedText, err := extractor.Extract(context.Background(), "test.txt", bytes.NewReader([]byte(content)), 0, testBudget())
 	require.NoError(t, err)
 	require.Equal(t, content, extractedText)
 }
@@ -29,7 +30,7 @@ func TestPlainTextSmallFile(t *testing.T) {
 func TestPlainBigFile(t *testing.T) {
 	extractor := plainExtractor{}
 	content := strings.Repeat("test \n", 1000)
-	extractedText, err := extractor.Extract("test.txt", bytes.NewReader([]byte(content)), 0, testBudget())
+	extractedText, err := extractor.Extract(context.Background(), "test.txt", bytes.NewReader([]byte(content)), 0, testBudget())
 	require.NoError(t, err)
 	require.Equal(t, content, extractedText)
 }
@@ -38,7 +39,7 @@ func TestSmallBinaryFile(t *testing.T) {
 	extractor := plainExtractor{}
 	notUTF8Char := byte(0x7)
 	content := bytes.Repeat([]byte{notUTF8Char}, 1000)
-	extractedText, err := extractor.Extract("test.bin", bytes.NewReader(content), 0, testBudget())
+	extractedText, err := extractor.Extract(context.Background(), "test.bin", bytes.NewReader(content), 0, testBudget())
 	require.NoError(t, err)
 	require.Equal(t, "", extractedText)
 }
@@ -47,7 +48,7 @@ func TestBigBinaryFile(t *testing.T) {
 	extractor := plainExtractor{}
 	notUTF8Char := byte(0x7)
 	content := bytes.Repeat([]byte{notUTF8Char}, 10000)
-	extractedText, err := extractor.Extract("test.bin", bytes.NewReader(content), 0, testBudget())
+	extractedText, err := extractor.Extract(context.Background(), "test.bin", bytes.NewReader(content), 0, testBudget())
 	require.NoError(t, err)
 	require.Equal(t, "", extractedText)
 }


### PR DESCRIPTION
MM-70272

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Changes affect shared extractor interfaces and archive extraction behavior across multiple formats. Automated tests cover key limits and cancellation paths, but integration regressions remain possible.

**QA Recommendation:** Manual QA can be skipped if the full automated test suite passes.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

```release-note
Fixed an issue where extracting content from ZIP archives could lead to excessive memory consumption.
```