### PR TITLE
MM-70307: Bump Go version in missed go.mod files

### DIFF
--- a/api/server/go.mod
+++ b/api/server/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost/api/internal
 
-go 1.26.4
+go 1.26.7
 
 require (
 	github.com/pb33f/libopenapi v0.36.4

--- a/tools/mattermost-govet/go.mod
+++ b/tools/mattermost-govet/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost/tools/mattermost-govet
 
-go 1.26.4
+go 1.26.7
 
 require (
 	github.com/pb33f/libopenapi v0.36.4

--- a/tools/mmgotool/go.mod
+++ b/tools/mmgotool/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost/tools/mmgotool
 
-go 1.26.4
+go 1.26.7
 
 require github.com/spf13/cobra v1.10.2
 

--- a/tools/sharedchannel-test/go.mod
+++ b/tools/sharedchannel-test/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattermost/mattermost/tools/sharedchannel-test
 
-go 1.26.4
+go 1.26.7
 
 require github.com/mattermost/mattermost/server/public v0.4.0
 


### PR DESCRIPTION
#### Summary
https://github.com/mattermost/mattermost/pull/38046 missed a couple of go.mod files, this PR fixes that.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70307

#### Screenshots
--

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes update only Go version directives in four isolated modules. They do not affect application behavior, APIs, data integrity, or critical user flows.

**QA Recommendation:** Skip manual QA. Run the standard module validation and build checks.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->