### PR TITLE
[GH-37883] Let mm-blocks with markdown tables use the full post width

### DIFF
--- a/webapp/channels/src/components/block_renderer/block_renderer.scss
+++ b/webapp/channels/src/components/block_renderer/block_renderer.scss
@@ -40,6 +40,10 @@ $mm-blocks-container-max-heights: (
     margin-bottom: 8px;
     gap: 12px;
 
+    &:has(.markdown__table) {
+        max-width: none;
+    }
+
     // Reset the margin on the first paragraph of a text block.
     // Removes the style added by bootstrap.
     p {
@@ -321,6 +325,14 @@ $mm-blocks-container-max-heights: (
         font-size: 14px;
         line-height: 20px;
         word-break: break-word;
+
+        .table-responsive {
+            overflow-x: auto;
+        }
+
+        .markdown__table {
+            word-break: normal;
+        }
 
         p:first-child {
             margin-top: 0;


### PR DESCRIPTION
#### Summary

Legacy message attachments are rendered through the `mm-blocks` layout, which caps the whole block at 700px and applies `word-break: break-word` to text blocks. A markdown table inside `attachments[].text` gets squeezed into the 700px card even when the post body is much wider, and the compressed headers are broken apart character-by-character ("Res ult", "Atte mpts", "Responsi ble person").

This PR:

- lifts the 700px cap only for blocks that contain a markdown table (`.mm-blocks:has(.markdown__table)`), so the attachment can use the available post width — `:has()` is already used elsewhere in the webapp sass;
- makes `.table-responsive` scroll horizontally inside text blocks (Bootstrap 3 only enables that below 768px), so a table wider than the post scrolls instead of wrecking the layout;
- restores `word-break: normal` inside tables so header words are kept intact.

QA steps: send the incoming-webhook payload from the issue and check the rendered attachment in a wide window; then narrow the window until the table no longer fits and confirm it scrolls horizontally without breaking words.

Credit to @vpecinka, who proposed the core of this fix in the issue comments (added as co-author).

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/37883

#### Screenshots

Rendered with the exact DOM produced for the payload from the issue, post body 1000px wide:

| Before | After |
| --- | --- |
| ![before](https://raw.githubusercontent.com/ahmdyaasiin/mattermost/pr-assets/before-37883.png) | ![after](https://raw.githubusercontent.com/ahmdyaasiin/mattermost/pr-assets/after-37883.png) |

With the post body narrowed to 480px, the table scrolls horizontally (`scrollWidth` 717px > `clientWidth` 420px) and header words stay intact.

#### Release Note
```release-note
Fixed markdown tables in message attachments being constrained to 700px and breaking header words character-by-character.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to CSS for Markdown tables in `mm-blocks`. It does not affect shared utilities, data, APIs, or critical flows.

**QA Recommendation:** Manual QA can be skipped because automated testing provides full coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->