### PR TITLE
MM-48001 - Increase max height of the Find Channels modal

### DIFF
--- a/webapp/channels/src/components/browse_channels/browse_channels.scss
+++ b/webapp/channels/src/components/browse_channels/browse_channels.scss
@@ -139,7 +139,7 @@
         padding: 0;
 
         .filtered-user-list {
-            height: 500px;
+            height: calc(90vh - 180px);
         }
 
         .more-modal__row {


### PR DESCRIPTION
﻿#### Summary
Fixes #21558

The Browse Channels modal (`#browseChannelsModal`) uses a static `height: 500px` on the `.filtered-user-list` container, which feels small on larger monitors and wastes available vertical space.

#### Changes
Replaced the static `500px` height with `calc(90vh - 180px)` — the same viewport-relative approach used by the global `.filtered-user-list` style and the `.more-public-direct-channels` variant in `_modal.scss`. This lets the modal scale to the viewport while keeping consistent margins for the header and filter row.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-48001

#### Screenshots
The modal now uses up to 90% of the viewport height minus header/filter chrome, compared to the previous fixed 500px.

``release-note
NONE
``
