### PR TITLE
[MM-70507] Filter OAuth endpoint requests that hit reserved IPs

### DIFF
--- a/server/channels/app/oauth.go
+++ b/server/channels/app/oauth.go
@@ -1100,7 +1100,7 @@ func (a *App) AuthorizeOAuthUser(rctx request.CTX, w http.ResponseWriter, r *htt
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := a.HTTPService().MakeClient(true).Do(req)
+	resp, err := a.HTTPService().MakeClient(false).Do(req)
 	if err != nil {
 		return nil, stateProps, nil, model.NewAppError("AuthorizeOAuthUser", "api.user.authorize_oauth_user.token_failed.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
 	}
@@ -1142,7 +1142,7 @@ func (a *App) AuthorizeOAuthUser(rctx request.CTX, w http.ResponseWriter, r *htt
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("Authorization", "Bearer "+ar.AccessToken)
 
-	resp, err = a.HTTPService().MakeClient(true).Do(req)
+	resp, err = a.HTTPService().MakeClient(false).Do(req)
 	if err != nil {
 		return nil, stateProps, nil, model.NewAppError("AuthorizeOAuthUser", "api.user.authorize_oauth_user.service.app_error", map[string]any{"Service": service}, "", http.StatusInternalServerError).Wrap(err)
 	} else if resp.StatusCode != http.StatusOK {

--- a/server/channels/app/oauth_test.go
+++ b/server/channels/app/oauth_test.go
@@ -318,6 +318,14 @@ func TestAuthorizeOAuthUser(t *testing.T) {
 			} else {
 				*cfg.GitLabSettings.UserAPIEndpoint = ""
 			}
+
+			// The test server binds to a loopback (reserved) address, which the
+			// filtered OAuth client refuses unless it is explicitly allowlisted.
+			if serverURL != "" {
+				if u, parseErr := url.Parse(serverURL); parseErr == nil {
+					*cfg.ServiceSettings.AllowedUntrustedInternalConnections = u.Hostname()
+				}
+			}
 		})
 
 		return th
@@ -453,6 +461,32 @@ func TestAuthorizeOAuthUser(t *testing.T) {
 		_, _, _, err := th.App.AuthorizeOAuthUser(th.Context, &httptest.ResponseRecorder{}, request, model.ServiceGitlab, "", state, "")
 		require.NotNil(t, err)
 		assert.Equal(t, "api.user.authorize_oauth_user.token_failed.app_error", err.Id)
+	})
+
+	t.Run("refuses a reserved-IP token endpoint that is not allowlisted", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			err := json.NewEncoder(w).Encode(&model.AccessResponse{
+				AccessToken: model.NewId(),
+				TokenType:   model.AccessTokenType,
+			})
+			require.NoError(t, err)
+		}))
+		defer server.Close()
+
+		th := setup(t, true, true, true, server.URL)
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			*cfg.ServiceSettings.AllowedUntrustedInternalConnections = ""
+		})
+
+		cookie := model.NewId()
+		request := makeRequest(cookie)
+		state := makeState(makeToken(th, cookie))
+
+		_, _, _, err := th.App.AuthorizeOAuthUser(th.Context, &httptest.ResponseRecorder{}, request, model.ServiceGitlab, "", state, "")
+		require.NotNil(t, err)
+		assert.Equal(t, "api.user.authorize_oauth_user.token_failed.app_error", err.Id)
+		assert.ErrorContains(t, err.Unwrap(), "reserved range")
 	})
 
 	t.Run("with an error token response", func(t *testing.T) {


### PR DESCRIPTION
#### Summary
The OAuth and SSO sign-in flow issued outbound requests to the configured token and userinfo endpoints using an HTTP client that skipped the server's internal-connection protections. As a result those requests were not subject to the same reserved/internal-address restrictions applied elsewhere.

This PR routes those fetches through the filtered HTTP client so they honor the server's outbound connection restrictions, while still allowing explicitly allowlisted internal endpoints. A regression test covers the blocked path.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-70507

#### Release Note
```release-note
Fixed an issue where OAuth and SSO sign-in requests did not honor the server's outbound connection restrictions.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟠 Medium

**Regression Risk:** The change affects OAuth and SSO authentication requests. The scope is isolated, and a regression test covers blocked reserved-IP endpoints.

**QA Recommendation:** Skip manual QA. Automated test coverage is sufficient for this focused change.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->