### PR TITLE
Automated cherry pick of #38012

### DIFF
--- a/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.test.tsx
+++ b/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.test.tsx
@@ -130,4 +130,22 @@ describe('MediaGallery', () => {
         expect(rows).toHaveClass('MediaGallery__rows--collapsed');
         expect(rows).toHaveAttribute('aria-hidden', 'true');
     });
+
+    it('renders a collapse toggle for a collapsed single video', async () => {
+        const onToggle = jest.fn();
+        renderWithContext(
+            <MediaGallery
+                fileInfos={[fileInfo({id: 'v', name: 'clip.mp4', extension: 'mp4', mime_type: 'video/mp4'})]}
+                postId='p1'
+                isEmbedVisible={false}
+                onItemClick={jest.fn()}
+                onToggleCollapse={onToggle}
+            />,
+            baseState,
+        );
+
+        const toggle = screen.getByRole('button', {name: /toggle media gallery/i});
+        await userEvent.click(toggle);
+        expect(onToggle).toHaveBeenCalledWith('p1');
+    });
 });

--- a/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.tsx
+++ b/webapp/channels/src/components/file_attachment_list/media_gallery/media_gallery.tsx
@@ -123,7 +123,9 @@ const MediaGallery = ({fileInfos, postId, compactDisplay, isEmbedVisible = true,
     );
 
     const isSingle = tiles.length === 1;
-    const showHeader = !isSingle && Boolean(onToggleCollapse);
+
+    // Collapsed single videos need a header, otherwise the tile disappears with no toggle.
+    const showHeader = Boolean(onToggleCollapse) && (!isSingle || !isEmbedVisible);
 
     let tileIdx = 0;
 


### PR DESCRIPTION
Cherry pick of #38012 on release-11.10.

/cc  @jwilander

```release-note
NONE
```