### PR TITLE
Fix profile picture preview double-applying EXIF orientation

### DIFF
--- a/webapp/channels/src/components/setting_picture.tsx
+++ b/webapp/channels/src/components/setting_picture.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import React, {Component, createRef} from 'react';
-import type {ChangeEvent, CSSProperties, MouseEvent, ReactNode, RefObject} from 'react';
+import type {ChangeEvent, MouseEvent, ReactNode, RefObject} from 'react';
 import {defineMessage, FormattedMessage} from 'react-intl';
 
 import {Button} from '@mattermost/shared/components/button';
@@ -12,7 +12,6 @@ import FormError from 'components/form_error';
 import LoadingWrapper from 'components/widgets/loading/loading_wrapper';
 
 import {Constants} from 'utils/constants';
-import * as FileUtils from 'utils/file_utils';
 import {localizeMessage} from 'utils/utils';
 
 type Props = {
@@ -37,7 +36,6 @@ type State = {
     image: string | null;
     removeSrc: boolean;
     setDefaultSrc: boolean;
-    orientationStyles?: CSSProperties;
 };
 
 export default class SettingPicture extends Component<Props, State> {
@@ -144,18 +142,7 @@ export default class SettingPicture extends Component<Props, State> {
     setPicture = (file: File) => {
         if (file) {
             this.previewBlob = URL.createObjectURL(file);
-
-            const reader = new FileReader();
-            reader.onload = (e) => {
-                const orientation = FileUtils.getExifOrientation(e.target!.result! as ArrayBuffer);
-                const orientationStyles = FileUtils.getOrientationStyles(orientation);
-
-                this.setState({
-                    image: this.previewBlob,
-                    orientationStyles,
-                });
-            };
-            reader.readAsArrayBuffer(file);
+            this.setState({image: this.previewBlob});
         }
     };
 
@@ -165,7 +152,6 @@ export default class SettingPicture extends Component<Props, State> {
         if (this.props.file) {
             const imageStyles = {
                 backgroundImage: 'url(' + this.state.image + ')',
-                ...this.state.orientationStyles,
             };
 
             return (


### PR DESCRIPTION
#### Summary
Profile picture preview was applying a CSS EXIF transform on top of the browser's built-in image orientation, so photos from phones appeared rotated in the upload preview. Remove the manual transform and let the browser handle EXIF orientation.

#### Screenshots
Before: the selected profile photo appears rotated 90 degrees in the preview.
[
<img width="792" height="584" alt="Screenshot 2026-08-18 at 13 37 47" src="https://github.com/user-attachments/assets/c8a40126-8a2a-4900-95ca-ecbc9ab9db3e" />
](url)
After: the same photo appears upright.
<img width="793" height="582" alt="Screenshot 2026-08-18 at 13 38 57" src="https://github.com/user-attachments/assets/d57a2d9f-8364-476d-b247-0f2e0010f505" />


#### Release Note
```release-note
Fixed profile picture preview showing incorrectly rotated images due to double EXIF orientation.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change is isolated to the profile picture preview. Regression risk remains if browser image-orientation behavior differs across supported formats or browsers.

**QA Recommendation:** Perform focused manual testing with phone photos that contain EXIF orientation data and with BMP, JPG, JPEG, and PNG files.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->