### PR TITLE
E2E/Test: Bump playwright workers from 15 to 20

### DIFF
--- a/.github/workflows/e2e-tests-playwright.yml
+++ b/.github/workflows/e2e-tests-playwright.yml
@@ -177,7 +177,7 @@ jobs:
       pull-requests: write
     uses: ./.github/workflows/e2e-tests-playwright-template.yml
     with:
-      workers: 15
+      workers: 20
       enabled_docker_services: "postgres inbucket"
       commit_sha: ${{ inputs.commit_sha }}
       branch: ${{ needs.generate-build-variables.outputs.branch }}


### PR DESCRIPTION
#### Summary
Bump playwright workers from 15 to 20 to keep below 15 mins and a headroom to accommodate additional Playwright tests.

From:
<img width="799" height="47" alt="Screenshot 2026-08-19 at 8 25 52 AM" src="https://github.com/user-attachments/assets/0283184a-b07a-4adf-9df1-7408508f02a3" />

To:
<img width="797" height="50" alt="Screenshot 2026-08-19 at 8 22 57 AM" src="https://github.com/user-attachments/assets/f12118c0-21df-47f3-88b1-2e3e9eb935b3" />


#### Ticket Link
none

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change only updates Playwright worker configuration. It does not affect application code or critical user flows.
**QA Recommendation:** Skip manual QA because automated end-to-end coverage is in place.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->