### PR TITLE
Keep a collapse toggle for single video attachments

### DIFF
--- a/webapp/channels/src/components/file_attachment_list/file_attachment_list.test.tsx
+++ b/webapp/channels/src/components/file_attachment_list/file_attachment_list.test.tsx
@@ -6,7 +6,10 @@ import React from 'react';
 
 import type {PostMetadata} from '@mattermost/types/posts';
 
+import {getPreferenceKey} from 'mattermost-redux/utils/preference_utils';
+
 import {renderWithContext} from 'tests/react_testing_utils';
+import {Preferences} from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
 
 import type {GlobalState} from 'types/store';
@@ -80,6 +83,82 @@ describe('FileAttachmentList', () => {
         expect(tiles[0]?.getAttribute('data-file-name')).toBe('image_1.png');
         expect(tiles[1]?.getAttribute('data-file-name')).toBe('image_2.png');
         expect(tiles[2]?.getAttribute('data-file-name')).toBe('image_3.png');
+    });
+
+    test('should render a MediaGallery for a single video', () => {
+        const video = TestHelper.getFileInfoMock({id: 'file_id_1', name: 'clip.mp4', extension: 'mp4', create_at: 1, delete_at: 0, post_id: post.id});
+        const props = {
+            ...baseProps,
+            isEmbedVisible: true,
+            post: {
+                ...baseProps.post,
+                file_ids: ['file_id_1'],
+            },
+        };
+
+        const state = {
+            ...defaultState,
+            entities: {
+                files: {
+                    files: {
+                        file_id_1: video,
+                    },
+                    fileIdsByPostId: {
+                        post_id: ['file_id_1'],
+                    },
+                },
+            },
+        } as unknown as GlobalState;
+
+        renderWithContext(<FileAttachmentList {...props}/>, state);
+
+        expect(screen.getByTestId('fileAttachmentList').querySelectorAll('[data-testid="media-gallery-tile"]').length).toBe(1);
+        expect(screen.queryByRole('button', {name: /toggle media gallery/i})).not.toBeInTheDocument();
+    });
+
+    test('should keep a collapse toggle for a collapsed single video', () => {
+        const video = TestHelper.getFileInfoMock({id: 'file_id_1', name: 'clip.mp4', extension: 'mp4', create_at: 1, delete_at: 0, post_id: post.id});
+        const props = {
+            ...baseProps,
+            post: {
+                ...baseProps.post,
+                file_ids: ['file_id_1'],
+            },
+        };
+
+        const state = {
+            ...defaultState,
+            entities: {
+                ...defaultState.entities,
+                files: {
+                    files: {
+                        file_id_1: video,
+                    },
+                    fileIdsByPostId: {
+                        post_id: ['file_id_1'],
+                    },
+                },
+                preferences: {
+                    myPreferences: {
+                        [getPreferenceKey(Preferences.CATEGORY_DISPLAY_SETTINGS, Preferences.COLLAPSE_DISPLAY)]: {
+                            category: Preferences.CATEGORY_DISPLAY_SETTINGS,
+                            name: Preferences.COLLAPSE_DISPLAY,
+                            user_id: 'current_user_id',
+                            value: 'true',
+                        },
+                    },
+                },
+                users: {
+                    currentUserId: 'current_user_id',
+                },
+            },
+        } as unknown as GlobalState;
+
+        renderWithContext(<FileAttachmentList {...props}/>, state);
+
+        const toggle = screen.getByRole('button', {name: /toggle media gallery/i});
+        expect(toggle).toHaveTextContent('clip.mp4');
+        expect(screen.getByTestId('fileAttachmentList')).toHaveClass('MediaGallery--collapsed');
     });
 
     test('should render a SingleImageView for a single image', () => {

--- a/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.scss
+++ b/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.scss
@@ -28,6 +28,8 @@
 
     &__toggle {
         display: inline-flex;
+        max-width: 100%;
+        min-width: 0;
         height: 24px;
         align-items: center;
         padding: 0 6px 0 2px;
@@ -46,6 +48,7 @@
             display: inline-flex;
             width: 18px;
             height: 18px;
+            flex-shrink: 0;
             align-items: center;
             justify-content: center;
             font-size: 18px;
@@ -54,6 +57,13 @@
             &::before {
                 margin: 0;
             }
+        }
+
+        .MediaGallery__filename {
+            overflow: hidden;
+            min-width: 0;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
 
         &:hover {

--- a/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.test.tsx
+++ b/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.test.tsx
@@ -131,4 +131,41 @@ describe('MediaGallery', () => {
         expect(rows).toHaveClass('MediaGallery__rows--collapsed');
         expect(rows).toHaveAttribute('aria-hidden', 'true');
     });
+
+    it('does not render a header for an expanded single video', () => {
+        renderWithContext(
+            <MediaGallery
+                fileInfos={[fileInfo({id: 'v', name: 'clip.mp4', extension: 'mp4', mime_type: 'video/mp4'})]}
+                postId='p1'
+                isEmbedVisible={true}
+                onItemClick={jest.fn()}
+                onToggleCollapse={jest.fn()}
+            />,
+            baseState,
+        );
+
+        expect(screen.queryByRole('button', {name: /toggle media gallery/i})).not.toBeInTheDocument();
+        expect(screen.getByTestId('media-gallery-tile')).toBeInTheDocument();
+    });
+
+    it('renders a filename toggle for a collapsed single video so the attachment stays reachable', async () => {
+        const onToggle = jest.fn();
+        const {container} = renderWithContext(
+            <MediaGallery
+                fileInfos={[fileInfo({id: 'v', name: 'clip.mp4', extension: 'mp4', mime_type: 'video/mp4'})]}
+                postId='p1'
+                isEmbedVisible={false}
+                onItemClick={jest.fn()}
+                onToggleCollapse={onToggle}
+            />,
+            baseState,
+        );
+
+        const toggle = screen.getByRole('button', {name: /toggle media gallery/i});
+        expect(toggle).toHaveTextContent('clip.mp4');
+        expect(container.querySelector('.MediaGallery__rows')).toHaveClass('MediaGallery__rows--collapsed');
+
+        await userEvent.click(toggle);
+        expect(onToggle).toHaveBeenCalledWith('p1');
+    });
 });

--- a/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.tsx
+++ b/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.tsx
@@ -123,7 +123,10 @@ const MediaGallery = ({fileInfos, postId, compactDisplay, isEmbedVisible = true,
     );
 
     const isSingle = tiles.length === 1;
-    const showHeader = !isSingle && Boolean(onToggleCollapse);
+
+    // Collapsed single videos need a header; otherwise the tile is hidden
+    // with no toggle, unlike SingleImageView which keeps a filename bar.
+    const showHeader = Boolean(onToggleCollapse) && (!isSingle || !isEmbedVisible);
 
     let tileIdx = 0;
 
@@ -157,27 +160,35 @@ const MediaGallery = ({fileInfos, postId, compactDisplay, isEmbedVisible = true,
                                 'icon-menu-right': !isEmbedVisible,
                             })}
                         />
-                        <FormattedMessage
-                            id='media_gallery.count_label'
-                            defaultMessage='{count, plural, one {# item} other {# items}}'
-                            values={{count: tiles.length}}
-                        />
-                    </button>
-                    <button
-                        type='button'
-                        className='style--none MediaGallery__download_all'
-                        aria-label={formatMessage(
-                            {id: 'media_gallery.download_all_label', defaultMessage: 'Download all {count, plural, one {# item} other {# items}}'},
-                            {count: tiles.length},
+                        {isSingle ? (
+                            <span className='MediaGallery__filename'>
+                                {tiles[0].file.name}
+                            </span>
+                        ) : (
+                            <FormattedMessage
+                                id='media_gallery.count_label'
+                                defaultMessage='{count, plural, one {# item} other {# items}}'
+                                values={{count: tiles.length}}
+                            />
                         )}
-                        onClick={handleDownloadAll}
-                    >
-                        <DownloadOutlineIcon size={14}/>
-                        <FormattedMessage
-                            id='media_gallery.download_all'
-                            defaultMessage='Download all'
-                        />
                     </button>
+                    {!isSingle && (
+                        <button
+                            type='button'
+                            className='style--none MediaGallery__download_all'
+                            aria-label={formatMessage(
+                                {id: 'media_gallery.download_all_label', defaultMessage: 'Download all {count, plural, one {# item} other {# items}}'},
+                                {count: tiles.length},
+                            )}
+                            onClick={handleDownloadAll}
+                        >
+                            <DownloadOutlineIcon size={14}/>
+                            <FormattedMessage
+                                id='media_gallery.download_all'
+                                defaultMessage='Download all'
+                            />
+                        </button>
+                    )}
                 </div>
             )}
             <div


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Collapsed single video attachments disappear from the post: no thumbnail, no file card, and no control to expand them.

`MediaGallery` (MM-24208 / #36922) renders single videos as a tile and omits the header when `isSingle` is true. With Default Appearance of Image Previews set to Collapsed (or `/collapse`), the tile is hidden via `grid-template-rows: 0fr` and there is nothing left to click. Single images still use `SingleImageView`, which keeps a filename bar when collapsed. Multi-item galleries keep an "N items" toggle.

This change shows a filename + chevron when a single gallery tile is collapsed, matching `SingleImageView`. Expanded single videos stay chrome-free.

**QA steps:**
1. Set Settings → Display → Default Appearance of Image Previews to Collapsed (or run `/collapse`).
2. Post a single video attachment.
3. Confirm the post shows a filename and chevron instead of an empty gap.
4. Click the chevron and confirm the video tile expands.
5. Confirm an expanded single video still has no extra header, and a collapsed multi-image gallery still shows "N items".

#### Release Note
```release-note
Fixed collapsed single video attachments disappearing from posts with no way to expand them.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99b7e70d-1be8-475c-9703-396bf2577dc3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99b7e70d-1be8-475c-9703-396bf2577dc3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

