### PR TITLE
Ensure global relay settings are correctly marked as set by env var

### DIFF
--- a/server/channels/api4/config_test.go
+++ b/server/channels/api4/config_test.go
@@ -663,6 +663,33 @@ func TestGetEnvironmentConfig(t *testing.T) {
 	})
 }
 
+func TestGetEnvironmentConfigGlobalRelayNested(t *testing.T) {
+	// These MUST be t.Setenv (not UpdateConfig) because GetEnvironmentConfig
+	// returns only config values sourced from environment variables.
+	// t.Setenv prevents t.Parallel — intentionally serial.
+	t.Setenv("MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_SMTPUSERNAME", "envUser")
+	t.Setenv("MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_EMAILADDRESS", "env@example.com")
+
+	th := Setup(t)
+
+	envConfig, _, err := th.SystemAdminClient.GetEnvironmentConfig(context.Background())
+	require.NoError(t, err)
+
+	messageExportSettings, ok := envConfig["MessageExportSettings"].(map[string]any)
+	require.True(t, ok, "should've returned MessageExportSettings")
+
+	globalRelaySettings, ok := messageExportSettings["GlobalRelaySettings"].(map[string]any)
+	require.True(t, ok, "should've returned nested GlobalRelaySettings for pointer-to-struct env overrides")
+
+	smtpUsername, ok := globalRelaySettings["SMTPUsername"].(bool)
+	require.True(t, ok, "should've returned GlobalRelaySettings.SMTPUsername as a boolean")
+	require.True(t, smtpUsername)
+
+	emailAddress, ok := globalRelaySettings["EmailAddress"].(bool)
+	require.True(t, ok, "should've returned GlobalRelaySettings.EmailAddress as a boolean")
+	require.True(t, emailAddress)
+}
+
 func TestGetClientConfig(t *testing.T) {
 	th := Setup(t)
 

--- a/server/config/environment.go
+++ b/server/config/environment.go
@@ -114,8 +114,16 @@ func generateEnvironmentMapWithBaseKey(env map[string]string, rType reflect.Type
 		if filter != nil && !filter(rField) {
 			continue
 		}
-		if rField.Type.Kind() == reflect.Struct {
-			if val := generateEnvironmentMapWithBaseKey(env, rField.Type, base+"_"+rField.Name, filter); val != nil {
+
+		fieldType := rField.Type
+		// Recurse into pointer-to-struct fields (e.g. MessageExportSettings.GlobalRelaySettings)
+		// the same way applyEnvKey unwraps pointers before descending.
+		if fieldType.Kind() == reflect.Pointer && fieldType.Elem().Kind() == reflect.Struct {
+			fieldType = fieldType.Elem()
+		}
+
+		if fieldType.Kind() == reflect.Struct {
+			if val := generateEnvironmentMapWithBaseKey(env, fieldType, base+"_"+rField.Name, filter); val != nil {
 				mapRepresentation[rField.Name] = val
 			}
 		} else {

--- a/server/config/environment_test.go
+++ b/server/config/environment_test.go
@@ -6,6 +6,7 @@ package config
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/model"
@@ -199,4 +200,74 @@ func TestRemoveEnvOverrides(t *testing.T) {
 			require.Equal(t, testCase.expectedConfig, applyEnvironmentMap(testCase.inputConfig, testCase.env))
 		})
 	}
+}
+
+func TestGenerateEnvironmentMapPointerToStruct(t *testing.T) {
+	env := map[string]string{
+		"MM_MESSAGEEXPORTSETTINGS_ENABLEEXPORT":                             "true",
+		"MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_CUSTOMERTYPE":         "CUSTOM",
+		"MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_SMTPUSERNAME":         "envUser",
+		"MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_SMTPPASSWORD":         "envPassword",
+		"MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_EMAILADDRESS":         "env@example.com",
+		"MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_CUSTOMSMTPSERVERNAME": "feeds.example.com",
+		"MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_CUSTOMSMTPPORT":       "2525",
+		"MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_CUSTOMHEADERNAME":     "X-Custom",
+		"MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_CUSTOMHEADERVALUE":    "Message",
+	}
+
+	overrides := generateEnvironmentMap(env, nil)
+	require.NotNil(t, overrides)
+
+	messageExportSettings, ok := overrides["MessageExportSettings"].(map[string]any)
+	require.True(t, ok, "expected MessageExportSettings override map")
+	assert.Equal(t, true, messageExportSettings["EnableExport"])
+
+	globalRelaySettings, ok := messageExportSettings["GlobalRelaySettings"].(map[string]any)
+	require.True(t, ok, "expected nested GlobalRelaySettings override map for pointer-to-struct fields")
+	assert.Equal(t, map[string]any{
+		"CustomerType":         true,
+		"SMTPUsername":         true,
+		"SMTPPassword":         true,
+		"EmailAddress":         true,
+		"CustomSMTPServerName": true,
+		"CustomSMTPPort":       true,
+		"CustomHeaderName":     true,
+		"CustomHeaderValue":    true,
+	}, globalRelaySettings)
+}
+
+func TestRemoveEnvOverridesPointerToStruct(t *testing.T) {
+	cfgWithoutEnv := modifiedDefault(func(in *model.Config) {
+		*in.MessageExportSettings.GlobalRelaySettings.SMTPUsername = "storedUser"
+		*in.MessageExportSettings.GlobalRelaySettings.EmailAddress = "stored@example.com"
+	})
+
+	cfgWithEnv := cfgWithoutEnv.Clone()
+	*cfgWithEnv.MessageExportSettings.GlobalRelaySettings.SMTPUsername = "envUser"
+	*cfgWithEnv.MessageExportSettings.GlobalRelaySettings.EmailAddress = "env@example.com"
+
+	envOverrides := generateEnvironmentMap(map[string]string{
+		"MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_SMTPUSERNAME": "envUser",
+		"MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_EMAILADDRESS": "env@example.com",
+	}, nil)
+	require.NotNil(t, envOverrides)
+
+	cleaned := removeEnvOverrides(cfgWithEnv, cfgWithoutEnv, envOverrides)
+	assert.Equal(t, "storedUser", *cleaned.MessageExportSettings.GlobalRelaySettings.SMTPUsername)
+	assert.Equal(t, "stored@example.com", *cleaned.MessageExportSettings.GlobalRelaySettings.EmailAddress)
+}
+
+func TestApplyEnvironmentMapPointerToStruct(t *testing.T) {
+	input := modifiedDefault(func(in *model.Config) {
+		*in.MessageExportSettings.GlobalRelaySettings.SMTPUsername = "storedUser"
+		*in.MessageExportSettings.GlobalRelaySettings.CustomerType = "A9"
+	})
+
+	applied := applyEnvironmentMap(input, map[string]string{
+		"MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_SMTPUSERNAME": "envUser",
+		"MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_CUSTOMERTYPE": "CUSTOM",
+	})
+
+	assert.Equal(t, "envUser", *applied.MessageExportSettings.GlobalRelaySettings.SMTPUsername)
+	assert.Equal(t, "CUSTOM", *applied.MessageExportSettings.GlobalRelaySettings.CustomerType)
 }


### PR DESCRIPTION
#### Summary
When Global Relay compliance export settings are configured via environment variables (e.g. MM_MESSAGEEXPORTSETTINGS_GLOBALRELAYSETTINGS_SMTPUSERNAME), the System Console Compliance Export page still shows those fields as editable and does not display the “set by environment variable” warning.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70499

#### Screenshots
<!-- Include screenshots or GIFs for UI changes. -->

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note
Global Relay settings are now correctly marked as set by env var
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change updates shared environment configuration logic and may affect nested pointer-based configuration fields. Automated tests cover the affected paths.

**QA Recommendation:** Manual QA is not required. Run the automated test suite.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->