### PR TITLE
docs: give specialized personas a distinct visual tier on the homepage

### DIFF
--- a/docs/main/index.mdx
+++ b/docs/main/index.mdx
@@ -19,9 +19,12 @@ The secure, self-hosted collaboration platform for defense, intelligence, securi
 ]} />
 
 Or jump to one of the specialized personas:
-[SREs / Platform Operators](/for/sre) ·
-[Compliance Officers](/for/compliance-officer) ·
-[Air-Gapped Operators](/for/air-gapped-operator)
+
+<CardGrid variant="compact" cards={[
+  {title: 'SREs / Platform Operators', to: '/for/sre', description: 'Deploy, scale, observability, disaster recovery.'},
+  {title: 'Compliance Officers', to: '/for/compliance-officer', description: 'Audit evidence, exports, framework mappings.'},
+  {title: 'Air-Gapped Operators', to: '/for/air-gapped-operator', description: 'Network-isolated enclaves and the tactical edge.'},
+]} />
 
 ## The Intelligent Mission Environment (IME)
 

--- a/docs/pdf/styles/print.css
+++ b/docs/pdf/styles/print.css
@@ -5,7 +5,7 @@
  *   page.addStyleTag({ path: 'pdf/styles/print.css' })
  * before printing.
  *
- * Why this lives here instead of docs-site/src/css:
+ * Why this lives here instead of docs/site/src/css:
  *   The docs site is media-screen first; print is a publishing artifact
  *   produced by a separate pipeline. Keeping the print CSS next to the
  *   PDF builder makes the dependency obvious and lets us iterate on
@@ -13,7 +13,7 @@
  *
  * If you need to move it back into the docs site (e.g., to enable a
  * "Download PDF" button that does in-browser print-preview), drop it
- * into docs-site/src/css/ and add a `<link rel="stylesheet"
+ * into docs/site/src/css/ and add a `<link rel="stylesheet"
  * media="print" …>` reference.
  */
 
@@ -333,6 +333,33 @@ tbody tr { page-break-inside: avoid; }
 }
 [class*="card"] [class*="arrow"] { display: none !important; }
 [class*="card"] [class*="icon"]  { display: none !important; }
+
+/* CardGrid compact variant — hashed class names are `chip_*`, so the
+ * `[class*="card"]` rules above don't reach it. Collapse to the same
+ * list, one weight down. */
+[class*="chipRow"] {
+  display: block !important;
+}
+[class*="chip_"] {
+  display: block !important;
+  margin: 3pt 0 !important;
+  padding: 4pt 8pt !important;
+  border: 0.5pt solid #D6DDEC !important;
+  border-radius: 2pt !important;
+  background: #FFFFFF !important;
+  box-shadow: none !important;
+  page-break-inside: avoid;
+}
+[class*="chipTitle"] {
+  font-family: 'Archivo Black', system-ui, sans-serif;
+  font-size: 9.5pt;
+  color: #1E325C !important;
+}
+[class*="chipDescription"] {
+  font-size: 8.5pt;
+  color: #1B1D22 !important;
+}
+[class*="chipArrow"] { display: none !important; }
 
 /* ============================================================
  * OpenAPI plugin — print-specific overrides

--- a/docs/site/src/components/CardGrid/index.tsx
+++ b/docs/site/src/components/CardGrid/index.tsx
@@ -4,7 +4,7 @@ import styles from './styles.module.css';
 
 type Card = {
   title: string;
-  description: string;
+  description?: string;
   to: string;
   icon?: string;       // CompassIcon name
   meta?: string;       // small annotation (e.g., "549 endpoints")
@@ -15,6 +15,10 @@ type Card = {
  * of links — each card is a discrete navigation surface with title,
  * description, and optional Compass icon + meta.
  *
+ * The `compact` variant renders the same cards as a wrapping row of
+ * low-weight chips, for secondary destinations that need to stay
+ * scannable without competing with a primary card grid above them.
+ *
  * Usage:
  *   <CardGrid cards={[
  *     {title: 'Examples', icon: 'channels', to: '/api/examples',
@@ -22,8 +26,37 @@ type Card = {
  *     {title: 'Reference', icon: 'boards', to: '/api/reference/login',
  *      description: 'Every endpoint, grouped by resource.', meta: '549 endpoints'},
  *   ]} />
+ *
+ *   <CardGrid variant="compact" cards={[
+ *     {title: 'Compliance Officers', to: '/for/compliance-officer',
+ *      description: 'Audit evidence, exports.'},
+ *   ]} />
  */
-export default function CardGrid({cards, columns = 3}: {cards: Card[]; columns?: 2 | 3 | 4}) {
+export default function CardGrid({
+  cards,
+  columns = 3,
+  variant = 'default',
+}: {
+  cards: Card[];
+  columns?: 2 | 3 | 4;
+  variant?: 'default' | 'compact';
+}) {
+  if (variant === 'compact') {
+    return (
+      <div className={styles.chipRow}>
+        {cards.map((c, i) => (
+          <Link key={`${c.to}-${i}`} to={c.to} className={styles.chip}>
+            <span className={styles.chipBody}>
+              <span className={styles.chipTitle}>{c.title}</span>
+              {c.description && <span className={styles.chipDescription}>{c.description}</span>}
+            </span>
+            <span className={styles.chipArrow} aria-hidden>→</span>
+          </Link>
+        ))}
+      </div>
+    );
+  }
+
   return (
     <div className={`${styles.grid} ${styles[`cols${columns}`]}`}>
       {cards.map((c, i) => (

--- a/docs/site/src/components/CardGrid/styles.module.css
+++ b/docs/site/src/components/CardGrid/styles.module.css
@@ -144,3 +144,85 @@
   background: rgba(255, 255, 255, 0.08);
   color: var(--mm-color-white);
 }
+
+/* Compact variant — secondary destinations that sit under a primary
+ * card grid. Same affordances (surface, hover, arrow) at roughly half
+ * the visual weight, so they read as a second tier rather than a
+ * competing one. */
+.chipRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(230px, 1fr));
+  gap: 0.6rem;
+  margin: 0.75rem 0 2.5rem;
+}
+
+.chip {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.6rem 0.85rem;
+  background: var(--mm-bg-surface);
+  border: 1px solid var(--mm-border-subtle);
+  border-radius: 6px;
+  text-decoration: none;
+  color: inherit;
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.chip:hover {
+  background: var(--mm-bg-subtle);
+  border-color: var(--mm-border-strong);
+  text-decoration: none;
+  color: inherit;
+}
+.chip:focus-visible {
+  outline: 2px solid var(--mm-color-denim);
+  outline-offset: 2px;
+}
+
+[data-theme='dark'] .chip {
+  background: rgba(255, 255, 255, 0.035);
+  border-color: rgba(255, 255, 255, 0.14);
+}
+[data-theme='dark'] .chip:hover {
+  background: rgba(255, 255, 255, 0.06);
+  border-color: var(--mm-denim-300);
+}
+[data-theme='dark'] .chip:focus-visible {
+  outline-color: var(--mm-denim-300, #8499C5);
+}
+
+.chipBody {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.chipTitle {
+  display: block;
+  font-family: var(--mm-font-sans);
+  font-weight: 700;
+  font-size: 0.92rem;
+  letter-spacing: -0.01em;
+  color: var(--mm-text-primary);
+}
+
+.chipDescription {
+  display: block;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  color: var(--mm-text-secondary);
+}
+
+.chipArrow {
+  flex: 0 0 auto;
+  color: var(--mm-text-secondary);
+  font-size: 0.85rem;
+  transition: transform 0.15s ease, color 0.15s ease;
+}
+.chip:hover .chipArrow {
+  color: var(--mm-color-denim);
+  transform: translateX(3px);
+}
+
+[data-theme='dark'] .chip:hover .chipArrow {
+  color: var(--mm-color-white);
+}


### PR DESCRIPTION
#### Summary

The SREs / Platform Operators, Compliance Officers, and Air-Gapped Operators links sat under the four primary persona cards as plain middot-separated inline text, so they were easy to miss.

This adds a `variant="compact"` option to `CardGrid` and uses it for those three personas. The chips reuse the same surface, border, hover, and arrow affordance as the full cards, but at roughly half the height with smaller type, tighter padding, and no shadow — so they read as a second tier rather than competing with the primary grid. They lay out on an `auto-fit` grid, so the three line up in one row on desktop and reflow on narrow viewports.

Notes on blast radius:

- The default rendering path is unchanged. The compact branch is an early return; all 24 existing `<CardGrid>` call sites omit `variant` and hit the identical code as before.
- `Card.description` is now optional so title-only chips are possible. Every existing card already passes a description, so nothing renders differently.
- All CSS is new `chip*` classes appended to the module; no existing selector was touched.
- The PDF print stylesheet collapses `CardGrid` to a list via `[class*="card"]` / `[class*="grid"]`. CSS module names hash to `chip_*` / `chipRow_*`, which those selectors do not match, so the second commit adds the equivalent print rules.

Before:
<img width="1408" height="426" alt="Screenshot 2026-08-31 at 14 59 29" src="https://github.com/user-attachments/assets/ab3402a5-17ab-46c0-aac0-88a46db21459" />

After the PR:

<img width="1273" height="459" alt="Screenshot 2026-08-31 at 14 58 10" src="https://github.com/user-attachments/assets/1c08fb6b-48e6-4d2f-811e-df58ec66634b" />


#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change updates a shared `CardGrid` component and its public props. The default variant remains unchanged, but compact layout and print styles require targeted validation.

**QA Recommendation:** Manual QA can be limited to compact and default layouts, responsive behavior, themes, print output, links, and keyboard focus states.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->