### PR TITLE
[MM-65738] Clarify main logger shutdown timeout diagnostic

### DIFF
--- a/server/channels/app/server.go
+++ b/server/channels/app/server.go
@@ -863,7 +863,7 @@ func (s *Server) Shutdown() {
 	timeoutCtx, timeoutCancel := context.WithTimeout(context.Background(), time.Second*15)
 	defer timeoutCancel()
 	if err = s.Log().ShutdownWithTimeout(timeoutCtx); err != nil {
-		fmt.Fprintf(os.Stderr, "Error shutting down main logger: %v", err)
+		fmt.Fprintf(os.Stderr, "Error shutting down main logger (this can happen if a log target, e.g. a remote TCP endpoint, is unreachable; check preceding connection error logs for the affected target): %v\n", err)
 	}
 }
 


### PR DESCRIPTION
#### Summary
When the main logger fails to shut down within its 15s timeout (e.g. because an advanced-logging TCP target is unreachable), the resulting stderr message just said "Error shutting down main logger" with no indication of the cause. This adds context pointing the operator at the connection error logs for the affected target, and fixes a missing trailing newline.

This is a companion fix to https://github.com/mattermost/logr/pull/59, which throttles the repeated connection-error logging from an unreachable TCP target so operators aren't flooded with identical retry lines in the first place.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-65738

#### Screenshots
N/A (log message wording change only)

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to shutdown diagnostic text in `server/channels/app/server.go`. It does not modify logger behavior, APIs, data handling, or critical flows.

**QA Recommendation:** Skip manual QA. Automated testing is sufficient for this low-risk text-only change.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->