### PR TITLE
MM-70071: Drop redundant InitEmailBatching invite-mock stubs

### DIFF
--- a/server/channels/app/team_test.go
+++ b/server/channels/app/team_test.go
@@ -2258,8 +2258,6 @@ func TestInviteNewUsersToTeamGracefully(t *testing.T) {
 			inviteDataMatches(memberInvite),
 		).Once().Return(nil)
 		emailServiceMock.On("Stop").Once().Return()
-		// The teardown license reset saves a config change, whose listener re-inits email batching.
-		emailServiceMock.On("InitEmailBatching").Return().Maybe()
 		th.App.Srv().EmailService = &emailServiceMock
 
 		res, err := th.App.InviteNewUsersToTeamGracefully(th.Context, memberInvite, th.BasicTeam.Id, th.BasicUser.Id, "")
@@ -2278,8 +2276,6 @@ func TestInviteNewUsersToTeamGracefully(t *testing.T) {
 			inviteDataMatches(memberInvite),
 		).Once().Return(email.SendMailError)
 		emailServiceMock.On("Stop").Once().Return()
-		// The teardown license reset saves a config change, whose listener re-inits email batching.
-		emailServiceMock.On("InitEmailBatching").Return().Maybe()
 		th.App.Srv().EmailService = &emailServiceMock
 
 		res, err := th.App.InviteNewUsersToTeamGracefully(th.Context, memberInvite, th.BasicTeam.Id, th.BasicUser.Id, "")
@@ -2299,8 +2295,6 @@ func TestInviteNewUsersToTeamGracefully(t *testing.T) {
 			inviteDataMatches(memberInvite),
 		).Once().Return([]*model.EmailInviteWithError{}, nil)
 		emailServiceMock.On("Stop").Once().Return()
-		// The teardown license reset saves a config change, whose listener re-inits email batching.
-		emailServiceMock.On("InitEmailBatching").Return().Maybe()
 		th.App.Srv().EmailService = &emailServiceMock
 
 		res, err := th.App.InviteNewUsersToTeamGracefully(th.Context, memberInvite, th.BasicTeam.Id, th.BasicUser.Id, "")
@@ -2319,8 +2313,6 @@ func TestInviteNewUsersToTeamGracefully(t *testing.T) {
 			inviteDataMatches(memberInvite),
 		).Once().Return(nil)
 		emailServiceMock.On("Stop").Once().Return()
-		// The teardown license reset saves a config change, whose listener re-inits email batching.
-		emailServiceMock.On("InitEmailBatching").Return().Maybe()
 		th.App.Srv().EmailService = &emailServiceMock
 
 		res, err := th.App.InviteNewUsersToTeamGracefully(th.Context, memberInvite, th.BasicTeam.Id, th.BasicUser.Id, "")
@@ -2345,8 +2337,6 @@ func TestInviteNewUsersToTeamGracefully(t *testing.T) {
 			inviteDataMatches(memberInvite),
 		).Once().Return(nil)
 		emailServiceMock.On("Stop").Once().Return()
-		// The teardown license reset saves a config change, whose listener re-inits email batching.
-		emailServiceMock.On("InitEmailBatching").Return().Maybe()
 		th.App.Srv().EmailService = &emailServiceMock
 
 		res, err := th.App.InviteNewUsersToTeamGracefully(th.Context, memberInvite, th.BasicTeam.Id, th.BasicUser.Id, "")
@@ -2365,8 +2355,6 @@ func TestInviteNewUsersToTeamGracefully(t *testing.T) {
 			}},
 		}
 		emailServiceMock.On("Stop").Once().Return()
-		// The teardown license reset saves a config change, whose listener re-inits email batching.
-		emailServiceMock.On("InitEmailBatching").Return().Maybe()
 		th.App.Srv().EmailService = &emailServiceMock
 
 		res, err := th.App.InviteNewUsersToTeamGracefully(th.Context, memberInvite, th.BasicTeam.Id, th.BasicUser.Id, "")
@@ -2380,8 +2368,6 @@ func TestInviteNewUsersToTeamGracefully(t *testing.T) {
 	t.Run("it returns error for deactivated user without sending email", func(t *testing.T) {
 		emailServiceMock := emailmocks.ServiceInterface{}
 		emailServiceMock.On("Stop").Once().Return()
-		// The teardown license reset saves a config change, whose listener re-inits email batching.
-		emailServiceMock.On("InitEmailBatching").Return().Maybe()
 		th.App.Srv().EmailService = &emailServiceMock
 
 		_, appErr := th.App.UpdateActive(th.Context, th.BasicUser2, false)
@@ -2455,8 +2441,6 @@ func TestInviteGuestsToChannelsGracefully(t *testing.T) {
 			false,
 		).Once().Return(nil)
 		emailServiceMock.On("Stop").Once().Return()
-		// The teardown license reset saves a config change, whose listener re-inits email batching.
-		emailServiceMock.On("InitEmailBatching").Return().Maybe()
 		th.App.Srv().EmailService = &emailServiceMock
 
 		res, err := th.App.InviteGuestsToChannelsGracefully(th.Context, th.BasicTeam.Id, &model.GuestsInvite{
@@ -2486,8 +2470,6 @@ func TestInviteGuestsToChannelsGracefully(t *testing.T) {
 			false,
 		).Once().Return(email.SendMailError)
 		emailServiceMock.On("Stop").Once().Return()
-		// The teardown license reset saves a config change, whose listener re-inits email batching.
-		emailServiceMock.On("InitEmailBatching").Return().Maybe()
 		th.App.Srv().EmailService = &emailServiceMock
 
 		res, err := th.App.InviteGuestsToChannelsGracefully(th.Context, th.BasicTeam.Id, &model.GuestsInvite{


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Stacked on #37802 to show the simpler CI fix: keep the email-batching listener gate, remove the per-test `InitEmailBatching` stubs.

Those `Maybe()` stubs were covering teardown `SaveConfig` of `PushNotificationServer`. After the listener only re-inits batching when `EnableEmailBatching` or `EmailBatchingInterval` changes, the stubs are unused. The license-sync regression test in `push_notification_server_test.go` still asserts a mocked email service does not get `InitEmailBatching`.

No production code change.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70071

#### Release Note
```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a01cb3-98fb-71e2-ac07-5048b8a16fcf?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a01cb3-98fb-71e2-ac07-5048b8a16fcf&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

