### PR TITLE
Deduplicate System Console config isDisabled dependencies

### DIFF
--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -177,6 +177,8 @@ const SAML_SETTINGS_CANONICAL_ALGORITHM_C14N11 = 'Canonical1.1';
 //   - type: which define the widget type.
 //   - label (and label_default): which define the main text of the setting.
 //   - isDisabled: a function which receive current config, the state of the page and the license.
+//     Prefer depending on a parent bool setting (it.stateIsFalse('Parent.Key')) over repeating that
+//     parent's config/state checks; @mattermost/no-redundant-admin-config-deps enforces this.
 //   - isHidden: a function which receive current config, the state of the page and the license.
 //
 // Custom Widget (extends from Widget):
@@ -4585,7 +4587,6 @@ const AdminDefinition: AdminDefinitionType = {
                                 it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.SAML)),
                                 it.configIsFalse('GuestAccountsSettings', 'Enable'),
                                 it.stateIsFalse('SamlSettings.EnableSyncWithLdap'),
-                                it.stateIsFalse('SamlSettings.Enable'),
                             ),
                         },
                         {
@@ -4607,7 +4608,6 @@ const AdminDefinition: AdminDefinitionType = {
                             help_text_markdown: false,
                             isDisabled: it.any(
                                 it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.SAML)),
-                                it.stateIsFalse('SamlSettings.Enable'),
                                 it.stateIsFalse('SamlSettings.EnableSyncWithLdap'),
                             ),
                         },
@@ -4761,7 +4761,6 @@ const AdminDefinition: AdminDefinitionType = {
                             remove_action: removePrivateSamlCertificate,
                             isDisabled: it.any(
                                 it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.SAML)),
-                                it.stateIsFalse('SamlSettings.Enable'),
                                 it.stateIsFalse('SamlSettings.Encrypt'),
                             ),
                         },
@@ -4779,7 +4778,6 @@ const AdminDefinition: AdminDefinitionType = {
                             remove_action: removePublicSamlCertificate,
                             isDisabled: it.any(
                                 it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.SAML)),
-                                it.stateIsFalse('SamlSettings.Enable'),
                                 it.stateIsFalse('SamlSettings.Encrypt'),
                             ),
                         },
@@ -4801,7 +4799,6 @@ const AdminDefinition: AdminDefinitionType = {
                             label: defineMessage({id: 'admin.saml.signatureAlgorithmTitle', defaultMessage: 'Signature Algorithm'}),
                             isDisabled: it.any(
                                 it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.SAML)),
-                                it.stateIsFalse('SamlSettings.Encrypt'),
                                 it.stateIsFalse('SamlSettings.SignRequest'),
                             ),
                             options: [
@@ -4845,7 +4842,6 @@ const AdminDefinition: AdminDefinitionType = {
                             ],
                             isDisabled: it.any(
                                 it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.AUTHENTICATION.SAML)),
-                                it.stateIsFalse('SamlSettings.Encrypt'),
                                 it.stateIsFalse('SamlSettings.SignRequest'),
                             ),
                         },
@@ -4914,7 +4910,6 @@ const AdminDefinition: AdminDefinitionType = {
                             isDisabled: it.any(
                                 it.not(it.isSystemAdmin),
                                 it.stateIsFalse('SamlSettings.EnableAdminAttribute'),
-                                it.stateIsFalse('SamlSettings.Enable'),
                             ),
                         },
                         {
@@ -6026,7 +6021,6 @@ const AdminDefinition: AdminDefinitionType = {
                             placeholder: defineMessage({id: 'admin.oauth.dcrRedirectURIAllowlistPlaceholder', defaultMessage: 'E.g.: https://*.example.com/**, https://app.example.com/callback'}),
                             isDisabled: it.any(
                                 it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.INTEGRATIONS.INTEGRATION_MANAGEMENT)),
-                                it.stateIsFalse('ServiceSettings.EnableOAuthServiceProvider'),
                                 it.stateIsFalse('ServiceSettings.EnableDynamicClientRegistration'),
                             ),
                             isHidden: it.licensedForFeature('Cloud'),

--- a/webapp/platform/eslint-plugin/README.md
+++ b/webapp/platform/eslint-plugin/README.md
@@ -34,6 +34,8 @@ Enforces that System Console settings in `admin_definition` files do not repeat 
 
 When setting B disables itself with `it.stateIsFalse('A')`, A is a bool setting, and A already includes condition C (for example `it.configIsTrue('ClusterSettings', 'Enable')`), repeating C on B is redundant and tends to drift. Keep the dependency on A and omit the duplicated checks. Inheritance only follows bool parents (disabled bools are forced false on save). Permission and license helpers are not treated as config dependencies.
 
+The rule builds the full bool-parent dependency tree before reporting. If a setting lists both a parent and a grandparent, redundant conditions are attributed to the closest (most specific) parent — not whichever ancestor appears first in `isDisabled`.
+
 Examples of **incorrect** code for this rule:
 ```javascript
 {

--- a/webapp/platform/eslint-plugin/README.md
+++ b/webapp/platform/eslint-plugin/README.md
@@ -28,6 +28,52 @@ export function someAction() {
 }
 ```
 
+### no-redundant-admin-config-deps
+
+Enforces that System Console settings in `admin_definition` files do not repeat `isDisabled` config/state checks already implied by a parent setting they depend on.
+
+When setting B disables itself with `it.stateIsFalse('A')`, A is a bool setting, and A already includes condition C (for example `it.configIsTrue('ClusterSettings', 'Enable')`), repeating C on B is redundant and tends to drift. Keep the dependency on A and omit the duplicated checks. Inheritance only follows bool parents (disabled bools are forced false on save). Permission and license helpers are not treated as config dependencies.
+
+Examples of **incorrect** code for this rule:
+```javascript
+{
+    type: 'bool',
+    key: 'EmailSettings.EnableEmailBatching',
+    isDisabled: it.any(
+        it.stateIsFalse('EmailSettings.SendEmailNotifications'),
+        it.configIsTrue('ClusterSettings', 'Enable'),
+    ),
+},
+{
+    type: 'number',
+    key: 'EmailSettings.EmailBatchingBufferSize',
+    isDisabled: it.any(
+        it.stateIsFalse('EmailSettings.SendEmailNotifications'),
+        it.stateIsFalse('EmailSettings.EnableEmailBatching'),
+        it.configIsTrue('ClusterSettings', 'Enable'),
+    ),
+},
+```
+
+Examples of **correct** code for this rule:
+```javascript
+{
+    type: 'bool',
+    key: 'EmailSettings.EnableEmailBatching',
+    isDisabled: it.any(
+        it.stateIsFalse('EmailSettings.SendEmailNotifications'),
+        it.configIsTrue('ClusterSettings', 'Enable'),
+    ),
+},
+{
+    type: 'number',
+    key: 'EmailSettings.EmailBatchingBufferSize',
+    isDisabled: it.any(
+        it.stateIsFalse('EmailSettings.EnableEmailBatching'),
+    ),
+},
+```
+
 ### use-external-link
 
 Ensures that any link which opens a URL outside of Mattermost using `target="_blank"` uses the `ExternalLink` component.

--- a/webapp/platform/eslint-plugin/configs/base.js
+++ b/webapp/platform/eslint-plugin/configs/base.js
@@ -52,6 +52,7 @@ const base = {
     },
     rules: {
         '@mattermost/no-dispatch-getstate': 2,
+        '@mattermost/no-redundant-admin-config-deps': 2,
         '@mattermost/use-external-link': 2,
         '@stylistic/array-bracket-spacing': [
             2,

--- a/webapp/platform/eslint-plugin/package.json
+++ b/webapp/platform/eslint-plugin/package.json
@@ -41,6 +41,7 @@
   "scripts": {
     "check": "eslint . --quiet",
     "fix": "eslint . --quiet --fix",
+    "test": "node --test rules/*.test.js",
     "clean": "rm -rf node_modules"
   }
 }

--- a/webapp/platform/eslint-plugin/rules/index.js
+++ b/webapp/platform/eslint-plugin/rules/index.js
@@ -2,9 +2,11 @@
 // See LICENSE.txt for license information.
 
 import noDispatchGetState from './no-dispatch-getstate.js';
+import noRedundantAdminConfigDeps from './no-redundant-admin-config-deps.js';
 import useExternalLink from './use-external-link.js';
 
 export default {
     'no-dispatch-getstate': noDispatchGetState,
+    'no-redundant-admin-config-deps': noRedundantAdminConfigDeps,
     'use-external-link': useExternalLink,
 };

--- a/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.js
+++ b/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.js
@@ -135,13 +135,20 @@ function getProperty(objectExpression, name) {
         if (prop.type !== 'Property' || prop.computed) {
             continue;
         }
-        const keyName =
-            prop.key.type === 'Identifier' ? prop.key.name :
-                prop.key.type === 'Literal' ? prop.key.value :
-                    null;
+        const keyName = getPropertyKeyName(prop.key);
         if (keyName === name) {
             return prop;
         }
+    }
+    return null;
+}
+
+function getPropertyKeyName(keyNode) {
+    if (keyNode.type === 'Identifier') {
+        return keyNode.name;
+    }
+    if (keyNode.type === 'Literal') {
+        return keyNode.value;
     }
     return null;
 }
@@ -166,7 +173,7 @@ function dependencyParentKeys(conditions) {
     const parents = [];
     for (const {key} of conditions) {
         // stateIsFalse:"Section.Setting" or not:stateIsTrue:"Section.Setting"
-        let match = /^stateIsFalse:(.*)$/.exec(key);
+        let match = (/^stateIsFalse:(.*)$/).exec(key);
         if (match) {
             const value = JSON.parse(match[1]);
             if (typeof value === 'string') {
@@ -174,7 +181,7 @@ function dependencyParentKeys(conditions) {
             }
             continue;
         }
-        match = /^not:stateIsTrue:(.*)$/.exec(key);
+        match = (/^not:stateIsTrue:(.*)$/).exec(key);
         if (match) {
             const value = JSON.parse(match[1]);
             if (typeof value === 'string') {
@@ -188,10 +195,6 @@ function dependencyParentKeys(conditions) {
 function isBoolSetting(key, settingsByKey) {
     const defs = settingsByKey.get(key) || [];
     return defs.some((def) => def.settingType === 'bool');
-}
-
-function boolParentKeys(parentKeys, settingsByKey) {
-    return parentKeys.filter((parentKey) => isBoolSetting(parentKey, settingsByKey));
 }
 
 /**
@@ -238,9 +241,11 @@ function buildDependencyTree(settingsByKey) {
         });
     }
 
+    const walked = new Set();
+
     function walk(settingKey, visiting) {
         const node = tree.get(settingKey);
-        if (!node || node._walked) {
+        if (!node || walked.has(settingKey)) {
             return node;
         }
         if (visiting.has(settingKey)) {
@@ -270,17 +275,13 @@ function buildDependencyTree(settingsByKey) {
 
         node.inheritedConditions = inheritedConditions;
         node.ancestors = ancestors;
-        node._walked = true;
+        walked.add(settingKey);
         visiting.delete(settingKey);
         return node;
     }
 
     for (const key of tree.keys()) {
         walk(key, new Set());
-    }
-
-    for (const node of tree.values()) {
-        delete node._walked;
     }
 
     return tree;
@@ -343,7 +344,7 @@ export default {
     },
     create(context) {
         const filename = context.filename || context.getFilename();
-        if (!/admin_definition/.test(filename)) {
+        if (!(/admin_definition/).test(filename)) {
             return {};
         }
 

--- a/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.js
+++ b/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.js
@@ -14,6 +14,11 @@
  * config checks. File/text parents can remain truthy while disabled, so their
  * checks are not treated as transitive.
  *
+ * The dependency tree is built fully before reporting. When a setting lists
+ * both a parent and a grandparent, redundant conditions are attributed to the
+ * closest (most specific) bool parent — not whichever ancestor appears first
+ * in the isDisabled list.
+ *
  * Only config/state helpers are considered (stateIsFalse/True/Equals/...,
  * configIsFalse/True, …). Permission and license checks are left alone —
  * non-bool children still need their own permission gates.
@@ -180,37 +185,148 @@ function dependencyParentKeys(conditions) {
     return parents;
 }
 
-function boolParentKeys(parentKeys, settingsByKey) {
-    return parentKeys.filter((parentKey) => {
-        const parentDefs = settingsByKey.get(parentKey) || [];
-        return parentDefs.some((def) => def.settingType === 'bool');
-    });
+function isBoolSetting(key, settingsByKey) {
+    const defs = settingsByKey.get(key) || [];
+    return defs.some((def) => def.settingType === 'bool');
 }
 
-function inheritedConditionKeys(settingKey, settingsByKey, visiting = new Set()) {
-    if (visiting.has(settingKey)) {
-        return new Set();
-    }
-    visiting.add(settingKey);
+function boolParentKeys(parentKeys, settingsByKey) {
+    return parentKeys.filter((parentKey) => isBoolSetting(parentKey, settingsByKey));
+}
 
-    const inherited = new Set();
-    const definitions = settingsByKey.get(settingKey) || [];
-    for (const def of definitions) {
-        for (const parentKey of boolParentKeys(def.parentKeys, settingsByKey)) {
-            const parentDefs = settingsByKey.get(parentKey) || [];
-            for (const parentDef of parentDefs) {
-                for (const {key} of parentDef.conditions) {
-                    inherited.add(key);
+/**
+ * Build the full bool-parent dependency tree once, then derive inherited
+ * condition sets. Reporting uses this snapshot so parent attribution does not
+ * depend on isDisabled declaration order.
+ *
+ * @returns {Map<string, {
+ *   isBool: boolean,
+ *   directConditions: Set<string>,
+ *   boolParents: string[],
+ *   inheritedConditions: Set<string>,
+ *   ancestors: Set<string>,
+ * }>}
+ */
+function buildDependencyTree(settingsByKey) {
+    const tree = new Map();
+
+    for (const [key, defs] of settingsByKey) {
+        const directConditions = new Set();
+        const parentKeys = [];
+        let isBool = false;
+
+        for (const def of defs) {
+            if (def.settingType === 'bool') {
+                isBool = true;
+            }
+            for (const {key: conditionKey} of def.conditions) {
+                directConditions.add(conditionKey);
+            }
+            for (const parentKey of def.parentKeys) {
+                if (!parentKeys.includes(parentKey)) {
+                    parentKeys.push(parentKey);
                 }
             }
-            for (const key of inheritedConditionKeys(parentKey, settingsByKey, visiting)) {
-                inherited.add(key);
-            }
         }
+
+        tree.set(key, {
+            isBool,
+            directConditions,
+            boolParents: parentKeys.filter((parentKey) => isBoolSetting(parentKey, settingsByKey)),
+            inheritedConditions: new Set(),
+            ancestors: new Set(),
+        });
     }
 
-    visiting.delete(settingKey);
-    return inherited;
+    function walk(settingKey, visiting) {
+        const node = tree.get(settingKey);
+        if (!node || node._walked) {
+            return node;
+        }
+        if (visiting.has(settingKey)) {
+            return node;
+        }
+        visiting.add(settingKey);
+
+        const inheritedConditions = new Set();
+        const ancestors = new Set();
+
+        for (const parentKey of node.boolParents) {
+            ancestors.add(parentKey);
+            const parentNode = walk(parentKey, visiting);
+            if (!parentNode) {
+                continue;
+            }
+            for (const conditionKey of parentNode.directConditions) {
+                inheritedConditions.add(conditionKey);
+            }
+            for (const conditionKey of parentNode.inheritedConditions) {
+                inheritedConditions.add(conditionKey);
+            }
+            for (const ancestorKey of parentNode.ancestors) {
+                ancestors.add(ancestorKey);
+            }
+        }
+
+        node.inheritedConditions = inheritedConditions;
+        node.ancestors = ancestors;
+        node._walked = true;
+        visiting.delete(settingKey);
+        return node;
+    }
+
+    for (const key of tree.keys()) {
+        walk(key, new Set());
+    }
+
+    for (const node of tree.values()) {
+        delete node._walked;
+    }
+
+    return tree;
+}
+
+function nodeImpliesCondition(node, conditionKey) {
+    return node.directConditions.has(conditionKey) || node.inheritedConditions.has(conditionKey);
+}
+
+/**
+ * Among immediate bool parents that imply the condition, pick the closest /
+ * most specific one: a parent that is a descendant of another candidate wins
+ * over that ancestor. Declaration order is ignored.
+ */
+function closestImplyingParent(settingKey, conditionKey, tree) {
+    const node = tree.get(settingKey);
+    if (!node) {
+        return null;
+    }
+
+    const candidates = node.boolParents.filter((parentKey) => {
+        const parentNode = tree.get(parentKey);
+        return parentNode && nodeImpliesCondition(parentNode, conditionKey);
+    });
+
+    if (candidates.length === 0) {
+        return null;
+    }
+
+    return candidates.reduce((best, candidate) => {
+        const bestNode = tree.get(best);
+        const candidateNode = tree.get(candidate);
+
+        // Prefer the candidate that is under the current best (more specific).
+        if (candidateNode.ancestors.has(best)) {
+            return candidate;
+        }
+
+        // Keep best when it is under the candidate.
+        if (bestNode.ancestors.has(candidate)) {
+            return best;
+        }
+
+        // Disjoint parents that both imply the condition: stable tie-break by key.
+        return candidate < best ? candidate : best;
+    });
 }
 
 export default {
@@ -274,35 +390,27 @@ export default {
                     settingsByKey.get(setting.key).push(setting);
                 }
 
+                // Build the complete tree before attributing any parent.
+                const tree = buildDependencyTree(settingsByKey);
+
                 for (const setting of settings) {
-                    const parents = boolParentKeys(setting.parentKeys, settingsByKey);
-                    if (parents.length === 0) {
+                    const node = tree.get(setting.key);
+                    if (!node || node.boolParents.length === 0 || node.inheritedConditions.size === 0) {
                         continue;
                     }
 
-                    const inherited = inheritedConditionKeys(setting.key, settingsByKey);
-                    if (inherited.size === 0) {
-                        continue;
-                    }
-
-                    for (const {key, node} of setting.conditions) {
-                        if (!inherited.has(key)) {
+                    for (const {key, node: conditionNode} of setting.conditions) {
+                        if (!node.inheritedConditions.has(key)) {
                             continue;
                         }
 
-                        let implyingParent = parents[0];
-                        for (const parentKey of parents) {
-                            const parentDefs = settingsByKey.get(parentKey) || [];
-                            const parentHas = parentDefs.some((d) => d.conditions.some((c) => c.key === key));
-                            const parentInherits = inheritedConditionKeys(parentKey, settingsByKey).has(key);
-                            if (parentHas || parentInherits) {
-                                implyingParent = parentKey;
-                                break;
-                            }
+                        const implyingParent = closestImplyingParent(setting.key, key, tree);
+                        if (!implyingParent) {
+                            continue;
                         }
 
                         context.report({
-                            node,
+                            node: conditionNode,
                             messageId: 'redundant',
                             data: {
                                 condition: key,

--- a/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.js
+++ b/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.js
@@ -63,6 +63,12 @@ function literalValue(node) {
 }
 
 function serializeArg(node) {
+    // Regex literals must be keyed by pattern+flags. literalValue returns a
+    // RegExp whose JSON.stringify is "{}", which would collapse distinct patterns.
+    if (node?.type === 'Literal' && node.regex) {
+        return `re:${JSON.stringify(node.regex.pattern)}:${JSON.stringify(node.regex.flags)}`;
+    }
+
     const value = literalValue(node);
     if (value === undefined) {
         if (node?.type === 'Identifier') {
@@ -73,9 +79,6 @@ function serializeArg(node) {
         }
         if (node?.type === 'UnaryExpression' && node.operator === '!' && node.argument?.type === 'Literal') {
             return `!${JSON.stringify(node.argument.value)}`;
-        }
-        if (node?.type === 'Literal' && node.regex) {
-            return String(node.raw);
         }
         return null;
     }
@@ -169,22 +172,31 @@ function getSettingType(objectExpression) {
     return literalValue(typeProp.value);
 }
 
+function parseSerializedStringArg(serialized) {
+    try {
+        const value = JSON.parse(serialized);
+        return typeof value === 'string' ? value : undefined;
+    } catch {
+        return undefined;
+    }
+}
+
 function dependencyParentKeys(conditions) {
     const parents = [];
     for (const {key} of conditions) {
         // stateIsFalse:"Section.Setting" or not:stateIsTrue:"Section.Setting"
         let match = (/^stateIsFalse:(.*)$/).exec(key);
         if (match) {
-            const value = JSON.parse(match[1]);
-            if (typeof value === 'string') {
+            const value = parseSerializedStringArg(match[1]);
+            if (value !== undefined) {
                 parents.push(value);
             }
             continue;
         }
         match = (/^not:stateIsTrue:(.*)$/).exec(key);
         if (match) {
-            const value = JSON.parse(match[1]);
-            if (typeof value === 'string') {
+            const value = parseSerializedStringArg(match[1]);
+            if (value !== undefined) {
                 parents.push(value);
             }
         }

--- a/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.js
+++ b/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.js
@@ -1,0 +1,318 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * Detects redundant System Console isDisabled conditions that are already
+ * implied by a parent config setting dependency.
+ *
+ * When setting B declares `it.stateIsFalse('A')` (or equivalent) and A is a bool
+ * setting that already disables itself under condition C, repeating C on B is
+ * redundant and can drift when A's dependencies change.
+ *
+ * Inheritance only follows bool parents: disabled bools are forced false on
+ * save (see getSettingValue), so stateIsFalse(parent) covers the parent's
+ * config checks. File/text parents can remain truthy while disabled, so their
+ * checks are not treated as transitive.
+ *
+ * Only config/state helpers are considered (stateIsFalse/True/Equals/...,
+ * configIsFalse/True, …). Permission and license checks are left alone —
+ * non-bool children still need their own permission gates.
+ */
+
+const CONFIG_HELPERS = new Set([
+    'stateIsFalse',
+    'stateIsTrue',
+    'stateEquals',
+    'stateEqualsOrDefault',
+    'stateMatches',
+    'configIsFalse',
+    'configIsTrue',
+    'configContains',
+    'clientConfigIsTrue',
+    'clientConfigIsFalse',
+]);
+
+function isItMemberCall(node, name) {
+    return (
+        node?.type === 'CallExpression' &&
+        node.callee?.type === 'MemberExpression' &&
+        !node.callee.computed &&
+        node.callee.object?.type === 'Identifier' &&
+        node.callee.object.name === 'it' &&
+        node.callee.property?.type === 'Identifier' &&
+        (name === undefined || node.callee.property.name === name)
+    );
+}
+
+function literalValue(node) {
+    if (!node) {
+        return undefined;
+    }
+    if (node.type === 'Literal') {
+        return node.value;
+    }
+    if (node.type === 'TemplateLiteral' && node.expressions.length === 0) {
+        return node.quasis[0]?.value?.cooked;
+    }
+    return undefined;
+}
+
+function serializeArg(node) {
+    const value = literalValue(node);
+    if (value === undefined) {
+        if (node?.type === 'Identifier') {
+            return `id:${node.name}`;
+        }
+        if (node?.type === 'MemberExpression') {
+            return `mem:${serializeArg(node.object)}.${node.property?.name ?? '?'}`;
+        }
+        if (node?.type === 'UnaryExpression' && node.operator === '!' && node.argument?.type === 'Literal') {
+            return `!${JSON.stringify(node.argument.value)}`;
+        }
+        if (node?.type === 'Literal' && node.regex) {
+            return String(node.raw);
+        }
+        return null;
+    }
+    return JSON.stringify(value);
+}
+
+function canonicalize(node) {
+    if (!node) {
+        return null;
+    }
+
+    if (isItMemberCall(node, 'not') && node.arguments.length === 1) {
+        const inner = canonicalize(node.arguments[0]);
+        return inner ? `not:${inner}` : null;
+    }
+
+    if (!isItMemberCall(node) || node.arguments.length === 0) {
+        return null;
+    }
+
+    const name = node.callee.property.name;
+    if (!CONFIG_HELPERS.has(name)) {
+        return null;
+    }
+
+    const args = node.arguments.map(serializeArg);
+    if (args.some((a) => a === null)) {
+        return null;
+    }
+
+    return `${name}:${args.join(',')}`;
+}
+
+function collectTopLevelConditions(node, out) {
+    if (!node) {
+        return;
+    }
+
+    if (isItMemberCall(node, 'any')) {
+        for (const arg of node.arguments) {
+            collectTopLevelConditions(arg, out);
+        }
+        return;
+    }
+
+    const key = canonicalize(node);
+    if (key) {
+        out.push({key, node});
+    }
+}
+
+function getProperty(objectExpression, name) {
+    if (objectExpression?.type !== 'ObjectExpression') {
+        return null;
+    }
+    for (const prop of objectExpression.properties) {
+        if (prop.type !== 'Property' || prop.computed) {
+            continue;
+        }
+        const keyName =
+            prop.key.type === 'Identifier' ? prop.key.name :
+                prop.key.type === 'Literal' ? prop.key.value :
+                    null;
+        if (keyName === name) {
+            return prop;
+        }
+    }
+    return null;
+}
+
+function getSettingKey(objectExpression) {
+    const keyProp = getProperty(objectExpression, 'key');
+    if (!keyProp) {
+        return null;
+    }
+    return literalValue(keyProp.value);
+}
+
+function getSettingType(objectExpression) {
+    const typeProp = getProperty(objectExpression, 'type');
+    if (!typeProp) {
+        return null;
+    }
+    return literalValue(typeProp.value);
+}
+
+function dependencyParentKeys(conditions) {
+    const parents = [];
+    for (const {key} of conditions) {
+        // stateIsFalse:"Section.Setting" or not:stateIsTrue:"Section.Setting"
+        let match = /^stateIsFalse:(.*)$/.exec(key);
+        if (match) {
+            const value = JSON.parse(match[1]);
+            if (typeof value === 'string') {
+                parents.push(value);
+            }
+            continue;
+        }
+        match = /^not:stateIsTrue:(.*)$/.exec(key);
+        if (match) {
+            const value = JSON.parse(match[1]);
+            if (typeof value === 'string') {
+                parents.push(value);
+            }
+        }
+    }
+    return parents;
+}
+
+function boolParentKeys(parentKeys, settingsByKey) {
+    return parentKeys.filter((parentKey) => {
+        const parentDefs = settingsByKey.get(parentKey) || [];
+        return parentDefs.some((def) => def.settingType === 'bool');
+    });
+}
+
+function inheritedConditionKeys(settingKey, settingsByKey, visiting = new Set()) {
+    if (visiting.has(settingKey)) {
+        return new Set();
+    }
+    visiting.add(settingKey);
+
+    const inherited = new Set();
+    const definitions = settingsByKey.get(settingKey) || [];
+    for (const def of definitions) {
+        for (const parentKey of boolParentKeys(def.parentKeys, settingsByKey)) {
+            const parentDefs = settingsByKey.get(parentKey) || [];
+            for (const parentDef of parentDefs) {
+                for (const {key} of parentDef.conditions) {
+                    inherited.add(key);
+                }
+            }
+            for (const key of inheritedConditionKeys(parentKey, settingsByKey, visiting)) {
+                inherited.add(key);
+            }
+        }
+    }
+
+    visiting.delete(settingKey);
+    return inherited;
+}
+
+export default {
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'Disallow System Console isDisabled conditions already implied by a parent config dependency',
+        },
+        schema: [],
+        messages: {
+            redundant:
+                "Redundant isDisabled condition '{{condition}}' on '{{setting}}' — already implied by dependency on '{{parent}}'. Depend on the parent setting and omit duplicated config checks.",
+        },
+    },
+    create(context) {
+        const filename = context.filename || context.getFilename();
+        if (!/admin_definition/.test(filename)) {
+            return {};
+        }
+
+        const settings = [];
+
+        return {
+            ObjectExpression(node) {
+                const settingKey = getSettingKey(node);
+                if (typeof settingKey !== 'string' || !settingKey.includes('.')) {
+                    return;
+                }
+
+                const settingType = getSettingType(node);
+                if (typeof settingType !== 'string') {
+                    return;
+                }
+
+                const isDisabledProp = getProperty(node, 'isDisabled');
+                if (!isDisabledProp) {
+                    return;
+                }
+
+                const conditions = [];
+                collectTopLevelConditions(isDisabledProp.value, conditions);
+                if (conditions.length === 0) {
+                    return;
+                }
+
+                settings.push({
+                    key: settingKey,
+                    settingType,
+                    conditions,
+                    parentKeys: dependencyParentKeys(conditions),
+                    node,
+                });
+            },
+
+            'Program:exit'() {
+                const settingsByKey = new Map();
+                for (const setting of settings) {
+                    if (!settingsByKey.has(setting.key)) {
+                        settingsByKey.set(setting.key, []);
+                    }
+                    settingsByKey.get(setting.key).push(setting);
+                }
+
+                for (const setting of settings) {
+                    const parents = boolParentKeys(setting.parentKeys, settingsByKey);
+                    if (parents.length === 0) {
+                        continue;
+                    }
+
+                    const inherited = inheritedConditionKeys(setting.key, settingsByKey);
+                    if (inherited.size === 0) {
+                        continue;
+                    }
+
+                    for (const {key, node} of setting.conditions) {
+                        if (!inherited.has(key)) {
+                            continue;
+                        }
+
+                        let implyingParent = parents[0];
+                        for (const parentKey of parents) {
+                            const parentDefs = settingsByKey.get(parentKey) || [];
+                            const parentHas = parentDefs.some((d) => d.conditions.some((c) => c.key === key));
+                            const parentInherits = inheritedConditionKeys(parentKey, settingsByKey).has(key);
+                            if (parentHas || parentInherits) {
+                                implyingParent = parentKey;
+                                break;
+                            }
+                        }
+
+                        context.report({
+                            node,
+                            messageId: 'redundant',
+                            data: {
+                                condition: key,
+                                setting: setting.key,
+                                parent: implyingParent,
+                            },
+                        });
+                    }
+                }
+            },
+        };
+    },
+};

--- a/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.test.js
+++ b/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.test.js
@@ -103,6 +103,54 @@ ruleTester.run('no-redundant-admin-config-deps', rule, {
         },
         {
 
+            // Distinct regex patterns on the same helper+key are not the same condition.
+
+            filename,
+            code: `
+                const AdminDefinition = {
+                    settings: [
+                        {
+                            type: 'bool',
+                            key: 'SupportSettings.Enable',
+                            isDisabled: it.stateMatches('SupportSettings.ReportAProblemType', /link/),
+                        },
+                        {
+                            type: 'text',
+                            key: 'SupportSettings.Mail',
+                            isDisabled: it.any(
+                                it.stateIsFalse('SupportSettings.Enable'),
+                                it.stateMatches('SupportSettings.ReportAProblemType', /email/),
+                            ),
+                        },
+                    ],
+                };
+            `,
+        },
+        {
+
+            // Identifier parent keys must not throw during canonicalize/JSON.parse.
+
+            filename,
+            code: `
+                const PARENT_KEY = 'ServiceSettings.EnableOAuthServiceProvider';
+                const AdminDefinition = {
+                    settings: [
+                        {
+                            type: 'bool',
+                            key: 'ServiceSettings.EnableDynamicClientRegistration',
+                            isDisabled: it.stateIsFalse(PARENT_KEY),
+                        },
+                        {
+                            type: 'text',
+                            key: 'ServiceSettings.DCRRedirectURIAllowlist',
+                            isDisabled: it.stateIsFalse('ServiceSettings.EnableDynamicClientRegistration'),
+                        },
+                    ],
+                };
+            `,
+        },
+        {
+
             // Non-admin_definition files are ignored
 
             filename: 'other_file.tsx',
@@ -257,6 +305,34 @@ ruleTester.run('no-redundant-admin-config-deps', rule, {
                 {messageId: 'redundant', data: {condition: 'configIsTrue:"ClusterSettings","Enable"', setting: 'FeatureSettings.Mid', parent: 'FeatureSettings.Root'}},
                 {messageId: 'redundant', data: {condition: 'stateIsFalse:"FeatureSettings.Root"', setting: 'FeatureSettings.Leaf', parent: 'FeatureSettings.Mid'}},
                 {messageId: 'redundant', data: {condition: 'configIsTrue:"ClusterSettings","Enable"', setting: 'FeatureSettings.Leaf', parent: 'FeatureSettings.Mid'}},
+            ],
+        },
+        {
+
+            // Same regex on parent and child is redundant; distinct patterns are not.
+
+            filename,
+            code: `
+                const AdminDefinition = {
+                    settings: [
+                        {
+                            type: 'bool',
+                            key: 'SupportSettings.Enable',
+                            isDisabled: it.stateMatches('SupportSettings.ReportAProblemType', /link/),
+                        },
+                        {
+                            type: 'text',
+                            key: 'SupportSettings.Mail',
+                            isDisabled: it.any(
+                                it.stateIsFalse('SupportSettings.Enable'),
+                                it.stateMatches('SupportSettings.ReportAProblemType', /link/),
+                            ),
+                        },
+                    ],
+                };
+            `,
+            errors: [
+                {messageId: 'redundant', data: {condition: 'stateMatches:"SupportSettings.ReportAProblemType",re:"link":""', setting: 'SupportSettings.Mail', parent: 'SupportSettings.Enable'}},
             ],
         },
     ],

--- a/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.test.js
+++ b/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.test.js
@@ -1,0 +1,217 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {RuleTester} from 'eslint';
+
+import rule from './no-redundant-admin-config-deps.js';
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        ecmaVersion: 2022,
+        sourceType: 'module',
+    },
+});
+
+const filename = 'admin_definition.tsx';
+
+ruleTester.run('no-redundant-admin-config-deps', rule, {
+    valid: [
+        {
+            filename,
+            code: `
+                const AdminDefinition = {
+                    settings: [
+                        {
+                            type: 'bool',
+                            key: 'EmailSettings.EnableEmailBatching',
+                            isDisabled: it.any(
+                                it.stateIsFalse('EmailSettings.SendEmailNotifications'),
+                                it.configIsTrue('ClusterSettings', 'Enable'),
+                            ),
+                        },
+                        {
+                            type: 'number',
+                            key: 'EmailSettings.EmailBatchingBufferSize',
+                            isDisabled: it.any(
+                                it.stateIsFalse('EmailSettings.EnableEmailBatching'),
+                            ),
+                        },
+                    ],
+                };
+            `,
+        },
+        {
+            filename,
+            code: `
+                const AdminDefinition = {
+                    settings: [
+                        {
+                            type: 'bool',
+                            key: 'ServiceSettings.EnableOAuthServiceProvider',
+                            isDisabled: it.not(it.userHasWritePermissionOnResource('integrations')),
+                        },
+                        {
+                            type: 'bool',
+                            key: 'ServiceSettings.EnableDynamicClientRegistration',
+                            isDisabled: it.any(
+                                it.not(it.userHasWritePermissionOnResource('integrations')),
+                                it.stateIsFalse('ServiceSettings.EnableOAuthServiceProvider'),
+                            ),
+                        },
+                        {
+                            type: 'text',
+                            key: 'ServiceSettings.DCRRedirectURIAllowlist',
+                            isDisabled: it.any(
+                                it.not(it.userHasWritePermissionOnResource('integrations')),
+                                it.stateIsFalse('ServiceSettings.EnableDynamicClientRegistration'),
+                            ),
+                        },
+                    ],
+                };
+            `,
+        },
+        {
+            // Non-bool parents (fileupload) do not imply their isDisabled conditions,
+            // so repeating Encrypt alongside PrivateKeyFile is intentional.
+            filename,
+            code: `
+                const AdminDefinition = {
+                    settings: [
+                        {
+                            type: 'bool',
+                            key: 'SamlSettings.Encrypt',
+                            isDisabled: it.stateIsFalse('SamlSettings.Enable'),
+                        },
+                        {
+                            type: 'fileupload',
+                            key: 'SamlSettings.PrivateKeyFile',
+                            isDisabled: it.stateIsFalse('SamlSettings.Encrypt'),
+                        },
+                        {
+                            type: 'bool',
+                            key: 'SamlSettings.SignRequest',
+                            isDisabled: it.any(
+                                it.stateIsFalse('SamlSettings.Encrypt'),
+                                it.stateIsFalse('SamlSettings.PrivateKeyFile'),
+                            ),
+                        },
+                    ],
+                };
+            `,
+        },
+        {
+            // Non-admin_definition files are ignored
+            filename: 'other_file.tsx',
+            code: `
+                const x = {
+                    type: 'number',
+                    key: 'EmailSettings.EmailBatchingBufferSize',
+                    isDisabled: it.any(
+                        it.stateIsFalse('EmailSettings.SendEmailNotifications'),
+                        it.stateIsFalse('EmailSettings.EnableEmailBatching'),
+                    ),
+                };
+                const y = {
+                    type: 'bool',
+                    key: 'EmailSettings.EnableEmailBatching',
+                    isDisabled: it.stateIsFalse('EmailSettings.SendEmailNotifications'),
+                };
+            `,
+        },
+    ],
+    invalid: [
+        {
+            filename,
+            code: `
+                const AdminDefinition = {
+                    settings: [
+                        {
+                            type: 'bool',
+                            key: 'EmailSettings.EnableEmailBatching',
+                            isDisabled: it.any(
+                                it.stateIsFalse('EmailSettings.SendEmailNotifications'),
+                                it.configIsTrue('ClusterSettings', 'Enable'),
+                                it.configIsFalse('ServiceSettings', 'SiteURL'),
+                            ),
+                        },
+                        {
+                            type: 'number',
+                            key: 'EmailSettings.EmailBatchingBufferSize',
+                            isDisabled: it.any(
+                                it.stateIsFalse('EmailSettings.SendEmailNotifications'),
+                                it.stateIsFalse('EmailSettings.EnableEmailBatching'),
+                                it.configIsTrue('ClusterSettings', 'Enable'),
+                                it.configIsFalse('ServiceSettings', 'SiteURL'),
+                            ),
+                        },
+                    ],
+                };
+            `,
+            errors: [
+                {messageId: 'redundant', data: {condition: 'stateIsFalse:"EmailSettings.SendEmailNotifications"', setting: 'EmailSettings.EmailBatchingBufferSize', parent: 'EmailSettings.EnableEmailBatching'}},
+                {messageId: 'redundant', data: {condition: 'configIsTrue:"ClusterSettings","Enable"', setting: 'EmailSettings.EmailBatchingBufferSize', parent: 'EmailSettings.EnableEmailBatching'}},
+                {messageId: 'redundant', data: {condition: 'configIsFalse:"ServiceSettings","SiteURL"', setting: 'EmailSettings.EmailBatchingBufferSize', parent: 'EmailSettings.EnableEmailBatching'}},
+            ],
+        },
+        {
+            filename,
+            code: `
+                const AdminDefinition = {
+                    settings: [
+                        {
+                            type: 'bool',
+                            key: 'ServiceSettings.EnableOAuthServiceProvider',
+                            isDisabled: it.not(it.userHasWritePermissionOnResource('integrations')),
+                        },
+                        {
+                            type: 'bool',
+                            key: 'ServiceSettings.EnableDynamicClientRegistration',
+                            isDisabled: it.any(
+                                it.not(it.userHasWritePermissionOnResource('integrations')),
+                                it.stateIsFalse('ServiceSettings.EnableOAuthServiceProvider'),
+                            ),
+                        },
+                        {
+                            type: 'text',
+                            key: 'ServiceSettings.DCRRedirectURIAllowlist',
+                            isDisabled: it.any(
+                                it.not(it.userHasWritePermissionOnResource('integrations')),
+                                it.stateIsFalse('ServiceSettings.EnableOAuthServiceProvider'),
+                                it.stateIsFalse('ServiceSettings.EnableDynamicClientRegistration'),
+                            ),
+                        },
+                    ],
+                };
+            `,
+            errors: [
+                {messageId: 'redundant', data: {condition: 'stateIsFalse:"ServiceSettings.EnableOAuthServiceProvider"', setting: 'ServiceSettings.DCRRedirectURIAllowlist', parent: 'ServiceSettings.EnableDynamicClientRegistration'}},
+            ],
+        },
+        {
+            // Bool parent Encrypt implies Enable; PrivateKeyFile should not repeat Enable
+            filename,
+            code: `
+                const AdminDefinition = {
+                    settings: [
+                        {
+                            type: 'bool',
+                            key: 'SamlSettings.Encrypt',
+                            isDisabled: it.stateIsFalse('SamlSettings.Enable'),
+                        },
+                        {
+                            type: 'fileupload',
+                            key: 'SamlSettings.PrivateKeyFile',
+                            isDisabled: it.any(
+                                it.stateIsFalse('SamlSettings.Enable'),
+                                it.stateIsFalse('SamlSettings.Encrypt'),
+                            ),
+                        },
+                    ],
+                };
+            `,
+            errors: [
+                {messageId: 'redundant', data: {condition: 'stateIsFalse:"SamlSettings.Enable"', setting: 'SamlSettings.PrivateKeyFile', parent: 'SamlSettings.Encrypt'}},
+            ],
+        },
+    ],
+});

--- a/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.test.js
+++ b/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.test.js
@@ -71,8 +71,10 @@ ruleTester.run('no-redundant-admin-config-deps', rule, {
             `,
         },
         {
+
             // Non-bool parents (fileupload) do not imply their isDisabled conditions,
             // so repeating Encrypt alongside PrivateKeyFile is intentional.
+
             filename,
             code: `
                 const AdminDefinition = {
@@ -100,7 +102,9 @@ ruleTester.run('no-redundant-admin-config-deps', rule, {
             `,
         },
         {
+
             // Non-admin_definition files are ignored
+
             filename: 'other_file.tsx',
             code: `
                 const x = {
@@ -188,7 +192,9 @@ ruleTester.run('no-redundant-admin-config-deps', rule, {
             ],
         },
         {
+
             // Bool parent Encrypt implies Enable; PrivateKeyFile should not repeat Enable
+
             filename,
             code: `
                 const AdminDefinition = {
@@ -214,8 +220,10 @@ ruleTester.run('no-redundant-admin-config-deps', rule, {
             ],
         },
         {
+
             // Grandparent listed before parent: still attribute to the closest parent (Mid),
             // not Root, after the full tree is built.
+
             filename,
             code: `
                 const AdminDefinition = {

--- a/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.test.js
+++ b/webapp/platform/eslint-plugin/rules/no-redundant-admin-config-deps.test.js
@@ -213,5 +213,43 @@ ruleTester.run('no-redundant-admin-config-deps', rule, {
                 {messageId: 'redundant', data: {condition: 'stateIsFalse:"SamlSettings.Enable"', setting: 'SamlSettings.PrivateKeyFile', parent: 'SamlSettings.Encrypt'}},
             ],
         },
+        {
+            // Grandparent listed before parent: still attribute to the closest parent (Mid),
+            // not Root, after the full tree is built.
+            filename,
+            code: `
+                const AdminDefinition = {
+                    settings: [
+                        {
+                            type: 'bool',
+                            key: 'FeatureSettings.Root',
+                            isDisabled: it.configIsTrue('ClusterSettings', 'Enable'),
+                        },
+                        {
+                            type: 'bool',
+                            key: 'FeatureSettings.Mid',
+                            isDisabled: it.any(
+                                it.stateIsFalse('FeatureSettings.Root'),
+                                it.configIsTrue('ClusterSettings', 'Enable'),
+                            ),
+                        },
+                        {
+                            type: 'number',
+                            key: 'FeatureSettings.Leaf',
+                            isDisabled: it.any(
+                                it.stateIsFalse('FeatureSettings.Root'),
+                                it.stateIsFalse('FeatureSettings.Mid'),
+                                it.configIsTrue('ClusterSettings', 'Enable'),
+                            ),
+                        },
+                    ],
+                };
+            `,
+            errors: [
+                {messageId: 'redundant', data: {condition: 'configIsTrue:"ClusterSettings","Enable"', setting: 'FeatureSettings.Mid', parent: 'FeatureSettings.Root'}},
+                {messageId: 'redundant', data: {condition: 'stateIsFalse:"FeatureSettings.Root"', setting: 'FeatureSettings.Leaf', parent: 'FeatureSettings.Mid'}},
+                {messageId: 'redundant', data: {condition: 'configIsTrue:"ClusterSettings","Enable"', setting: 'FeatureSettings.Leaf', parent: 'FeatureSettings.Mid'}},
+            ],
+        },
     ],
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
From the discussion on #38024 ([comment](https://github.com/mattermost/mattermost/pull/38024#discussion_r3847444599)): when a System Console setting already depends on a parent bool (e.g. `it.stateIsFalse('EmailSettings.EnableEmailBatching')`), repeating that parent's config/state disable checks (Cluster, SiteURL, SendEmailNotifications, etc.) is redundant and drifts easily.

This PR:
1. Adds `@mattermost/no-redundant-admin-config-deps` to build the admin_definition dependency tree and flag duplicated config/state `isDisabled` conditions implied by a bool parent.
2. Removes the existing violations under SAML and OAuth DCR settings.

Inheritance only follows bool parents (disabled bools are forced false on save). Permission/license checks are not treated as config dependencies.

The rule builds the **full** bool-parent tree before attributing a parent. When a setting lists both a parent and a grandparent, redundant conditions are attributed to the **closest** (most specific) parent — not whichever ancestor appears first in `isDisabled`.

#### Dependency trees (fixed settings)

Eight settings were deduplicated. In each tree, **bold** is the closest bool parent kept on the child; ~~strikethrough~~ is the redundant condition removed by this PR. Permission checks are omitted for clarity.

**SAML — LDAP sync**

```
SamlSettings.Enable (bool)
└─ permission only
   └─► EnableSyncWithLdap (bool)
       ├─ permission
       └─ stateIsFalse(Enable)
          ├─► IgnoreGuestsLdapSync (bool)
          │   ├─ configIsFalse(GuestAccountsSettings.Enable)  [own, kept]
          │   ├─ **stateIsFalse(EnableSyncWithLdap)**           [parent edge, kept]
          │   └─ ~~stateIsFalse(Enable)~~                      [removed]
          └─► EnableSyncWithLdapIncludeAuth (bool)
              ├─ **stateIsFalse(EnableSyncWithLdap)**           [parent edge, kept]
              └─ ~~stateIsFalse(Enable)~~                      [removed]
```

**SAML — encryption / signing**

```
SamlSettings.Enable (bool)
└─ permission only
   └─► Encrypt (bool)
       ├─ permission
       └─ stateIsFalse(Enable)
          ├─► PrivateKeyFile (fileupload)
          │   ├─ **stateIsFalse(Encrypt)**                     [parent edge, kept]
          │   └─ ~~stateIsFalse(Enable)~~                      [removed]
          ├─► PublicCertificateFile (fileupload)
          │   ├─ **stateIsFalse(Encrypt)**                     [parent edge, kept]
          │   └─ ~~stateIsFalse(Enable)~~                      [removed]
          └─► SignRequest (bool)  [unchanged parent]
              ├─ stateIsFalse(Encrypt)
              ├─ stateIsFalse(PrivateKeyFile)   [non-bool parent — not transitive]
              └─ stateIsFalse(PublicCertificateFile)
                 ├─► SignatureAlgorithm (dropdown)
                 │   ├─ **stateIsFalse(SignRequest)**           [parent edge, kept]
                 │   └─ ~~stateIsFalse(Encrypt)~~               [removed]
                 └─► CanonicalAlgorithm (dropdown)
                     ├─ **stateIsFalse(SignRequest)**           [parent edge, kept]
                     └─ ~~stateIsFalse(Encrypt)~~               [removed]
```

**SAML — admin attribute**

```
SamlSettings.Enable (bool)
└─ permission only
   └─► EnableAdminAttribute (bool)
       ├─ isSystemAdmin
       └─ stateIsFalse(Enable)
          └─► AdminAttribute (text)
              ├─ **stateIsFalse(EnableAdminAttribute)**        [parent edge, kept]
              └─ ~~stateIsFalse(Enable)~~                      [removed]
```

**OAuth — DCR**

```
EnableOAuthServiceProvider (bool)
└─ permission only
   └─► EnableDynamicClientRegistration (bool)
       ├─ permission
       └─ stateIsFalse(EnableOAuthServiceProvider)
          └─► DCRRedirectURIAllowlist (text)
              ├─ **stateIsFalse(EnableDynamicClientRegistration)** [parent edge, kept]
              └─ ~~stateIsFalse(EnableOAuthServiceProvider)~~      [removed]
```

| Modified setting | Closest bool parent kept | Removed (redundant) |
|---|---|---|
| `IgnoreGuestsLdapSync` | `EnableSyncWithLdap` | `stateIsFalse(Enable)` |
| `EnableSyncWithLdapIncludeAuth` | `EnableSyncWithLdap` | `stateIsFalse(Enable)` |
| `PrivateKeyFile` | `Encrypt` | `stateIsFalse(Enable)` |
| `PublicCertificateFile` | `Encrypt` | `stateIsFalse(Enable)` |
| `SignatureAlgorithm` | `SignRequest` | `stateIsFalse(Encrypt)` |
| `CanonicalAlgorithm` | `SignRequest` | `stateIsFalse(Encrypt)` |
| `AdminAttribute` | `EnableAdminAttribute` | `stateIsFalse(Enable)` |
| `DCRRedirectURIAllowlist` | `EnableDynamicClientRegistration` | `stateIsFalse(EnableOAuthServiceProvider)` |


#### Release Note
```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a035b1-e10a-7cab-a219-82319a511594?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a035b1-e10a-7cab-a219-82319a511594&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change affects shared ESLint configuration and multiple SAML and OAuth admin settings. Automated rule tests cover key dependency paths, but lint behavior changes can affect additional admin definitions.

**QA Recommendation:** Manual QA is not required. Run the ESLint rule and lint test suites.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->