### PR TITLE
[MM-43331] fix: keep retrying focus of post textbox after channel switcher closes

### DIFF
--- a/webapp/channels/src/components/quick_switch_modal/quick_switch_modal.test.tsx
+++ b/webapp/channels/src/components/quick_switch_modal/quick_switch_modal.test.tsx
@@ -38,6 +38,65 @@ describe('components/QuickSwitchModal', () => {
         expect(container).toMatchSnapshot();
     });
 
+    describe('focusPostTextbox', () => {
+        const originalQuerySelector = document.querySelector;
+
+        afterEach(() => {
+            document.querySelector = originalQuerySelector;
+            jest.useRealTimers();
+        });
+
+        it('should focus post textbox when it is available', () => {
+            jest.useFakeTimers();
+
+            const ref = React.createRef<QuickSwitchModalClass>();
+            renderWithContext(
+                <QuickSwitchModalWithRef
+                    {...baseProps}
+                    ref={ref}
+                />,
+            );
+            const instance = ref.current!;
+
+            const mockTextbox = {focus: jest.fn()} as unknown as HTMLElement;
+            document.querySelector = jest.fn().mockReturnValue(mockTextbox);
+
+            instance['focusPostTextbox']();
+            jest.runAllTimers();
+
+            expect(document.querySelector).toHaveBeenCalledWith('#post_textbox');
+            expect(mockTextbox.focus).toHaveBeenCalledTimes(1);
+        });
+
+        it('should keep retrying until the post textbox exists', () => {
+            jest.useFakeTimers();
+
+            const ref = React.createRef<QuickSwitchModalClass>();
+            renderWithContext(
+                <QuickSwitchModalWithRef
+                    {...baseProps}
+                    ref={ref}
+                />,
+            );
+            const instance = ref.current!;
+
+            // Simulate the textbox not being mounted yet (e.g. after a channel
+            // switch from the Threads view) and then appearing.
+            const mockTextbox = {focus: jest.fn()} as unknown as HTMLElement;
+            let queryCount = 0;
+            document.querySelector = jest.fn().mockImplementation(() => {
+                queryCount++;
+                return queryCount < 3 ? null : mockTextbox;
+            });
+
+            instance['focusPostTextbox']();
+            jest.runAllTimers();
+
+            expect(queryCount).toBeGreaterThanOrEqual(3);
+            expect(mockTextbox.focus).toHaveBeenCalledTimes(1);
+        });
+    });
+
     describe('handleSubmit', () => {
         it('should do nothing if nothing selected', () => {
             const props = {...baseProps};

--- a/webapp/channels/src/components/quick_switch_modal/quick_switch_modal.tsx
+++ b/webapp/channels/src/components/quick_switch_modal/quick_switch_modal.tsx
@@ -99,13 +99,27 @@ export class QuickSwitchModal extends React.PureComponent<Props, State> {
 
     private focusPostTextbox = (): void => {
         if (!UserAgent.isMobile()) {
-            setTimeout(() => {
-                const textbox = document.querySelector('#post_textbox') as HTMLElement;
-                if (textbox) {
-                    textbox.focus();
-                }
-            });
+            // The channel view is mounted asynchronously after the route change,
+            // so the post textbox might not exist yet. Keep retrying briefly
+            // instead of giving up after a single attempt (MM-43331).
+            this.focusPostTextboxWhenAvailable(10);
         }
+    };
+
+    private focusPostTextboxWhenAvailable = (remainingAttempts: number): void => {
+        // Retry on the next animation frame rather than with a zero-delay
+        // timeout: a chained setTimeout can exhaust its attempts before the
+        // (asynchronously mounted) channel view has rendered, which would
+        // still drop focus. requestAnimationFrame lines up with the render
+        // loop instead (MM-43331).
+        requestAnimationFrame(() => {
+            const textbox = document.querySelector('#post_textbox') as HTMLElement;
+            if (textbox) {
+                textbox.focus();
+            } else if (remainingAttempts > 1) {
+                this.focusPostTextboxWhenAvailable(remainingAttempts - 1);
+            }
+        });
     };
 
     private hideOnCancel = () => {


### PR DESCRIPTION
#### Summary
When switching channels via the channel switcher (ctrl/cmd+K), the post textbox was only focused with a **single** `setTimeout` attempt. If the channel view hadn't finished mounting asynchronously (e.g. after switching away from the Threads view on a slower machine), `#post_textbox` didn't exist yet, focus was lost, and it stayed on whatever element had it before — commonly leaving the RHS focused instead of the composer.

This changes `focusPostTextbox` to retry for up to 10 animation ticks until `#post_textbox` appears, then focus it.

#### Ticket Link
Fixes #19983
Jira: [MM-43331](https://mattermost.atlassian.net/browse/MM-43331)

#### Screenshots
n/a (focus behavior)

#### Release Note
Release note not required because this is a small UX bug fix; if desired:
```release-note
Fixed the post textbox sometimes not receiving focus after switching channels with ctrl/cmd+K.
```


[MM-43331]: https://mattermost.atlassian.net/browse/MM-43331?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to channel-switcher focus behavior and has automated test coverage. The main risk is an incorrect retry timing edge case.

**QA Recommendation:** Manual QA is not required. Automated tests provide sufficient coverage for this low-risk change.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->