### PR TITLE
[MM-70290] Avoid reading back the new Managed Category field unnecessarily after creation

### DIFF
--- a/server/channels/app/migrations.go
+++ b/server/channels/app/migrations.go
@@ -1064,7 +1064,7 @@ func (s *Server) doSetupManagedCategoryProperties() error {
 
 	if data != nil {
 		if data.Value == managedCategoryMigrationVersion {
-			return s.cacheManagedCategoryIDs()
+			return s.cacheExistingManagedCategoryIDs()
 		}
 
 		if incrementErr := s.Store().PropertyGroup().IncrementVersion(model.ManagedCategoryPropertyGroupName); incrementErr != nil {
@@ -1075,7 +1075,7 @@ func (s *Server) doSetupManagedCategoryProperties() error {
 			return fmt.Errorf("failed to save managed category setup done flag: %w", saveErr)
 		}
 
-		return s.cacheManagedCategoryIDs()
+		return s.cacheExistingManagedCategoryIDs()
 	}
 
 	group, err := s.propertyService.RegisterPropertyGroup(&model.PropertyGroup{Name: model.ManagedCategoryPropertyGroupName, Version: model.PropertyGroupVersionV2})
@@ -1083,9 +1083,9 @@ func (s *Server) doSetupManagedCategoryProperties() error {
 		return fmt.Errorf("failed to register managed category group: %w", err)
 	}
 
-	_, err = s.propertyService.GetPropertyFieldByNameForObjectType(nil, group.ID, "", model.PropertyValueTargetTypeChannel, model.ManagedCategoryPropertyFieldName)
+	field, err := s.propertyService.GetPropertyFieldByNameForObjectType(nil, group.ID, "", model.PropertyValueTargetTypeChannel, model.ManagedCategoryPropertyFieldName)
 	if err != nil {
-		field := &model.PropertyField{
+		field, err = s.propertyService.CreatePropertyField(nil, &model.PropertyField{
 			GroupID:           group.ID,
 			Name:              model.ManagedCategoryPropertyFieldName,
 			Type:              model.PropertyFieldTypeText,
@@ -1096,12 +1096,13 @@ func (s *Server) doSetupManagedCategoryProperties() error {
 			PermissionField:   model.NewPointer(model.PermissionLevelNone),
 			PermissionValues:  model.NewPointer(model.PermissionLevelMember),
 			PermissionOptions: model.NewPointer(model.PermissionLevelMember),
-		}
-
-		if _, err := s.propertyService.CreatePropertyField(nil, field); err != nil {
-			if _, retryErr := s.propertyService.GetPropertyFieldByNameForObjectType(nil, group.ID, "", field.ObjectType, model.ManagedCategoryPropertyFieldName); retryErr != nil {
+		})
+		if err != nil {
+			existing, retryErr := s.propertyService.GetPropertyFieldByNameForObjectType(nil, group.ID, "", model.PropertyValueTargetTypeChannel, model.ManagedCategoryPropertyFieldName)
+			if retryErr != nil {
 				return fmt.Errorf("failed to create managed category field: %w", err)
 			}
+			field = existing
 		}
 	}
 
@@ -1109,7 +1110,10 @@ func (s *Server) doSetupManagedCategoryProperties() error {
 		return fmt.Errorf("failed to save managed category setup done flag: %w", err)
 	}
 
-	return s.cacheManagedCategoryIDs()
+	s.Channels().managedCategoryGroupID = group.ID
+	s.Channels().managedCategoryFieldID = field.ID
+
+	return nil
 }
 
 func (s *Server) doSetupCPADisplayNameBackfill(rctx request.CTX) error {
@@ -1149,7 +1153,7 @@ func (s *Server) doSetupCPADisplayNameBackfill(rctx request.CTX) error {
 	return nil
 }
 
-func (s *Server) cacheManagedCategoryIDs() error {
+func (s *Server) cacheExistingManagedCategoryIDs() error {
 	group, err := s.propertyService.GetPropertyGroup(model.ManagedCategoryPropertyGroupName)
 	if err != nil {
 		return fmt.Errorf("failed to get managed category group: %w", err)

--- a/server/channels/app/migrations_test.go
+++ b/server/channels/app/migrations_test.go
@@ -31,6 +31,36 @@ func TestDoSetupManagedCategoryProperties(t *testing.T) {
 		data, sysErr := th.Store.System().GetByName(managedCategorySetupDoneKey)
 		require.NoError(t, sysErr)
 		require.NotEmpty(t, data.Value)
+
+		// The fresh-install path must populate these from the rows it just
+		// wrote rather than reading them back, since the read-back routes to a
+		// replica that may not have the write yet.
+		require.Equal(t, group.ID, th.Server.Channels().managedCategoryGroupID)
+		require.Equal(t, propertyFields[0].ID, th.Server.Channels().managedCategoryFieldID)
+	})
+
+	t.Run("should cache the IDs of an already existing group and field", func(t *testing.T) {
+		th := Setup(t)
+
+		group, appErr := th.App.GetPropertyGroup(th.Context, model.ManagedCategoryPropertyGroupName)
+		require.Nil(t, appErr)
+
+		propertyFields, appErr := th.App.SearchPropertyFields(th.Context, group.ID, model.PropertyFieldSearchOpts{PerPage: 100})
+		require.Nil(t, appErr)
+		require.Len(t, propertyFields, 1)
+
+		// Drop the done flag so the migration runs the fresh-install path again
+		// while both rows are already present.
+		_, sysErr := th.Store.System().PermanentDeleteByName(managedCategorySetupDoneKey)
+		require.NoError(t, sysErr)
+
+		th.Server.Channels().managedCategoryGroupID = ""
+		th.Server.Channels().managedCategoryFieldID = ""
+
+		require.NoError(t, th.Server.doSetupManagedCategoryProperties())
+
+		require.Equal(t, group.ID, th.Server.Channels().managedCategoryGroupID)
+		require.Equal(t, propertyFields[0].ID, th.Server.Channels().managedCategoryFieldID)
 	})
 
 	t.Run("should upgrade from a pre-v2 setup by incrementing the group version and updating the system key", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
The Managed Category properties migration created its property field on the primary database and then immediately read it back from a read replica to get its ID. On a licensed server with read replicas configured, if the replica hadn't caught up yet the read returned no rows, and `doAppMigrations` treats any migration error as fatal — so the server refused to start.

This PR removes the read-back. `RegisterPropertyGroup` and `CreatePropertyField` both return the rows they created, so `doSetupManagedCategoryProperties` already holds the group and field IDs in memory and now assigns them to the channel cache directly instead of calling `cacheManagedCategoryIDs()`.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70290

#### Release Note
```release-note
Fixed an issue where a server with read replicas configured could fail to start after upgrading
```