### PR TITLE
Allow direct modifications to non-English translation files

### DIFF
--- a/.github/workflows/i18n-ci-template.yml
+++ b/.github/workflows/i18n-ci-template.yml
@@ -7,11 +7,14 @@ on:
 permissions:
   contents: read
 
+# Translations used to arrive exclusively through Weblate, so this job failed
+# any PR that touched a non-English file unless it came from the weblate
+# account. Translations may now be authored in-repo and land in the same PR as
+# the English string, so the change is reported instead of rejected.
 jobs:
   check-files:
-    name: Check only English translation files changed
+    name: Report non-English translation file changes
     runs-on: ubuntu-22.04
-    if: github.event.pull_request.user.login != 'weblate' # Allow weblate to modify non-English
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -31,5 +34,4 @@ jobs:
       - name: Check changed files
         if: steps.changed-files.outputs.any_changed == 'true'
         run: |
-          echo "::error title=Non-English i18n files changed::Only PRs from weblate should modify non-English translation files."
-          exit 1
+          echo "::warning title=Non-English i18n files changed::This PR modifies non-English translation files directly. Ensure the changes are intentional and will not be overwritten by Weblate."


### PR DESCRIPTION
#### Summary
We are beginning to transition to a pipeline that supports AI-generated translations. Relax the CI check to allow these subsequent pull requests to build and merge.

#### Ticket Link

N/A

#### Release Note

```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to the i18n CI workflow. It does not affect application code, data, authentication, or public APIs.

**QA Recommendation:** Rely on automated CI checks. Manual QA is not required.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->