### PR TITLE
MM-70358: export Avatars on window.Components

### DIFF
--- a/webapp/channels/src/plugins/export.test.ts
+++ b/webapp/channels/src/plugins/export.test.ts
@@ -17,6 +17,16 @@ describe('window.Components exposes plugin modals', () => {
     });
 });
 
+describe('window.Components exposes user avatar components', () => {
+    test('Avatar is defined', () => {
+        expect((window as any).Components.Avatar).toBeDefined();
+    });
+
+    test('Avatars is defined', () => {
+        expect((window as any).Components.Avatars).toBeDefined();
+    });
+});
+
 describe('window.Components exposes ABAC policy editors', () => {
     test('AccessControlTableEditor is defined', () => {
         expect((window as any).Components.AccessControlTableEditor).toBeDefined();

--- a/webapp/channels/src/plugins/export.ts
+++ b/webapp/channels/src/plugins/export.ts
@@ -27,6 +27,7 @@ import ThreadViewer from 'components/threading/thread_viewer';
 import Timestamp from 'components/timestamp';
 import BotTag from 'components/widgets/tag/bot_tag';
 import Avatar from 'components/widgets/users/avatar';
+import Avatars from 'components/widgets/users/avatars';
 
 import {getHistory} from 'utils/browser_history';
 import {ModalIdentifiers} from 'utils/constants';
@@ -103,6 +104,7 @@ interface WindowWithLibraries {
         ChannelNotificationsModal: typeof ChannelNotificationsModal;
         EditChannelHeaderModal: typeof EditChannelHeaderModal;
         Avatar: typeof Avatar;
+        Avatars: typeof Avatars;
         imageURLForUser: typeof imageURLForUser;
         BotBadge: typeof BotTag;
         StartTrialFormModal: typeof StartTrialFormModal;
@@ -199,6 +201,7 @@ window.Components = {
     ChannelNotificationsModal,
     EditChannelHeaderModal,
     Avatar,
+    Avatars,
     imageURLForUser,
     BotBadge: BotTag,
     StartTrialFormModal,


### PR DESCRIPTION
#### Summary

Plugins could already use core's `Avatar` via `window.Components`, but not `Avatars` — the
overlapping stack with its "+N" overflow chip and profile popovers. As a result the Docs plugin
reimplemented the stack and reintroduced styling bugs core had already fixed (MM-70358: a
translucent overflow chip, a hardcoded overlap offset, no profile popovers, no keyboard access).

This publishes `Avatars` alongside `Avatar` so plugins consume the canonical component instead of
copying it.

QA: no user-visible change in the web app. Verified `window.Components.Avatars` is defined
(`export.test.ts`).

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-70358

#### Release Note

```release-note
Exposed the Avatars component to plugins via window.Components.
```
