### PR TITLE
MM-70294: Keep a collapse toggle for single video attachments

### DIFF
--- a/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.test.tsx
+++ b/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.test.tsx
@@ -131,4 +131,22 @@ describe('MediaGallery', () => {
         expect(rows).toHaveClass('MediaGallery__rows--collapsed');
         expect(rows).toHaveAttribute('aria-hidden', 'true');
     });
+
+    it('renders a collapse toggle for a collapsed single video', async () => {
+        const onToggle = jest.fn();
+        renderWithContext(
+            <MediaGallery
+                fileInfos={[fileInfo({id: 'v', name: 'clip.mp4', extension: 'mp4', mime_type: 'video/mp4'})]}
+                postId='p1'
+                isEmbedVisible={false}
+                onItemClick={jest.fn()}
+                onToggleCollapse={onToggle}
+            />,
+            baseState,
+        );
+
+        const toggle = screen.getByRole('button', {name: /toggle media gallery/i});
+        await userEvent.click(toggle);
+        expect(onToggle).toHaveBeenCalledWith('p1');
+    });
 });

--- a/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.tsx
+++ b/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.tsx
@@ -123,7 +123,9 @@ const MediaGallery = ({fileInfos, postId, compactDisplay, isEmbedVisible = true,
     );
 
     const isSingle = tiles.length === 1;
-    const showHeader = !isSingle && Boolean(onToggleCollapse);
+
+    // Collapsed single videos need a header, otherwise the tile disappears with no toggle.
+    const showHeader = Boolean(onToggleCollapse) && (!isSingle || !isEmbedVisible);
 
     let tileIdx = 0;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Collapsed single video attachments disappear from the post because `MediaGallery` omits its header when there is only one tile. With previews collapsed, the tile is hidden and there is no control left to expand it.

This only changes the `showHeader` condition so a collapsed single video still gets the existing gallery header.

**QA steps:**
1. Set Settings → Display → Default Appearance of Image Previews to Collapsed (or run `/collapse`).
2. Post a single video attachment.
3. Confirm the post shows the gallery header instead of an empty gap.
4. Click the chevron and confirm the video tile expands.
5. Confirm an expanded single video still has no header.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-70294

#### Screenshots
Collapsed (Default Appearance of Image Previews = Collapsed). The video is hidden but the gallery header remains, so the attachment is still reachable:

![Collapsed single video shows 1 item header](https://cursor.com/artifacts/c/art-bcc7f0b2-d871-4355-ba07-d7315f2ad9ff)

After clicking the header, the video tile expands:

![Expanded single video tile](https://cursor.com/artifacts/c/art-f7f78012-0534-49e8-ac6f-a9f98f959dac)

#### Release Note
```release-note
Fixed collapsed single video attachments disappearing from posts with no way to expand them.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-99b7e70d-1be8-475c-9703-396bf2577dc3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-99b7e70d-1be8-475c-9703-396bf2577dc3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to `MediaGallery` header visibility. An automated test covers the collapsed single-video toggle behavior.

**QA Recommendation:** Manual QA is optional because automated coverage is present and the change has a low blast radius.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->