### PR TITLE
Support running the E2E suite under React strict mode

### DIFF
--- a/.github/workflows/e2e-tests-cypress-template.yml
+++ b/.github/workflows/e2e-tests-cypress-template.yml
@@ -291,9 +291,6 @@ jobs:
       BRANCH: "${{ inputs.branch }}"
       BUILD_ID: "${{ inputs.build_id }}"
       CI_BASE_URL: "${{ inputs.test_type }}-test-${{ matrix.worker_index }}"
-      # DO NOT MERGE: fails a test when the web app reports a React strict mode violation, so this
-      # branch's run maps out the components that aren't safe under concurrent rendering.
-      CYPRESS_failOnPageError: "strict-mode"
       CYPRESS_pushNotificationServer: "${{ secrets.PUSH_NOTIFICATION_SERVER }}"
       CWS_URL: "${{ secrets.CWS_URL }}"
       CWS_EXTRA_HTTP_HEADERS: "${{ secrets.CWS_EXTRA_HTTP_HEADERS }}"

--- a/.github/workflows/e2e-tests-cypress-template.yml
+++ b/.github/workflows/e2e-tests-cypress-template.yml
@@ -291,6 +291,9 @@ jobs:
       BRANCH: "${{ inputs.branch }}"
       BUILD_ID: "${{ inputs.build_id }}"
       CI_BASE_URL: "${{ inputs.test_type }}-test-${{ matrix.worker_index }}"
+      # DO NOT MERGE: fails a test when the web app reports a React strict mode violation, so this
+      # branch's run maps out the components that aren't safe under concurrent rendering.
+      CYPRESS_failOnPageError: "strict-mode"
       CYPRESS_pushNotificationServer: "${{ secrets.PUSH_NOTIFICATION_SERVER }}"
       CWS_URL: "${{ secrets.CWS_URL }}"
       CWS_EXTRA_HTTP_HEADERS: "${{ secrets.CWS_EXTRA_HTTP_HEADERS }}"

--- a/e2e-tests/.ci/server.generate.sh
+++ b/e2e-tests/.ci/server.generate.sh
@@ -390,6 +390,7 @@ generate_env_files() {
 	BROWSER
         HEADLESS
         REPO
+        CYPRESS_failOnPageError
         CYPRESS_pushNotificationServer
 	EOF
     # Adding service-specific cypress variables

--- a/e2e-tests/cypress/cypress.config.ts
+++ b/e2e-tests/cypress/cypress.config.ts
@@ -36,6 +36,9 @@ export default defineConfig({
         dbClient: 'postgres',
         dbConnection: 'postgres://mmuser:mostest_password@localhost/mattermost_test?sslmode=disable&connect_timeout=10',
         elasticsearchConnectionURL: 'http://localhost:9200',
+
+        // 'off', 'strict-mode' or 'all'; see tests/support/page_error.ts
+        failOnPageError: process.env.CYPRESS_failOnPageError || 'off',
         firstTest: false,
         keycloakAppName: 'mattermost',
         keycloakBaseUrl: 'http://localhost:8484',

--- a/e2e-tests/cypress/tests/integration/channels/react_strict_mode/react_strict_mode_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/react_strict_mode/react_strict_mode_spec.ts
@@ -18,8 +18,8 @@ import {isStrictModeViolation} from '../../../support/page_error';
  *
  * Every other spec covers this only by accident: it reports a violation when the app happens to have
  * one, and says nothing when it doesn't, so "the app is clean" and "detection is broken" produce
- * identical runs. Cypress ignored uncaught exceptions outright until recently, which is exactly the
- * kind of silence this test is here to prevent coming back.
+ * identical runs. Cypress ignored uncaught exceptions outright until recently, which is the kind of
+ * silence this test exists to stop coming back.
  *
  * The warning is injected through console.error rather than caused by a real component. React only
  * emits these from its own internals, so the alternative is keeping a deliberately broken component
@@ -32,37 +32,54 @@ type StrictModeViolation = {
     componentStack?: string;
 };
 
-/** How React reports a findDOMNode call under StrictMode: a format string, its arguments, then the
- * component stack. */
-const REACT_WARNING_ARGS = [
-    'Warning: %s is deprecated in StrictMode. %s was passed an instance of %s which is inside StrictMode.%s',
-    'findDOMNode',
-    'findDOMNode',
-    'Transition',
-    '\n    in Transition (created by CSSTransition)\n    in CSSTransition (created by MenuWrapperAnimation)',
-];
-
-const EXPECTED_MESSAGE =
-    'React strict mode violation: Warning: findDOMNode is deprecated in StrictMode. ' +
-    'findDOMNode was passed an instance of Transition which is inside StrictMode.';
+/**
+ * How React reports a findDOMNode call under StrictMode: a format string, its arguments, then the
+ * component stack.
+ *
+ * The component name is unique per call because the web app reports each distinct violation once per
+ * page load. This spec runs with testIsolation off and a retry, so a fixed name would be swallowed
+ * on the second attempt and the retry could only ever fail.
+ */
+function reactWarningArgs(component: string) {
+    return [
+        'Warning: %s is deprecated in StrictMode. %s was passed an instance of %s which is inside StrictMode.%s',
+        'findDOMNode',
+        'findDOMNode',
+        component,
+        `\n    in ${component} (created by CSSTransition)\n    in CSSTransition (created by MenuWrapperAnimation)`,
+    ];
+}
 
 describe('React strict mode detection', () => {
+    // The diagnostics are only installed in a build made with MM_REACT_STRICT_MODE, which is not how
+    // the web app ships. Decided here rather than in the test body because this.skip() only takes
+    // effect synchronously, and reading it before the app has rendered would read it as absent.
+    let diagnosticsInstalled = false;
+
     before(() => {
         cy.apiInitSetup({loginAfter: true}).then(({team}) => {
             cy.visit(`/${team.name}/channels/town-square`);
         });
+
+        cy.uiGetPostTextBox().should('be.visible');
+
+        cy.window().then((win) => {
+            diagnosticsInstalled = Array.isArray(
+                (win as {reactStrictModeViolations?: StrictModeViolation[]}).reactStrictModeViolations,
+            );
+        });
     });
 
     it('reports a strict mode violation as an uncaught exception', function() {
-        // The diagnostics are only installed in a build made with MM_REACT_STRICT_MODE, which is not
-        // how the web app ships. There is nothing to detect in any other build.
-        cy.window().then((win) => {
-            const installed = Array.isArray((win as {reactStrictModeViolations?: StrictModeViolation[]}).reactStrictModeViolations);
-            if (!installed) {
-                cy.log('Web app was not built with MM_REACT_STRICT_MODE, skipping');
-                this.skip();
-            }
-        });
+        if (!diagnosticsInstalled) {
+            cy.log('Web app was not built with MM_REACT_STRICT_MODE, skipping');
+            this.skip();
+        }
+
+        const component = `Transition${Date.now()}`;
+        const expectedMessage =
+            'React strict mode violation: Warning: findDOMNode is deprecated in StrictMode. ' +
+            `findDOMNode was passed an instance of ${component} which is inside StrictMode.`;
 
         // # Collect the violation instead of letting it fail this test, which is what the global
         // handler in tests/support/index.js would otherwise do
@@ -74,7 +91,7 @@ describe('React strict mode detection', () => {
 
         // # Report a warning the way React's development runtime does
         cy.window().then((win) => {
-            (win.console.error as (...args: unknown[]) => void)(...REACT_WARNING_ARGS);
+            (win.console.error as (...args: unknown[]) => void)(...reactWarningArgs(component));
         });
 
         // * The warning should be rethrown as an uncaught exception. It is rethrown from a queued
@@ -86,12 +103,13 @@ describe('React strict mode detection', () => {
         cy.wrap(null).then(() => {
             const violation = uncaught.find((error) => error.name === 'ReactStrictModeViolation')!;
 
-            // * The message should be the warning React would have printed, with its arguments
-            // substituted and the component stack split off
-            expect(violation.message).to.equal(EXPECTED_MESSAGE);
+            // * The reported error should carry the warning React would have printed, with its
+            // arguments substituted and the component stack split off. Cypress wraps the message in
+            // its own "originated from your application code" text, hence contain rather than equal.
+            expect(violation.message).to.contain(expectedMessage);
 
             // * The stack should name the components responsible, not just the warning
-            expect(violation.stack).to.contain('in Transition (created by CSSTransition)');
+            expect(violation.stack).to.contain(`in ${component} (created by CSSTransition)`);
             expect(violation.stack).to.contain('in CSSTransition (created by MenuWrapperAnimation)');
 
             // * The harness should classify it as something to fail on
@@ -101,7 +119,7 @@ describe('React strict mode detection', () => {
         // * The app should record it for anyone reading the page afterwards
         cy.window().then((win) => {
             const recorded = (win as {reactStrictModeViolations?: StrictModeViolation[]}).reactStrictModeViolations ?? [];
-            const match = recorded.find((entry) => entry.componentStack?.includes('in Transition (created by CSSTransition)'));
+            const match = recorded.find((entry) => entry.componentStack?.includes(`in ${component} (created by CSSTransition)`));
 
             expect(match, 'violation recorded on window.reactStrictModeViolations').to.not.equal(undefined);
         });

--- a/e2e-tests/cypress/tests/integration/channels/react_strict_mode/react_strict_mode_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/react_strict_mode/react_strict_mode_spec.ts
@@ -1,0 +1,109 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// ***************************************************************
+// - [#] indicates a test step (e.g. # Go to a page)
+// - [*] indicates an assertion (e.g. * Check the title)
+// - Use element ID when selecting an element. Create one if none.
+// ***************************************************************
+
+// Stage: @prod
+// Group: @channels @react_strict_mode
+
+import {isStrictModeViolation} from '../../../support/page_error';
+
+/**
+ * Verifies that a React strict mode violation in the web app reaches the run as an uncaught
+ * exception, which is what CYPRESS_failOnPageError fails on.
+ *
+ * Every other spec covers this only by accident: it reports a violation when the app happens to have
+ * one, and says nothing when it doesn't, so "the app is clean" and "detection is broken" produce
+ * identical runs. Cypress ignored uncaught exceptions outright until recently, which is exactly the
+ * kind of silence this test is here to prevent coming back.
+ *
+ * The warning is injected through console.error rather than caused by a real component. React only
+ * emits these from its own internals, so the alternative is keeping a deliberately broken component
+ * in the app, and the coverage would disappear the moment someone fixed it. Everything downstream of
+ * console.error is the real thing.
+ */
+
+type StrictModeViolation = {
+    message: string;
+    componentStack?: string;
+};
+
+/** How React reports a findDOMNode call under StrictMode: a format string, its arguments, then the
+ * component stack. */
+const REACT_WARNING_ARGS = [
+    'Warning: %s is deprecated in StrictMode. %s was passed an instance of %s which is inside StrictMode.%s',
+    'findDOMNode',
+    'findDOMNode',
+    'Transition',
+    '\n    in Transition (created by CSSTransition)\n    in CSSTransition (created by MenuWrapperAnimation)',
+];
+
+const EXPECTED_MESSAGE =
+    'React strict mode violation: Warning: findDOMNode is deprecated in StrictMode. ' +
+    'findDOMNode was passed an instance of Transition which is inside StrictMode.';
+
+describe('React strict mode detection', () => {
+    before(() => {
+        cy.apiInitSetup({loginAfter: true}).then(({team}) => {
+            cy.visit(`/${team.name}/channels/town-square`);
+        });
+    });
+
+    it('reports a strict mode violation as an uncaught exception', function() {
+        // The diagnostics are only installed in a build made with MM_REACT_STRICT_MODE, which is not
+        // how the web app ships. There is nothing to detect in any other build.
+        cy.window().then((win) => {
+            const installed = Array.isArray((win as {reactStrictModeViolations?: StrictModeViolation[]}).reactStrictModeViolations);
+            if (!installed) {
+                cy.log('Web app was not built with MM_REACT_STRICT_MODE, skipping');
+                this.skip();
+            }
+        });
+
+        // # Collect the violation instead of letting it fail this test, which is what the global
+        // handler in tests/support/index.js would otherwise do
+        const uncaught: Error[] = [];
+        cy.on('uncaught:exception', (error) => {
+            uncaught.push(error);
+            return false;
+        });
+
+        // # Report a warning the way React's development runtime does
+        cy.window().then((win) => {
+            (win.console.error as (...args: unknown[]) => void)(...REACT_WARNING_ARGS);
+        });
+
+        // * The warning should be rethrown as an uncaught exception. It is rethrown from a queued
+        // task, so this has to be retried rather than asserted once.
+        cy.wrap(null).should(() => {
+            expect(uncaught.map((error) => error.name)).to.include('ReactStrictModeViolation');
+        });
+
+        cy.wrap(null).then(() => {
+            const violation = uncaught.find((error) => error.name === 'ReactStrictModeViolation')!;
+
+            // * The message should be the warning React would have printed, with its arguments
+            // substituted and the component stack split off
+            expect(violation.message).to.equal(EXPECTED_MESSAGE);
+
+            // * The stack should name the components responsible, not just the warning
+            expect(violation.stack).to.contain('in Transition (created by CSSTransition)');
+            expect(violation.stack).to.contain('in CSSTransition (created by MenuWrapperAnimation)');
+
+            // * The harness should classify it as something to fail on
+            expect(isStrictModeViolation(violation)).to.equal(true);
+        });
+
+        // * The app should record it for anyone reading the page afterwards
+        cy.window().then((win) => {
+            const recorded = (win as {reactStrictModeViolations?: StrictModeViolation[]}).reactStrictModeViolations ?? [];
+            const match = recorded.find((entry) => entry.componentStack?.includes('in Transition (created by CSSTransition)'));
+
+            expect(match, 'violation recorded on window.reactStrictModeViolations').to.not.equal(undefined);
+        });
+    });
+});

--- a/e2e-tests/cypress/tests/support/index.js
+++ b/e2e-tests/cypress/tests/support/index.js
@@ -34,6 +34,7 @@ import './task_commands';
 import './ui';
 import './ui_commands'; // soon to deprecate
 import {DEFAULT_TEAM} from './constants';
+import {shouldFailOnPageError} from './page_error';
 import {getDefaultConfig} from './api/system';
 
 Cypress.dayjs = dayjs;
@@ -99,10 +100,8 @@ Cypress.on('test:after:run', (test, runnable) => {
     }
 });
 
-// Turn off all uncaught exception handling
-Cypress.on('uncaught:exception', () => {
-    return false;
-});
+// Uncaught exceptions are ignored unless CYPRESS_failOnPageError opts into them.
+Cypress.on('uncaught:exception', (error) => shouldFailOnPageError(error));
 
 before(() => {
     // # Clear localforage state

--- a/e2e-tests/cypress/tests/support/page_error.ts
+++ b/e2e-tests/cypress/tests/support/page_error.ts
@@ -1,0 +1,54 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+/**
+ * Cypress ignores every uncaught browser exception (see the `uncaught:exception` handler in
+ * index.js), so a component that throws in the background is invisible to a run for as long as the
+ * UI it produced still satisfies the test's assertions.
+ *
+ * `CYPRESS_failOnPageError` turns them back into failures:
+ *
+ *   strict-mode  only React strict mode violations, which is what a web app built with
+ *                MM_REACT_STRICT_MODE reports (webapp/channels/src/utils/react_strict_mode.ts)
+ *   all          every uncaught exception, including ones from plugins and from the server being
+ *                unreachable
+ *   off          the default, and the behaviour the suite has always had
+ *
+ * This mirrors PW_FAIL_ON_PAGE_ERROR in e2e-tests/playwright/lib/src/page_error.ts.
+ */
+
+type FailureMode = 'off' | 'strict-mode' | 'all';
+
+const STRICT_MODE_ERROR_NAME = 'ReactStrictModeViolation';
+const STRICT_MODE_VIOLATION = 'React strict mode violation:';
+
+function failureMode(): FailureMode {
+    switch (Cypress.expose('failOnPageError')) {
+    case 'all':
+        return 'all';
+    case 'strict-mode':
+        return 'strict-mode';
+    default:
+        return 'off';
+    }
+}
+
+/**
+ * The web app names these errors and prefixes their message, so either is enough to recognise one.
+ * Both are checked because a browser that reconstructs the error across a boundary can drop `name`.
+ */
+export function isStrictModeViolation(error: Error): boolean {
+    return error.name === STRICT_MODE_ERROR_NAME || error.message.includes(STRICT_MODE_VIOLATION);
+}
+
+/** Whether an uncaught browser exception should fail the test that was running when it happened. */
+export function shouldFailOnPageError(error: Error): boolean {
+    switch (failureMode()) {
+    case 'all':
+        return true;
+    case 'strict-mode':
+        return isStrictModeViolation(error);
+    default:
+        return false;
+    }
+}

--- a/e2e-tests/playwright/lib/src/browser_context.ts
+++ b/e2e-tests/playwright/lib/src/browser_context.ts
@@ -9,6 +9,7 @@ import type {Browser, BrowserContext} from '@playwright/test';
 import {request} from '@playwright/test';
 import type {UserProfile} from '@mattermost/types/users';
 
+import {watchForPageErrors} from './page_error';
 import {testConfig} from './test_config';
 import {pages} from './ui/pages';
 import {resolvePlaywrightPath} from './util';
@@ -32,6 +33,7 @@ export class TestBrowser {
         // Sign in a user in new browser context
         const context = await this.browser.newContext(options);
         const page = await context.newPage();
+        watchForPageErrors(page);
 
         const channelsPage = new pages.ChannelsPage(page);
         const systemConsolePage = new pages.SystemConsolePage(page);

--- a/e2e-tests/playwright/lib/src/index.ts
+++ b/e2e-tests/playwright/lib/src/index.ts
@@ -12,7 +12,7 @@ export {setupFileServer} from './file_server';
 export {decomposeKorean, koreanTestPhrase, typeHangulCharacterWithIme, typeHangulWithIme} from './ime';
 export {type SizeObservation, type SizeWatcher, watchElementSize} from './layout_shift';
 export {duration, getRandomId, wait, newTestPassword} from './util';
-export {shouldFailOnPageError, watchForPageErrors} from './page_error';
+export {formatPageErrors, getPageErrors, resetPageErrors, shouldFailOnPageError, watchForPageErrors} from './page_error';
 export type {PageError} from './page_error';
 export {LicenseSkus, appsPluginId, callsPluginId, playbooksPluginId} from './constant';
 

--- a/e2e-tests/playwright/lib/src/index.ts
+++ b/e2e-tests/playwright/lib/src/index.ts
@@ -12,7 +12,13 @@ export {setupFileServer} from './file_server';
 export {decomposeKorean, koreanTestPhrase, typeHangulCharacterWithIme, typeHangulWithIme} from './ime';
 export {type SizeObservation, type SizeWatcher, watchElementSize} from './layout_shift';
 export {duration, getRandomId, wait, newTestPassword} from './util';
-export {formatPageErrors, getPageErrors, resetPageErrors, shouldFailOnPageError, watchForPageErrors} from './page_error';
+export {
+    formatPageErrors,
+    getPageErrors,
+    resetPageErrors,
+    shouldFailOnPageError,
+    watchForPageErrors,
+} from './page_error';
 export type {PageError} from './page_error';
 export {LicenseSkus, appsPluginId, callsPluginId, playbooksPluginId} from './constant';
 

--- a/e2e-tests/playwright/lib/src/index.ts
+++ b/e2e-tests/playwright/lib/src/index.ts
@@ -12,6 +12,8 @@ export {setupFileServer} from './file_server';
 export {decomposeKorean, koreanTestPhrase, typeHangulCharacterWithIme, typeHangulWithIme} from './ime';
 export {type SizeObservation, type SizeWatcher, watchElementSize} from './layout_shift';
 export {duration, getRandomId, wait, newTestPassword} from './util';
+export {shouldFailOnPageError, watchForPageErrors} from './page_error';
+export type {PageError} from './page_error';
 export {LicenseSkus, appsPluginId, callsPluginId, playbooksPluginId} from './constant';
 
 export {

--- a/e2e-tests/playwright/lib/src/page_error.ts
+++ b/e2e-tests/playwright/lib/src/page_error.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {Page} from '@playwright/test';
+
+/**
+ * Uncaught exceptions in the browser normally go unnoticed by a Playwright run: a test only fails
+ * if a locator times out or an assertion fails, so a component that throws in the background looks
+ * fine as long as the UI it produced is still usable.
+ *
+ * When PW_FAIL_ON_PAGE_ERROR is set, every page opened by the harness is watched for uncaught
+ * exceptions and the test fails at teardown with the exceptions it saw. This is what makes the web
+ * app's React strict mode diagnostics (webapp/channels/src/utils/react_strict_mode.ts) visible in
+ * CI, since those are reported as uncaught exceptions.
+ */
+
+export type PageError = {
+    message: string;
+    stack?: string;
+};
+
+let collected: PageError[] = [];
+
+export function shouldFailOnPageError(): boolean {
+    return process.env.PW_FAIL_ON_PAGE_ERROR === 'true';
+}
+
+export function resetPageErrors(): void {
+    collected = [];
+}
+
+export function watchForPageErrors(page: Page): void {
+    if (!shouldFailOnPageError()) {
+        return;
+    }
+
+    page.on('pageerror', (error) => {
+        collected.push({message: error.message, stack: error.stack});
+    });
+}
+
+export function getPageErrors(): PageError[] {
+    return collected;
+}
+
+export function formatPageErrors(errors: PageError[]): string {
+    const details = errors.map((error, index) => `${index + 1}. ${error.stack ?? error.message}`).join('\n\n');
+
+    return `${errors.length} uncaught browser exception(s) during this test:\n\n${details}`;
+}
+
+/** Throws if any watched page reported an uncaught exception. Call after the test body has run. */
+export function assertNoPageErrors(): void {
+    if (!shouldFailOnPageError() || collected.length === 0) {
+        return;
+    }
+
+    const errors = collected;
+    resetPageErrors();
+
+    throw new Error(formatPageErrors(errors));
+}

--- a/e2e-tests/playwright/lib/src/page_error.ts
+++ b/e2e-tests/playwright/lib/src/page_error.ts
@@ -8,10 +8,13 @@ import type {Page} from '@playwright/test';
  * if a locator times out or an assertion fails, so a component that throws in the background looks
  * fine as long as the UI it produced is still usable.
  *
- * When PW_FAIL_ON_PAGE_ERROR is set, every page opened by the harness is watched for uncaught
- * exceptions and the test fails at teardown with the exceptions it saw. This is what makes the web
- * app's React strict mode diagnostics (webapp/channels/src/utils/react_strict_mode.ts) visible in
- * CI, since those are reported as uncaught exceptions.
+ * PW_FAIL_ON_PAGE_ERROR makes those exceptions fail the test at teardown:
+ *
+ *   strict-mode  only React strict mode violations, which is what a web app built with
+ *                MM_REACT_STRICT_MODE reports (webapp/channels/src/utils/react_strict_mode.ts)
+ *   all          every uncaught exception, including ones from plugins and from the server being
+ *                unreachable
+ *   unset        off
  */
 
 export type PageError = {
@@ -19,10 +22,25 @@ export type PageError = {
     stack?: string;
 };
 
+type FailureMode = 'off' | 'strict-mode' | 'all';
+
+const STRICT_MODE_VIOLATION = 'React strict mode violation:';
+
 let collected: PageError[] = [];
 
+function failureMode(): FailureMode {
+    switch (process.env.PW_FAIL_ON_PAGE_ERROR) {
+        case 'all':
+            return 'all';
+        case 'strict-mode':
+            return 'strict-mode';
+        default:
+            return 'off';
+    }
+}
+
 export function shouldFailOnPageError(): boolean {
-    return process.env.PW_FAIL_ON_PAGE_ERROR === 'true';
+    return failureMode() !== 'off';
 }
 
 export function resetPageErrors(): void {
@@ -30,11 +48,17 @@ export function resetPageErrors(): void {
 }
 
 export function watchForPageErrors(page: Page): void {
-    if (!shouldFailOnPageError()) {
+    const mode = failureMode();
+
+    if (mode === 'off') {
         return;
     }
 
     page.on('pageerror', (error) => {
+        if (mode === 'strict-mode' && !error.message.includes(STRICT_MODE_VIOLATION)) {
+            return;
+        }
+
         collected.push({message: error.message, stack: error.stack});
     });
 }
@@ -51,7 +75,7 @@ export function formatPageErrors(errors: PageError[]): string {
 
 /** Throws if any watched page reported an uncaught exception. Call after the test body has run. */
 export function assertNoPageErrors(): void {
-    if (!shouldFailOnPageError() || collected.length === 0) {
+    if (collected.length === 0) {
         return;
     }
 

--- a/e2e-tests/playwright/lib/src/page_error.ts
+++ b/e2e-tests/playwright/lib/src/page_error.ts
@@ -68,7 +68,9 @@ export function getPageErrors(): PageError[] {
 }
 
 export function formatPageErrors(errors: PageError[]): string {
-    const details = errors.map((error, index) => `${index + 1}. ${error.stack ?? error.message}`).join('\n\n');
+    // `||` rather than `??`: Playwright reports an empty stack for errors it could not read frames
+    // from, and an empty entry here would say nothing at all.
+    const details = errors.map((error, index) => `${index + 1}. ${error.stack || error.message}`).join('\n\n');
 
     return `${errors.length} uncaught browser exception(s) during this test:\n\n${details}`;
 }

--- a/e2e-tests/playwright/lib/src/test_fixture.ts
+++ b/e2e-tests/playwright/lib/src/test_fixture.ts
@@ -18,6 +18,7 @@ import {
     skipIfNoLicense,
 } from './flag';
 import {getBlobFromAsset, getFileFromAsset} from './file';
+import {assertNoPageErrors, resetPageErrors, watchForPageErrors} from './page_error';
 import {
     configureAIBridgeMock,
     createKeycloakUser,
@@ -102,9 +103,14 @@ export const test = base.extend<ExtendedFixtures>({
         await use(ab);
     },
     pw: async ({browser, page, isMobile}, use) => {
+        resetPageErrors();
+        watchForPageErrors(page);
+
         const pw = new PlaywrightExtended(browser, page, isMobile);
         await use(pw);
         await pw.testBrowser.close();
+
+        assertNoPageErrors();
     },
 });
 

--- a/e2e-tests/playwright/specs/functional/channels/react_strict_mode/react_strict_mode.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/react_strict_mode/react_strict_mode.spec.ts
@@ -10,21 +10,6 @@ import {
     test,
 } from '@mattermost/playwright-lib';
 
-/**
- * @objective Verify that a React strict mode violation in the web app reaches the E2E run as an
- * uncaught browser exception, so PW_FAIL_ON_PAGE_ERROR has something real to fail on.
- *
- * Every other spec covers this only by accident: it reports a violation when the app happens to have
- * one, and says nothing when it doesn't. That makes "the app is clean" and "detection is broken"
- * produce identical runs, which is exactly the guesswork this test removes.
- *
- * The warning is injected through console.error rather than caused by a real component. React only
- * emits these from its own internals, so the alternative is keeping a deliberately broken component
- * in the app, and the coverage would disappear the moment someone fixed it. Everything downstream of
- * console.error is the real thing: the pattern matching, the printf-style formatting, the component
- * stack split, the rethrow, and the harness that collects it.
- */
-
 type StrictModeViolation = {
     message: string;
     componentStack?: string;
@@ -51,6 +36,20 @@ test.afterEach(() => {
     resetPageErrors();
 });
 
+/**
+ * @objective Verify that a React strict mode violation in the web app reaches the E2E run as an
+ * uncaught browser exception, so PW_FAIL_ON_PAGE_ERROR has something real to fail on.
+ *
+ * Every other spec covers this only by accident: it reports a violation when the app happens to have
+ * one, and says nothing when it doesn't. That makes "the app is clean" and "detection is broken"
+ * produce identical runs, which is exactly the guesswork this test removes.
+ *
+ * The warning is injected through console.error rather than caused by a real component. React only
+ * emits these from its own internals, so the alternative is keeping a deliberately broken component
+ * in the app, and the coverage would disappear the moment someone fixed it. Everything downstream of
+ * console.error is the real thing: the pattern matching, the printf-style formatting, the component
+ * stack split, the rethrow, and the harness that collects it.
+ */
 test(
     'a React strict mode violation surfaces as an uncaught browser exception',
     {tag: '@react_strict_mode'},
@@ -63,8 +62,8 @@ test(
 
         // The diagnostics are only installed in a build made with MM_REACT_STRICT_MODE, which is not
         // how the web app ships. There is nothing to detect in any other build.
-        const diagnosticsInstalled = await page.evaluate(
-            () => Array.isArray((window as StrictModeWindow).reactStrictModeViolations),
+        const diagnosticsInstalled = await page.evaluate(() =>
+            Array.isArray((window as StrictModeWindow).reactStrictModeViolations),
         );
         test.skip(!diagnosticsInstalled, 'Web app was not built with MM_REACT_STRICT_MODE');
 
@@ -80,9 +79,7 @@ test(
         }, REACT_WARNING_ARGS);
 
         // * The warning should be rethrown as an uncaught exception
-        await expect
-            .poll(() => uncaught.map((error) => error.name))
-            .toContain('ReactStrictModeViolation');
+        await expect.poll(() => uncaught.map((error) => error.name)).toContain('ReactStrictModeViolation');
 
         const violation = uncaught.find((error) => error.name === 'ReactStrictModeViolation')!;
 
@@ -101,9 +98,7 @@ test(
         expect(violation.stack).toContain('in CSSTransition (created by MenuWrapperAnimation)');
 
         // * The app should record it for anyone reading the page afterwards
-        const recorded = await page.evaluate(
-            () => (window as StrictModeWindow).reactStrictModeViolations ?? [],
-        );
+        const recorded = await page.evaluate(() => (window as StrictModeWindow).reactStrictModeViolations ?? []);
         expect(recorded).toContainEqual(
             expect.objectContaining({
                 componentStack: expect.stringContaining('in Transition (created by CSSTransition)'),

--- a/e2e-tests/playwright/specs/functional/channels/react_strict_mode/react_strict_mode.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/react_strict_mode/react_strict_mode.spec.ts
@@ -1,0 +1,121 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {
+    expect,
+    formatPageErrors,
+    getPageErrors,
+    resetPageErrors,
+    shouldFailOnPageError,
+    test,
+} from '@mattermost/playwright-lib';
+
+/**
+ * @objective Verify that a React strict mode violation in the web app reaches the E2E run as an
+ * uncaught browser exception, so PW_FAIL_ON_PAGE_ERROR has something real to fail on.
+ *
+ * Every other spec covers this only by accident: it reports a violation when the app happens to have
+ * one, and says nothing when it doesn't. That makes "the app is clean" and "detection is broken"
+ * produce identical runs, which is exactly the guesswork this test removes.
+ *
+ * The warning is injected through console.error rather than caused by a real component. React only
+ * emits these from its own internals, so the alternative is keeping a deliberately broken component
+ * in the app, and the coverage would disappear the moment someone fixed it. Everything downstream of
+ * console.error is the real thing: the pattern matching, the printf-style formatting, the component
+ * stack split, the rethrow, and the harness that collects it.
+ */
+
+type StrictModeViolation = {
+    message: string;
+    componentStack?: string;
+};
+
+type StrictModeWindow = Window & {
+    reactStrictModeViolations?: StrictModeViolation[];
+};
+
+/**
+ * How React reports a findDOMNode call under StrictMode: a printf-style format string, its
+ * arguments, and the component stack last.
+ */
+const REACT_WARNING_ARGS = [
+    'Warning: %s is deprecated in StrictMode. %s was passed an instance of %s which is inside StrictMode.%s',
+    'findDOMNode',
+    'findDOMNode',
+    'Transition',
+    '\n    in Transition (created by CSSTransition)\n    in CSSTransition (created by MenuWrapperAnimation)',
+];
+
+// The violation this test provokes would otherwise fail it during fixture teardown.
+test.afterEach(() => {
+    resetPageErrors();
+});
+
+test(
+    'a React strict mode violation surfaces as an uncaught browser exception',
+    {tag: '@react_strict_mode'},
+    async ({pw}) => {
+        const {user} = await pw.initSetup();
+        const {page, channelsPage} = await pw.testBrowser.login(user);
+
+        await channelsPage.goto();
+        await channelsPage.toBeVisible();
+
+        // The diagnostics are only installed in a build made with MM_REACT_STRICT_MODE, which is not
+        // how the web app ships. There is nothing to detect in any other build.
+        const diagnosticsInstalled = await page.evaluate(
+            () => Array.isArray((window as StrictModeWindow).reactStrictModeViolations),
+        );
+        test.skip(!diagnosticsInstalled, 'Web app was not built with MM_REACT_STRICT_MODE');
+
+        // # Watch for uncaught exceptions directly, so this holds whether or not the run enables
+        // PW_FAIL_ON_PAGE_ERROR
+        const uncaught: Error[] = [];
+        page.on('pageerror', (error) => uncaught.push(error));
+
+        // # Report a warning the way React's development runtime does
+        await page.evaluate((args) => {
+            // eslint-disable-next-line no-console
+            console.error(...args);
+        }, REACT_WARNING_ARGS);
+
+        // * The warning should be rethrown as an uncaught exception
+        await expect
+            .poll(() => uncaught.map((error) => error.name))
+            .toContain('ReactStrictModeViolation');
+
+        const violation = uncaught.find((error) => error.name === 'ReactStrictModeViolation')!;
+
+        // * The message should be the warning React would have printed, with its arguments
+        // substituted and the component stack split off
+        expect(violation.message).toBe(
+            'React strict mode violation: Warning: findDOMNode is deprecated in StrictMode. ' +
+                'findDOMNode was passed an instance of Transition which is inside StrictMode.',
+        );
+
+        // * The stack should name the components responsible, not just the warning. Playwright
+        // rebuilds this error from the browser and drops any stack it cannot read frames from, so
+        // this also pins down that the component stack is appended to a real one rather than
+        // replacing it.
+        expect(violation.stack).toContain('in Transition (created by CSSTransition)');
+        expect(violation.stack).toContain('in CSSTransition (created by MenuWrapperAnimation)');
+
+        // * The app should record it for anyone reading the page afterwards
+        const recorded = await page.evaluate(
+            () => (window as StrictModeWindow).reactStrictModeViolations ?? [],
+        );
+        expect(recorded).toContainEqual(
+            expect.objectContaining({
+                componentStack: expect.stringContaining('in Transition (created by CSSTransition)'),
+            }),
+        );
+
+        // * A run configured to fail on these should have collected it, and the report it would
+        // fail with should be readable rather than an empty line
+        if (shouldFailOnPageError()) {
+            const collected = getPageErrors();
+            expect(collected.map((error) => error.message)).toContain(violation.message);
+            expect(formatPageErrors(collected)).toContain('in CSSTransition (created by MenuWrapperAnimation)');
+        }
+    },
+);

--- a/webapp/channels/scripts/react_development_build_loader.js
+++ b/webapp/channels/scripts/react_development_build_loader.js
@@ -1,0 +1,30 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// The strict mode build links against React's development runtime while leaving NODE_ENV at
+// production for the rest of the bundle (see webpack.config.js). React's own packaging picks its
+// implementation from NODE_ENV, so aliasing to the development files isn't enough on its own:
+//
+//   - react/react-dom/scheduler's development bundles wrap their entire body in
+//     `if (process.env.NODE_ENV !== "production")`, which would compile away to nothing.
+//   - react-dom/client picks between a thin wrapper that flags the entry point as supported and a
+//     bare re-export that doesn't, so the production branch makes react-dom warn on every
+//     createRoot call.
+//
+// This loader flips those two guards, and is only applied to the React packages.
+
+const GUARDS = [
+    {from: 'if (process.env.NODE_ENV !== "production") {', to: 'if (true) {'},
+    {from: "if (process.env.NODE_ENV === 'production') {", to: 'if (false) {'},
+];
+
+module.exports = function reactDevelopmentBuildLoader(source) {
+    const guard = GUARDS.find(({from}) => source.includes(from));
+
+    if (!guard) {
+        this.emitError(new Error("Expected a NODE_ENV guard in one of React's entry points. Its packaging may have changed."));
+        return source;
+    }
+
+    return source.replace(guard.from, guard.to);
+};

--- a/webapp/channels/src/entry.tsx
+++ b/webapp/channels/src/entry.tsx
@@ -12,6 +12,7 @@ import store from 'stores/redux_store';
 import App from 'components/app';
 
 import {AnnouncementBarTypes} from 'utils/constants';
+import {installReactStrictModeDiagnostics} from 'utils/react_strict_mode';
 import {setCSRFFromCookie} from 'utils/utils';
 
 // Import our styles
@@ -59,17 +60,27 @@ function preRenderSetup(onPreRenderSetupReady: () => void) {
 function renderReactRootComponent() {
     const container = document.getElementById('root')!;
 
+    let app = <App/>;
+
+    if (REACT_STRICT_MODE) {
+        // eslint-disable-next-line no-console
+        console.log('Enabling React strict mode diagnostics due to the REACT_STRICT_MODE build flag');
+
+        installReactStrictModeDiagnostics();
+        app = <React.StrictMode>{app}</React.StrictMode>;
+    }
+
     if (window.enableConcurrentReact) {
         // eslint-disable-next-line no-console
         console.log('Enabling concurrent React 18 due to server-wide feature flag');
 
         // Enable this experimentally since it may cause other issues
-        ReactDOMClient.createRoot(container).render(<App/>);
+        ReactDOMClient.createRoot(container).render(app);
     } else {
         // We're using React 18, but we're using the deprecated way of starting React because ReactDOM.createRoot enables
         // new features such as automatic batching which breaks some components. This will need to be changed in the future
         // because this method of starting the app will be removed in React 19.
-        ReactDOM.render(<App/>, container);
+        ReactDOM.render(app, container);
     }
 }
 

--- a/webapp/channels/src/types/products.d.ts
+++ b/webapp/channels/src/types/products.d.ts
@@ -3,6 +3,8 @@
 
 declare const REMOTE_CONTAINERS: Record<string, string>;
 
+declare const REACT_STRICT_MODE: boolean;
+
 declare module 'boards' {
     // eslint-disable-next-line import/no-duplicates
     import {ProductPlugin} from 'plugins/products';

--- a/webapp/channels/src/utils/react_strict_mode.test.ts
+++ b/webapp/channels/src/utils/react_strict_mode.test.ts
@@ -65,6 +65,11 @@ describe('installReactStrictModeDiagnostics', () => {
 
         expect(thrown?.message).toBe('React strict mode violation: Warning: findDOMNode is deprecated in StrictMode.');
         expect(thrown?.stack).toContain('in Overlay (at tooltip.tsx:20)');
+
+        // The component stack has to be appended to the real one rather than replace it. Playwright
+        // rebuilds this error out of the browser and reports an empty stack for any error it can't
+        // read frames from, which would throw away the component stack on the way to a test report.
+        expect(thrown?.stack).toContain('\n    at ');
     });
 
     test('should record every distinct violation on the window', () => {

--- a/webapp/channels/src/utils/react_strict_mode.test.ts
+++ b/webapp/channels/src/utils/react_strict_mode.test.ts
@@ -1,0 +1,111 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {installReactStrictModeDiagnostics} from './react_strict_mode';
+
+/* eslint-disable no-console */
+
+describe('installReactStrictModeDiagnostics', () => {
+    const originalConsoleError = console.error;
+
+    beforeEach(() => {
+        jest.useFakeTimers();
+        console.error = jest.fn();
+        delete window.reactStrictModeViolations;
+        delete window.reactStrictModeThrowSynchronously;
+    });
+
+    afterEach(() => {
+        jest.useRealTimers();
+        console.error = originalConsoleError;
+    });
+
+    function flushPendingThrow() {
+        // The rethrow is queued as a task, so running the timers is what surfaces it.
+        jest.runOnlyPendingTimers();
+    }
+
+    test('should rethrow a concurrency hazard warning out of band', () => {
+        installReactStrictModeDiagnostics();
+
+        console.error(
+            'Warning: Cannot update a component (`%s`) while rendering a different component (`%s`).',
+            'ChannelView',
+            'PostList',
+        );
+
+        expect(flushPendingThrow).toThrow(
+            'React strict mode violation: Warning: Cannot update a component (`ChannelView`) while rendering a different component (`PostList`).',
+        );
+    });
+
+    test('should throw synchronously when asked to', () => {
+        installReactStrictModeDiagnostics();
+        window.reactStrictModeThrowSynchronously = true;
+
+        expect(() => console.error('Warning: Maximum update depth exceeded.')).toThrow(
+            'React strict mode violation: Warning: Maximum update depth exceeded.',
+        );
+    });
+
+    test('should keep the component stack out of the message but on the error', () => {
+        installReactStrictModeDiagnostics();
+
+        console.error(
+            'Warning: findDOMNode is deprecated in StrictMode.%s',
+            '\n    in Overlay (at tooltip.tsx:20)\n    in Tooltip',
+        );
+
+        let thrown: Error | undefined;
+        try {
+            flushPendingThrow();
+        } catch (error) {
+            thrown = error as Error;
+        }
+
+        expect(thrown?.message).toBe('React strict mode violation: Warning: findDOMNode is deprecated in StrictMode.');
+        expect(thrown?.stack).toContain('in Overlay (at tooltip.tsx:20)');
+    });
+
+    test('should record every distinct violation on the window', () => {
+        installReactStrictModeDiagnostics();
+
+        console.error('Warning: Maximum update depth exceeded.');
+        console.error('Warning: findDOMNode is deprecated in StrictMode.');
+
+        expect(window.reactStrictModeViolations).toEqual([
+            {message: 'Warning: Maximum update depth exceeded.'},
+            {message: 'Warning: findDOMNode is deprecated in StrictMode.'},
+        ]);
+    });
+
+    test('should report a repeated violation only once', () => {
+        installReactStrictModeDiagnostics();
+
+        console.error('Warning: The result of getSnapshot should be cached to avoid an infinite loop');
+        expect(flushPendingThrow).toThrow();
+
+        console.error('Warning: The result of getSnapshot should be cached to avoid an infinite loop');
+        expect(flushPendingThrow).not.toThrow();
+
+        expect(window.reactStrictModeViolations).toHaveLength(1);
+    });
+
+    test('should leave unrelated console errors alone', () => {
+        installReactStrictModeDiagnostics();
+
+        console.error('Warning: Failed prop type: Invalid prop `children` supplied to `Post`.');
+
+        expect(flushPendingThrow).not.toThrow();
+        expect(window.reactStrictModeViolations).toEqual([]);
+    });
+
+    test('should still write the warning to the console', () => {
+        const spy = jest.spyOn(console, 'error');
+
+        installReactStrictModeDiagnostics();
+        console.error('Warning: Maximum update depth exceeded.');
+
+        expect(spy).toHaveBeenCalledWith('Warning: Maximum update depth exceeded.');
+    });
+});

--- a/webapp/channels/src/utils/react_strict_mode.ts
+++ b/webapp/channels/src/utils/react_strict_mode.ts
@@ -1,0 +1,163 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+// React only runs its StrictMode checks in a development build of react-dom, and it reports every
+// violation by calling console.error. Both halves of that are a problem when we want to find code
+// that misbehaves under concurrent rendering in a build that behaves like the one we ship: the
+// checks have to be compiled in, and a console message is too easy to lose in a CI log.
+//
+// This module is only pulled in when the REACT_STRICT_MODE build flag is set (see webpack.config.js,
+// which also swaps in React's development runtime). It intercepts the warnings React writes to
+// console.error and rethrows the ones that indicate a concurrency hazard as real exceptions, so they
+// surface to window.onerror and to Playwright's `pageerror` event.
+
+/* eslint-disable no-console */
+
+export type StrictModeViolation = {
+    message: string;
+    componentStack?: string;
+};
+
+declare global {
+    interface Window {
+
+        /** Every distinct violation seen so far, in the order they were reported. */
+        reactStrictModeViolations?: StrictModeViolation[];
+
+        /**
+         * Throw from inside console.error rather than rethrowing out of band. This aborts the
+         * render that triggered the warning, so the app usually dies on the first violation and
+         * hides the rest. Useful when debugging a single violation by hand.
+         */
+        reactStrictModeThrowSynchronously?: boolean;
+    }
+}
+
+/**
+ * React warnings that mean the code being warned about is unsafe under concurrent rendering: it
+ * either uses an API StrictMode has deprecated, or it has a side effect ordering bug that double
+ * invoking render and effects has exposed.
+ */
+const CONCURRENCY_HAZARDS = [
+
+    // StrictMode-only deprecation warnings
+    /has been found within a strict mode tree/,
+    /is deprecated in StrictMode/,
+    /in strict mode is not recommended/,
+    /uses the legacy (childContextTypes|contextTypes) API/,
+    /Legacy context API has been detected within a strict-mode tree/,
+
+    // Render purity and effect ordering
+    /Cannot update a component \(.+\) while rendering a different component/,
+    /Cannot update during an existing state transition/,
+    /Can't perform a React state update on an unmounted component/,
+    /Maximum update depth exceeded/,
+    /flushSync was called from inside a lifecycle method/,
+
+    // External store subscriptions, which react-redux and useSyncExternalStore rely on
+    /The result of getSnapshot should be cached to avoid an infinite loop/,
+    /The result of getServerSnapshot should be cached/,
+    /Detected multiple renderers concurrently rendering the same context provider/,
+
+    // Hook ordering, which only breaks once a render is interrupted and restarted
+    /React has detected a change in the order of Hooks/,
+    /Rendered (more|fewer) hooks than during the previous render/,
+    /Should have a queue\. This is likely a bug in React/,
+
+    // Suspense under a synchronous update
+    /A component suspended while responding to synchronous input/,
+];
+
+/** Warnings React only emits from the test renderer, which can never fire in the browser anyway. */
+const IGNORED = [
+    /inside a test was not wrapped in act/,
+];
+
+/**
+ * Rebuild the string React would have printed. React always calls console.error with a printf
+ * style format string followed by string arguments, the last of which is the component stack.
+ */
+function formatWarning(args: unknown[]): string {
+    const [format, ...rest] = args;
+
+    if (typeof format !== 'string') {
+        return args.map(String).join(' ');
+    }
+
+    let index = 0;
+    const substituted = format.replace(/%[sdifoOc]/g, (match) => {
+        if (index >= rest.length) {
+            return match;
+        }
+        return String(rest[index++]);
+    });
+
+    return [substituted, ...rest.slice(index).map(String)].join(' ');
+}
+
+/**
+ * React appends the component stack as the last argument, prefixed by a newline. Splitting it off
+ * keeps the exception message short enough to read in a test report while preserving the stack.
+ */
+function splitComponentStack(message: string): StrictModeViolation {
+    const stackStart = message.search(/\n\s+(in|at) \S/);
+
+    if (stackStart === -1) {
+        return {message};
+    }
+
+    return {
+        message: message.slice(0, stackStart).trim(),
+        componentStack: message.slice(stackStart).trim(),
+    };
+}
+
+export function installReactStrictModeDiagnostics() {
+    const violations: StrictModeViolation[] = [];
+    const reported = new Set<string>();
+
+    window.reactStrictModeViolations = violations;
+
+    const originalConsoleError = console.error;
+
+    console.error = (...args: unknown[]) => {
+        originalConsoleError.apply(console, args);
+
+        const formatted = formatWarning(args);
+
+        if (IGNORED.some((pattern) => pattern.test(formatted))) {
+            return;
+        }
+
+        if (!CONCURRENCY_HAZARDS.some((pattern) => pattern.test(formatted))) {
+            return;
+        }
+
+        const violation = splitComponentStack(formatted);
+
+        // React repeats most warnings once per offending component instance. Reporting each
+        // distinct message once keeps a single bad component from burying every other violation.
+        if (reported.has(violation.message)) {
+            return;
+        }
+        reported.add(violation.message);
+        violations.push(violation);
+
+        const error = new Error(`React strict mode violation: ${violation.message}`);
+        error.name = 'ReactStrictModeViolation';
+        if (violation.componentStack) {
+            error.stack = `${error.name}: ${violation.message}\n${violation.componentStack}`;
+        }
+
+        if (window.reactStrictModeThrowSynchronously) {
+            throw error;
+        }
+
+        // Rethrowing from a fresh task still produces an uncaught exception, but it does so after
+        // React has finished the work that emitted the warning. That keeps the app alive so a
+        // single run reports every violation instead of only the first one.
+        setTimeout(() => {
+            throw error;
+        }, 0);
+    };
+}

--- a/webapp/channels/src/utils/react_strict_mode.ts
+++ b/webapp/channels/src/utils/react_strict_mode.ts
@@ -146,7 +146,10 @@ export function installReactStrictModeDiagnostics() {
         const error = new Error(`React strict mode violation: ${violation.message}`);
         error.name = 'ReactStrictModeViolation';
         if (violation.componentStack) {
-            error.stack = `${error.name}: ${violation.message}\n${violation.componentStack}`;
+            // Appended rather than assigned. An Error whose stack holds no recognisable frames
+            // reaches Playwright's pageerror event as an empty string, which drops the component
+            // stack exactly when there is one worth reading.
+            error.stack = `${error.stack}\n${violation.componentStack}`;
         }
 
         if (window.reactStrictModeThrowSynchronously) {

--- a/webapp/channels/webpack.config.js
+++ b/webapp/channels/webpack.config.js
@@ -12,6 +12,7 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ImageMinimizerPlugin = require('image-minimizer-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
 const webpack = require('webpack');
 const {ModuleFederationPlugin} = require('webpack').container;
 const WebpackPwaManifest = require('webpack-pwa-manifest');
@@ -451,7 +452,15 @@ if (DEV) {
     config.optimization = {
         ...config.optimization,
         minimizer: [
-            '...',
+
+            // React derives component names from function and class names, so mangling them would
+            // leave every strict mode violation pointing at a one-letter component.
+            REACT_STRICT_MODE ? new TerserPlugin({
+                terserOptions: {
+                    keep_classnames: true,
+                    keep_fnames: true,
+                },
+            }) : '...',
             new ImageMinimizerPlugin({
                 minimizer: {
                     implementation: ImageMinimizerPlugin.sharpMinify,
@@ -471,16 +480,39 @@ if (DEV) {
 const env = {};
 if (DEV) {
     env.PUBLIC_PATH = JSON.stringify(publicPath);
-} else if (REACT_STRICT_MODE) {
-    console.log('Enabling React strict mode: building against the React development runtime');
-
-    env.NODE_ENV = JSON.stringify('development');
-
-    // Webpack's production mode defines process.env.NODE_ENV as 'production' on its own, which
-    // would conflict with the definition above.
-    config.optimization.nodeEnv = false;
 } else {
     env.NODE_ENV = JSON.stringify('production');
+}
+
+if (!DEV && REACT_STRICT_MODE) {
+    console.log('Enabling React strict mode: linking against the React development runtime');
+
+    // NODE_ENV deliberately stays at production above. Flipping it for the whole bundle would also
+    // switch every other library into its development mode, and some of those are far from free:
+    // mattermost-redux deep freezes the entire store on every action when NODE_ENV isn't
+    // production, which on its own is slow enough to make the E2E suite time out. Point React (and
+    // the packages it shares its internals with) at their development builds instead.
+    //
+    // These have to be absolute paths: the cjs directory isn't listed in each package's exports
+    // field, so webpack can't resolve it from a bare request.
+    const reactBuild = (packageName, file) => path.join(path.dirname(require.resolve(`${packageName}/package.json`)), 'cjs', file);
+
+    config.resolve.alias = {
+        ...config.resolve.alias,
+        react$: reactBuild('react', 'react.development.js'),
+        'react/jsx-runtime$': reactBuild('react', 'react-jsx-runtime.development.js'),
+        'react/jsx-dev-runtime$': reactBuild('react', 'react-jsx-dev-runtime.development.js'),
+        'react-dom$': reactBuild('react-dom', 'react-dom.development.js'),
+        scheduler$: reactBuild('scheduler', 'scheduler.development.js'),
+    };
+
+    config.module.rules.push({
+        test: [
+            /[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]cjs[\\/][\w-]+\.development\.js$/,
+            /[\\/]node_modules[\\/]react-dom[\\/]client\.js$/,
+        ],
+        loader: path.resolve(__dirname, 'scripts/react_development_build_loader.js'),
+    });
 }
 
 config.plugins.push(new webpack.DefinePlugin({

--- a/webapp/channels/webpack.config.js
+++ b/webapp/channels/webpack.config.js
@@ -28,6 +28,13 @@ const targetIsEsLint = !targetIsBuild && !targetIsRun && !targetIsDevServer;
 
 const DEV = targetIsRun || targetIsStats || targetIsDevServer;
 
+// React's StrictMode checks, and the warnings it logs when a component isn't safe to render
+// concurrently, only exist in a development build of React. Setting MM_REACT_STRICT_MODE keeps the
+// whole production pipeline (minification, chunking, real source maps) but links against React's
+// development runtime so those checks run. See src/utils/react_strict_mode.ts for what the web app
+// then does with the warnings.
+const REACT_STRICT_MODE = process.env.MM_REACT_STRICT_MODE === 'true';
+
 const STANDARD_EXCLUDE = [
     /node_modules/,
 ];
@@ -464,12 +471,21 @@ if (DEV) {
 const env = {};
 if (DEV) {
     env.PUBLIC_PATH = JSON.stringify(publicPath);
+} else if (REACT_STRICT_MODE) {
+    console.log('Enabling React strict mode: building against the React development runtime');
+
+    env.NODE_ENV = JSON.stringify('development');
+
+    // Webpack's production mode defines process.env.NODE_ENV as 'production' on its own, which
+    // would conflict with the definition above.
+    config.optimization.nodeEnv = false;
 } else {
     env.NODE_ENV = JSON.stringify('production');
 }
 
 config.plugins.push(new webpack.DefinePlugin({
     'process.env': env,
+    REACT_STRICT_MODE: JSON.stringify(REACT_STRICT_MODE),
 }));
 
 if (targetIsDevServer) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

We have a feature flag (`EnableConcurrentReact`) that switches the web app from `ReactDOM.render` to `ReactDOMClient.createRoot`, and we suspect the app has code that isn't safe under concurrent rendering. React's `StrictMode` is built to find exactly that code, but two things stop it from being useful against a build that behaves like the one we ship: the checks only exist in a development build of react-dom, and every violation is reported with `console.error`, which is easy to lose in a CI log.

This adds the tooling to close both gaps. Everything here is off by default and changes nothing about a normal build or a normal E2E run. The component fixes it found are in separate PRs.

**`MM_REACT_STRICT_MODE=true` build flag** (`webapp/channels/webpack.config.js`) keeps `process.env.NODE_ENV` at `production` for the bundle as a whole and instead aliases `react`, `react-dom` and `scheduler` to their development builds, with a small loader (`scripts/react_development_build_loader.js`) flipping the `NODE_ENV` guards those files wrap themselves in. Defining `NODE_ENV` as `development` globally was the first attempt and it does not work: mattermost-redux deep freezes the whole store on every action outside production, which slows the app down enough to make the E2E suite time out. Terser is also told to keep class and function names, otherwise every violation points at a one-letter component.

**Violations become exceptions** (`webapp/channels/src/utils/react_strict_mode.ts`). The app wraps itself in `<React.StrictMode>` and intercepts `console.error`. Warnings that indicate a concurrency hazard — StrictMode deprecations, render impurity, hook ordering, `useSyncExternalStore` snapshot caching — are reformatted into a `ReactStrictModeViolation` error carrying the React component stack and rethrown. Anything else is passed through untouched.

The rethrow is queued as a task rather than thrown from inside `console.error`. Throwing synchronously aborts the render that produced the warning, which usually kills the app on the first violation and hides every other one; queueing it still produces an uncaught exception but lets a single run report everything. `window.reactStrictModeThrowSynchronously = true` opts into the synchronous throw when debugging one violation by hand, and `window.reactStrictModeViolations` holds everything seen so far.

**`PW_FAIL_ON_PAGE_ERROR`** (`e2e-tests/playwright/lib/src/page_error.ts`) watches every page the harness opens and fails the test at teardown with the uncaught exceptions it saw — `strict-mode` for just the React violations, `all` for every uncaught exception, unset for off. Without it, a component that throws in the background is invisible to a run as long as the UI it produced still satisfies the test's locators.

**`CYPRESS_failOnPageError`** (`e2e-tests/cypress/tests/support/page_error.ts`) is the same switch for the Cypress half of the suite, which has ignored every uncaught exception since it was written (`Cypress.on('uncaught:exception', () => false)`). It takes the same three values. Cypress fails inline from the `uncaught:exception` handler rather than collecting and asserting at teardown: a throw from an `afterEach` hook would take the rest of the spec file with it, and with `testIsolation` off that is most of a run. The web app dedupes each distinct violation per page load, so a noisy component fails one test rather than every test after it.

**A self-test in each suite** (`specs/functional/channels/react_strict_mode/` and `tests/integration/channels/react_strict_mode/`). Without these, a suite only exercises detection when the app happens to have a violation, so a clean run and a broken detector look identical. Each spec provokes a violation and asserts it arrives: as an uncaught `ReactStrictModeViolation`, carrying the substituted warning text and the component stack, recorded on `window.reactStrictModeViolations`, and collected by the harness. The warning is injected through `console.error` rather than caused by a real component, because React only emits these from its own internals and the alternative is keeping a deliberately broken component around, which the next person to tidy up would delete. Both skip when the app was not built with `MM_REACT_STRICT_MODE`.

#### How to use it

```
# build the web app with the checks compiled in
MM_REACT_STRICT_MODE=true npm run build --workspace webapp

# fail tests on what it reports
PW_FAIL_ON_PAGE_ERROR=strict-mode npx playwright test
CYPRESS_failOnPageError=strict-mode npx cypress run
```

`EnableConcurrentReact` is independent: StrictMode runs either way, and turning the flag on as well is what makes a run representative of concurrent rendering.

#### Testing

Both self-tests were run three ways each — against a strict mode build with detection on, with it off, and against a normal build — and pass, pass, skip respectively.

Writing the Playwright one turned up a bug worth calling out. Playwright rebuilds a page error out of the browser and reports an empty stack for any error whose stack holds no recognisable frames, which is what `react_strict_mode.ts` produced when it replaced the stack with the component stack. Every violation that carried one, which is the useful case, would have reached the report as an empty line. The component stack is appended to the real stack instead, `formatPageErrors` falls back to the message on an empty one, and both the unit test and the new spec pin the behaviour down.

Unit tests cover the warning classifier, the printf-style formatting, the component stack split, the dedupe and the queued rethrow. The full web app suite is green.

#### Release Note

```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a048f9-6875-7f39-b562-b4b4252e0959?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a048f9-6875-7f39-b562-b4b4252e0959&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes affect shared build configuration, React runtime behavior, and E2E error handling across multiple test systems. Automated coverage reduces risk, but production-like builds and error interception have broad behavior impact.

**QA Recommendation:** Manual QA can be skipped. Automated unit, Cypress, and Playwright coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->