### PR TITLE
[GH-36802] Fetch the team by name when a thread popout opens without it

### DIFF
--- a/webapp/channels/src/components/thread_popout/thread_popout.test.tsx
+++ b/webapp/channels/src/components/thread_popout/thread_popout.test.tsx
@@ -48,8 +48,10 @@ jest.mock('mattermost-redux/actions/channels', () => ({
     selectChannel: jest.fn().mockReturnValue(() => ({type: 'SELECT_CHANNEL'})),
 }));
 
+const mockGetTeamByName = jest.fn().mockReturnValue(() => ({type: 'GET_TEAM_BY_NAME'}));
 jest.mock('mattermost-redux/actions/teams', () => ({
     selectTeam: jest.fn().mockReturnValue(() => ({type: 'SELECT_TEAM'})),
+    getTeamByName: jest.fn((...args) => mockGetTeamByName(...args)),
 }));
 
 jest.mock('mattermost-redux/actions/threads', () => ({
@@ -127,6 +129,7 @@ describe('ThreadPopout', () => {
     };
 
     beforeEach(() => {
+        mockGetTeamByName.mockClear();
         Object.defineProperty(window, 'isActive', {
             writable: true,
             value: false,
@@ -190,6 +193,45 @@ describe('ThreadPopout', () => {
         expect(threadViewer).toHaveAttribute('data-root-post-id', 'post-123');
         expect(threadViewer).toHaveAttribute('data-use-relative-timestamp', 'true');
         expect(threadViewer).toHaveAttribute('data-is-thread-view', 'true');
+    });
+
+    it('should fetch the team by name when it is not loaded yet', () => {
+        const stateWithoutTeam = {
+            ...baseState,
+            entities: {
+                ...baseState.entities,
+                teams: {
+                    currentTeamId: '',
+                    teams: {},
+                },
+            },
+        };
+
+        renderWithContext(
+            <MemoryRouter initialEntries={['/_popout/thread/test-team/post-123']}>
+                <Route
+                    path='/_popout/thread/:team/:postId'
+                    component={ThreadPopout}
+                />
+            </MemoryRouter>,
+            stateWithoutTeam,
+        );
+
+        expect(mockGetTeamByName).toHaveBeenCalledWith('test-team');
+    });
+
+    it('should not refetch the team when it is already loaded', () => {
+        renderWithContext(
+            <MemoryRouter initialEntries={['/_popout/thread/test-team/post-123']}>
+                <Route
+                    path='/_popout/thread/:team/:postId'
+                    component={ThreadPopout}
+                />
+            </MemoryRouter>,
+            baseState,
+        );
+
+        expect(mockGetTeamByName).not.toHaveBeenCalled();
     });
 
     it('should handle missing post gracefully', () => {

--- a/webapp/channels/src/components/thread_popout/thread_popout.tsx
+++ b/webapp/channels/src/components/thread_popout/thread_popout.tsx
@@ -18,7 +18,6 @@ import {getThread} from 'mattermost-redux/actions/threads';
 import {getProfilesByIds} from 'mattermost-redux/actions/users';
 import {getChannel, getCurrentChannel} from 'mattermost-redux/selectors/entities/channels';
 import {isScheduledPostsEnabled} from 'mattermost-redux/selectors/entities/scheduled_posts';
-import {getTeamByName} from 'mattermost-redux/selectors/entities/teams';
 import {makeGetThreadOrSynthetic} from 'mattermost-redux/selectors/entities/threads';
 import {getCurrentUserId} from 'mattermost-redux/selectors/entities/users';
 
@@ -26,6 +25,7 @@ import {loadStatusesByIds} from 'actions/status_actions';
 import {selectPost} from 'actions/views/rhs';
 import {markThreadAsRead} from 'actions/views/threads';
 
+import {useTeamByName} from 'components/common/hooks/use_team';
 import {usePost} from 'components/common/hooks/usePost';
 import {useUser} from 'components/common/hooks/useUser';
 import ThreadPane from 'components/threading/global_threads/thread_pane';
@@ -63,7 +63,7 @@ export default function ThreadPopout() {
     const currentUserId = useSelector(getCurrentUserId);
 
     const post = usePost(postId);
-    const team = useSelector((state: GlobalState) => getTeamByName(state, teamName));
+    const team = useTeamByName(teamName);
     const channel = useSelector((state: GlobalState) => getChannel(state, post?.channel_id ?? ''));
     const currentChannel = useSelector(getCurrentChannel);
     useUser(currentChannel?.type === Constants.DM_CHANNEL && currentChannel.teammate_id ? currentChannel.teammate_id : '');


### PR DESCRIPTION
#### Summary

Opening a thread with "Open in a new window" in the browser shows only the thread header and the message box — none of the thread's messages load.

Root cause: a browser popout window boots a fresh Redux store (popouts only exchange navigate/close messages with the opener via `postMessage`, no state is shared). `ThreadPopout` read the team with the bare `getTeamByName` selector and never fetched it, so `teamId` stayed `undefined` and the effects gated on it — `getThread`, `getPostThread`, `fetchChannelsAndMembers`, `selectTeam` — never ran. The root post still loads through `usePost`, which is why the header and the message box render but the conversation stays empty.

The fix mirrors what `ChannelPopout` already does: use the `useTeamByName` hook, which fetches the team when it isn't loaded yet.

Added two regression tests: the team is fetched by name when missing from the store (this test fails without the fix), and no refetch happens when the team is already loaded.

QA steps: open any thread in the RHS, click "Open in a new window" (browser, not desktop app), and confirm the full conversation renders in the popout.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/36802

#### Release Note
```release-note
Fixed thread popout windows opening empty, showing only the thread header and message box.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to `ThreadPopout` team loading. Regression risk is low because regression tests cover missing and already-loaded teams.
**QA Recommendation:** Manual QA can be skipped because automated coverage is complete.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->