### PR TITLE
Prepackage mattermost-plugin-agents v2.4.4 (release-11.9)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -163,7 +163,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.1
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.10.1
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.2
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.4
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.1
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.6.2
@@ -177,7 +177,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.10.1%2B42a4753-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.2%2B1305067-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.4%2B8db0426-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.1%2B29b4688-fips
 endif
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Updates the default prepackaged [mattermost-plugin-agents](https://github.com/mattermost/mattermost-plugin-agents) artifact from **2.4.2** to **2.4.4** ([release v2.4.4](https://github.com/mattermost/mattermost-plugin-agents/releases/tag/v2.4.4)) for the `release-11.9` branch.

Both prepackaged plugin lists are updated:
- non-FIPS: `mattermost-plugin-agents-v2.4.4`
- FIPS: `mattermost-plugin-agents-v2.4.4%2B8db0426-fips` (`8db0426` is the tagged release commit)

Bundles verified on `plugins.releases.mattermost.com`.

#### Release Note
```release-note
Prepackaged the Mattermost Agents plugin at version 2.4.4 instead of 2.4.2.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ae47209-7fc4-484d-9bae-25f9f16915cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ae47209-7fc4-484d-9bae-25f9f16915cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

