### PR TITLE
Fix Cmd+K posting a new message to the previous channel

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
@@ -5,13 +5,14 @@ import React from 'react';
 
 import Permissions from 'mattermost-redux/constants/permissions';
 
+import {onSubmit} from 'actions/views/create_comment';
 import {removeDraft, updateDraft} from 'actions/views/drafts';
 
 import type {FileUpload} from 'components/file_upload/file_upload';
 import type Textbox from 'components/textbox/textbox';
 
 import mergeObjects from 'packages/mattermost-redux/test/merge_objects';
-import {renderWithContext, userEvent, screen} from 'tests/react_testing_utils';
+import {act, fireEvent, renderWithContext, userEvent, screen} from 'tests/react_testing_utils';
 import Constants, {Locations, StoragePrefixes} from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
 
@@ -24,6 +25,11 @@ jest.mock('actions/views/drafts', () => ({
     ...jest.requireActual('actions/views/drafts'),
     updateDraft: jest.fn((...args) => ({type: 'MOCK_UPDATE_DRAFT', args})),
     removeDraft: jest.fn((...args) => ({type: 'MOCK_REMOVE_DRAFT', args})),
+}));
+
+jest.mock('actions/views/create_comment', () => ({
+    ...jest.requireActual('actions/views/create_comment'),
+    onSubmit: jest.fn(() => () => Promise.resolve({data: true})),
 }));
 
 jest.mock('utils/exec_commands.ts', () => ({
@@ -44,6 +50,7 @@ jest.mock('utils/exec_commands.ts', () => ({
 
 const mockedRemoveDraft = jest.mocked(removeDraft);
 const mockedUpdateDraft = jest.mocked(updateDraft);
+const mockedOnSubmit = jest.mocked(onSubmit);
 
 const currentUserId = 'current_user_id';
 const channelId = 'current_channel_id';
@@ -285,6 +292,87 @@ describe('components/avanced_text_editor/advanced_text_editor', () => {
         );
 
         expect(screen.getByPlaceholderText('Write to Other Channel')).toHaveValue('a different draft');
+    });
+
+    it('should submit a new message to the destination channel while the textbox still holds the previous channel draft', async () => {
+        const sourceDraft = 'stale draft from the source channel';
+        const destinationMessage = 'new message composed for the destination channel';
+        const submitOnSwitchRef = {current: false};
+
+        function Harness({editorChannelId}: {editorChannelId: string}) {
+            const [submitStaleDraft, setSubmitStaleDraft] = React.useState(false);
+
+            // Cmd+K can focus the composer after channelId updates but before ATE's
+            // useEffect replaces the local draft. RTL flushes that effect before
+            // userEvent, so type here — after the destination placeholder paints,
+            // before the swap.
+            React.useLayoutEffect(() => {
+                if (!submitOnSwitchRef.current) {
+                    return;
+                }
+                submitOnSwitchRef.current = false;
+
+                const textbox = screen.getByPlaceholderText('Write to Other Channel');
+                expect(textbox).toHaveValue(sourceDraft);
+
+                // SuggestionBox listens to onInput, not onChange.
+                fireEvent.input(textbox, {target: {value: destinationMessage}});
+                setSubmitStaleDraft(true);
+            }, [editorChannelId]);
+
+            // Input setState is applied on the next render, still before the draft-swap
+            // useEffect. Submit from this layout effect so handleSubmit closes over the
+            // new message while draft.channelId is still the source channel.
+            React.useLayoutEffect(() => {
+                if (!submitStaleDraft) {
+                    return;
+                }
+
+                expect(screen.getByPlaceholderText('Write to Other Channel')).toHaveValue(destinationMessage);
+                fireEvent.click(screen.getByTestId('SendMessageButton'));
+            }, [submitStaleDraft]);
+
+            return (
+                <AdvancedTextEditor
+                    {...baseProps}
+                    channelId={editorChannelId}
+                />
+            );
+        }
+
+        const {rerender} = renderWithContext(
+            <Harness editorChannelId={channelId}/>,
+            mergeObjects(initialState, {
+                storage: {
+                    storage: {
+                        [StoragePrefixes.DRAFT + channelId]: {
+                            value: TestHelper.getPostDraftMock({
+                                message: sourceDraft,
+                                channelId,
+                            }),
+                        },
+                    },
+                },
+            }),
+        );
+
+        expect(screen.getByPlaceholderText('Write to Test Channel')).toHaveValue(sourceDraft);
+
+        submitOnSwitchRef.current = true;
+        rerender(<Harness editorChannelId={otherChannelId}/>);
+
+        await act(async () => {
+            await Promise.resolve();
+        });
+
+        expect(mockedOnSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message: destinationMessage,
+                channelId: otherChannelId,
+            }),
+            expect.anything(),
+            undefined,
+        );
     });
 
     it('should save a new draft when changing channels', async () => {

--- a/webapp/channels/src/components/advanced_text_editor/use_submit.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_submit.test.tsx
@@ -5,6 +5,7 @@ import type {DeepPartial} from '@mattermost/types/utilities';
 
 import {Permissions} from 'mattermost-redux/constants';
 
+import {onSubmit} from 'actions/views/create_comment';
 import {openModal} from 'actions/views/modals';
 
 import {renderHookWithContext} from 'tests/react_testing_utils';
@@ -17,6 +18,11 @@ import useSubmit from './use_submit';
 
 jest.mock('actions/views/modals', () => ({
     openModal: jest.fn(() => ({type: ''})),
+}));
+
+jest.mock('actions/views/create_comment', () => ({
+    ...jest.requireActual('actions/views/create_comment'),
+    onSubmit: jest.fn(() => () => Promise.resolve({data: true})),
 }));
 
 describe('useSubmit', () => {
@@ -264,6 +270,63 @@ describe('useSubmit', () => {
         expect(openModal).not.toHaveBeenCalledWith(expect.objectContaining({
             modalId: ModalIdentifiers.EDIT_CHANNEL_HEADER,
         }));
+    });
+
+    // Cmd+K (Find Channels) only history.push-es; SELECT_CHANNEL and the composer
+    // draft swap happen later. The focused textbox can submit a new message whose
+    // draft.channelId is still the channel we switched away from.
+    it('should submit a new message to the destination channel when the draft still belongs to the previous channel', async () => {
+        const sourceChannelId = 'source_channel_id';
+        const destinationChannelId = 'destination_channel_id';
+        const message = 'new message composed for the destination channel';
+
+        const state = getBaseState();
+        state.entities!.channels!.channels = {
+            [sourceChannelId]: {},
+            [destinationChannelId]: {},
+        };
+        state.entities!.channels!.stats = {
+            [sourceChannelId]: {member_count: 1},
+            [destinationChannelId]: {member_count: 1},
+        };
+
+        const staleDraft: PostDraft = {
+            ...mockDraft,
+            message,
+            channelId: sourceChannelId,
+            rootId: '',
+        };
+
+        const {result} = renderHookWithContext(() => useSubmit(
+            staleDraft,
+            mockPostError,
+            destinationChannelId,
+            '',
+            mockServerError,
+            mockLastBlurAt,
+            mockFocusTextbox,
+            mockSetServerError,
+            mockSetShowPreview,
+            mockHandleDraftChange,
+            mockPrioritySubmitCheck,
+            mockAfterOptimisticSubmit,
+            mockAfterSubmit,
+            false,
+            false,
+        ), state);
+
+        const [handleSubmit] = result.current;
+        await handleSubmit();
+
+        expect(onSubmit).toHaveBeenCalledWith(
+            expect.objectContaining({
+                message,
+                channelId: destinationChannelId,
+                rootId: '',
+            }),
+            expect.anything(),
+            undefined,
+        );
     });
 });
 

--- a/webapp/channels/src/components/advanced_text_editor/use_submit.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_submit.tsx
@@ -304,7 +304,13 @@ const useSubmit = (
             return;
         }
 
-        const submittingDraft = setUpdatedFileIds(submittingDraftParam);
+        // The editor channel/root are the destination. draft.channelId can still
+        // belong to the previous channel after Cmd+K until Redux and local draft state catch up.
+        const submittingDraft = setUpdatedFileIds({
+            ...submittingDraftParam,
+            channelId,
+            rootId,
+        });
         setShowPreview(false);
         isDraftSubmitting.current = true;
 
@@ -407,6 +413,7 @@ const useSubmit = (
         isInEditMode,
         channel,
         channelId,
+        rootId,
         channelMembersCount,
         dispatch,
         enableConfirmNotificationsToChannel,


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
After Find Channels (Cmd+K) switches from channel X to Y, a newly typed message could still be posted in X. `switchToChannel` only updates the URL, so the composer can be focused and submitted while `draft.channelId` still belongs to X.

`useSubmit` already uses the editor `channelId` for channel lookup, permissions, and mention confirms. This change stamps that editor `channelId`/`rootId` onto the draft at submit so `onSubmit` posts to the same destination.

Coverage:
- `use_submit.test.tsx` submits a draft whose `channelId` is still the previous channel.
- `advanced_text_editor.test.tsx` switches the editor `channelId`, asserts the textbox still shows the previous channel's draft, types a new destination message through that stale state, and checks submit goes to Y.

Drafts list “Send now” (`DraftRow`) also uses `useSubmit`, but it already passes the item’s channel as both the draft and the hook `channelId`, so this is a no-op there.

QA:
1. In channel/DM X with an empty composer, open Find Channels (Cmd/Ctrl+K) and switch to Y.
2. Immediately type a new message and send.
3. Confirm the post appears in Y, not X.

#### Release Note
```release-note
Fixed a bug where a message typed after switching channels with Find Channels could be posted in the previous channel.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c952cb4e-bce9-4d8f-98ff-98fbd8e48d08?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c952cb4e-bce9-4d8f-98ff-98fbd8e48d08&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

