### PR TITLE
Prepackage mattermost-plugin-agents v2.0.8 (release-11.8)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -163,7 +163,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.0
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.9.4
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.7
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.8
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.7
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.6.2
@@ -177,7 +177,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.9.4%2B39a72fa-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.7%2B7e9d095-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.8%2B1b17baf-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.7%2Bfccd738-fips
 endif
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Updates the default prepackaged [mattermost-plugin-agents](https://github.com/mattermost/mattermost-plugin-agents) artifact from **2.0.7** to **2.0.8** ([release v2.0.8](https://github.com/mattermost/mattermost-plugin-agents/releases/tag/v2.0.8)) for the `release-11.8` branch.

Both prepackaged plugin lists are updated:
- non-FIPS: `mattermost-plugin-agents-v2.0.8`
- FIPS: `mattermost-plugin-agents-v2.0.8%2B1b17baf-fips` (`1b17baf` is the tagged release commit)

Bundles verified on `plugins.releases.mattermost.com`.

#### Release Note
```release-note
Prepackaged the Mattermost Agents plugin at version 2.0.8 instead of 2.0.7.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5ae47209-7fc4-484d-9bae-25f9f16915cd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5ae47209-7fc4-484d-9bae-25f9f16915cd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

