### PR TITLE
[GH-21558] Increase max height of the Find Channels modal

### DIFF
--- a/webapp/channels/src/components/quick_switch_modal/quick_switch_modal.tsx
+++ b/webapp/channels/src/components/quick_switch_modal/quick_switch_modal.tsx
@@ -245,6 +245,7 @@ export class QuickSwitchModal extends React.PureComponent<Props, State> {
                         value={this.state.text}
                         onItemSelected={this.handleSubmit}
                         listComponent={SuggestionList}
+                        listMaxHeight={Constants.SUGGESTION_LIST_MAXHEIGHT_MODAL}
                         listPosition='bottom'
                         maxLength='64'
                         providers={providers}

--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.d.ts
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.d.ts
@@ -52,6 +52,12 @@ export type SuggestionBoxProps = {
     renderNoResults?: boolean;
 
     /**
+     * Optional maximum height in pixels for the suggestion list, overriding the default cap.
+     * Used by taller modal-based lists such as the Find Channels modal.
+     */
+    listMaxHeight?: number;
+
+    /**
      * Set to true if we want the suggestions to take in the complete word as the pretext, defaults to false
      */
     shouldSearchCompleteText?: boolean;

--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.jsx
@@ -70,6 +70,12 @@ export default class SuggestionBox extends React.PureComponent {
         renderNoResults: PropTypes.bool,
 
         /**
+         * Optional maximum height in pixels for the suggestion list, overriding the default cap.
+         * Used by taller modal-based lists such as the Find Channels modal.
+         */
+        listMaxHeight: PropTypes.number,
+
+        /**
          * Set to true if we want the suggestions to take in the complete word as the pretext, defaults to false
          */
         shouldSearchCompleteText: PropTypes.bool,
@@ -717,6 +723,7 @@ export default class SuggestionBox extends React.PureComponent {
         const {
             dateComponent,
             listComponent,
+            listMaxHeight,
             listPosition,
             renderNoResults,
             ...props
@@ -768,6 +775,7 @@ export default class SuggestionBox extends React.PureComponent {
                         pretext={this.pretext}
                         position={this.getListPosition(listPosition)}
                         renderNoResults={renderNoResults}
+                        maxHeight={listMaxHeight}
                         onCompleteWord={this.handleCompleteWord}
                         preventClose={this.preventSuggestionListClose}
                         onItemHover={this.setSelection}

--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.test.tsx
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.test.tsx
@@ -4,6 +4,7 @@
 import React, {useCallback, useState} from 'react';
 
 import {act, renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
+import Constants from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
 
 import SuggestionBox from './suggestion_box';
@@ -163,6 +164,55 @@ describe('SuggestionBox', () => {
         await userEvent.keyboard('{escape}');
 
         expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
+    });
+
+    test('should cap the suggestion list height using the default max height', async () => {
+        const provider = new TestProvider();
+
+        renderWithContext(
+            <TestWrapper
+                {...makeBaseProps()}
+                providers={[provider]}
+            />,
+        );
+
+        await userEvent.click(screen.getByPlaceholderText('test input'));
+        await userEvent.keyboard('test');
+
+        await waitFor(() => {
+            expect(screen.getByRole('listbox')).toBeVisible();
+        });
+
+        const expectedMaxHeight = Math.min(
+            window.innerHeight - Constants.POST_MODAL_PADDING,
+            Constants.SUGGESTION_LIST_MAXHEIGHT,
+        );
+        expect(document.getElementById('suggestionList')).toHaveStyle(`max-height: ${expectedMaxHeight}px`);
+    });
+
+    test('should use listMaxHeight to allow a taller suggestion list', async () => {
+        const provider = new TestProvider();
+
+        renderWithContext(
+            <TestWrapper
+                {...makeBaseProps()}
+                providers={[provider]}
+                listMaxHeight={Constants.SUGGESTION_LIST_MAXHEIGHT + 300}
+            />,
+        );
+
+        await userEvent.click(screen.getByPlaceholderText('test input'));
+        await userEvent.keyboard('test');
+
+        await waitFor(() => {
+            expect(screen.getByRole('listbox')).toBeVisible();
+        });
+
+        const expectedMaxHeight = Math.min(
+            window.innerHeight - Constants.POST_MODAL_PADDING,
+            Constants.SUGGESTION_LIST_MAXHEIGHT + 300,
+        );
+        expect(document.getElementById('suggestionList')).toHaveStyle(`max-height: ${expectedMaxHeight}px`);
     });
 
     test('should autocomplete suggestions by pressing enter', async () => {

--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.test.tsx
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.test.tsx
@@ -3,6 +3,8 @@
 
 import React, {useCallback, useState} from 'react';
 
+import {Button} from '@mattermost/shared/components/button';
+
 import {act, renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
 import Constants from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
@@ -230,12 +232,11 @@ describe('SuggestionBox', () => {
 
             return (
                 <div>
-                    <button
-                        type='button'
+                    <Button
                         onClick={() => setUseModalHeight(true)}
                     >
                         {buttonText}
-                    </button>
+                    </Button>
                     <SuggestionBox
                         {...makeBaseProps()}
                         providers={providers}

--- a/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.test.tsx
+++ b/webapp/channels/src/components/suggestion/suggestion_box/suggestion_box.test.tsx
@@ -215,6 +215,68 @@ describe('SuggestionBox', () => {
         expect(document.getElementById('suggestionList')).toHaveStyle(`max-height: ${expectedMaxHeight}px`);
     });
 
+    test('should recompute the list height when listMaxHeight changes while results remain visible', async () => {
+        const provider = new TestProvider();
+
+        function HeightToggleWrapper({providers}: {providers: Provider[]}) {
+            const [value, setValue] = useState('');
+            const [useModalHeight, setUseModalHeight] = useState(false);
+
+            const handleChange = useCallback((e: React.FormEvent) => {
+                setValue((e.target as HTMLInputElement).value);
+            }, []);
+
+            const buttonText = 'Make taller';
+
+            return (
+                <div>
+                    <button
+                        type='button'
+                        onClick={() => setUseModalHeight(true)}
+                    >
+                        {buttonText}
+                    </button>
+                    <SuggestionBox
+                        {...makeBaseProps()}
+                        providers={providers}
+                        forceSuggestionsWhenBlur={true}
+                        listMaxHeight={useModalHeight ? Constants.SUGGESTION_LIST_MAXHEIGHT_MODAL : undefined}
+                        onChange={handleChange}
+                        value={value}
+                    />
+                </div>
+            );
+        }
+
+        renderWithContext(
+            <HeightToggleWrapper providers={[provider]}/>,
+        );
+
+        await userEvent.click(screen.getByPlaceholderText('test input'));
+        await userEvent.keyboard('test');
+
+        await waitFor(() => {
+            expect(screen.getByRole('listbox')).toBeVisible();
+        });
+
+        const defaultMaxHeight = Math.min(
+            window.innerHeight - Constants.POST_MODAL_PADDING,
+            Constants.SUGGESTION_LIST_MAXHEIGHT,
+        );
+        expect(document.getElementById('suggestionList')).toHaveStyle(`max-height: ${defaultMaxHeight}px`);
+
+        // Increase the max height while the results stay visible
+        await userEvent.click(screen.getByRole('button', {name: 'Make taller'}));
+
+        const tallerMaxHeight = Math.min(
+            window.innerHeight - Constants.POST_MODAL_PADDING,
+            Constants.SUGGESTION_LIST_MAXHEIGHT_MODAL,
+        );
+        await waitFor(() => {
+            expect(document.getElementById('suggestionList')).toHaveStyle(`max-height: ${tallerMaxHeight}px`);
+        });
+    });
+
     test('should autocomplete suggestions by pressing enter', async () => {
         const provider = new TestProvider();
 

--- a/webapp/channels/src/components/suggestion/suggestion_list.tsx
+++ b/webapp/channels/src/components/suggestion/suggestion_list.tsx
@@ -66,7 +66,10 @@ export default class SuggestionList extends React.PureComponent<Props> {
             this.scrollToItem(this.props.selection);
         }
 
-        if (hasResults(this.props.results) && !hasResults(prevProps.results)) {
+        if (
+            (hasResults(this.props.results) && !hasResults(prevProps.results)) ||
+            this.props.maxHeight !== prevProps.maxHeight
+        ) {
             this.updateMaxHeight();
         }
     }

--- a/webapp/channels/src/components/suggestion/suggestion_list.tsx
+++ b/webapp/channels/src/components/suggestion/suggestion_list.tsx
@@ -23,6 +23,13 @@ export interface Props {
     results: SuggestionResults;
     selection: string;
 
+    /**
+     * Optional maximum height in pixels for the suggestion list content.
+     * Overrides {@link Constants.SUGGESTION_LIST_MAXHEIGHT} when set (e.g. to allow
+     * modal-based lists like the Find Channels modal to grow taller).
+     */
+    maxHeight?: number;
+
     // suggestionBoxAlgn is an optional object that can be passed to align the SuggestionList with the keyboard caret
     // as the user is typing.
     suggestionBoxAlgn?: {
@@ -73,7 +80,7 @@ export default class SuggestionList extends React.PureComponent<Props> {
 
         this.maxHeight = Math.min(
             window.innerHeight - (inputHeight + Constants.POST_MODAL_PADDING),
-            Constants.SUGGESTION_LIST_MAXHEIGHT,
+            this.props.maxHeight ?? Constants.SUGGESTION_LIST_MAXHEIGHT,
         );
 
         if (this.contentRef.current) {

--- a/webapp/channels/src/sass/components/_channel-switcher.scss
+++ b/webapp/channels/src/sass/components/_channel-switcher.scss
@@ -4,7 +4,9 @@
     .channel-switcher,
     .channel-invite {
         &.modal-dialog {
-            margin-top: calc(50vh - 240px);
+            // Vertical centering is handled by the GenericModal (flex) so the modal
+            // stays centered in the view regardless of its height.
+            margin-top: 0;
         }
 
         .modal-header {
@@ -32,7 +34,8 @@
 
     .channel-switcher__suggestion-box {
         position: relative;
-        height: 362px;
+        height: 662px;
+        max-height: calc(100vh - 220px);
         padding: 0;
 
         .input-wrapper {

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -1613,9 +1613,6 @@ export const Constants = {
     SYSTEM_MESSAGE_PREFIX: 'system_',
     SUGGESTION_LIST_MAXHEIGHT: 292,
     SUGGESTION_LIST_MAXWIDTH: 496,
-
-    // Suggestion list max height for taller modal-based lists (e.g. the Find Channels
-    // modal), allowing 300px more than the default cap so they use larger monitors better.
     SUGGESTION_LIST_MAXHEIGHT_MODAL: 592,
     SUGGESTION_LIST_SPACE_RHS: 420,
     MOBILE_SUGGESTION_LIST_SPACE_RHS: 220,

--- a/webapp/channels/src/utils/constants.tsx
+++ b/webapp/channels/src/utils/constants.tsx
@@ -1613,6 +1613,10 @@ export const Constants = {
     SYSTEM_MESSAGE_PREFIX: 'system_',
     SUGGESTION_LIST_MAXHEIGHT: 292,
     SUGGESTION_LIST_MAXWIDTH: 496,
+
+    // Suggestion list max height for taller modal-based lists (e.g. the Find Channels
+    // modal), allowing 300px more than the default cap so they use larger monitors better.
+    SUGGESTION_LIST_MAXHEIGHT_MODAL: 592,
     SUGGESTION_LIST_SPACE_RHS: 420,
     MOBILE_SUGGESTION_LIST_SPACE_RHS: 220,
     SUGGESTION_LIST_MODAL_WIDTH: 496,


### PR DESCRIPTION
#### Summary
The Find Channels modal (`QuickSwitchModal`) capped its results list at 292px (`Constants.SUGGESTION_LIST_MAXHEIGHT`) regardless of the monitor size, making it feel small on larger monitors.

- Threaded an optional `listMaxHeight` prop through `SuggestionBox` to the `SuggestionList` so modal-based lists can override the global cap without affecting other autocomplete dropdowns app-wide.
- Added `Constants.SUGGESTION_LIST_MAXHEIGHT_MODAL` (default + 300px) and used it from the Find Channels modal.
- Grew the channel-switcher suggestion box height by 300px with a viewport fallback (`max-height: calc(100vh - 220px)`) so short screens still fit.
- Removed the stale `margin-top: calc(50vh - 240px)` rule; the modal is kept vertically centered by the `GenericModal` flex layout regardless of height.
- Added unit tests covering the default cap and the `listMaxHeight` override.

Manual QA: open the Find Channels switcher on a tall portrait monitor and confirm ~300px more results display and the modal stays centered. On a short viewport, confirm the modal shrinks to fit and remains centered.

#### Ticket Link
Fixes: https://github.com/mattermost/mattermost/issues/21558

#### Screenshots
Available on request if needed.

#### Release Note
```release-note
Increased the maximum height of the Find Channels modal so it better uses larger monitors, while remaining vertically centered in the view.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The changes affect shared suggestion components and modal layout behavior. Automated tests cover default, override, and dynamic height paths.

**QA Recommendation:** Manual QA can be skipped.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->