### PR TITLE
Require release team review for release documentation

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,19 @@
 /webapp/channels/src/packages/mattermost-redux/src/store/configureStore.ts @hmhealey
 /server/channels/app/authentication.go @mattermost/product-security
 /server/channels/app/authorization.go @mattermost/product-security
+
+# Release-owned documentation. A review from either @mattermost/release-eng or
+# @mattermost/release-managers is required for changes to these pages.
+/docs/main/product-overview/*changelog.mdx @mattermost/release-eng @mattermost/release-managers
+/docs/main/product-overview/*release*.mdx @mattermost/release-eng @mattermost/release-managers
+/docs/main/product-overview/common-esr-support*.mdx @mattermost/release-eng @mattermost/release-managers
+/docs/main/product-overview/deprecated-features.mdx @mattermost/release-eng @mattermost/release-managers
+/docs/main/product-overview/server.mdx @mattermost/release-eng @mattermost/release-managers
+/docs/main/product-overview/version-archive.mdx @mattermost/release-eng @mattermost/release-managers
+/docs/main/administration-guide/upgrade/important-upgrade-notes.mdx @mattermost/release-eng @mattermost/release-managers
+/docs/main/administration-guide/upgrade/open-source-components.mdx @mattermost/release-eng @mattermost/release-managers
+/docs/main/administration-guide/upgrade/prepare-to-upgrade-mattermost.mdx @mattermost/release-eng @mattermost/release-managers
+/docs/main/deployment-guide/software-hardware-requirements.mdx @mattermost/release-eng @mattermost/release-managers
+/docs/main/deployment-guide/desktop/*install.mdx @mattermost/release-eng @mattermost/release-managers
+/docs/main/deployment-guide/server/linux/deploy-rhel.mdx @mattermost/release-eng @mattermost/release-managers
+/docs/main/deployment-guide/server/linux/deploy-tar.mdx @mattermost/release-eng @mattermost/release-managers


### PR DESCRIPTION
#### Summary

Adds CODEOWNERS rules routing review of release-owned documentation to `@mattermost/release-eng` or `@mattermost/release-managers`. A review from either team satisfies the requirement.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change only updates root `CODEOWNERS` rules. It does not affect application code, runtime behavior, data, APIs, or critical user flows.

**QA Recommendation:** Skip manual QA. Verify the `CODEOWNERS` syntax and rule paths through repository checks.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->