### PR TITLE
Automated cherry pick of #38115

### DIFF
--- a/e2e-tests/playwright/lib/src/ui/components/channels/channel_settings/info_settings.ts
+++ b/e2e-tests/playwright/lib/src/ui/components/channels/channel_settings/info_settings.ts
@@ -7,12 +7,16 @@ import {expect} from '@playwright/test';
 export default class InfoSettings {
     readonly container: Locator;
     readonly nameInput: Locator;
+    readonly purposeInput: Locator;
     readonly headerInput: Locator;
+    readonly saveChangesPanel: Locator;
 
     constructor(container: Locator) {
         this.container = container;
         this.nameInput = container.locator('#input_channel-settings-name');
+        this.purposeInput = container.getByPlaceholder('Enter a purpose for this channel (optional)');
         this.headerInput = container.getByPlaceholder('Enter a header for this channel');
+        this.saveChangesPanel = container.locator('.SaveChangesPanel');
     }
 
     async toBeVisible() {
@@ -28,5 +32,10 @@ export default class InfoSettings {
     async updateHeader(header: string) {
         await expect(this.headerInput).toBeVisible();
         await this.headerInput.fill(header);
+    }
+
+    async updatePurpose(purpose: string) {
+        await expect(this.purposeInput).toBeVisible();
+        await this.purposeInput.fill(purpose);
     }
 }

--- a/e2e-tests/playwright/specs/functional/channels/channel_settings/unsaved_changes_on_open.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/channel_settings/unsaved_changes_on_open.spec.ts
@@ -1,0 +1,97 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {expect, test} from '@mattermost/playwright-lib';
+
+/**
+ * @objective Verify that Channel Settings opens with no unsaved-changes warning and no channel name
+ * validation error, and closes on a single click, for a channel whose stored purpose and header carry
+ * leading or trailing whitespace. The server keeps that whitespace verbatim, so channels populated
+ * outside this form reach it untidy.
+ */
+test(
+    'opens Channel Settings cleanly for a channel whose stored text has surrounding whitespace',
+    {tag: '@channel_settings'},
+    async ({pw}) => {
+        const {adminClient, team, user} = await pw.initSetup();
+
+        // # Create a channel whose stored purpose and header have surrounding whitespace
+        const channel = await adminClient.createPublicChannel(team.id, `Untidy ${pw.random.id()}`);
+        const paddedPurpose = '  Small annoyances that add up  ';
+        const paddedHeader = 'Runbook: [Ops guide](https://example.com/runbook)\nEscalate to the on-call\n';
+        await adminClient.patchChannel(channel.id, {purpose: paddedPurpose, header: paddedHeader});
+        await adminClient.addToChannel(user.id, channel.id);
+
+        const {channelsPage} = await pw.testBrowser.login(user);
+        await channelsPage.goto(team.name, channel.name);
+        await channelsPage.toBeVisible();
+
+        // # Open Channel Settings without touching any field
+        const channelSettings = await channelsPage.openChannelSettings();
+        const infoSettings = await channelSettings.openInfoTab();
+
+        // * Verify the stored text is shown as-is and the form does not report unsaved changes
+        await expect(infoSettings.purposeInput).toHaveValue(paddedPurpose);
+        await expect(infoSettings.headerInput).toHaveValue(paddedHeader);
+        await expect(infoSettings.saveChangesPanel).not.toBeVisible();
+
+        // * Verify no channel name validation error is shown for the populated name field
+        await expect(infoSettings.nameInput).toHaveValue(channel.display_name);
+        await expect(
+            channelSettings.container.getByText('Channel names must have at least 1 character.'),
+        ).not.toBeVisible();
+
+        // # Close the modal with a single click
+        await channelSettings.closeButton.click();
+
+        // * Verify the modal closes without the second click that unsaved changes would demand
+        await expect(channelSettings.container).not.toBeVisible();
+    },
+);
+
+/**
+ * @objective Verify that editing a channel whose stored text has surrounding whitespace still surfaces the
+ * unsaved-changes panel and saves the edit.
+ */
+test(
+    'saves an edit made on a channel whose stored text has surrounding whitespace',
+    {tag: '@channel_settings'},
+    async ({pw}) => {
+        const {adminClient, team, user} = await pw.initSetup();
+
+        // # Create a channel whose stored header ends in a newline
+        const channel = await adminClient.createPublicChannel(team.id, `Untidy ${pw.random.id()}`);
+        const paddedHeader = 'padded header\n';
+        await adminClient.patchChannel(channel.id, {purpose: '  padded purpose  ', header: paddedHeader});
+        await adminClient.addToChannel(user.id, channel.id);
+
+        const {channelsPage} = await pw.testBrowser.login(user);
+        await channelsPage.goto(team.name, channel.name);
+        await channelsPage.toBeVisible();
+
+        // # Open Channel Settings and edit the purpose
+        const channelSettings = await channelsPage.openChannelSettings();
+        const infoSettings = await channelSettings.openInfoTab();
+        await infoSettings.updatePurpose('A brand new purpose');
+
+        // * Verify the edit is recognised as an unsaved change
+        await expect(channelSettings.container.getByText('You have unsaved changes')).toBeVisible();
+
+        // # Save the edit
+        await channelSettings.save();
+
+        // * Verify the save completes and the panel leaves the unsaved state
+        await expect(channelSettings.saveButton).not.toBeVisible();
+
+        // # Close and reopen Channel Settings
+        await channelSettings.close();
+        const reopenedSettings = await channelsPage.openChannelSettings();
+        const reopenedInfo = await reopenedSettings.openInfoTab();
+
+        // * Verify the saved purpose persisted, the untouched header was left exactly as stored, and the
+        // * reopened form is clean
+        await expect(reopenedInfo.purposeInput).toHaveValue('A brand new purpose');
+        await expect(reopenedInfo.headerInput).toHaveValue(paddedHeader);
+        await expect(reopenedInfo.saveChangesPanel).not.toBeVisible();
+    },
+);

--- a/webapp/channels/src/components/channel_name_form_field/channel_name_form_field.test.tsx
+++ b/webapp/channels/src/components/channel_name_form_field/channel_name_form_field.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import ChannelNameFormField from 'components/channel_name_form_field/channel_name_form_field';
 
-import {renderWithContext, screen} from 'tests/react_testing_utils';
+import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
 import {LicenseSkus} from 'utils/constants';
 
 const baseProps = {
@@ -78,5 +78,86 @@ describe('ChannelNameFormField - URL editor visibility', () => {
         );
 
         expect(screen.getByTestId('urlInputLabel')).toBeVisible();
+    });
+});
+
+describe('ChannelNameFormField - display name validation', () => {
+    const emptyErrorMessage = 'Channel names must have at least 1 character.';
+
+    // The parent owns the value, as it does everywhere this field is used.
+    const ControlledField = (props: {onErrorStateChange?: (isError: boolean, errorMessage?: string) => void}) => {
+        const [value, setValue] = React.useState('Test Channel');
+        return (
+            <ChannelNameFormField
+                {...baseProps}
+                value={value}
+                isEditingExistingChannel={true}
+                currentUrl='test-channel'
+                onDisplayNameChange={setValue}
+                onErrorStateChange={props.onErrorStateChange}
+            />
+        );
+    };
+
+    test('should not report an error when focus leaves an untouched pre-filled field', async () => {
+        const onErrorStateChange = jest.fn();
+        renderWithContext(<ControlledField onErrorStateChange={onErrorStateChange}/>, makeState('false'));
+
+        await userEvent.click(screen.getByRole('textbox', {name: 'Channel name'}));
+        await userEvent.tab();
+
+        expect(screen.queryByText(emptyErrorMessage)).not.toBeInTheDocument();
+        expect(onErrorStateChange).toHaveBeenCalledWith(false, '');
+    });
+
+    test('should not report an error while the rendered value is still valid', async () => {
+        // baseProps.onDisplayNameChange is a no-op, so the parent never accepts
+        // the cleared value and the input keeps rendering the original name.
+        const onErrorStateChange = jest.fn();
+        renderWithContext(
+            <ChannelNameFormField
+                {...baseProps}
+                isEditingExistingChannel={true}
+                currentUrl='test-channel'
+                onErrorStateChange={onErrorStateChange}
+            />,
+            makeState('false'),
+        );
+
+        const nameInput = screen.getByRole('textbox', {name: 'Channel name'});
+        await userEvent.clear(nameInput);
+        await userEvent.tab();
+
+        expect(nameInput).toHaveValue('Test Channel');
+        expect(screen.queryByText(emptyErrorMessage)).not.toBeInTheDocument();
+        expect(onErrorStateChange).toHaveBeenLastCalledWith(false, '');
+    });
+
+    test('should report an error when focus leaves a field the user emptied', async () => {
+        const onErrorStateChange = jest.fn();
+        renderWithContext(<ControlledField onErrorStateChange={onErrorStateChange}/>, makeState('false'));
+
+        const nameInput = screen.getByRole('textbox', {name: 'Channel name'});
+        await userEvent.clear(nameInput);
+        await userEvent.tab();
+
+        expect(nameInput).toHaveValue('');
+        expect(screen.getByText(emptyErrorMessage)).toBeInTheDocument();
+        expect(onErrorStateChange).toHaveBeenCalledWith(true, emptyErrorMessage);
+    });
+
+    test('should clear the error once the user types a valid name again', async () => {
+        renderWithContext(<ControlledField/>, makeState('false'));
+
+        const nameInput = screen.getByRole('textbox', {name: 'Channel name'});
+        await userEvent.clear(nameInput);
+        await userEvent.tab();
+        expect(screen.getByText(emptyErrorMessage)).toBeInTheDocument();
+
+        await userEvent.type(nameInput, 'Renamed Channel');
+        await userEvent.tab();
+
+        expect(nameInput).toHaveValue('Renamed Channel');
+        expect(screen.queryByText(emptyErrorMessage)).not.toBeInTheDocument();
     });
 });

--- a/webapp/channels/src/components/channel_name_form_field/channel_name_form_field.tsx
+++ b/webapp/channels/src/components/channel_name_form_field/channel_name_form_field.tsx
@@ -63,16 +63,10 @@ const ChannelNameFormField = (props: Props): JSX.Element => {
     // Track if the field has been interacted with
     const [hasInteracted, setHasInteracted] = useState(false);
     const [displayNameError, setDisplayNameError] = useState<string>('');
-    const displayName = useRef<string>('');
     const urlModified = useRef<boolean>(false);
     const [url, setURL] = useState<string>(props.currentUrl || '');
     const [urlError, setURLError] = useState<string>('');
     const [inputCustomMessage, setInputCustomMessage] = useState<CustomMessageInputType | null>(null);
-
-    // Initialize displayName.current with props.value when component mounts
-    useEffect(() => {
-        displayName.current = props.value;
-    }, [props.value]);
 
     const currentTeamName = useSelector(getCurrentTeam)?.name;
     const teamName = props.team ? props.team.name : currentTeamName;
@@ -102,7 +96,6 @@ const ChannelNameFormField = (props: Props): JSX.Element => {
             }
         }
 
-        displayName.current = updatedDisplayName;
         props.onDisplayNameChange(updatedDisplayName);
 
         if (!urlModified.current && !props.isEditingExistingChannel) {
@@ -119,7 +112,7 @@ const ChannelNameFormField = (props: Props): JSX.Element => {
         setHasInteracted(true);
 
         // Validate on blur - always show errors on blur regardless of interaction state
-        const displayNameErrors = validateDisplayName(intl, displayName.current);
+        const displayNameErrors = validateDisplayName(intl, props.value);
         setDisplayNameError(displayNameErrors.length ? displayNameErrors[displayNameErrors.length - 1] : '');
 
         if (displayNameErrors.length) {
@@ -132,12 +125,12 @@ const ChannelNameFormField = (props: Props): JSX.Element => {
         }
 
         // Handle URL generation if needed
-        if (displayName.current && !url) {
+        if (props.value && !url) {
             const url = generateSlug();
             setURL(url);
             props.onURLChange(url);
         }
-    }, [props.onURLChange, displayName.current, url, intl]);
+    }, [props.onURLChange, props.value, url, intl]);
 
     const handleOnURLChange = useCallback((e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
         e.preventDefault();

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_info_tab.test.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_info_tab.test.tsx
@@ -294,6 +294,36 @@ describe('ChannelSettingsInfoTab', () => {
         expect(screen.getByTestId('channel_settings_header_textbox')).toHaveValue('Header with whitespace');
     });
 
+    it('detects removing stored whitespace and saves the trimmed value', async () => {
+        const {patchChannel} = require('mattermost-redux/actions/channels');
+        patchChannel.mockReturnValue({type: 'MOCK_ACTION', data: {}});
+
+        const paddedHeaderChannel = {...mockChannel, header: 'Initial header   '};
+        renderWithContext(
+            <ChannelSettingsInfoTab
+                channel={paddedHeaderChannel}
+                setAreThereUnsavedChanges={jest.fn()}
+            />,
+        );
+
+        // The untidy stored text opens the form cleanly.
+        const headerInput = screen.getByTestId('channel_settings_header_textbox');
+        expect(headerInput).toHaveValue('Initial header   ');
+        expect(screen.queryByRole('button', {name: 'Save'})).not.toBeInTheDocument();
+
+        // Removing the stored trailing whitespace is a real edit the user can save.
+        await userEvent.clear(headerInput);
+        await userEvent.type(headerInput, 'Initial header');
+
+        expect(screen.getByRole('button', {name: 'Save'})).toBeInTheDocument();
+
+        await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+        expect(patchChannel).toHaveBeenCalledWith('channel1', {
+            header: 'Initial header',
+        });
+    });
+
     it('should hide SaveChangesPanel after successful save', async () => {
         // Mock the patchChannel function to return a successful response
         const {patchChannel} = require('mattermost-redux/actions/channels');
@@ -783,6 +813,145 @@ describe('ChannelSettingsInfoTab', () => {
             const calls = patchChannel.mock.calls;
             const lastPatch = calls[calls.length - 1][1];
             expect(lastPatch).not.toHaveProperty('discoverable');
+        });
+    });
+
+    describe('opening the tab on a channel with untidy stored text', () => {
+        // Channels populated outside this form can carry surrounding whitespace.
+        const paddedChannel = TestHelper.getChannelMock({
+            id: 'channel1',
+            team_id: 'team1',
+            display_name: 'Padded Channel',
+            name: 'padded-channel',
+            purpose: '  Small annoyances that add up  ',
+            header: 'Runbook: [Ops guide](http://example.com)\nEscalate to @admin\n',
+            type: 'O',
+        });
+
+        it('reports no unsaved changes when purpose and header have surrounding whitespace', () => {
+            const setAreThereUnsavedChanges = jest.fn();
+            renderWithContext(
+                <ChannelSettingsInfoTab
+                    channel={paddedChannel}
+                    setAreThereUnsavedChanges={setAreThereUnsavedChanges}
+                />,
+            );
+
+            expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
+            expect(setAreThereUnsavedChanges).toHaveBeenCalledWith(false);
+            expect(setAreThereUnsavedChanges).not.toHaveBeenCalledWith(true);
+        });
+
+        it('reports no unsaved changes when the channel has no purpose or header at all', () => {
+            const bareChannel = TestHelper.getChannelMock({
+                id: 'channel1',
+                team_id: 'team1',
+                display_name: 'Bare Channel',
+                name: 'bare-channel',
+                purpose: undefined as unknown as string,
+                header: undefined as unknown as string,
+                type: 'O',
+            });
+
+            const setAreThereUnsavedChanges = jest.fn();
+            renderWithContext(
+                <ChannelSettingsInfoTab
+                    channel={bareChannel}
+                    setAreThereUnsavedChanges={setAreThereUnsavedChanges}
+                />,
+            );
+
+            expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
+            expect(setAreThereUnsavedChanges).toHaveBeenCalledWith(false);
+            expect(setAreThereUnsavedChanges).not.toHaveBeenCalledWith(true);
+        });
+
+        it('reports no unsaved changes on a DM whose header ends in a newline', () => {
+            const paddedDmChannel = {...mockDirectMessageChannel, header: 'DM initial header\n'};
+
+            const setAreThereUnsavedChanges = jest.fn();
+            renderWithContext(
+                <ChannelSettingsInfoTab
+                    channel={paddedDmChannel}
+                    setAreThereUnsavedChanges={setAreThereUnsavedChanges}
+                />,
+            );
+
+            expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
+            expect(setAreThereUnsavedChanges).toHaveBeenCalledWith(false);
+            expect(setAreThereUnsavedChanges).not.toHaveBeenCalledWith(true);
+        });
+
+        it('stays clean when focus leaves the untouched name field', async () => {
+            renderWithContext(
+                <ChannelSettingsInfoTab
+                    channel={paddedChannel}
+                    setAreThereUnsavedChanges={jest.fn()}
+                />,
+            );
+
+            const nameInput = screen.getByRole('textbox', {name: 'Channel name'});
+            await userEvent.click(nameInput);
+            await userEvent.tab();
+
+            expect(screen.queryByText('Channel names must have at least 1 character.')).not.toBeInTheDocument();
+            expect(nameInput).toHaveValue('Padded Channel');
+            expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
+        });
+
+        it('restores the stored text and clears the panel when Reset is clicked', async () => {
+            renderWithContext(
+                <ChannelSettingsInfoTab
+                    channel={paddedChannel}
+                    setAreThereUnsavedChanges={jest.fn()}
+                />,
+            );
+
+            const purposeInput = screen.getByTestId('channel_settings_purpose_textbox');
+            await userEvent.clear(purposeInput);
+            await userEvent.type(purposeInput, 'A brand new purpose');
+
+            await userEvent.click(screen.getByRole('button', {name: 'Reset'}));
+
+            expect(purposeInput).toHaveValue('  Small annoyances that add up  ');
+            expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
+        });
+
+        it('detects and saves an edit made on untidy stored text', async () => {
+            const {patchChannel} = require('mattermost-redux/actions/channels');
+            patchChannel.mockReturnValue({type: 'MOCK_ACTION', data: {}});
+
+            const setAreThereUnsavedChanges = jest.fn();
+            const {rerender} = renderWithContext(
+                <ChannelSettingsInfoTab
+                    channel={paddedChannel}
+                    setAreThereUnsavedChanges={setAreThereUnsavedChanges}
+                />,
+            );
+
+            const purposeInput = screen.getByTestId('channel_settings_purpose_textbox');
+            await userEvent.clear(purposeInput);
+            await userEvent.type(purposeInput, 'A brand new purpose');
+
+            expect(screen.getByText('You have unsaved changes')).toBeInTheDocument();
+            expect(setAreThereUnsavedChanges).toHaveBeenLastCalledWith(true);
+
+            await userEvent.click(screen.getByRole('button', {name: 'Save'}));
+
+            // The untouched header keeps its stored whitespace.
+            expect(patchChannel).toHaveBeenCalledWith('channel1', {
+                purpose: 'A brand new purpose',
+            });
+
+            // Simulate the patched channel arriving back through the store.
+            rerender(
+                <ChannelSettingsInfoTab
+                    channel={{...paddedChannel, purpose: 'A brand new purpose'}}
+                    setAreThereUnsavedChanges={setAreThereUnsavedChanges}
+                />,
+            );
+            expect(setAreThereUnsavedChanges).toHaveBeenLastCalledWith(false);
+            expect(screen.queryByText('You have unsaved changes')).not.toBeInTheDocument();
         });
     });
 });

--- a/webapp/channels/src/components/channel_settings_modal/channel_settings_info_tab.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/channel_settings_info_tab.tsx
@@ -45,6 +45,15 @@ type ChannelSettingsInfoTabProps = {
     showTabSwitchError?: boolean;
 };
 
+// The form seeds each field from the raw channel record and trims only when
+// building the save payload, so change detection compares the raw values. That
+// keeps an untouched channel clean on open (local value equals the stored one)
+// while still letting a user save the removal of stored leading/trailing
+// whitespace.
+function hasTextChanged(value: string, savedValue?: string): boolean {
+    return value !== (savedValue ?? '');
+}
+
 function ChannelSettingsInfoTab({
     channel,
     onCancel,
@@ -191,22 +200,27 @@ function ChannelSettingsInfoTab({
         }
     }, [channelNameError, formError, setFormError]);
 
-    // Update parent component when changes occur
-    useEffect(() => {
-        // Calculate unsaved changes directly
-        const unsavedChanges = channel ? (
-            displayName.trim() !== channel.display_name ||
-            channelUrl.trim() !== channel.name ||
-            channelPurpose.trim() !== channel.purpose ||
-            channelHeader.trim() !== channel.header ||
+    const hasUnsavedChanges = useMemo(() => {
+        if (hasTextChanged(channelHeader, channel.header)) {
+            return true;
+        }
+
+        if (isDMorGroupChannel) {
+            return false;
+        }
+
+        return hasTextChanged(displayName, channel.display_name) ||
+            hasTextChanged(channelUrl, channel.name) ||
+            hasTextChanged(channelPurpose, channel.purpose) ||
             channelType !== channel.type ||
             (defaultCategoryName ?? '') !== (serverDefaultCategoryName ?? '') ||
             managedCategoryName !== serverManagedCategoryName ||
-            discoverable !== Boolean(channel.discoverable)
-        ) : false;
+            (showDiscoverableToggle && discoverable !== Boolean(channel.discoverable));
+    }, [channel, isDMorGroupChannel, displayName, channelUrl, channelPurpose, channelHeader, channelType, defaultCategoryName, serverDefaultCategoryName, managedCategoryName, serverManagedCategoryName, discoverable, showDiscoverableToggle]);
 
-        setAreThereUnsavedChanges?.(unsavedChanges);
-    }, [channel, displayName, channelUrl, channelPurpose, channelHeader, channelType, defaultCategoryName, serverDefaultCategoryName, managedCategoryName, serverManagedCategoryName, discoverable, setAreThereUnsavedChanges]);
+    useEffect(() => {
+        setAreThereUnsavedChanges?.(hasUnsavedChanges);
+    }, [hasUnsavedChanges, setAreThereUnsavedChanges]);
 
     const handleURLChange = useCallback((newURL: string) => {
         if (internalUrlError) {
@@ -344,16 +358,16 @@ function ChannelSettingsInfoTab({
         }
 
         const updated: Partial<Channel> = {};
-        if (!isDMorGroupChannel && displayName.trim() !== channel.display_name) {
+        if (!isDMorGroupChannel && hasTextChanged(displayName, channel.display_name)) {
             updated.display_name = displayName.trim();
         }
-        if (!isDMorGroupChannel && channelUrl.trim() !== channel.name) {
+        if (!isDMorGroupChannel && hasTextChanged(channelUrl, channel.name)) {
             updated.name = channelUrl.trim();
         }
-        if (!isDMorGroupChannel && channelPurpose.trim() !== channel.purpose) {
+        if (!isDMorGroupChannel && hasTextChanged(channelPurpose, channel.purpose)) {
             updated.purpose = channelPurpose.trim();
         }
-        if (channelHeader.trim() !== channel.header) {
+        if (hasTextChanged(channelHeader, channel.header)) {
             updated.header = channelHeader.trim();
         }
         if ((defaultCategoryName ?? '') !== (serverDefaultCategoryName ?? '')) {
@@ -462,24 +476,7 @@ function ChannelSettingsInfoTab({
                      Boolean(showTabSwitchError) ||
                      Boolean(internalUrlError);
 
-    // Memoize the calculation for whether to show the save changes panel
-    const shouldShowPanel = useMemo(() => {
-        let unsavedChanges = false;
-        if (channel) {
-            unsavedChanges = unsavedChanges || channelHeader.trim() !== channel.header;
-            if (!isDMorGroupChannel) {
-                unsavedChanges = unsavedChanges || displayName.trim() !== channel.display_name;
-                unsavedChanges = unsavedChanges || channelUrl.trim() !== channel.name;
-                unsavedChanges = unsavedChanges || channelPurpose.trim() !== channel.purpose;
-                unsavedChanges = unsavedChanges || channelType !== channel.type;
-                unsavedChanges = unsavedChanges || (defaultCategoryName ?? '') !== (serverDefaultCategoryName ?? '');
-                unsavedChanges = unsavedChanges || managedCategoryName !== serverManagedCategoryName;
-                unsavedChanges = unsavedChanges || (showDiscoverableToggle && discoverable !== Boolean(channel.discoverable));
-            }
-        }
-
-        return unsavedChanges || saveChangesPanelState === 'saved';
-    }, [channel, isDMorGroupChannel, displayName, channelUrl, channelPurpose, channelHeader, channelType, saveChangesPanelState, defaultCategoryName, serverDefaultCategoryName, managedCategoryName, serverManagedCategoryName, discoverable, showDiscoverableToggle]);
+    const shouldShowPanel = hasUnsavedChanges || saveChangesPanelState === 'saved';
 
     return (
         <div


### PR DESCRIPTION
Cherry pick of #38115 on release-11.11.

/cc  @cursor[bot]

```release-note
NONE
```