### PR TITLE
docs: add RepoCloud as a deployment option

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Other install guides:
 - [Kubernetes](https://docs.mattermost.com/install/install-kubernetes.html)
 - [Helm](https://docs.mattermost.com/install/install-kubernetes.html#installing-the-operators-via-helm)
 - [More server install guides](https://docs.mattermost.com/guides/deployment.html)
+- [Deploy on RepoCloud](https://repocloud.io/details/Mattermost/) [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Mattermost/)
 
 ## Native mobile and desktop apps
 

--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ Other install guides:
 - [Ubuntu 20.04 LTS](https://docs.mattermost.com/install/installing-ubuntu-2004-LTS.html)
 - [Kubernetes](https://docs.mattermost.com/install/install-kubernetes.html)
 - [Helm](https://docs.mattermost.com/install/install-kubernetes.html#installing-the-operators-via-helm)
+- [Deploy on RepoCloud](https://repocloud.io/details/Mattermost/)
 - [More server install guides](https://docs.mattermost.com/guides/deployment.html)
-- [Deploy on RepoCloud](https://repocloud.io/details/Mattermost/) [![Deploy on RepoCloud](https://d16t0pc4846x52.cloudfront.net/deploylobe.svg)](https://repocloud.io/details/Mattermost/)
 
 ## Native mobile and desktop apps
 


### PR DESCRIPTION
Adds [RepoCloud](https://repocloud.io) as a deployment option in the "Other install guides"
section alongside Docker, Omnibus, Tar, Ubuntu, Kubernetes, and Helm.

RepoCloud provides managed cloud hosting for open-source applications with one-click deployment.

- Adds RepoCloud text link to `README.md` Install section
- Follows existing bullet point text link format
- Links to: https://repocloud.io/details/Mattermost/

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is limited to a README link. It does not affect code, shared dependencies, or critical flows.  
**QA Recommendation:** Skip manual QA.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->