### PR TITLE
Backport i18n packaging and locale fallback fixes

### DIFF
--- a/server/build/release.mk
+++ b/server/build/release.mk
@@ -188,7 +188,8 @@ package-prep: setup-go-work
 	cp -RL fonts $(DIST_PATH)
 	cp -RL templates $(DIST_PATH)
 	rm -rf $(DIST_PATH)/templates/*.mjml $(DIST_PATH)/templates/partials/
-	cp -RL i18n $(DIST_PATH)
+	mkdir -p $(DIST_PATH)/i18n
+	cp -L i18n/*.json $(DIST_PATH)/i18n
 
 	@# Disable developer settings
 	sed -i'' -e 's|"ConsoleLevel": "DEBUG"|"ConsoleLevel": "INFO"|g' $(DIST_PATH)/config/config.json

--- a/webapp/channels/src/components/user_settings/display/index.test.tsx
+++ b/webapp/channels/src/components/user_settings/display/index.test.tsx
@@ -66,6 +66,7 @@ describe('components/user_settings/display/index', () => {
         });
 
         const userLocale = userLocaleFor(state, 'de');
+        expect(userLocale).toBe('en');
         expect(getLanguageInfo(userLocale)).toBeDefined();
     });
 });

--- a/webapp/channels/src/components/user_settings/display/index.test.tsx
+++ b/webapp/channels/src/components/user_settings/display/index.test.tsx
@@ -1,0 +1,71 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {UserProfile} from '@mattermost/types/users';
+
+import {getLanguageInfo} from 'i18n/i18n';
+import mergeObjects from 'packages/mattermost-redux/test/merge_objects';
+import {TestHelper} from 'utils/test_helper';
+
+import type {GlobalState} from 'types/store';
+
+import {makeMapStateToProps} from './index';
+
+describe('components/user_settings/display/index', () => {
+    const user = TestHelper.getUserMock({id: 'user_id', locale: 'de'});
+
+    const baseState = {
+        entities: {
+            general: {
+                config: {
+                    DefaultClientLocale: 'en',
+                },
+                license: {},
+            },
+            users: {
+                currentUserId: 'user_id',
+                profiles: {user_id: user},
+            },
+            preferences: {myPreferences: {}},
+            teams: {teams: {}, myMembers: {}},
+            channels: {channels: {}, myMembers: {}},
+        },
+    } as unknown as GlobalState;
+
+    const ownProps = {adminMode: false, user} as {adminMode: boolean; user: UserProfile};
+
+    function userLocaleFor(state: GlobalState, locale: string) {
+        const mapStateToProps = makeMapStateToProps();
+        return mapStateToProps(state, {...ownProps, user: {...user, locale}}).userLocale;
+    }
+
+    test('keeps a supported user locale', () => {
+        expect(userLocaleFor(baseState, 'de')).toBe('de');
+    });
+
+    test('falls back to DefaultClientLocale when the user locale is not supported', () => {
+        expect(userLocaleFor(baseState, 'cs')).toBe('en');
+    });
+
+    test('falls back to English when DefaultClientLocale is not supported either', () => {
+        // fixInvalidLocales normalizes this server side, but the settings modal
+        // reads .name off the result without a guard, so the fallback has to
+        // resolve on its own.
+        const state = mergeObjects(baseState, {
+            entities: {general: {config: {DefaultClientLocale: 'cs'}}},
+        });
+
+        const userLocale = userLocaleFor(state, 'cs');
+        expect(userLocale).toBe('en');
+        expect(getLanguageInfo(userLocale)).toBeDefined();
+    });
+
+    test('falls back to English when AvailableLocales excludes DefaultClientLocale', () => {
+        const state = mergeObjects(baseState, {
+            entities: {general: {config: {AvailableLocales: 'fr', DefaultClientLocale: 'cs'}}},
+        });
+
+        const userLocale = userLocaleFor(state, 'de');
+        expect(getLanguageInfo(userLocale)).toBeDefined();
+    });
+});

--- a/webapp/channels/src/components/user_settings/display/index.ts
+++ b/webapp/channels/src/components/user_settings/display/index.ts
@@ -11,6 +11,7 @@ import {CollapsedThreads} from '@mattermost/types/config';
 import {savePreferences} from 'mattermost-redux/actions/preferences';
 import {autoUpdateTimezone} from 'mattermost-redux/actions/timezone';
 import {patchUser, updateMe} from 'mattermost-redux/actions/users';
+import {General} from 'mattermost-redux/constants';
 import {getConfig, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {
     get,
@@ -57,9 +58,16 @@ export function makeMapStateToProps() {
             lastActiveDisplay = false;
         }
 
+        // DefaultClientLocale is normalized to a supported locale server side by
+        // fixInvalidLocales, but user_settings_display reads the name off this
+        // value without a guard, so don't rely on an invariant three layers away
+        // to keep the settings modal from throwing.
         let userLocale = props.user.locale;
         if (!isLanguageAvailable(state, userLocale)) {
             userLocale = config.DefaultClientLocale as string;
+        }
+        if (!isLanguageAvailable(state, userLocale)) {
+            userLocale = General.DEFAULT_LOCALE;
         }
 
         return {


### PR DESCRIPTION
#### Summary
- Packaged only JSON locale catalogs in release artifacts.
- Added a safe English fallback when the configured or user locale was unavailable.

#### Release Note
```release-note
Updated display settings to fall back to English when the configured locale was unavailable.
```

#### Validation
- Based on freshly fetched `origin/master`.
- `git diff --check` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Locale fallback changes affect user-facing behavior, and packaging changes affect release artifacts. Automated tests cover locale selection, but packaging paths have limited direct coverage.

**QA Recommendation:** Manual QA can be skipped. Automated coverage and straightforward rollback provide sufficient confidence.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->