### PR TITLE
[GH-35782] Document CPA value endpoints with their actual object shape

### DIFF
--- a/api/v4/source/custom_profile_attributes.yaml
+++ b/api/v4/source/custom_profile_attributes.yaml
@@ -300,42 +300,48 @@
         content:
           application/json:
             schema:
-              type: array
-              items:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  value:
-                    oneOf:
-                      - type: string
-                      - type: array
-                        items:
-                          type: string
+              type: object
+              description: |
+                Object keyed by Custom Profile Attribute field ID. Each value is
+                a string, an array of strings for `multiselect` and `multiuser`
+                fields, or `null` to clear the value.
+              additionalProperties:
+                nullable: true
+                oneOf:
+                  - type: string
+                  - type: array
+                    items:
+                      type: string
+              example:
+                eqyzt9guiibnxreinsnyruep6r: dxgbcfk9jpgmzb3dc9gtkzxm6o
       responses:
         "200":
           description: Custom Profile Attribute values patch successful
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    value:
-                      oneOf:
-                        - type: string
-                        - type: array
-                          items:
-                            type: string
+                type: object
+                description: |
+                  Object keyed by Custom Profile Attribute field ID. Each value is
+                  a string, an array of strings for `multiselect` and `multiuser`
+                  fields, or `null` for a value that was cleared.
+                additionalProperties:
+                  nullable: true
+                  oneOf:
+                    - type: string
+                    - type: array
+                      items:
+                        type: string
+                example:
+                  eqyzt9guiibnxreinsnyruep6r: dxgbcfk9jpgmzb3dc9gtkzxm6o
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
           $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
   "/api/v4/custom_profile_attributes/group":
     get:
       tags:
@@ -390,15 +396,21 @@
           description: Custom Profile Attribute values fetch successful. Result may be empty.
           content:
             application/json:
-            schema:
-              type: array
-              items:
+              schema:
                 type: object
-                properties:
-                  field_id:
-                    type: string
-                  value:
-                    type: string
+                description: |
+                  Object keyed by Custom Profile Attribute field ID. Each value is
+                  a string, an array of strings for `multiselect` and `multiuser`
+                  fields, or `null` for a value that was cleared.
+                additionalProperties:
+                  nullable: true
+                  oneOf:
+                    - type: string
+                    - type: array
+                      items:
+                        type: string
+                example:
+                  eqyzt9guiibnxreinsnyruep6r: dxgbcfk9jpgmzb3dc9gtkzxm6o
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -433,38 +445,44 @@
         content:
           application/json:
             schema:
-              type: array
-              items:
-                type: object
-                properties:
-                  id:
-                    type: string
-                  value:
-                    oneOf:
-                      - type: string
-                      - type: array
-                        items:
-                          type: string
+              type: object
+              description: |
+                Object keyed by Custom Profile Attribute field ID. Each value is
+                a string, an array of strings for `multiselect` and `multiuser`
+                fields, or `null` to clear the value.
+              additionalProperties:
+                nullable: true
+                oneOf:
+                  - type: string
+                  - type: array
+                    items:
+                      type: string
+              example:
+                eqyzt9guiibnxreinsnyruep6r: dxgbcfk9jpgmzb3dc9gtkzxm6o
       responses:
         '200':
           description: Custom profile attribute values updated successfully
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    id:
-                      type: string
-                    value:
-                      oneOf:
-                        - type: string
-                        - type: array
-                          items:
-                            type: string
+                type: object
+                description: |
+                  Object keyed by Custom Profile Attribute field ID. Each value is
+                  a string, an array of strings for `multiselect` and `multiuser`
+                  fields, or `null` for a value that was cleared.
+                additionalProperties:
+                  nullable: true
+                  oneOf:
+                    - type: string
+                    - type: array
+                      items:
+                        type: string
+                example:
+                  eqyzt9guiibnxreinsnyruep6r: dxgbcfk9jpgmzb3dc9gtkzxm6o
         '400':
           $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
         '403':
           $ref: '#/components/responses/Forbidden'
         '404':

--- a/api/v4/source/custom_profile_attributes.yaml
+++ b/api/v4/source/custom_profile_attributes.yaml
@@ -306,14 +306,18 @@
                 a string, an array of strings for `multiselect` and `multiuser`
                 fields, or `null` to clear the value.
               additionalProperties:
-                nullable: true
                 oneOf:
                   - type: string
+                    nullable: true
                   - type: array
                     items:
                       type: string
               example:
-                eqyzt9guiibnxreinsnyruep6r: dxgbcfk9jpgmzb3dc9gtkzxm6o
+                eqyzt9guiibnxreinsnyruep6r: Backend
+                x8p3mwqk9zdrbn6yhtsjaf1cve:
+                  - dxgbcfk9jpgmzb3dc9gtkzxm6o
+                  - t9wq3rzcyxbn8kmhped5uafj7o
+                k2rdynm7bwqtxgcp5hzefa9su3: null
       responses:
         "200":
           description: Custom Profile Attribute values patch successful
@@ -326,14 +330,18 @@
                   a string, an array of strings for `multiselect` and `multiuser`
                   fields, or `null` for a value that was cleared.
                 additionalProperties:
-                  nullable: true
                   oneOf:
                     - type: string
+                      nullable: true
                     - type: array
                       items:
                         type: string
                 example:
-                  eqyzt9guiibnxreinsnyruep6r: dxgbcfk9jpgmzb3dc9gtkzxm6o
+                  eqyzt9guiibnxreinsnyruep6r: Backend
+                  x8p3mwqk9zdrbn6yhtsjaf1cve:
+                    - dxgbcfk9jpgmzb3dc9gtkzxm6o
+                    - t9wq3rzcyxbn8kmhped5uafj7o
+                  k2rdynm7bwqtxgcp5hzefa9su3: null
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -403,14 +411,18 @@
                   a string, an array of strings for `multiselect` and `multiuser`
                   fields, or `null` for a value that was cleared.
                 additionalProperties:
-                  nullable: true
                   oneOf:
                     - type: string
+                      nullable: true
                     - type: array
                       items:
                         type: string
                 example:
-                  eqyzt9guiibnxreinsnyruep6r: dxgbcfk9jpgmzb3dc9gtkzxm6o
+                  eqyzt9guiibnxreinsnyruep6r: Backend
+                  x8p3mwqk9zdrbn6yhtsjaf1cve:
+                    - dxgbcfk9jpgmzb3dc9gtkzxm6o
+                    - t9wq3rzcyxbn8kmhped5uafj7o
+                  k2rdynm7bwqtxgcp5hzefa9su3: null
         "400":
           $ref: "#/components/responses/BadRequest"
         "401":
@@ -451,14 +463,18 @@
                 a string, an array of strings for `multiselect` and `multiuser`
                 fields, or `null` to clear the value.
               additionalProperties:
-                nullable: true
                 oneOf:
                   - type: string
+                    nullable: true
                   - type: array
                     items:
                       type: string
               example:
-                eqyzt9guiibnxreinsnyruep6r: dxgbcfk9jpgmzb3dc9gtkzxm6o
+                eqyzt9guiibnxreinsnyruep6r: Backend
+                x8p3mwqk9zdrbn6yhtsjaf1cve:
+                  - dxgbcfk9jpgmzb3dc9gtkzxm6o
+                  - t9wq3rzcyxbn8kmhped5uafj7o
+                k2rdynm7bwqtxgcp5hzefa9su3: null
       responses:
         '200':
           description: Custom profile attribute values updated successfully
@@ -471,14 +487,18 @@
                   a string, an array of strings for `multiselect` and `multiuser`
                   fields, or `null` for a value that was cleared.
                 additionalProperties:
-                  nullable: true
                   oneOf:
                     - type: string
+                      nullable: true
                     - type: array
                       items:
                         type: string
                 example:
-                  eqyzt9guiibnxreinsnyruep6r: dxgbcfk9jpgmzb3dc9gtkzxm6o
+                  eqyzt9guiibnxreinsnyruep6r: Backend
+                  x8p3mwqk9zdrbn6yhtsjaf1cve:
+                    - dxgbcfk9jpgmzb3dc9gtkzxm6o
+                    - t9wq3rzcyxbn8kmhped5uafj7o
+                  k2rdynm7bwqtxgcp5hzefa9su3: null
         '400':
           $ref: '#/components/responses/BadRequest'
         '401':


### PR DESCRIPTION
#### Summary

The CPA value endpoints take and return an object keyed by field ID (`{"<field_id>": "<value>"}`), but the spec documented an array of `{id, value}`, so a request written from the docs fails with `400 Invalid or missing value in request body`. The array shape belongs to the generic property values API, which uses `field_id` and is documented correctly.

Corrected the request and response schemas of `PatchCPAValues` and `PatchCPAValuesForUser` and the response of `ListCPAValues`. Values are a string, an array of strings for `multiselect` and `multiuser` fields, or `null` to clear a value — which mmctl relies on. `ListCPAValues` also had `schema` indented as a sibling of `application/json`, so its response had no schema at all.

While in the file: the shared handler returns 404 for an unknown field, which only the user-scoped endpoint documented, and the user-scoped endpoint was missing 401.

Verified against the handlers in `channels/api4/custom_profile_attributes.go` and with `make build-v4`, which validates the bundled spec.

#### Ticket Link

Fixes https://github.com/mattermost/mattermost/issues/35782

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The changes update public API schemas for three CPA endpoints. The API implementation is unchanged, but clients that depend on the previous schemas may need updates.

**QA Recommendation:** Skip manual QA. The change is documentation-only, and build validation provides sufficient coverage.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->