### PR TITLE
Automated cherry pick of #38179

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -36,7 +36,6 @@ require (
 	github.com/jaytaylor/html2text v0.0.0-20230321000545-74c2419ad056
 	github.com/jmoiron/sqlx v1.4.0
 	github.com/klauspost/compress v1.18.0
-	github.com/ledongthuc/pdf v0.0.0-20250511090121-5959a4027728
 	github.com/lib/pq v1.10.9
 	github.com/mattermost/go-i18n v1.11.1-0.20211013152124-5c415071e404
 	github.com/mattermost/gosaml2 v0.10.0
@@ -44,6 +43,7 @@ require (
 	github.com/mattermost/logr/v2 v2.0.22
 	github.com/mattermost/mattermost/server/public v0.1.12
 	github.com/mattermost/morph v1.1.0
+	github.com/mattermost/pdf v0.0.0-20260828123129-5b7509a6ca01
 	github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0
 	github.com/mattermost/squirrel v0.5.0
 	github.com/mholt/archives v0.1.5
@@ -255,6 +255,3 @@ replace github.com/olekukonko/tablewriter => github.com/olekukonko/tablewriter v
 
 // See MM-66167, MM-68222 for more details.
 replace github.com/vmihailenco/msgpack/v5 => github.com/mattermost/msgpack/v5 v5.0.0-20260408165622-cadfad56a815
-
-// See MM-63434 for more details.
-replace github.com/ledongthuc/pdf => github.com/jgheithcock/pdf v0.0.0-20260404175814-28cd6530c1fe

--- a/server/go.sum
+++ b/server/go.sum
@@ -352,8 +352,6 @@ github.com/jaytaylor/html2text v0.0.0-20180606194806-57d518f124b0/go.mod h1:CVKl
 github.com/jaytaylor/html2text v0.0.0-20230321000545-74c2419ad056 h1:iCHtR9CQyktQ5+f3dMVZfwD2KWJUgm7M0gdL9NGr8KA=
 github.com/jaytaylor/html2text v0.0.0-20230321000545-74c2419ad056/go.mod h1:CVKlgaMiht+LXvHG173ujK6JUhZXKb2u/BQtjPDIvyk=
 github.com/jellevandenhooff/dkim v0.0.0-20150330215556-f50fe3d243e1/go.mod h1:E0B/fFc00Y+Rasa88328GlI/XbtyysCtTHZS8h7IrBU=
-github.com/jgheithcock/pdf v0.0.0-20260404175814-28cd6530c1fe h1:9GAP+hdboArdSUwi82IXaNd+Qq8+cGFQh7xAcwZNN+s=
-github.com/jgheithcock/pdf v0.0.0-20260404175814-28cd6530c1fe/go.mod h1:1fEHWurg7pvf5SG6XNE5Q8UZmOwex51Mkx3SLhrW5B4=
 github.com/jhump/protoreflect v1.15.1 h1:HUMERORf3I3ZdX05WaQ6MIpd/NJ434hTp5YiKgfCL6c=
 github.com/jhump/protoreflect v1.15.1/go.mod h1:jD/2GMKKE6OqX8qTjhADU1e6DShO+gavG9e0Q693nKo=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -425,6 +423,8 @@ github.com/mattermost/morph v1.1.0 h1:Q9vrJbeM3s2jfweGheq12EFIzdNp9a/6IovcbvOQ6C
 github.com/mattermost/morph v1.1.0/go.mod h1:gD+EaqX2UMyyuzmF4PFh4r33XneQ8Nzi+0E8nXjMa3A=
 github.com/mattermost/msgpack/v5 v5.0.0-20260408165622-cadfad56a815 h1:uOi89NvrFmDngqMKjlLDxi+MNzJQLA3TqcU2p8czv34=
 github.com/mattermost/msgpack/v5 v5.0.0-20260408165622-cadfad56a815/go.mod h1:GaZTsDaehaPpQVyxrf5mtQlH+pc21PIudVV/E3rRQok=
+github.com/mattermost/pdf v0.0.0-20260828123129-5b7509a6ca01 h1:bXDcd5MREhXeaY+Gn1qixqN91GEClojJBG9v98cbB6s=
+github.com/mattermost/pdf v0.0.0-20260828123129-5b7509a6ca01/go.mod h1:pNks5J7leEpCnswIJaGfqiz/MQ0lExHgKl+A53aEXrg=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0 h1:G9tL6JXRBMzjuD1kkBtcnd42kUiT6QDwxfFYu7adM6o=
 github.com/mattermost/rsc v0.0.0-20160330161541-bbaefb05eaa0/go.mod h1:nV5bfVpT//+B1RPD2JvRnxbkLmJEYXmRaaVl15fsXjs=
 github.com/mattermost/squirrel v0.5.0 h1:81QPS0aA+inQbpA7Pzmv6O9sWwB6VaBh/VYw3oJf8ZY=

--- a/server/platform/services/docextractor/pdf.go
+++ b/server/platform/services/docextractor/pdf.go
@@ -12,7 +12,7 @@ import (
 	"path"
 	"strings"
 
-	"github.com/ledongthuc/pdf"
+	"github.com/mattermost/pdf"
 
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
 )

--- a/server/platform/services/docextractor/pdf.go
+++ b/server/platform/services/docextractor/pdf.go
@@ -5,6 +5,7 @@ package docextractor
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -62,7 +63,7 @@ func (pe *pdfExtractor) Extract(filename string, r io.ReadSeeker, maxFileSize in
 	}
 
 	var buf bytes.Buffer
-	b, err := reader.GetPlainText()
+	b, err := reader.GetPlainText(context.Background())
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
#### Summary
Cherry pick of #38179 on release-10.11.

#### Conflict Resolution Changes
- Replaced the PDF module path and import with `github.com/mattermost/pdf` on release-10.11.
- Removed the old PDF replacement directive and regenerated module metadata.
- Added a background context for the updated PDF reader API.

#### Release Note
```release-note
NONE
```