### PR TITLE
Fix nil context panic in TestDoSetupSessionAttributesProperties

### DIFF
--- a/server/channels/app/migrations_test.go
+++ b/server/channels/app/migrations_test.go
@@ -545,7 +545,7 @@ func TestDoSetupSessionAttributesProperties(t *testing.T) {
 		}
 		require.Len(t, trimmed, len(persisted)-1)
 		field.Attrs[model.PropertyFieldAttributeOptions] = trimmed
-		_, _, _, err := th.Server.propertyService.UpdatePropertyFields(nil, group.ID, []*model.PropertyField{field})
+		_, _, _, err := th.Server.propertyService.UpdatePropertyFields(properties.SystemCallerContext(th.Context), group.ID, []*model.PropertyField{field})
 		require.NoError(t, err)
 
 		before := sessionAttributeOptionIDsByName(t, sessionAttributeFieldByName(t, th, group.ID, model.SessionAttributesPropertyFieldUserAgentPlatform))


### PR DESCRIPTION
#### Summary

`TestDoSetupSessionAttributesProperties/adds_newly_declared_options_to_an_already-seeded_select` (introduced in #38059) panics with a nil pointer dereference because `UpdatePropertyFields` is called with a `nil` context. `RequestContextWithMaster` dereferences the context unconditionally, causing the crash.

Fix: pass `properties.SystemCallerContext(th.Context)` as all other sub-tests in the same function already do.

#### Ticket Link

N/A

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to a migration test and does not affect production code, shared utilities, or public APIs.  
**QA Recommendation:** Skip manual QA. Run the affected automated test.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->