### PR TITLE
Prepackage mattermost-plugin-agents v2.0.7 (release-11.7)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -162,7 +162,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.1
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.9.4
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.4
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.7
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.7
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.6.2
@@ -176,7 +176,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.9.4%2B39a72fa-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.4%2Bf359551-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.7%2B7e9d095-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.7%2Bfccd738-fips
 endif
 


### PR DESCRIPTION
#### Summary

Updates the default prepackaged [mattermost-plugin-agents](https://github.com/mattermost/mattermost-plugin-agents) artifact from **2.0.4** to **2.0.7** ([release v2.0.7](https://github.com/mattermost/mattermost-plugin-agents/releases/tag/v2.0.7)) for the `release-11.7` branch.

Both prepackaged plugin lists are updated:
- non-FIPS: `mattermost-plugin-agents-v2.0.7`
- FIPS: `mattermost-plugin-agents-v2.0.7%2B7e9d095-fips` (`7e9d095` is the tagged release commit)

Bundles verified on `plugins.releases.mattermost.com`.

#### Release Note

```release-note
Prepackaged the Mattermost Agents plugin at version 2.0.7 instead of 2.0.4.
```

Made with [Cursor](https://cursor.com)