### PR TITLE
MM-70300 Adding Dataminr v2.0.0 as a prepackaged plugin

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -170,6 +170,7 @@ PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.7.0
 PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.4.1
 PLUGIN_PACKAGES += mattermost-plugin-metrics-v0.7.0
 PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
+PLUGIN_PACKAGES += mattermost-plugin-dataminr-v2.0.0
 
 # Overwrite the definition of PLUGIN_PACKAGES with the list of FIPS-ready plugins
 # Note that the '+' in the file name is encoded as %2B for the URL we use to


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
<!-- What does this PR do? Include QA steps if not covered in the ticket. -->
This PR adds Dataminr v2.0.0 as a prepackaged plugin 

#### Ticket Link
<!--
Fixes: https://github.com/mattermost/mattermost/issues/XXX
Fixes: https://mattermost.atlassian.net/browse/MM-XXX
-->
Fixes https://mattermost.atlassian.net/browse/MM-70300

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note
Pre-packaged Dataminr plugin version v2.0.0
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change only updates the prepackaged plugin list. It does not modify shared code or critical system flows.

**QA Recommendation:** Manual QA can be skipped because the change is isolated and automated testing has full coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->