### PR TITLE
fix: accept numeric message attachment timestamps

### DIFF
--- a/server/public/model/message_attachment.go
+++ b/server/public/model/message_attachment.go
@@ -33,7 +33,7 @@ type MessageAttachment struct {
 	ThumbURL   string                    `json:"thumb_url"`
 	Footer     string                    `json:"footer"`
 	FooterIcon string                    `json:"footer_icon"`
-	Timestamp  any                       `json:"ts"` // This is either a string or an int64
+	Timestamp  any                       `json:"ts"` // This is either a string, int64, or float64
 	Actions    []*PostAction             `json:"actions,omitempty"`
 }
 
@@ -96,7 +96,7 @@ func (s *MessageAttachment) IsValid() error {
 		case string, int64, float64:
 			// Valid types
 		default:
-			multiErr = multierror.Append(multiErr, fmt.Errorf("timestamp must be either a string or int64"))
+			multiErr = multierror.Append(multiErr, fmt.Errorf("timestamp must be either a string, int64, or float64"))
 		}
 	}
 

--- a/server/public/model/message_attachment.go
+++ b/server/public/model/message_attachment.go
@@ -90,10 +90,10 @@ func (s *MessageAttachment) IsValid() error {
 		multiErr = multierror.Append(multiErr, fmt.Errorf("invalid footer icon URL"))
 	}
 
-	// Validate timestamp is either string or int64
+	// Validate timestamp is either string, int64, or float64
 	if s.Timestamp != nil {
 		switch s.Timestamp.(type) {
-		case string, int64:
+		case string, int64, float64:
 			// Valid types
 		default:
 			multiErr = multierror.Append(multiErr, fmt.Errorf("timestamp must be either a string or int64"))

--- a/server/public/model/message_attachment_test.go
+++ b/server/public/model/message_attachment_test.go
@@ -104,7 +104,7 @@ func TestMessageAttachment_IsValid(t *testing.T) {
 			attachment: &MessageAttachment{
 				Timestamp: []string{"invalid"},
 			},
-			wantErr: "timestamp must be either a string or int64",
+			wantErr: "timestamp must be either a string, int64, or float64",
 		},
 		"valid timestamp string": {
 			attachment: &MessageAttachment{

--- a/server/public/model/message_attachment_test.go
+++ b/server/public/model/message_attachment_test.go
@@ -154,6 +154,12 @@ func TestMessageAttachment_IsValid(t *testing.T) {
 			},
 			wantErr: "",
 		},
+		"valid timestamp float64 from JSON": {
+			attachment: &MessageAttachment{
+				Timestamp: float64(1234567890),
+			},
+			wantErr: "",
+		},
 	}
 
 	for name, tc := range tests {


### PR DESCRIPTION
#### Summary

Accepts `float64` timestamps in `MessageAttachment.IsValid`, matching how Go's `encoding/json` decodes JSON numbers stored in an `any` field.

Adds a regression test covering a numeric timestamp decoded from JSON.

QA:
- `go test ./model -run '^TestMessageAttachment_IsValid$' -count=1 -v`
- `go test ./model -count=1`

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/38127

#### Release Note

```release-note
Fixed validation of numeric timestamps in message attachments sent by JSON integrations.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to timestamp validation and adds regression coverage for JSON-decoded numeric timestamps. It does not affect authentication, persistence, or unrelated modules.

**QA Recommendation:** Manual QA can be skipped. Run the targeted automated tests.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->