### PR TITLE
Boost documentation results in docs site search ranking

### DIFF
--- a/docs/site/docusaurus.config.ts
+++ b/docs/site/docusaurus.config.ts
@@ -27,6 +27,13 @@ const algoliaThemeConfig =
           indexName: 'mattermost-docs',
           contextualSearch: true,
           searchPagePath: 'search',
+          searchParameters: {
+            optionalFilters: [
+              'docusaurus_tag:docs-documentation-current<score=3>',
+              'docusaurus_tag:docs-developers-current<score=2>',
+              'docusaurus_tag:docs-api-current<score=1>',
+            ],
+          },
         },
       }
     : {};


### PR DESCRIPTION
#### Summary

The docs site runs three instances (documentation, developers, API reference) against a single `mattermost-docs` Algolia index, so a query like "notifications" mixes admin/end-user pages with developer and API reference pages at equal weight.

This adds `searchParameters.optionalFilters` on the `docusaurus_tag` facet so results are ranked documentation (score 3) > developers (score 2) > API reference (score 1). Optional filters only influence ranking, so no instance is excluded from results — a developer-only match still surfaces.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to Algolia search configuration. Optional filters affect result ranking but do not exclude eligible results.

**QA Recommendation:** Manual QA is not required beyond targeted verification of shared and instance-specific search terms.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->