### PR TITLE
[GH-37825] Match signed integer lexemes when searching bare numbers

### DIFF
--- a/server/channels/store/searchtest/post_layer.go
+++ b/server/channels/store/searchtest/post_layer.go
@@ -41,6 +41,11 @@ var searchPostStoreTests = []searchTest{
 		Tags: []string{EnginePostgres, EngineElasticSearch},
 	},
 	{
+		Name: "Should be able to search numbers that only appear after a hyphen",
+		Fn:   testSearchNumbersAfterHyphens,
+		Tags: []string{EnginePostgres},
+	},
+	{
 		Name: "Should be able to search when markdown underscores are applied",
 		Fn:   testSearchMarkdownUnderscores,
 		Tags: []string{EnginePostgres, EngineElasticSearch},
@@ -500,6 +505,41 @@ func testSearchEmailAddresses(t *testing.T, th *SearchTestHelper) {
 
 		require.Len(t, results.Posts, 1)
 		th.checkPostInSearchResults(t, p1.Id, results.Posts)
+	})
+}
+
+func testSearchNumbersAfterHyphens(t *testing.T, th *SearchTestHelper) {
+	p1, err := th.createPost(th.User.Id, th.ChannelBasic.Id, "we should discuss CVE-2026-2332 today", "", model.PostTypeDefault, 0, false)
+	require.NoError(t, err)
+	p2, err := th.createPost(th.User.Id, th.ChannelBasic.Id, "room 2332 is booked", "", model.PostTypeDefault, 0, false)
+	require.NoError(t, err)
+	defer th.deleteUserPosts(th.User.Id)
+
+	t.Run("Should search the full hyphenated identifier", func(t *testing.T) {
+		params := &model.SearchParams{Terms: "CVE-2026-2332"}
+		results, err := th.Store.Post().SearchPostsForUser(th.Context, []*model.SearchParams{params}, th.User.Id, th.Team.Id, 0, 20)
+		require.NoError(t, err)
+
+		require.Len(t, results.Posts, 1)
+		th.checkPostInSearchResults(t, p1.Id, results.Posts)
+	})
+
+	t.Run("Should search a number that only appears after a hyphen", func(t *testing.T) {
+		params := &model.SearchParams{Terms: "2332"}
+		results, err := th.Store.Post().SearchPostsForUser(th.Context, []*model.SearchParams{params}, th.User.Id, th.Team.Id, 0, 20)
+		require.NoError(t, err)
+
+		require.Len(t, results.Posts, 2)
+		th.checkPostInSearchResults(t, p1.Id, results.Posts)
+		th.checkPostInSearchResults(t, p2.Id, results.Posts)
+	})
+
+	t.Run("Should exclude posts where the number only appears after a hyphen", func(t *testing.T) {
+		params := &model.SearchParams{Terms: "discuss", ExcludedTerms: "2332"}
+		results, err := th.Store.Post().SearchPostsForUser(th.Context, []*model.SearchParams{params}, th.User.Id, th.Team.Id, 0, 20)
+		require.NoError(t, err)
+
+		require.Len(t, results.Posts, 0)
 	})
 }
 

--- a/server/channels/store/sqlstore/post_store.go
+++ b/server/channels/store/sqlstore/post_store.go
@@ -2302,6 +2302,9 @@ func (s *SqlPostStore) search(teamId string, userId string, params *model.Search
 		terms = wildCardRegex.ReplaceAllLiteralString(terms, ":* ")
 		excludedTerms = wildCardRegex.ReplaceAllLiteralString(excludedTerms, ":* ")
 
+		terms = expandSignedNumberTokens(terms)
+		excludedTerms = expandSignedNumberTokens(excludedTerms)
+
 		// Replace spaces with to_tsquery symbols
 		replaceSpaces := func(input string, excludedInput bool) string {
 			if input == "" {

--- a/server/channels/store/sqlstore/utils.go
+++ b/server/channels/store/sqlstore/utils.go
@@ -10,6 +10,7 @@ import (
 	"io"
 	"maps"
 	"net/url"
+	"regexp"
 	"strconv"
 	"strings"
 	"unicode"
@@ -227,6 +228,38 @@ func neutralizeNonWordHyphens(s string) string {
 // attach to the preceding base letter rather than acting as a boundary.
 func isWordRune(r rune) bool {
 	return unicode.IsLetter(r) || unicode.IsDigit(r) || unicode.IsMark(r)
+}
+
+var numberSearchTokenRegex = regexp.MustCompile(`^\d+(:\*)?$`)
+
+func expandSignedNumberTokens(s string) string {
+	if !strings.ContainsAny(s, "0123456789") {
+		return s
+	}
+	var sb strings.Builder
+	last := 0
+	for _, loc := range quotedStringsRegex.FindAllStringIndex(s, -1) {
+		sb.WriteString(expandSignedNumberFields(s[last:loc[0]]))
+		sb.WriteString(s[loc[0]:loc[1]])
+		last = loc[1]
+	}
+	sb.WriteString(expandSignedNumberFields(s[last:]))
+	return sb.String()
+}
+
+func expandSignedNumberFields(s string) string {
+	fields := strings.Split(s, " ")
+	changed := false
+	for i, f := range fields {
+		if numberSearchTokenRegex.MatchString(f) {
+			fields[i] = "(" + f + "|-" + f + ")"
+			changed = true
+		}
+	}
+	if !changed {
+		return s
+	}
+	return strings.Join(fields, " ")
 }
 
 // scanRowsIntoMap scans SQL rows into a map, using a provided scanner function to extract key-value pairs

--- a/server/channels/store/sqlstore/utils_test.go
+++ b/server/channels/store/sqlstore/utils_test.go
@@ -37,6 +37,33 @@ func TestNeutralizeNonWordHyphens(t *testing.T) {
 	}
 }
 
+func TestExpandSignedNumberTokens(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"plain number expanded", "2332", "(2332|-2332)"},
+		{"number among words", "cve 2332", "cve (2332|-2332)"},
+		{"multiple numbers expanded", "2026 2332", "(2026|-2026) (2332|-2332)"},
+		{"wildcard number expanded", "2332:* ", "(2332:*|-2332:*) "},
+		{"plain word untouched", "t-shirt", "t-shirt"},
+		{"hyphenated compound untouched", "CVE-2026-2332", "CVE-2026-2332"},
+		{"word with digits untouched", "covid19", "covid19"},
+		{"quoted number untouched", `"2332"`, `"2332"`},
+		{"number inside quoted phrase untouched", `"error 2332 report"`, `"error 2332 report"`},
+		{"mixed quoted and bare", `"a 1" 2`, `"a 1" (2|-2)`},
+		{"no digits", "hello world", "hello world"},
+		{"empty string", "", ""},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			require.Equal(t, tc.expected, expandSignedNumberTokens(tc.input))
+		})
+	}
+}
+
 func TestChunkSlice(t *testing.T) {
 	if enableFullyParallelTests {
 		t.Parallel()


### PR DESCRIPTION
#### Summary

PostgreSQL's default text search parser lexes a number that follows a hyphenated word as a **signed integer**:

```sql
SELECT alias, token FROM ts_debug('english', 'CVE-2026-2332');
--  asciiword | CVE
--  int       | -2026
--  int       | -2332

SELECT to_tsvector('english', 'We should discuss CVE-2026-2332 here');
--  '-2026':5 '-2332':6 'cve':4 'discuss':3
```

Since #37360 (v11.10) the full identifier `CVE-2026-2332` is searchable again, because the hyphens are preserved and `to_tsquery` produces the matching phrase `'cve' <-> '-2026' <-> '-2332'`. But searching for a bare number that only appears after a hyphen — `2332` — still finds nothing: the query lexeme is `'2332'` while the index holds `'-2332'`.

This PR expands every purely numeric search token (with an optional trailing `:*` wildcard) to also match its signed form, e.g. `2332` becomes `(2332|-2332)`. Tokens inside quoted phrases are left untouched to preserve exact-phrase semantics, and the expansion applies to excluded terms as well, so `-2332` (exclusion) also excludes posts containing `CVE-2026-2332`.

Verified against PostgreSQL 17: new unit tests for the helper, plus a new `searchtest` case that fails without the store change and passes with it. The full `TestSearchPostStore` PostgreSQL suite (45 tests) passes.

Out of scope: an identifier that only appears inside a URL (e.g. `https://nvd.nist.gov/vuln/detail/CVE-2026-2332`) is indexed as opaque `url`/`url_path` tokens and remains unsearchable by the bare identifier. Fixing that requires changing the indexing side, which affects the expression index — happy to explore it in a follow-up if there's interest.

#### Ticket Link

Part of https://github.com/mattermost/mattermost/issues/37825

#### Release Note
```release-note
Searching for a bare number now also finds posts where the number appears after a hyphen, such as searching 2332 finding CVE-2026-2332.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change affects shared PostgreSQL search utilities and both included and excluded terms. Unit tests and the 45-test `TestSearchPostStore` suite reduce regression risk.

**QA Recommendation:** Manual QA is not required. Automated coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->