### PR TITLE
MM-70307: Fix FIPS E2E test failure due to short PostgreSQL password

### DIFF
--- a/e2e-tests/.ci/server.generate.sh
+++ b/e2e-tests/.ci/server.generate.sh
@@ -59,7 +59,7 @@ services:
       MM_CONNECTEDWORKSPACESSETTINGS_ENABLEREMOTECLUSTERSERVICE: "true"
       MM_CONNECTEDWORKSPACESSETTINGS_ENABLESHAREDWORKSPACES: "true"
       MM_FEATUREFLAGS_ENABLEREMOTECLUSTERSERVICE: "true"
-      MM_SQLSETTINGS_DATASOURCE: "postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes"
+      MM_SQLSETTINGS_DATASOURCE: "postgres://mmuser:mostest_password@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes"
       MM_SQLSETTINGS_DRIVERNAME: "postgres"
       MM_EMAILSETTINGS_SMTPSERVER: "localhost"
       MM_CLUSTERSETTINGS_READONLYCONFIG: "false"
@@ -240,7 +240,7 @@ $(if mme2e_is_token_in_list "cypress" "$ENABLED_DOCKER_SERVICES"; then
       - "../../e2e-tests/.ci/.env.cypress"
     environment:
       CYPRESS_baseUrl: "http://localhost:8065"
-      CYPRESS_dbConnection: "postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
+      CYPRESS_dbConnection: "postgres://mmuser:mostest_password@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10"
       CYPRESS_smtpUrl: "http://localhost:9001"
       CYPRESS_webhookBaseUrl: "http://localhost:3000"
       CYPRESS_chromeWebSecurity: "false"
@@ -318,7 +318,7 @@ $(if mme2e_is_token_in_list "playwright" "$ENABLED_DOCKER_SERVICES"; then
       PW_ADMIN_PASSWORD: Sys@dmin-sample1
       PW_ADMIN_EMAIL: sysadmin@sample.mattermost.com
       PW_ENSURE_PLUGINS_INSTALLED: ""
-      MM_TEST_DB_URL: "postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes"
+      MM_TEST_DB_URL: "postgres://mmuser:mostest_password@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes"
       PW_HA_CLUSTER_ENABLED: "false"
       PW_RESET_BEFORE_TEST: "false"
       PW_HEADLESS: "true"

--- a/e2e-tests/.ci/server.start.sh
+++ b/e2e-tests/.ci/server.start.sh
@@ -90,7 +90,7 @@ fi
 # shellcheck disable=SC2043
 for MIGRATION in migration_advanced_permissions_phase_2; do
   # Query explanation: if it doesn't find the migration in the table, there are 0 results and the command fails with a divide-by-zero error. Otherwise the command succeeds
-  MIGRATION_CHECK_COMMAND="${MME2E_DC_SERVER} exec -T postgres sh -c 'PGPASSWORD=mostest psql -U mmuser mattermost_test -c \"select 1 / (select count(*) from Systems where name = '\''${MIGRATION}'\'' and value = '\''true'\'');\"'"
+  MIGRATION_CHECK_COMMAND="${MME2E_DC_SERVER} exec -T postgres sh -c 'PGPASSWORD=mostest_password psql -U mmuser mattermost_test -c \"select 1 / (select count(*) from Systems where name = '\''${MIGRATION}'\'' and value = '\''true'\'');\"'"
   if ! mme2e_wait_command_success "$MIGRATION_CHECK_COMMAND" "Waiting for migration to be completed: ${MIGRATION}" "10" "10"; then
     mme2e_log "Migration ${MIGRATION} not completed, retry attempts exhausted. Giving up." >&2
 

--- a/e2e-tests/cypress/cypress.config.ts
+++ b/e2e-tests/cypress/cypress.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
         cwsURL: 'http://localhost:8076',
         cwsAPIURL: 'http://localhost:8076',
         dbClient: 'postgres',
-        dbConnection: 'postgres://mmuser:mostest@localhost/mattermost_test?sslmode=disable&connect_timeout=10',
+        dbConnection: 'postgres://mmuser:mostest_password@localhost/mattermost_test?sslmode=disable&connect_timeout=10',
         elasticsearchConnectionURL: 'http://localhost:9200',
         firstTest: false,
         keycloakAppName: 'mattermost',

--- a/e2e-tests/cypress/tests/support/api/on_prem_default_config.json
+++ b/e2e-tests/cypress/tests/support/api/on_prem_default_config.json
@@ -144,7 +144,7 @@
     },
     "SqlSettings": {
         "DriverName": "postgres",
-        "DataSource": "postgres://mmuser:mostest@localhost/mattermost_test?sslmode=disable\u0026connect_timeout=10\u0026binary_parameters=yes",
+        "DataSource": "postgres://mmuser:mostest_password@localhost/mattermost_test?sslmode=disable\u0026connect_timeout=10\u0026binary_parameters=yes",
         "DataSourceReplicas": [],
         "DataSourceSearchReplicas": [],
         "ConnMaxLifetimeMilliseconds": 3600000,

--- a/e2e-tests/playwright/lib/src/containers/constants.ts
+++ b/e2e-tests/playwright/lib/src/containers/constants.ts
@@ -10,7 +10,7 @@ export const POSTGRES_ALIAS = 'postgres';
 export const POSTGRES_PORT = 5432;
 export const POSTGRES_DB = 'mattermost_test';
 export const POSTGRES_USER = 'mmuser';
-export const POSTGRES_PASSWORD = 'mostest';
+export const POSTGRES_PASSWORD = 'mostest_password';
 
 export const INBUCKET_ALIAS = 'inbucket';
 export const INBUCKET_WEB_PORT = 9001;

--- a/e2e-tests/playwright/lib/src/server/default_config.ts
+++ b/e2e-tests/playwright/lib/src/server/default_config.ts
@@ -265,7 +265,7 @@ const defaultServerConfig: AdminConfig = {
     SqlSettings: {
         DriverName: 'postgres',
         DataSource:
-            'postgres://mmuser:mostest@localhost/mattermost_test?sslmode=disable\u0026connect_timeout=10\u0026binary_parameters=yes',
+            'postgres://mmuser:mostest_password@localhost/mattermost_test?sslmode=disable\u0026connect_timeout=10\u0026binary_parameters=yes',
         DataSourceReplicas: [],
         DataSourceSearchReplicas: [],
         MaxIdleConns: 50,

--- a/e2e-tests/playwright/lib/src/test_config.ts
+++ b/e2e-tests/playwright/lib/src/test_config.ts
@@ -153,7 +153,7 @@ export class TestConfig {
         this.smtpURL = process.env.PW_SMTP_URL || 'http://localhost:9001';
         this.postgresUrl =
             process.env.PW_POSTGRES_URL ||
-            'postgres://mmuser:mostest@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes';
+            'postgres://mmuser:mostest_password@localhost:5432/mattermost_test?sslmode=disable&connect_timeout=10&binary_parameters=yes';
         this.webhookBaseUrl = process.env.PW_WEBHOOK_BASE_URL || 'http://localhost:3000';
 
         // Testcontainers

--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -12,7 +12,7 @@ services:
       - mm-test
     environment:
       POSTGRES_USER: mmuser
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mostest}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-mostest_password}
       POSTGRES_DB: mattermost_test
       POSTGRES_INITDB_ARGS: "--auth-host=scram-sha-256 --auth-local=scram-sha-256"
     command: postgres -c 'config_file=/etc/postgresql/postgresql.conf'

--- a/server/build/dotenv/test.env
+++ b/server/build/dotenv/test.env
@@ -1,4 +1,4 @@
-TEST_DATABASE_POSTGRESQL_DSN=postgres://mmuser:mostest@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
+TEST_DATABASE_POSTGRESQL_DSN=postgres://mmuser:mostest_password@postgres:5432/mattermost_test?sslmode=disable&connect_timeout=10
 GOBIN=/mattermost/server/bin
 
 CI_INBUCKET_HOST=inbucket

--- a/server/docker-compose.yaml
+++ b/server/docker-compose.yaml
@@ -117,7 +117,7 @@ services:
     working_dir: '/home/mattermost-server/server'
     environment:
       - "MM_SQLSETTINGS_DRIVERNAME=postgres"
-      - "MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest@postgres/mattermost_test?sslmode=disable&connect_timeout=10"
+      - "MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest_password@postgres/mattermost_test?sslmode=disable&connect_timeout=10"
       - "MM_NO_DOCKER=true"
       - "RUN_SERVER_IN_BACKGROUND=false"
       - "MM_CLUSTERSETTINGS_ENABLE=true"
@@ -151,7 +151,7 @@ services:
     working_dir: '/home/mattermost-server/server'
     environment:
       - "MM_SQLSETTINGS_DRIVERNAME=postgres"
-      - "MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest@postgres/mattermost_test?sslmode=disable&connect_timeout=10"
+      - "MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest_password@postgres/mattermost_test?sslmode=disable&connect_timeout=10"
       - "MM_NO_DOCKER=true"
       - "RUN_SERVER_IN_BACKGROUND=false"
       - "MM_CLUSTERSETTINGS_ENABLE=true"
@@ -185,7 +185,7 @@ services:
     working_dir: '/home/mattermost-server/server'
     environment:
       - "MM_SQLSETTINGS_DRIVERNAME=postgres"
-      - "MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest@postgres/mattermost_test?sslmode=disable&connect_timeout=10"
+      - "MM_SQLSETTINGS_DATASOURCE=postgres://mmuser:mostest_password@postgres/mattermost_test?sslmode=disable&connect_timeout=10"
       - "MM_NO_DOCKER=true"
       - "RUN_SERVER_IN_BACKGROUND=false"
       - "MM_CLUSTERSETTINGS_ENABLE=true"


### PR DESCRIPTION
## Summary

- OpenSSL FIPS 140 requires HMAC keys to be at least 14 bytes (112 bits); the password `mostest` (6 bytes) is too short.
- When the server runs under `go-msft-fips` with the `glibc-openssl-fips:16` image (introduced in the parent PR), `lib/pq`'s SCRAM-SHA-256 authentication panics in `EVP_MAC_init` → `hmac_setkey: invalid key length` on the very first DB connection.
- Replace `mostest` → `mostest_password` (16 bytes) in all PostgreSQL connection strings and container configs used by E2E tests. LDAP admin passwords (`mostest`) are unaffected — LDAP uses a different protocol not subject to this HMAC key-length restriction.

## Files changed

| File | Change |
|------|--------|
| `e2e-tests/playwright/lib/src/containers/constants.ts` | `POSTGRES_PASSWORD = 'mostest_password'` |
| `server/build/docker-compose.common.yml` | `POSTGRES_PASSWORD` default updated |
| `e2e-tests/.ci/server.generate.sh` | 3 DSN occurrences updated |
| `e2e-tests/.ci/server.start.sh` | `PGPASSWORD` updated |
| `e2e-tests/cypress/cypress.config.ts` | `dbConnection` updated |
| `e2e-tests/cypress/tests/support/api/on_prem_default_config.json` | `DataSource` updated |
| `e2e-tests/playwright/lib/src/test_config.ts` | `postgresUrl` default updated |
| `e2e-tests/playwright/lib/src/server/default_config.ts` | `SqlSettings.DataSource` updated |
| `server/docker-compose.yaml` | leader/follower/follower2 DSNs updated |
| `server/build/dotenv/test.env` | `TEST_DATABASE_POSTGRESQL_DSN` updated |

## Test plan

- [ ] FIPS E2E Playwright tests pass (no "Log stream ended" panic)
- [ ] FIPS E2E Cypress tests pass (server container reaches healthy state)
- [ ] Non-FIPS E2E tests unaffected