### PR TITLE
Fix App Marketplace modal changing width when paging

### DIFF
--- a/webapp/channels/src/components/plugin_marketplace/__snapshots__/marketplace_modal.test.tsx.snap
+++ b/webapp/channels/src/components/plugin_marketplace/__snapshots__/marketplace_modal.test.tsx.snap
@@ -265,7 +265,7 @@ exports[`components/marketplace/ hides search and shows web marketplace banner 1
                     </a>
                     <a
                       aria-label="Plugin's website"
-                      class="style--none more-modal__row--link"
+                      class="style--none more-modal__row--link more-modal__description-link"
                       href="https://github.com/mattermost/mattermost-test"
                       location="marketplace_item"
                       rel="noopener noreferrer"
@@ -355,7 +355,7 @@ exports[`components/marketplace/ hides search and shows web marketplace banner 1
                     </a>
                     <a
                       aria-label="Plugin's website"
-                      class="style--none more-modal__row--link"
+                      class="style--none more-modal__row--link more-modal__description-link"
                       href="https://github.com/mattermost/mattermost-plugin-nps"
                       location="marketplace_item"
                       rel="noopener noreferrer"
@@ -1099,7 +1099,7 @@ exports[`components/marketplace/ should render with plugins available 1`] = `
                     </a>
                     <a
                       aria-label="Plugin's website"
-                      class="style--none more-modal__row--link"
+                      class="style--none more-modal__row--link more-modal__description-link"
                       href="https://github.com/mattermost/mattermost-plugin-nps"
                       location="marketplace_item"
                       rel="noopener noreferrer"
@@ -1319,7 +1319,7 @@ exports[`components/marketplace/ should render with plugins installed 1`] = `
                     </a>
                     <a
                       aria-label="Plugin's website"
-                      class="style--none more-modal__row--link"
+                      class="style--none more-modal__row--link more-modal__description-link"
                       href="https://github.com/mattermost/mattermost-test"
                       location="marketplace_item"
                       rel="noopener noreferrer"
@@ -1409,7 +1409,7 @@ exports[`components/marketplace/ should render with plugins installed 1`] = `
                     </a>
                     <a
                       aria-label="Plugin's website"
-                      class="style--none more-modal__row--link"
+                      class="style--none more-modal__row--link more-modal__description-link"
                       href="https://github.com/mattermost/mattermost-plugin-nps"
                       location="marketplace_item"
                       rel="noopener noreferrer"

--- a/webapp/channels/src/components/plugin_marketplace/marketplace_item/marketplace_item.tsx
+++ b/webapp/channels/src/components/plugin_marketplace/marketplace_item/marketplace_item.tsx
@@ -157,7 +157,7 @@ export default class MarketplaceItem extends React.PureComponent <MarketplaceIte
                     {labelComponents}
                     <ExternalLink
                         aria-label="Plugin's website"
-                        className='style--none more-modal__row--link'
+                        className='style--none more-modal__row--link more-modal__description-link'
                         href={this.props.homepageUrl}
                         location='marketplace_item'
                     >
@@ -177,7 +177,7 @@ export default class MarketplaceItem extends React.PureComponent <MarketplaceIte
                     {labelComponents}
                     <span
                         aria-label="Plugin\'s website"
-                        className='style--none'
+                        className='style--none more-modal__description-link'
                     >
                         {description}
                     </span>

--- a/webapp/channels/src/components/plugin_marketplace/marketplace_item/marketplace_item_app/__snapshots__/marketplace_item_app.test.tsx.snap
+++ b/webapp/channels/src/components/plugin_marketplace/marketplace_item/marketplace_item_app/__snapshots__/marketplace_item_app.test.tsx.snap
@@ -60,7 +60,7 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render 1`] = `
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -146,7 +146,7 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render installed a
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -233,7 +233,7 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render with empty 
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -287,7 +287,7 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render with icon 1
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -369,7 +369,7 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render with no hom
       </span>
       <span
         aria-label="Plugin\\\\'s website"
-        class="style--none"
+        class="style--none more-modal__description-link"
       >
         <p
           class="more-modal__description"
@@ -451,7 +451,7 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render with no plu
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -553,7 +553,7 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render with one la
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -639,7 +639,7 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render with server
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -761,7 +761,7 @@ exports[`components/MarketplaceItemApp MarketplaceItem should render with two la
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -847,7 +847,7 @@ exports[`components/MarketplaceItemApp MarketplaceItem when installing 1`] = `
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"

--- a/webapp/channels/src/components/plugin_marketplace/marketplace_item/marketplace_item_plugin/__snapshots__/marketplace_item_plugin.test.tsx.snap
+++ b/webapp/channels/src/components/plugin_marketplace/marketplace_item/marketplace_item_plugin/__snapshots__/marketplace_item_plugin.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`components/MarketplaceItemPlugin MarketplaceItem should render 1`] = `
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -92,7 +92,7 @@ exports[`components/MarketplaceItemPlugin MarketplaceItem should render installe
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -155,7 +155,7 @@ exports[`components/MarketplaceItemPlugin MarketplaceItem should render with emp
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -210,7 +210,7 @@ exports[`components/MarketplaceItemPlugin MarketplaceItem should render with no 
       </span>
       <span
         aria-label="Plugin\\\\'s website"
-        class="style--none"
+        class="style--none more-modal__description-link"
       >
         <p
           class="more-modal__description"
@@ -265,7 +265,7 @@ exports[`components/MarketplaceItemPlugin MarketplaceItem should render with no 
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -354,7 +354,7 @@ exports[`components/MarketplaceItemPlugin MarketplaceItem should render with no 
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -431,7 +431,7 @@ exports[`components/MarketplaceItemPlugin MarketplaceItem should render with one
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -490,7 +490,7 @@ exports[`components/MarketplaceItemPlugin MarketplaceItem should render with plu
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -549,7 +549,7 @@ exports[`components/MarketplaceItemPlugin MarketplaceItem should render with ser
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -644,7 +644,7 @@ exports[`components/MarketplaceItemPlugin MarketplaceItem should render with two
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -703,7 +703,7 @@ exports[`components/MarketplaceItemPlugin MarketplaceItem should render with upd
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"
@@ -786,7 +786,7 @@ exports[`components/MarketplaceItemPlugin MarketplaceItem should render with upd
       </a>
       <a
         aria-label="Plugin's website"
-        class="style--none more-modal__row--link"
+        class="style--none more-modal__row--link more-modal__description-link"
         href="http://example.com"
         location="marketplace_item"
         rel="noopener noreferrer"

--- a/webapp/channels/src/components/plugin_marketplace/marketplace_modal.scss
+++ b/webapp/channels/src/components/plugin_marketplace/marketplace_modal.scss
@@ -4,6 +4,14 @@
 .marketplace-modal {
     width: 832px;
 
+    // GenericModal centers the dialog with display:flex. Default min-width:auto lets
+    // nowrap plugin descriptions expand .modal-content past 832px when paging.
+    .modal-content {
+        width: 100%;
+        min-width: 0;
+        max-width: 100%;
+    }
+
     &.streamlined-marketplace {
         .modal-header {
             padding: 26px 32px 26px !important;
@@ -100,10 +108,13 @@
     .more-modal__list {
         height: 390px;
         margin: 0 6px 8px 12px;
+        overflow-x: hidden;
         overflow-y: scroll;
 
         .more-modal__row {
             overflow: hidden;
+            width: 100%;
+            min-width: 0;
             min-height: 80px;
             padding: 16px 20px;
             border-bottom: none;
@@ -121,6 +132,7 @@
             }
 
             .more-modal__details {
+                min-width: 0;
                 padding-left: 16px;
 
                 .more-modal__row--link {
@@ -130,12 +142,23 @@
                     line-height: 24px;
                 }
 
+                .more-modal__description-link {
+                    display: block;
+                    overflow: hidden;
+                    min-width: 0;
+                    max-width: 100%;
+                }
+
                 .more-modal__description {
+                    overflow: hidden;
+                    max-width: 100%;
                     margin: 2px 0 0;
                     color: var(--center-channel-color-rgb);
                     font-size: 14px;
                     font-weight: 400;
                     line-height: 20px;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
                 }
             }
 

--- a/webapp/channels/src/components/plugin_marketplace/marketplace_modal.test.tsx
+++ b/webapp/channels/src/components/plugin_marketplace/marketplace_modal.test.tsx
@@ -8,7 +8,7 @@ import {AuthorType, ReleaseStage} from '@mattermost/types/marketplace';
 
 import {fetchListing} from 'actions/marketplace';
 
-import {renderWithContext, screen, waitFor} from 'tests/react_testing_utils';
+import {renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
 import {ModalIdentifiers} from 'utils/constants';
 
 import type {GlobalState} from 'types/store';
@@ -202,6 +202,45 @@ describe('components/marketplace/', () => {
         expect(document.querySelector('.WebMarketplaceBanner')).toBeInTheDocument();
 
         expect(baseElement).toMatchSnapshot();
+    });
+
+    test('keeps paging through listings with mixed description lengths', async () => {
+        const longDescription = 'This plugin description is intentionally very long so that it would expand the modal if nowrap text were allowed to contribute to min-content width. '.repeat(8);
+
+        mockState.views.marketplace.plugins = Array.from({length: 16}, (_, index) => {
+            const paddedIndex = String(index).padStart(2, '0');
+            return {
+                ...samplePlugin,
+                homepage_url: `https://example.com/plugin-${paddedIndex}`,
+                download_url: `https://example.com/plugin-${paddedIndex}.tar.gz`,
+                manifest: {
+                    ...samplePlugin.manifest,
+                    id: `com.mattermost.plugin-${paddedIndex}`,
+                    name: `Plugin ${paddedIndex}`,
+                    description: index === 0 ? longDescription : `Short description ${paddedIndex}`,
+                },
+            };
+        });
+
+        renderWithContext(
+            <MarketplaceModal/>,
+            mockState,
+        );
+
+        await waitForListingToLoad();
+
+        const dialog = document.querySelector('.marketplace-modal.modal-dialog');
+        expect(dialog).toBeInTheDocument();
+        expect(screen.getByText('Plugin 00')).toBeInTheDocument();
+        expect(screen.queryByText('Plugin 15')).not.toBeInTheDocument();
+        expect(screen.getByText('Showing 1-15 of 16')).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('button', {name: 'Next'}));
+
+        expect(dialog).toBeInTheDocument();
+        expect(screen.queryByText('Plugin 00')).not.toBeInTheDocument();
+        expect(screen.getByText('Plugin 15')).toBeInTheDocument();
+        expect(screen.getByText('Showing 16-16 of 16')).toBeInTheDocument();
     });
 
     test("doesn't show web marketplace banner for Cloud", async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
The App Marketplace dialog grew or shrank when paging because plugin descriptions use `white-space: nowrap`, and GenericModal's centered dialog is a flex container. Flex items default to `min-width: auto`, so the longest nowrap description on a page became the dialog's min-content width.

This keeps the dialog at 832px regardless of listing content by:
- Constraining `.modal-content` with `min-width: 0` and `max-width: 100%`
- Letting plugin descriptions ellipsize inside the row instead of expanding it

**QA steps**
1. Open the App Marketplace as a system admin (Product menu → App Marketplace).
2. Confirm the dialog is 832px wide.
3. Page through the listing with Next/Previous.
4. Confirm the dialog width does not change when descriptions of different lengths appear.

#### Screenshots
Page 1 (longer descriptions, 832px):
![App Marketplace page 1 at 832px](https://cursor.com/artifacts/c/art-42b57c2e-738f-499b-9e83-37b214d3644a)

Page 2 (shorter description, still 832px):
![App Marketplace page 2 at 832px](https://cursor.com/artifacts/c/art-d33c3505-5c49-4a08-b56a-98e6a49d66a1)

#### Release Note
```release-note
Fixed the App Marketplace modal changing width when paging through plugins.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4609f2a4-fa67-4eef-a7da-44762f473ab3?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4609f2a4-fa67-4eef-a7da-44762f473ab3&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

