### PR TITLE
Bumping prepackaged Boards version to 9.4.0

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -164,7 +164,7 @@ PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.11.1
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
 PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.1
-PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.1
+PLUGIN_PACKAGES += mattermost-plugin-boards-v9.4.0
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.7.0
 PLUGIN_PACKAGES += mattermost-plugin-msteams-meetings-v2.4.1
@@ -179,7 +179,7 @@ PLUGIN_PACKAGES += mattermost-plugin-dataminr-v2.0.0
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.11.1%2B329b65c-fips
 	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.5.1%2B276cb86-fips
-	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.1%2B29b4688-fips
+	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.4.0%2B4b7dd4b-fips
 endif
 
 EE_PACKAGES=$(shell $(GO) list $(BUILD_ENTERPRISE_DIR)/...)


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
<!-- What does this PR do? Include QA steps if not covered in the ticket. -->
Bumping prepackaged Boards version to v9.4.0

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note
Pre-packaged Boards plugin version [v9.4.0](https://github.com/mattermost/mattermost-plugin-boards/releases/tag/v9.4.0).
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change updates only the prepackaged Boards plugin version in `server/Makefile`. It does not modify application logic, APIs, data, or security flows.
**QA Recommendation:** Skip manual QA. Automated testing is sufficient for this isolated version update.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->