### PR TITLE
MM-70501 new caller id for access control sync job

### DIFF
--- a/server/channels/app/properties/access_control.go
+++ b/server/channels/app/properties/access_control.go
@@ -769,11 +769,15 @@ func (h *AccessControlHook) getAccessMode(field *model.PropertyField) string {
 }
 
 // hasUnrestrictedFieldReadAccess checks if the given caller can read a PropertyField without restrictions.
-// Returns true if the caller has unrestricted read access (public field or source plugin).
+// Returns true if the caller has unrestricted read access (public field, source plugin, or access control sync job).
 func (h *AccessControlHook) hasUnrestrictedFieldReadAccess(field *model.PropertyField, callerID string) bool {
 	accessMode := h.getAccessMode(field)
 
 	if accessMode == model.PropertyAccessModePublic {
+		return true
+	}
+
+	if callerID == model.CallerIDAccessControlSync {
 		return true
 	}
 

--- a/server/channels/app/properties/access_control_field_test.go
+++ b/server/channels/app/properties/access_control_field_test.go
@@ -29,6 +29,7 @@ func TestGetPropertyFieldReadAccess(t *testing.T) {
 	rctx2 := RequestContextWithCallerID(th.Context, pluginID2)
 	rctxUser := RequestContextWithCallerID(th.Context, userID)
 	rctxTestPlugin := RequestContextWithCallerID(th.Context, "test-plugin")
+	rctxSync := RequestContextWithCallerID(th.Context, model.CallerIDAccessControlSync)
 
 	t.Run("public field - any caller can read without filtering", func(t *testing.T) {
 		field := &model.PropertyField{
@@ -175,6 +176,63 @@ func TestGetPropertyFieldReadAccess(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, created.ID, retrieved.ID)
 		assert.Empty(t, retrieved.Attrs[model.PropertyFieldAttributeOptions].([]any))
+	})
+
+	t.Run("source_only field - access control sync caller gets all options", func(t *testing.T) {
+		field := &model.PropertyField{
+			GroupID:    th.CPAGroupID,
+			Name:       "source-only-field-5",
+			Type:       model.PropertyFieldTypeRank,
+			ObjectType: model.PropertyFieldObjectTypeUser,
+			TargetType: string(model.PropertyFieldTargetLevelSystem),
+			Attrs: model.StringInterface{
+				model.PropertyAttrsAccessMode: model.PropertyAccessModeSourceOnly,
+				model.PropertyAttrsProtected:  true,
+				model.PropertyFieldAttributeOptions: []any{
+					map[string]any{"id": "opt1", "value": "Secret Option 1", "rank": 1},
+					map[string]any{"id": "opt2", "value": "Secret Option 2", "rank": 2},
+				},
+			},
+		}
+		created, err := th.service.CreatePropertyField(rctx1, field)
+		require.NoError(t, err)
+
+		// The membership sync jobs evaluate policy rules on behalf of the
+		// server and hold no values of their own, so they must read the field
+		// unfiltered — an empty options list makes a rule referencing this
+		// field fail closed and evict every member it governs.
+		retrieved, err := th.service.GetPropertyField(rctxSync, th.CPAGroupID, created.ID)
+		require.NoError(t, err)
+		assert.Equal(t, created.ID, retrieved.ID)
+		assert.Len(t, retrieved.Attrs[model.PropertyFieldAttributeOptions].([]any), 2)
+	})
+
+	t.Run("shared_only field - access control sync caller gets all options", func(t *testing.T) {
+		field := &model.PropertyField{
+			GroupID:    th.CPAGroupID,
+			Name:       "shared-only-field-sync",
+			Type:       model.PropertyFieldTypeRank,
+			ObjectType: model.PropertyFieldObjectTypeUser,
+			TargetType: string(model.PropertyFieldTargetLevelSystem),
+			Attrs: model.StringInterface{
+				model.PropertyAttrsAccessMode: model.PropertyAccessModeSharedOnly,
+				model.PropertyAttrsProtected:  true,
+				model.PropertyFieldAttributeOptions: []any{
+					map[string]any{"id": "opt1", "value": "Secret Option 1", "rank": 1},
+					map[string]any{"id": "opt2", "value": "Secret Option 2", "rank": 2},
+				},
+			},
+		}
+		created, err := th.service.CreatePropertyField(rctx1, field)
+		require.NoError(t, err)
+
+		// shared_only normally filters options down to the ones the caller
+		// holds. The sync caller holds none, so without the exemption it would
+		// see an empty list rather than every option.
+		retrieved, err := th.service.GetPropertyField(rctxSync, th.CPAGroupID, created.ID)
+		require.NoError(t, err)
+		assert.Equal(t, created.ID, retrieved.ID)
+		assert.Len(t, retrieved.Attrs[model.PropertyFieldAttributeOptions].([]any), 2)
 	})
 
 	t.Run("shared_only field - caller with values sees filtered options", func(t *testing.T) {

--- a/server/public/model/property_access_control.go
+++ b/server/public/model/property_access_control.go
@@ -16,8 +16,8 @@ const AccessControlCallerIDContextKey AccessControlContextKey = "access_control_
 // SCIM plugin) can subdivide its access per external system (e.g. "entra").
 const AccessControlScopeContextKey AccessControlContextKey = "access_control_scope"
 
-// Well-known caller IDs for internal services that need to write property
-// values on synced fields. These are set on the request context by the
+// Well-known caller IDs for internal services that need privileged access to
+// property values on synced fields. These are set on the request context by the
 // respective sync services so that the access control hook can identify them.
 //
 // The "system:" prefix contains a colon, which is not a valid character in a
@@ -30,9 +30,10 @@ const AccessControlScopeContextKey AccessControlContextKey = "access_control_sco
 // Session().IsUnrestricted() is true, so the attribute validation hook's
 // permission checker can grant admin privileges without a user lookup.
 const (
-	CallerIDLDAPSync   = "system:ldap_sync"
-	CallerIDSAMLSync   = "system:saml_sync"
-	CallerIDLocalAdmin = "system:local_admin"
+	CallerIDLDAPSync          = "system:ldap_sync"
+	CallerIDSAMLSync          = "system:saml_sync"
+	CallerIDAccessControlSync = "system:access_control_sync"
+	CallerIDLocalAdmin        = "system:local_admin"
 )
 
 // WithCallerID adds the caller ID to a context.Context for access control purposes.


### PR DESCRIPTION
#### Summary
This PR is part of a fix for MM-70501, in which a trusted `CallerID` is added to the Request Context of Access Control Sync jobs (i.e. ABAC channel membership sync and team membership sync).  This new `CallerID` is defined (similar to `ldap_sync` and `saml_sync` predecessors), and then ensures that requests with this `CallerID` are granted unfettered **read** access to protected property fields, so they can get the option details necessary to process policy CEL expressions.  This access requirement became relevant when Rank properties needed to be looked up in order get their options' `rank` values to evaluate expressions.

The business logic fix is in the `enterprise` repo - this PR needs to be merged first to add the new CallerID definition.  It is safe to merge this PR first as it only adds a new CallerID definition and the new behavior is only for a caller that uses it.

Steps to reproduce are in the Jira ticket.

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-70501

#### Release Note
```release-note
Fixed an issue in which policies with protected Rank attributes would result in every member being removed from the enforced channel or team
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change affects authorization logic and protected property reads. Tests cover the new caller ID and protected field access, but policy evaluation remains a sensitive path.

**QA Recommendation:** Manual QA is not required. Rely on automated tests and targeted policy checks.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->