### PR TITLE
[GH-36849] Count User Attributes text limit in characters, not bytes

### DIFF
--- a/server/channels/app/properties/access_control_attribute_validation.go
+++ b/server/channels/app/properties/access_control_attribute_validation.go
@@ -637,7 +637,7 @@ func (h *AccessControlAttributeValidationHook) validateValueAgainstField(field *
 		if err := json.Unmarshal(value.Value, &str); err != nil {
 			return fmt.Errorf("expected string value: %w", err)
 		}
-		if len(strings.TrimSpace(str)) > model.PropertyFieldValueTypeTextMaxLength {
+		if utf8.RuneCountInString(strings.TrimSpace(str)) > model.PropertyFieldValueTypeTextMaxLength {
 			return fmt.Errorf("text value exceeds maximum length of %d characters", model.PropertyFieldValueTypeTextMaxLength)
 		}
 

--- a/server/channels/app/properties/access_control_attribute_validation_test.go
+++ b/server/channels/app/properties/access_control_attribute_validation_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
@@ -1042,6 +1043,59 @@ func TestAccessControlAttributeValidationHook(t *testing.T) {
 			Value:      json.RawMessage(`"` + string(longValue) + `"`),
 		}
 		_, upsertErr := th.service.UpsertPropertyValue(th.Context, value)
+		require.Error(t, upsertErr)
+		assert.Contains(t, upsertErr.Error(), "maximum length")
+	})
+
+	t.Run("text — max length is counted in characters, not bytes", func(t *testing.T) {
+		field := th.CreatePropertyFieldDirect(t, &model.PropertyField{
+			GroupID:    group.ID,
+			Name:       "text_field_" + model.NewId(),
+			Type:       model.PropertyFieldTypeText,
+			TargetType: "system",
+			ObjectType: "user",
+		})
+
+		// Multibyte value that fits the documented 64-character limit but
+		// exceeds it when the limit is applied to bytes: LDAP/SAML sync of
+		// non-Latin attributes hits this. See issue #36849.
+		multibyte := "Развитие и оценка компетенций по работе с клиентами"
+		require.LessOrEqual(t, utf8.RuneCountInString(multibyte), model.PropertyFieldValueTypeTextMaxLength)
+		require.Greater(t, len(multibyte), model.PropertyFieldValueTypeTextMaxLength)
+
+		value := &model.PropertyValue{
+			GroupID:    group.ID,
+			FieldID:    field.ID,
+			TargetID:   model.NewId(),
+			TargetType: "user",
+			Value:      json.RawMessage(`"` + multibyte + `"`),
+		}
+		_, upsertErr := th.service.UpsertPropertyValue(th.Context, value)
+		require.NoError(t, upsertErr)
+
+		// Exactly at the limit is still accepted, so the fix cannot be an
+		// off-by-one that trades one wrong boundary for another.
+		atLimit := &model.PropertyValue{
+			GroupID:    group.ID,
+			FieldID:    field.ID,
+			TargetID:   model.NewId(),
+			TargetType: "user",
+			Value:      json.RawMessage(`"` + strings.Repeat("я", model.PropertyFieldValueTypeTextMaxLength) + `"`),
+		}
+		_, upsertErr = th.service.UpsertPropertyValue(th.Context, atLimit)
+		require.NoError(t, upsertErr)
+
+		// The limit still applies: the same script over the character limit
+		// must be rejected, so the fix cannot be "drop the check".
+		tooLong := strings.Repeat("я", model.PropertyFieldValueTypeTextMaxLength+1)
+		overLimit := &model.PropertyValue{
+			GroupID:    group.ID,
+			FieldID:    field.ID,
+			TargetID:   model.NewId(),
+			TargetType: "user",
+			Value:      json.RawMessage(`"` + tooLong + `"`),
+		}
+		_, upsertErr = th.service.UpsertPropertyValue(th.Context, overLimit)
 		require.Error(t, upsertErr)
 		assert.Contains(t, upsertErr.Error(), "maximum length")
 	})


### PR DESCRIPTION
#### Summary

The text limit for User Attributes is documented as 64 characters, but it was measured with `len()`, so it was applied to bytes: 32 characters for Cyrillic, ~16 for CJK. LDAP/SAML sync rejected values well inside the documented limit. It now counts runes, as the rest of this file already does.

Tests: 51-character Cyrillic value accepted, 64 accepted, 65 rejected.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/36849

#### Release Note

```release-note
Fixed User Attributes text values being limited to 64 bytes instead of 64 characters, which rejected non-Latin values during LDAP/SAML sync.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change affects text validation during LDAP/SAML attribute synchronization. Automated tests cover Unicode values below, at, and above the 64-character limit.

**QA Recommendation:** Manual QA is not required. Automated coverage is sufficient.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->