### PR TITLE
Stop react-transition-group from calling findDOMNode

### DIFF
--- a/webapp/channels/src/components/actions_menu/__snapshots__/actions_menu.test.tsx.snap
+++ b/webapp/channels/src/components/actions_menu/__snapshots__/actions_menu.test.tsx.snap
@@ -18,32 +18,34 @@ exports[`components/actions_menu/ActionsMenu has actions - marketplace disabled 
         class="icon icon-apps"
       />
     </button>
-    <div
-      aria-label="Post extra options"
-      class="a11y__popup Menu"
-    >
-      <ul
-        class="Menu__content dropdown-menu openLeft"
-        id="center_actions_dropdown_post_id_1"
-        role="menu"
+    <div>
+      <div
+        aria-label="Post extra options"
+        class="a11y__popup Menu"
       >
-        <li
-          class="MenuItem"
-          role="menuitem"
+        <ul
+          class="Menu__content dropdown-menu openLeft"
+          id="center_actions_dropdown_post_id_1"
+          role="menu"
         >
-          <button
-            class="style--none"
-            data-testid="undefined-button"
-            id="undefined-button"
+          <li
+            class="MenuItem"
+            role="menuitem"
           >
-            <span
-              class="MenuItem__primary-text"
+            <button
+              class="style--none"
+              data-testid="undefined-button"
+              id="undefined-button"
             >
-              Some text
-            </span>
-          </button>
-        </li>
-      </ul>
+              <span
+                class="MenuItem__primary-text"
+              >
+                Some text
+              </span>
+            </button>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>
@@ -67,66 +69,68 @@ exports[`components/actions_menu/ActionsMenu has actions - marketplace enabled a
         class="icon icon-apps"
       />
     </button>
-    <div
-      aria-label="Post extra options"
-      class="a11y__popup Menu"
-    >
-      <ul
-        class="Menu__content dropdown-menu openLeft"
-        id="center_actions_dropdown_post_id_1"
-        role="menu"
+    <div>
+      <div
+        aria-label="Post extra options"
+        class="a11y__popup Menu"
       >
-        <li
-          class="MenuItem"
-          role="menuitem"
+        <ul
+          class="Menu__content dropdown-menu openLeft"
+          id="center_actions_dropdown_post_id_1"
+          role="menu"
         >
-          <button
-            class="style--none"
-            data-testid="undefined-button"
-            id="undefined-button"
+          <li
+            class="MenuItem"
+            role="menuitem"
           >
-            <span
-              class="MenuItem__primary-text"
-            >
-              Some text
-            </span>
-          </button>
-        </li>
-        <li
-          class="MenuItem__divider"
-          id="divider_post_post_id_1_marketplace"
-          role="menuitem"
-        />
-        <li
-          class="MenuItem MenuItem--with-icon"
-          id="marketplace_icon_post_id_1"
-          role="menuitem"
-        >
-          <button
-            class="style--none"
-            data-testid="marketplace_icon_post_id_1-button"
-            id="marketplace_icon_post_id_1-button"
-          >
-            <span
-              class="MenuItem__primary-text"
+            <button
+              class="style--none"
+              data-testid="undefined-button"
+              id="undefined-button"
             >
               <span
-                class="icon"
+                class="MenuItem__primary-text"
+              >
+                Some text
+              </span>
+            </button>
+          </li>
+          <li
+            class="MenuItem__divider"
+            id="divider_post_post_id_1_marketplace"
+            role="menuitem"
+          />
+          <li
+            class="MenuItem MenuItem--with-icon"
+            id="marketplace_icon_post_id_1"
+            role="menuitem"
+          >
+            <button
+              class="style--none"
+              data-testid="marketplace_icon_post_id_1-button"
+              id="marketplace_icon_post_id_1-button"
+            >
+              <span
+                class="MenuItem__primary-text"
               >
                 <span
-                  aria-hidden="true"
-                  class="icon-view-grid-plus-outline MenuItem__compass-icon"
-                />
+                  class="icon"
+                >
+                  <span
+                    aria-hidden="true"
+                    class="icon-view-grid-plus-outline MenuItem__compass-icon"
+                  />
+                </span>
+                <div
+                  class="text"
+                >
+                  App Marketplace
+                </div>
               </span>
-              <div
-                class="text"
-              >
-                App Marketplace
-              </div>
-            </span>
-          </button>
-        </li>
-      </ul>
+            </button>
+          </li>
+        </ul>
+      </div>
     </div>
   </div>
 </div>

--- a/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/formatting_bar/formatting_bar.tsx
@@ -233,12 +233,13 @@ const FormattingBar = forwardRef<FormattingBarHandle, FormattingBarProps>((props
     const {formatMessage} = useIntl();
     const HiddenControlsButtonAriaLabel = formatMessage({id: 'accessibility.button.hidden_controls_button', defaultMessage: 'show hidden formatting options'});
 
-    const {x, y, strategy, update, context, refs: {setReference, setFloating}} = useFloating<HTMLButtonElement>({
+    const {x, y, strategy, update, context, refs} = useFloating<HTMLButtonElement>({
         open: showHiddenControls,
         onOpenChange: setShowHiddenControls,
         placement: 'top',
         middleware: [offset({mainAxis: 4})],
     });
+    const {setReference, setFloating} = refs;
 
     const click = useClick(context);
     const {getReferenceProps: getClickReferenceProps, getFloatingProps: getClickFloatingProps} = useInteractions([
@@ -363,6 +364,7 @@ const FormattingBar = forwardRef<FormattingBarHandle, FormattingBarProps>((props
                 timeout={250}
                 classNames='scale'
                 in={showHiddenControls}
+                nodeRef={refs.floating}
                 unmountOnExit={true}
             >
                 <HiddenControlsContainer

--- a/webapp/channels/src/components/channel_info_rhs/components/linelimiter.tsx
+++ b/webapp/channels/src/components/channel_info_rhs/components/linelimiter.tsx
@@ -22,6 +22,7 @@ const LineLimiterBase = ({children, maxLines, lineHeight, moreText, lessText, er
     const [open, setOpen] = useState(false);
     const [maxHeight, setMaxHeight] = useState('inherit');
     const ref = useRef<HTMLDivElement>(null);
+    const nodeRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (ref === null || ref.current === null) {
@@ -47,11 +48,13 @@ const LineLimiterBase = ({children, maxLines, lineHeight, moreText, lessText, er
     return (
         <CSSTransition
             in={open}
+            nodeRef={nodeRef}
             timeout={500}
             classNames='LineLimiter--Transition-'
         >
             <>
                 <div
+                    ref={nodeRef}
                     className={className}
                     style={{maxHeight}}
                 >

--- a/webapp/channels/src/components/common/auto_height_switcher.tsx
+++ b/webapp/channels/src/components/common/auto_height_switcher.tsx
@@ -96,6 +96,7 @@ const AutoHeightSwitcher = ({showSlot, onTransitionEnd, slot1 = null, slot2 = nu
     return (
         <Transition
             in={animate}
+            nodeRef={wrapperRef}
             timeout={duration}
             onEnter={() => {
                 setHeight(prevHeight.current ?? childRef.current!.offsetHeight);
@@ -105,12 +106,12 @@ const AutoHeightSwitcher = ({showSlot, onTransitionEnd, slot1 = null, slot2 = nu
             onEntering={() => {
                 setHeight(childRef.current!.offsetHeight);
             }}
-            onEntered={(node: HTMLElement) => {
+            onEntered={() => {
                 prevHeight.current = childRef.current!.offsetHeight;
                 setHeight('auto');
                 setOverflow('visible');
                 setAnimate(false);
-                onTransitionEnd?.(node);
+                onTransitionEnd?.(wrapperRef.current ?? undefined);
             }}
         >
             <div

--- a/webapp/channels/src/components/emoji_picker/components/emoji_picker_skin.tsx
+++ b/webapp/channels/src/components/emoji_picker/components/emoji_picker_skin.tsx
@@ -83,6 +83,8 @@ type State = {
 };
 
 export class EmojiPickerSkin extends React.PureComponent<Props, State> {
+    private nodeRef = React.createRef<HTMLDivElement>();
+
     constructor(props: Props) {
         super(props);
 
@@ -204,11 +206,15 @@ export class EmojiPickerSkin extends React.PureComponent<Props, State> {
         return (
             <CSSTransition
                 in={this.state.pickerExtended}
+                nodeRef={this.nodeRef}
                 onExited={this.handleSkinToneHidden}
                 classNames='skin-tones-animation'
                 timeout={200}
             >
-                <div className={classNames('skin-tones', {'skin-tones--active': this.state.pickerMounted})}>
+                <div
+                    ref={this.nodeRef}
+                    className={classNames('skin-tones', {'skin-tones--active': this.state.pickerMounted})}
+                >
                     <div
                         className={classNames('skin-tones__content', {'skin-tones__content__single': !this.state.pickerMounted}, {'skin-tones__close': this.state.pickerMounted})}
                         aria-orientation='horizontal'

--- a/webapp/channels/src/components/global_header/left_controls/product_menu/__snapshots__/product_menu.test.tsx.snap
+++ b/webapp/channels/src/components/global_header/left_controls/product_menu/__snapshots__/product_menu.test.tsx.snap
@@ -35,72 +35,73 @@ exports[`components/global/product_switcher should have an active button state w
           />
         </button>
       </nav>
-      <div
-        aria-label="switcherOpen"
-        class="a11y__popup Menu"
-        id="product-switcher-menu"
-      >
-        <ul
-          class="Menu__content dropdown-menu product-switcher-menu"
-          id="product-switcher-menu-dropdown"
-          role="menu"
+      <div>
+        <div
+          aria-label="switcherOpen"
+          class="a11y__popup Menu"
+          id="product-switcher-menu"
         >
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            role="menuitem"
+          <ul
+            class="Menu__content dropdown-menu product-switcher-menu"
+            id="product-switcher-menu-dropdown"
+            role="menu"
           >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              role="menuitem"
             >
-              <path
-                d="M6,7.75c0.69,0,1.25,0.56,1.25,1.25S6.69,10.25,6,10.25S4.75,9.69,4.75,9S5.31,7.75,6,7.75z M10.5,7.75c0.69,0,1.25,0.56,1.25,1.25s-0.56,1.25-1.25,1.25c-0.69,0-1.25-0.56-1.25-1.25S9.81,7.75,10.5,7.75z M16.25,9
+              <svg
+                fill="var(--button-bg)"
+                height="24"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6,7.75c0.69,0,1.25,0.56,1.25,1.25S6.69,10.25,6,10.25S4.75,9.69,4.75,9S5.31,7.75,6,7.75z M10.5,7.75c0.69,0,1.25,0.56,1.25,1.25s-0.56,1.25-1.25,1.25c-0.69,0-1.25-0.56-1.25-1.25S9.81,7.75,10.5,7.75z M16.25,9
 	c0-0.69-0.56-1.25-1.25-1.25S13.75,8.31,13.75,9s0.56,1.25,1.25,1.25S16.25,9.69,16.25,9z M4,3C2.895,3,2,3.895,2,5v8
 	c0,1.105,0.895,2,2,2h2v4l3.636-4H17c1.105,0,2-0.895,2-2V5c0-1.105-0.895-2-2-2H4z M11,13.5H9.318l-1.818,2v-2H6H4.5
 	c-0.552,0-1-0.448-1-1v-7c0-0.552,0.448-1,1-1h12c0.552,0,1,0.448,1,1v7c0,0.552-0.448,1-1,1H11z M10.063,16.5
 	C10.285,17.363,11.068,18,12,18h2.364L18,22v-4h2c1.104,0,2-0.896,2-2V8c0-0.932-0.637-1.715-1.5-1.937V8.5v7c0,0.552-0.448,1-1,1
 	H18h-1.5v2l-1.818-2H13h-0.5H10.063z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
+                />
+              </svg>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Channels
+              </span>
+              <svg
+                fill="var(--button-bg)"
+                height="18"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+                />
+              </svg>
+            </a>
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              id="product-menu-item-Boards"
+              role="menuitem"
             >
-              Channels
-            </span>
-            <svg
-              fill="var(--button-bg)"
-              height="18"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="18"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
-              />
-            </svg>
-          </a>
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            id="product-menu-item-Boards"
-            role="menuitem"
-          >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M16.736,3.191C15.327,2.431,13.714,2,12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10c0-1.708-0.428-3.316-1.183-4.722c-0.435,0.14-0.945,0.258-1.522,0.357C20.06,8.911,20.5,10.404,20.5,12c0,4.694-3.806,8.5-8.5,8.5
+              <svg
+                fill="var(--button-bg)"
+                height="24"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.736,3.191C15.327,2.431,13.714,2,12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10c0-1.708-0.428-3.316-1.183-4.722c-0.435,0.14-0.945,0.258-1.522,0.357C20.06,8.911,20.5,10.404,20.5,12c0,4.694-3.806,8.5-8.5,8.5
 	c-4.694,0-8.5-3.806-8.5-8.5c0-4.694,3.806-8.5,8.5-8.5c1.6,0,3.096,0.442,4.374,1.21C16.476,4.134,16.595,3.624,16.736,3.191z
 	 M16.084,6.943L16.084,6.943l-1.149,1.009c0,0,0,0,0,0L16.084,6.943z M15.233,6.36C14.281,5.813,13.177,5.5,12,5.5
 	c-3.59,0-6.5,2.91-6.5,6.5c0,3.59,2.91,6.5,6.5,6.5c3.59,0,6.5-2.91,6.5-6.5c0-1.17-0.309-2.268-0.85-3.216l-1.07,1.207
@@ -114,84 +115,85 @@ exports[`components/global/product_switcher should have an active button state w
 	c0.573-1.7,0.498-2.621-0.233-2.745c-0.722-0.124-1.25,1.109-1.574,3.697L13.012,9.64c-0.179,0.205-0.262,0.438-0.259,0.681
 	c0.003,0.166,0.053,0.32,0.147,0.46l-1.064,1.064c-0.092,0.092-0.092,0.24,0,0.332c0.092,0.092,0.24,0.092,0.332,0l1.07-1.07
 	c0.149,0.092,0.313,0.137,0.484,0.14c0.243,0.004,0.459-0.08,0.638-0.259L18.069,6.803z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
-            >
-              Boards
-            </span>
-            <button
-              aria-label="Open in new tab"
-              class="OpenInNewTabButton-fKoVVp cLFfqU"
+                />
+              </svg>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Boards
+              </span>
+              <button
+                aria-label="Open in new tab"
+                class="OpenInNewTabButton-fKoVVp cLFfqU"
+              >
+                <svg
+                  fill="currentColor"
+                  height="16"
+                  version="1.1"
+                  viewBox="0 0 24 24"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                  />
+                </svg>
+              </button>
+            </a>
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              id="product-menu-item-Playbooks"
+              role="menuitem"
             >
               <svg
-                fill="currentColor"
-                height="16"
+                fill="var(--button-bg)"
+                height="24"
                 version="1.1"
                 viewBox="0 0 24 24"
-                width="16"
+                width="24"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
-                />
-              </svg>
-            </button>
-          </a>
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            id="product-menu-item-Playbooks"
-            role="menuitem"
-          >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8,3.5H6c-1.105,0-2,0.895-2,2V19c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V5.5c0-1.105-0.895-2-2-2h-2V5h1.5c0.552,0,1,0.448,1,1v12.5c0,0.552-0.448,1-1,1h-11c-0.552,0-1-0.448-1-1V6c0-0.552,0.448-1,1-1H8V3.5z M11,2
+                  d="M8,3.5H6c-1.105,0-2,0.895-2,2V19c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V5.5c0-1.105-0.895-2-2-2h-2V5h1.5c0.552,0,1,0.448,1,1v12.5c0,0.552-0.448,1-1,1h-11c-0.552,0-1-0.448-1-1V6c0-0.552,0.448-1,1-1H8V3.5z M11,2
 	c-0.276,0-0.5,0.224-0.5,0.5V3H9v2.5h6V3h-1.5V2.5C13.5,2.224,13.276,2,13,2H11z M10.5,16H17v1h-6.5V16z M7.5,15.75H9v1.5H7.5V15.75
 	z M10.5,12H17v1h-6.5V12z M7.5,11.75H9v1.5H7.5V11.75z M10.5,8H17v1h-6.5V8z M7.409,9.091l-0.5-0.5l0.5-0.5l0.5,0.5L9,7.5L9.5,8
 	L7.909,9.591L7.409,9.091z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
-            >
-              Playbooks
-            </span>
-            <button
-              aria-label="Open in new tab"
-              class="OpenInNewTabButton-fKoVVp cLFfqU"
-            >
-              <svg
-                fill="currentColor"
-                height="16"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
                 />
               </svg>
-            </button>
-          </a>
-          <div
-            data-testid="product-menu-list"
-          />
-          <li
-            class="MenuGroup menu-divider"
-            role="separator"
-            style="display: none;"
-          />
-        </ul>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Playbooks
+              </span>
+              <button
+                aria-label="Open in new tab"
+                class="OpenInNewTabButton-fKoVVp cLFfqU"
+              >
+                <svg
+                  fill="currentColor"
+                  height="16"
+                  version="1.1"
+                  viewBox="0 0 24 24"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                  />
+                </svg>
+              </button>
+            </a>
+            <div
+              data-testid="product-menu-list"
+            />
+            <li
+              class="MenuGroup menu-divider"
+              role="separator"
+              style="display: none;"
+            />
+          </ul>
+        </div>
       </div>
     </div>
   </div>
@@ -311,72 +313,73 @@ exports[`components/global/product_switcher should match snapshot with a registe
           />
         </button>
       </nav>
-      <div
-        aria-label="switcherOpen"
-        class="a11y__popup Menu"
-        id="product-switcher-menu"
-      >
-        <ul
-          class="Menu__content dropdown-menu product-switcher-menu"
-          id="product-switcher-menu-dropdown"
-          role="menu"
+      <div>
+        <div
+          aria-label="switcherOpen"
+          class="a11y__popup Menu"
+          id="product-switcher-menu"
         >
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            role="menuitem"
+          <ul
+            class="Menu__content dropdown-menu product-switcher-menu"
+            id="product-switcher-menu-dropdown"
+            role="menu"
           >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              role="menuitem"
             >
-              <path
-                d="M6,7.75c0.69,0,1.25,0.56,1.25,1.25S6.69,10.25,6,10.25S4.75,9.69,4.75,9S5.31,7.75,6,7.75z M10.5,7.75c0.69,0,1.25,0.56,1.25,1.25s-0.56,1.25-1.25,1.25c-0.69,0-1.25-0.56-1.25-1.25S9.81,7.75,10.5,7.75z M16.25,9
+              <svg
+                fill="var(--button-bg)"
+                height="24"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6,7.75c0.69,0,1.25,0.56,1.25,1.25S6.69,10.25,6,10.25S4.75,9.69,4.75,9S5.31,7.75,6,7.75z M10.5,7.75c0.69,0,1.25,0.56,1.25,1.25s-0.56,1.25-1.25,1.25c-0.69,0-1.25-0.56-1.25-1.25S9.81,7.75,10.5,7.75z M16.25,9
 	c0-0.69-0.56-1.25-1.25-1.25S13.75,8.31,13.75,9s0.56,1.25,1.25,1.25S16.25,9.69,16.25,9z M4,3C2.895,3,2,3.895,2,5v8
 	c0,1.105,0.895,2,2,2h2v4l3.636-4H17c1.105,0,2-0.895,2-2V5c0-1.105-0.895-2-2-2H4z M11,13.5H9.318l-1.818,2v-2H6H4.5
 	c-0.552,0-1-0.448-1-1v-7c0-0.552,0.448-1,1-1h12c0.552,0,1,0.448,1,1v7c0,0.552-0.448,1-1,1H11z M10.063,16.5
 	C10.285,17.363,11.068,18,12,18h2.364L18,22v-4h2c1.104,0,2-0.896,2-2V8c0-0.932-0.637-1.715-1.5-1.937V8.5v7c0,0.552-0.448,1-1,1
 	H18h-1.5v2l-1.818-2H13h-0.5H10.063z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
+                />
+              </svg>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Channels
+              </span>
+              <svg
+                fill="var(--button-bg)"
+                height="18"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+                />
+              </svg>
+            </a>
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              id="product-menu-item-Boards"
+              role="menuitem"
             >
-              Channels
-            </span>
-            <svg
-              fill="var(--button-bg)"
-              height="18"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="18"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
-              />
-            </svg>
-          </a>
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            id="product-menu-item-Boards"
-            role="menuitem"
-          >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M16.736,3.191C15.327,2.431,13.714,2,12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10c0-1.708-0.428-3.316-1.183-4.722c-0.435,0.14-0.945,0.258-1.522,0.357C20.06,8.911,20.5,10.404,20.5,12c0,4.694-3.806,8.5-8.5,8.5
+              <svg
+                fill="var(--button-bg)"
+                height="24"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.736,3.191C15.327,2.431,13.714,2,12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10c0-1.708-0.428-3.316-1.183-4.722c-0.435,0.14-0.945,0.258-1.522,0.357C20.06,8.911,20.5,10.404,20.5,12c0,4.694-3.806,8.5-8.5,8.5
 	c-4.694,0-8.5-3.806-8.5-8.5c0-4.694,3.806-8.5,8.5-8.5c1.6,0,3.096,0.442,4.374,1.21C16.476,4.134,16.595,3.624,16.736,3.191z
 	 M16.084,6.943L16.084,6.943l-1.149,1.009c0,0,0,0,0,0L16.084,6.943z M15.233,6.36C14.281,5.813,13.177,5.5,12,5.5
 	c-3.59,0-6.5,2.91-6.5,6.5c0,3.59,2.91,6.5,6.5,6.5c3.59,0,6.5-2.91,6.5-6.5c0-1.17-0.309-2.268-0.85-3.216l-1.07,1.207
@@ -390,87 +393,36 @@ exports[`components/global/product_switcher should match snapshot with a registe
 	c0.573-1.7,0.498-2.621-0.233-2.745c-0.722-0.124-1.25,1.109-1.574,3.697L13.012,9.64c-0.179,0.205-0.262,0.438-0.259,0.681
 	c0.003,0.166,0.053,0.32,0.147,0.46l-1.064,1.064c-0.092,0.092-0.092,0.24,0,0.332c0.092,0.092,0.24,0.092,0.332,0l1.07-1.07
 	c0.149,0.092,0.313,0.137,0.484,0.14c0.243,0.004,0.459-0.08,0.638-0.259L18.069,6.803z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
-            >
-              Boards
-            </span>
-            <button
-              aria-label="Open in new tab"
-              class="OpenInNewTabButton-fKoVVp cLFfqU"
-            >
-              <svg
-                fill="currentColor"
-                height="16"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
                 />
               </svg>
-            </button>
-          </a>
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            id="product-menu-item-Playbooks"
-            role="menuitem"
-          >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8,3.5H6c-1.105,0-2,0.895-2,2V19c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V5.5c0-1.105-0.895-2-2-2h-2V5h1.5c0.552,0,1,0.448,1,1v12.5c0,0.552-0.448,1-1,1h-11c-0.552,0-1-0.448-1-1V6c0-0.552,0.448-1,1-1H8V3.5z M11,2
-	c-0.276,0-0.5,0.224-0.5,0.5V3H9v2.5h6V3h-1.5V2.5C13.5,2.224,13.276,2,13,2H11z M10.5,16H17v1h-6.5V16z M7.5,15.75H9v1.5H7.5V15.75
-	z M10.5,12H17v1h-6.5V12z M7.5,11.75H9v1.5H7.5V11.75z M10.5,8H17v1h-6.5V8z M7.409,9.091l-0.5-0.5l0.5-0.5l0.5,0.5L9,7.5L9.5,8
-	L7.909,9.591L7.409,9.091z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
-            >
-              Playbooks
-            </span>
-            <button
-              aria-label="Open in new tab"
-              class="OpenInNewTabButton-fKoVVp cLFfqU"
-            >
-              <svg
-                fill="currentColor"
-                height="16"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
               >
-                <path
-                  d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
-                />
-              </svg>
-            </button>
-          </a>
-          <li
-            class="MenuGroup menu-divider"
-            role="separator"
-            style="display: block;"
-          />
-          <li
-            id="product-switcher-menu-item-item-1"
-            role="menuitem"
-          >
-            <button
-              class="SwitcherActionButton-gnHZoG jMgsOP"
-              type="button"
+                Boards
+              </span>
+              <button
+                aria-label="Open in new tab"
+                class="OpenInNewTabButton-fKoVVp cLFfqU"
+              >
+                <svg
+                  fill="currentColor"
+                  height="16"
+                  version="1.1"
+                  viewBox="0 0 24 24"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                  />
+                </svg>
+              </button>
+            </a>
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              id="product-menu-item-Playbooks"
+              role="menuitem"
             >
               <svg
                 fill="var(--button-bg)"
@@ -481,25 +433,77 @@ exports[`components/global/product_switcher should match snapshot with a registe
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M21,11C21,16.55 17.16,21.74 12,23C6.84,21.74 3,16.55 3,11V5L12,1L21,5V11M12,21C15.75,20 19,15.54 19,11.22V6.3L12,3.18L5,6.3V11.22C5,15.54 8.25,20 12,21Z"
+                  d="M8,3.5H6c-1.105,0-2,0.895-2,2V19c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V5.5c0-1.105-0.895-2-2-2h-2V5h1.5c0.552,0,1,0.448,1,1v12.5c0,0.552-0.448,1-1,1h-11c-0.552,0-1-0.448-1-1V6c0-0.552,0.448-1,1-1H8V3.5z M11,2
+	c-0.276,0-0.5,0.224-0.5,0.5V3H9v2.5h6V3h-1.5V2.5C13.5,2.224,13.276,2,13,2H11z M10.5,16H17v1h-6.5V16z M7.5,15.75H9v1.5H7.5V15.75
+	z M10.5,12H17v1h-6.5V12z M7.5,11.75H9v1.5H7.5V11.75z M10.5,8H17v1h-6.5V8z M7.409,9.091l-0.5-0.5l0.5-0.5l0.5,0.5L9,7.5L9.5,8
+	L7.909,9.591L7.409,9.091z"
                 />
               </svg>
               <span
                 class="ProductMenuItemText-bbJshj kjMpVz"
               >
-                Create Encrypted Channel
+                Playbooks
               </span>
-            </button>
-          </li>
-          <div
-            data-testid="product-menu-list"
-          />
-          <li
-            class="MenuGroup menu-divider"
-            role="separator"
-            style="display: none;"
-          />
-        </ul>
+              <button
+                aria-label="Open in new tab"
+                class="OpenInNewTabButton-fKoVVp cLFfqU"
+              >
+                <svg
+                  fill="currentColor"
+                  height="16"
+                  version="1.1"
+                  viewBox="0 0 24 24"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                  />
+                </svg>
+              </button>
+            </a>
+            <li
+              class="MenuGroup menu-divider"
+              role="separator"
+              style="display: block;"
+            />
+            <li
+              id="product-switcher-menu-item-item-1"
+              role="menuitem"
+            >
+              <button
+                class="SwitcherActionButton-gnHZoG jMgsOP"
+                type="button"
+              >
+                <svg
+                  fill="var(--button-bg)"
+                  height="24"
+                  version="1.1"
+                  viewBox="0 0 24 24"
+                  width="24"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M21,11C21,16.55 17.16,21.74 12,23C6.84,21.74 3,16.55 3,11V5L12,1L21,5V11M12,21C15.75,20 19,15.54 19,11.22V6.3L12,3.18L5,6.3V11.22C5,15.54 8.25,20 12,21Z"
+                  />
+                </svg>
+                <span
+                  class="ProductMenuItemText-bbJshj kjMpVz"
+                >
+                  Create Encrypted Channel
+                </span>
+              </button>
+            </li>
+            <div
+              data-testid="product-menu-list"
+            />
+            <li
+              class="MenuGroup menu-divider"
+              role="separator"
+              style="display: none;"
+            />
+          </ul>
+        </div>
       </div>
     </div>
   </div>
@@ -541,72 +545,73 @@ exports[`components/global/product_switcher should match snapshot with product s
           />
         </button>
       </nav>
-      <div
-        aria-label="switcherOpen"
-        class="a11y__popup Menu"
-        id="product-switcher-menu"
-      >
-        <ul
-          class="Menu__content dropdown-menu product-switcher-menu"
-          id="product-switcher-menu-dropdown"
-          role="menu"
+      <div>
+        <div
+          aria-label="switcherOpen"
+          class="a11y__popup Menu"
+          id="product-switcher-menu"
         >
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            role="menuitem"
+          <ul
+            class="Menu__content dropdown-menu product-switcher-menu"
+            id="product-switcher-menu-dropdown"
+            role="menu"
           >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              role="menuitem"
             >
-              <path
-                d="M6,7.75c0.69,0,1.25,0.56,1.25,1.25S6.69,10.25,6,10.25S4.75,9.69,4.75,9S5.31,7.75,6,7.75z M10.5,7.75c0.69,0,1.25,0.56,1.25,1.25s-0.56,1.25-1.25,1.25c-0.69,0-1.25-0.56-1.25-1.25S9.81,7.75,10.5,7.75z M16.25,9
+              <svg
+                fill="var(--button-bg)"
+                height="24"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6,7.75c0.69,0,1.25,0.56,1.25,1.25S6.69,10.25,6,10.25S4.75,9.69,4.75,9S5.31,7.75,6,7.75z M10.5,7.75c0.69,0,1.25,0.56,1.25,1.25s-0.56,1.25-1.25,1.25c-0.69,0-1.25-0.56-1.25-1.25S9.81,7.75,10.5,7.75z M16.25,9
 	c0-0.69-0.56-1.25-1.25-1.25S13.75,8.31,13.75,9s0.56,1.25,1.25,1.25S16.25,9.69,16.25,9z M4,3C2.895,3,2,3.895,2,5v8
 	c0,1.105,0.895,2,2,2h2v4l3.636-4H17c1.105,0,2-0.895,2-2V5c0-1.105-0.895-2-2-2H4z M11,13.5H9.318l-1.818,2v-2H6H4.5
 	c-0.552,0-1-0.448-1-1v-7c0-0.552,0.448-1,1-1h12c0.552,0,1,0.448,1,1v7c0,0.552-0.448,1-1,1H11z M10.063,16.5
 	C10.285,17.363,11.068,18,12,18h2.364L18,22v-4h2c1.104,0,2-0.896,2-2V8c0-0.932-0.637-1.715-1.5-1.937V8.5v7c0,0.552-0.448,1-1,1
 	H18h-1.5v2l-1.818-2H13h-0.5H10.063z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
+                />
+              </svg>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Channels
+              </span>
+              <svg
+                fill="var(--button-bg)"
+                height="18"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+                />
+              </svg>
+            </a>
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              id="product-menu-item-Boards"
+              role="menuitem"
             >
-              Channels
-            </span>
-            <svg
-              fill="var(--button-bg)"
-              height="18"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="18"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
-              />
-            </svg>
-          </a>
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            id="product-menu-item-Boards"
-            role="menuitem"
-          >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M16.736,3.191C15.327,2.431,13.714,2,12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10c0-1.708-0.428-3.316-1.183-4.722c-0.435,0.14-0.945,0.258-1.522,0.357C20.06,8.911,20.5,10.404,20.5,12c0,4.694-3.806,8.5-8.5,8.5
+              <svg
+                fill="var(--button-bg)"
+                height="24"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.736,3.191C15.327,2.431,13.714,2,12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10c0-1.708-0.428-3.316-1.183-4.722c-0.435,0.14-0.945,0.258-1.522,0.357C20.06,8.911,20.5,10.404,20.5,12c0,4.694-3.806,8.5-8.5,8.5
 	c-4.694,0-8.5-3.806-8.5-8.5c0-4.694,3.806-8.5,8.5-8.5c1.6,0,3.096,0.442,4.374,1.21C16.476,4.134,16.595,3.624,16.736,3.191z
 	 M16.084,6.943L16.084,6.943l-1.149,1.009c0,0,0,0,0,0L16.084,6.943z M15.233,6.36C14.281,5.813,13.177,5.5,12,5.5
 	c-3.59,0-6.5,2.91-6.5,6.5c0,3.59,2.91,6.5,6.5,6.5c3.59,0,6.5-2.91,6.5-6.5c0-1.17-0.309-2.268-0.85-3.216l-1.07,1.207
@@ -620,84 +625,85 @@ exports[`components/global/product_switcher should match snapshot with product s
 	c0.573-1.7,0.498-2.621-0.233-2.745c-0.722-0.124-1.25,1.109-1.574,3.697L13.012,9.64c-0.179,0.205-0.262,0.438-0.259,0.681
 	c0.003,0.166,0.053,0.32,0.147,0.46l-1.064,1.064c-0.092,0.092-0.092,0.24,0,0.332c0.092,0.092,0.24,0.092,0.332,0l1.07-1.07
 	c0.149,0.092,0.313,0.137,0.484,0.14c0.243,0.004,0.459-0.08,0.638-0.259L18.069,6.803z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
-            >
-              Boards
-            </span>
-            <button
-              aria-label="Open in new tab"
-              class="OpenInNewTabButton-fKoVVp cLFfqU"
+                />
+              </svg>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Boards
+              </span>
+              <button
+                aria-label="Open in new tab"
+                class="OpenInNewTabButton-fKoVVp cLFfqU"
+              >
+                <svg
+                  fill="currentColor"
+                  height="16"
+                  version="1.1"
+                  viewBox="0 0 24 24"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                  />
+                </svg>
+              </button>
+            </a>
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              id="product-menu-item-Playbooks"
+              role="menuitem"
             >
               <svg
-                fill="currentColor"
-                height="16"
+                fill="var(--button-bg)"
+                height="24"
                 version="1.1"
                 viewBox="0 0 24 24"
-                width="16"
+                width="24"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
-                />
-              </svg>
-            </button>
-          </a>
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            id="product-menu-item-Playbooks"
-            role="menuitem"
-          >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8,3.5H6c-1.105,0-2,0.895-2,2V19c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V5.5c0-1.105-0.895-2-2-2h-2V5h1.5c0.552,0,1,0.448,1,1v12.5c0,0.552-0.448,1-1,1h-11c-0.552,0-1-0.448-1-1V6c0-0.552,0.448-1,1-1H8V3.5z M11,2
+                  d="M8,3.5H6c-1.105,0-2,0.895-2,2V19c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V5.5c0-1.105-0.895-2-2-2h-2V5h1.5c0.552,0,1,0.448,1,1v12.5c0,0.552-0.448,1-1,1h-11c-0.552,0-1-0.448-1-1V6c0-0.552,0.448-1,1-1H8V3.5z M11,2
 	c-0.276,0-0.5,0.224-0.5,0.5V3H9v2.5h6V3h-1.5V2.5C13.5,2.224,13.276,2,13,2H11z M10.5,16H17v1h-6.5V16z M7.5,15.75H9v1.5H7.5V15.75
 	z M10.5,12H17v1h-6.5V12z M7.5,11.75H9v1.5H7.5V11.75z M10.5,8H17v1h-6.5V8z M7.409,9.091l-0.5-0.5l0.5-0.5l0.5,0.5L9,7.5L9.5,8
 	L7.909,9.591L7.409,9.091z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
-            >
-              Playbooks
-            </span>
-            <button
-              aria-label="Open in new tab"
-              class="OpenInNewTabButton-fKoVVp cLFfqU"
-            >
-              <svg
-                fill="currentColor"
-                height="16"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
                 />
               </svg>
-            </button>
-          </a>
-          <div
-            data-testid="product-menu-list"
-          />
-          <li
-            class="MenuGroup menu-divider"
-            role="separator"
-            style="display: none;"
-          />
-        </ul>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Playbooks
+              </span>
+              <button
+                aria-label="Open in new tab"
+                class="OpenInNewTabButton-fKoVVp cLFfqU"
+              >
+                <svg
+                  fill="currentColor"
+                  height="16"
+                  version="1.1"
+                  viewBox="0 0 24 24"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                  />
+                </svg>
+              </button>
+            </a>
+            <div
+              data-testid="product-menu-list"
+            />
+            <li
+              class="MenuGroup menu-divider"
+              role="separator"
+              style="display: none;"
+            />
+          </ul>
+        </div>
       </div>
     </div>
   </div>
@@ -778,72 +784,73 @@ exports[`components/global/product_switcher should render once when there are no
           />
         </button>
       </nav>
-      <div
-        aria-label="switcherOpen"
-        class="a11y__popup Menu"
-        id="product-switcher-menu"
-      >
-        <ul
-          class="Menu__content dropdown-menu product-switcher-menu"
-          id="product-switcher-menu-dropdown"
-          role="menu"
+      <div>
+        <div
+          aria-label="switcherOpen"
+          class="a11y__popup Menu"
+          id="product-switcher-menu"
         >
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            role="menuitem"
+          <ul
+            class="Menu__content dropdown-menu product-switcher-menu"
+            id="product-switcher-menu-dropdown"
+            role="menu"
           >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              role="menuitem"
             >
-              <path
-                d="M6,7.75c0.69,0,1.25,0.56,1.25,1.25S6.69,10.25,6,10.25S4.75,9.69,4.75,9S5.31,7.75,6,7.75z M10.5,7.75c0.69,0,1.25,0.56,1.25,1.25s-0.56,1.25-1.25,1.25c-0.69,0-1.25-0.56-1.25-1.25S9.81,7.75,10.5,7.75z M16.25,9
+              <svg
+                fill="var(--button-bg)"
+                height="24"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6,7.75c0.69,0,1.25,0.56,1.25,1.25S6.69,10.25,6,10.25S4.75,9.69,4.75,9S5.31,7.75,6,7.75z M10.5,7.75c0.69,0,1.25,0.56,1.25,1.25s-0.56,1.25-1.25,1.25c-0.69,0-1.25-0.56-1.25-1.25S9.81,7.75,10.5,7.75z M16.25,9
 	c0-0.69-0.56-1.25-1.25-1.25S13.75,8.31,13.75,9s0.56,1.25,1.25,1.25S16.25,9.69,16.25,9z M4,3C2.895,3,2,3.895,2,5v8
 	c0,1.105,0.895,2,2,2h2v4l3.636-4H17c1.105,0,2-0.895,2-2V5c0-1.105-0.895-2-2-2H4z M11,13.5H9.318l-1.818,2v-2H6H4.5
 	c-0.552,0-1-0.448-1-1v-7c0-0.552,0.448-1,1-1h12c0.552,0,1,0.448,1,1v7c0,0.552-0.448,1-1,1H11z M10.063,16.5
 	C10.285,17.363,11.068,18,12,18h2.364L18,22v-4h2c1.104,0,2-0.896,2-2V8c0-0.932-0.637-1.715-1.5-1.937V8.5v7c0,0.552-0.448,1-1,1
 	H18h-1.5v2l-1.818-2H13h-0.5H10.063z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
+                />
+              </svg>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Channels
+              </span>
+              <svg
+                fill="var(--button-bg)"
+                height="18"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+                />
+              </svg>
+            </a>
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              id="product-menu-item-Boards"
+              role="menuitem"
             >
-              Channels
-            </span>
-            <svg
-              fill="var(--button-bg)"
-              height="18"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="18"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
-              />
-            </svg>
-          </a>
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            id="product-menu-item-Boards"
-            role="menuitem"
-          >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M16.736,3.191C15.327,2.431,13.714,2,12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10c0-1.708-0.428-3.316-1.183-4.722c-0.435,0.14-0.945,0.258-1.522,0.357C20.06,8.911,20.5,10.404,20.5,12c0,4.694-3.806,8.5-8.5,8.5
+              <svg
+                fill="var(--button-bg)"
+                height="24"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.736,3.191C15.327,2.431,13.714,2,12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10c0-1.708-0.428-3.316-1.183-4.722c-0.435,0.14-0.945,0.258-1.522,0.357C20.06,8.911,20.5,10.404,20.5,12c0,4.694-3.806,8.5-8.5,8.5
 	c-4.694,0-8.5-3.806-8.5-8.5c0-4.694,3.806-8.5,8.5-8.5c1.6,0,3.096,0.442,4.374,1.21C16.476,4.134,16.595,3.624,16.736,3.191z
 	 M16.084,6.943L16.084,6.943l-1.149,1.009c0,0,0,0,0,0L16.084,6.943z M15.233,6.36C14.281,5.813,13.177,5.5,12,5.5
 	c-3.59,0-6.5,2.91-6.5,6.5c0,3.59,2.91,6.5,6.5,6.5c3.59,0,6.5-2.91,6.5-6.5c0-1.17-0.309-2.268-0.85-3.216l-1.07,1.207
@@ -857,84 +864,85 @@ exports[`components/global/product_switcher should render once when there are no
 	c0.573-1.7,0.498-2.621-0.233-2.745c-0.722-0.124-1.25,1.109-1.574,3.697L13.012,9.64c-0.179,0.205-0.262,0.438-0.259,0.681
 	c0.003,0.166,0.053,0.32,0.147,0.46l-1.064,1.064c-0.092,0.092-0.092,0.24,0,0.332c0.092,0.092,0.24,0.092,0.332,0l1.07-1.07
 	c0.149,0.092,0.313,0.137,0.484,0.14c0.243,0.004,0.459-0.08,0.638-0.259L18.069,6.803z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
-            >
-              Boards
-            </span>
-            <button
-              aria-label="Open in new tab"
-              class="OpenInNewTabButton-fKoVVp cLFfqU"
+                />
+              </svg>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Boards
+              </span>
+              <button
+                aria-label="Open in new tab"
+                class="OpenInNewTabButton-fKoVVp cLFfqU"
+              >
+                <svg
+                  fill="currentColor"
+                  height="16"
+                  version="1.1"
+                  viewBox="0 0 24 24"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                  />
+                </svg>
+              </button>
+            </a>
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              id="product-menu-item-Playbooks"
+              role="menuitem"
             >
               <svg
-                fill="currentColor"
-                height="16"
+                fill="var(--button-bg)"
+                height="24"
                 version="1.1"
                 viewBox="0 0 24 24"
-                width="16"
+                width="24"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
-                />
-              </svg>
-            </button>
-          </a>
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            id="product-menu-item-Playbooks"
-            role="menuitem"
-          >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8,3.5H6c-1.105,0-2,0.895-2,2V19c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V5.5c0-1.105-0.895-2-2-2h-2V5h1.5c0.552,0,1,0.448,1,1v12.5c0,0.552-0.448,1-1,1h-11c-0.552,0-1-0.448-1-1V6c0-0.552,0.448-1,1-1H8V3.5z M11,2
+                  d="M8,3.5H6c-1.105,0-2,0.895-2,2V19c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V5.5c0-1.105-0.895-2-2-2h-2V5h1.5c0.552,0,1,0.448,1,1v12.5c0,0.552-0.448,1-1,1h-11c-0.552,0-1-0.448-1-1V6c0-0.552,0.448-1,1-1H8V3.5z M11,2
 	c-0.276,0-0.5,0.224-0.5,0.5V3H9v2.5h6V3h-1.5V2.5C13.5,2.224,13.276,2,13,2H11z M10.5,16H17v1h-6.5V16z M7.5,15.75H9v1.5H7.5V15.75
 	z M10.5,12H17v1h-6.5V12z M7.5,11.75H9v1.5H7.5V11.75z M10.5,8H17v1h-6.5V8z M7.409,9.091l-0.5-0.5l0.5-0.5l0.5,0.5L9,7.5L9.5,8
 	L7.909,9.591L7.409,9.091z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
-            >
-              Playbooks
-            </span>
-            <button
-              aria-label="Open in new tab"
-              class="OpenInNewTabButton-fKoVVp cLFfqU"
-            >
-              <svg
-                fill="currentColor"
-                height="16"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
                 />
               </svg>
-            </button>
-          </a>
-          <div
-            data-testid="product-menu-list"
-          />
-          <li
-            class="MenuGroup menu-divider"
-            role="separator"
-            style="display: none;"
-          />
-        </ul>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Playbooks
+              </span>
+              <button
+                aria-label="Open in new tab"
+                class="OpenInNewTabButton-fKoVVp cLFfqU"
+              >
+                <svg
+                  fill="currentColor"
+                  height="16"
+                  version="1.1"
+                  viewBox="0 0 24 24"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                  />
+                </svg>
+              </button>
+            </a>
+            <div
+              data-testid="product-menu-list"
+            />
+            <li
+              class="MenuGroup menu-divider"
+              role="separator"
+              style="display: none;"
+            />
+          </ul>
+        </div>
       </div>
     </div>
   </div>
@@ -976,72 +984,73 @@ exports[`components/global/product_switcher should render the correct amount of 
           />
         </button>
       </nav>
-      <div
-        aria-label="switcherOpen"
-        class="a11y__popup Menu"
-        id="product-switcher-menu"
-      >
-        <ul
-          class="Menu__content dropdown-menu product-switcher-menu"
-          id="product-switcher-menu-dropdown"
-          role="menu"
+      <div>
+        <div
+          aria-label="switcherOpen"
+          class="a11y__popup Menu"
+          id="product-switcher-menu"
         >
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            role="menuitem"
+          <ul
+            class="Menu__content dropdown-menu product-switcher-menu"
+            id="product-switcher-menu-dropdown"
+            role="menu"
           >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              role="menuitem"
             >
-              <path
-                d="M6,7.75c0.69,0,1.25,0.56,1.25,1.25S6.69,10.25,6,10.25S4.75,9.69,4.75,9S5.31,7.75,6,7.75z M10.5,7.75c0.69,0,1.25,0.56,1.25,1.25s-0.56,1.25-1.25,1.25c-0.69,0-1.25-0.56-1.25-1.25S9.81,7.75,10.5,7.75z M16.25,9
+              <svg
+                fill="var(--button-bg)"
+                height="24"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M6,7.75c0.69,0,1.25,0.56,1.25,1.25S6.69,10.25,6,10.25S4.75,9.69,4.75,9S5.31,7.75,6,7.75z M10.5,7.75c0.69,0,1.25,0.56,1.25,1.25s-0.56,1.25-1.25,1.25c-0.69,0-1.25-0.56-1.25-1.25S9.81,7.75,10.5,7.75z M16.25,9
 	c0-0.69-0.56-1.25-1.25-1.25S13.75,8.31,13.75,9s0.56,1.25,1.25,1.25S16.25,9.69,16.25,9z M4,3C2.895,3,2,3.895,2,5v8
 	c0,1.105,0.895,2,2,2h2v4l3.636-4H17c1.105,0,2-0.895,2-2V5c0-1.105-0.895-2-2-2H4z M11,13.5H9.318l-1.818,2v-2H6H4.5
 	c-0.552,0-1-0.448-1-1v-7c0-0.552,0.448-1,1-1h12c0.552,0,1,0.448,1,1v7c0,0.552-0.448,1-1,1H11z M10.063,16.5
 	C10.285,17.363,11.068,18,12,18h2.364L18,22v-4h2c1.104,0,2-0.896,2-2V8c0-0.932-0.637-1.715-1.5-1.937V8.5v7c0,0.552-0.448,1-1,1
 	H18h-1.5v2l-1.818-2H13h-0.5H10.063z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
+                />
+              </svg>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Channels
+              </span>
+              <svg
+                fill="var(--button-bg)"
+                height="18"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="18"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
+                />
+              </svg>
+            </a>
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              id="product-menu-item-Boards"
+              role="menuitem"
             >
-              Channels
-            </span>
-            <svg
-              fill="var(--button-bg)"
-              height="18"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="18"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M21,7L9,19L3.5,13.5L4.91,12.09L9,16.17L19.59,5.59L21,7Z"
-              />
-            </svg>
-          </a>
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            id="product-menu-item-Boards"
-            role="menuitem"
-          >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M16.736,3.191C15.327,2.431,13.714,2,12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10c0-1.708-0.428-3.316-1.183-4.722c-0.435,0.14-0.945,0.258-1.522,0.357C20.06,8.911,20.5,10.404,20.5,12c0,4.694-3.806,8.5-8.5,8.5
+              <svg
+                fill="var(--button-bg)"
+                height="24"
+                version="1.1"
+                viewBox="0 0 24 24"
+                width="24"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M16.736,3.191C15.327,2.431,13.714,2,12,2C6.477,2,2,6.477,2,12c0,5.523,4.477,10,10,10c5.523,0,10-4.477,10-10c0-1.708-0.428-3.316-1.183-4.722c-0.435,0.14-0.945,0.258-1.522,0.357C20.06,8.911,20.5,10.404,20.5,12c0,4.694-3.806,8.5-8.5,8.5
 	c-4.694,0-8.5-3.806-8.5-8.5c0-4.694,3.806-8.5,8.5-8.5c1.6,0,3.096,0.442,4.374,1.21C16.476,4.134,16.595,3.624,16.736,3.191z
 	 M16.084,6.943L16.084,6.943l-1.149,1.009c0,0,0,0,0,0L16.084,6.943z M15.233,6.36C14.281,5.813,13.177,5.5,12,5.5
 	c-3.59,0-6.5,2.91-6.5,6.5c0,3.59,2.91,6.5,6.5,6.5c3.59,0,6.5-2.91,6.5-6.5c0-1.17-0.309-2.268-0.85-3.216l-1.07,1.207
@@ -1055,84 +1064,85 @@ exports[`components/global/product_switcher should render the correct amount of 
 	c0.573-1.7,0.498-2.621-0.233-2.745c-0.722-0.124-1.25,1.109-1.574,3.697L13.012,9.64c-0.179,0.205-0.262,0.438-0.259,0.681
 	c0.003,0.166,0.053,0.32,0.147,0.46l-1.064,1.064c-0.092,0.092-0.092,0.24,0,0.332c0.092,0.092,0.24,0.092,0.332,0l1.07-1.07
 	c0.149,0.092,0.313,0.137,0.484,0.14c0.243,0.004,0.459-0.08,0.638-0.259L18.069,6.803z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
-            >
-              Boards
-            </span>
-            <button
-              aria-label="Open in new tab"
-              class="OpenInNewTabButton-fKoVVp cLFfqU"
+                />
+              </svg>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Boards
+              </span>
+              <button
+                aria-label="Open in new tab"
+                class="OpenInNewTabButton-fKoVVp cLFfqU"
+              >
+                <svg
+                  fill="currentColor"
+                  height="16"
+                  version="1.1"
+                  viewBox="0 0 24 24"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                  />
+                </svg>
+              </button>
+            </a>
+            <a
+              class="MenuItem-fJA-dRx CkdyB"
+              href="/"
+              id="product-menu-item-Playbooks"
+              role="menuitem"
             >
               <svg
-                fill="currentColor"
-                height="16"
+                fill="var(--button-bg)"
+                height="24"
                 version="1.1"
                 viewBox="0 0 24 24"
-                width="16"
+                width="24"
                 xmlns="http://www.w3.org/2000/svg"
               >
                 <path
-                  d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
-                />
-              </svg>
-            </button>
-          </a>
-          <a
-            class="MenuItem-fJA-dRx CkdyB"
-            href="/"
-            id="product-menu-item-Playbooks"
-            role="menuitem"
-          >
-            <svg
-              fill="var(--button-bg)"
-              height="24"
-              version="1.1"
-              viewBox="0 0 24 24"
-              width="24"
-              xmlns="http://www.w3.org/2000/svg"
-            >
-              <path
-                d="M8,3.5H6c-1.105,0-2,0.895-2,2V19c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V5.5c0-1.105-0.895-2-2-2h-2V5h1.5c0.552,0,1,0.448,1,1v12.5c0,0.552-0.448,1-1,1h-11c-0.552,0-1-0.448-1-1V6c0-0.552,0.448-1,1-1H8V3.5z M11,2
+                  d="M8,3.5H6c-1.105,0-2,0.895-2,2V19c0,1.105,0.895,2,2,2h12c1.105,0,2-0.895,2-2V5.5c0-1.105-0.895-2-2-2h-2V5h1.5c0.552,0,1,0.448,1,1v12.5c0,0.552-0.448,1-1,1h-11c-0.552,0-1-0.448-1-1V6c0-0.552,0.448-1,1-1H8V3.5z M11,2
 	c-0.276,0-0.5,0.224-0.5,0.5V3H9v2.5h6V3h-1.5V2.5C13.5,2.224,13.276,2,13,2H11z M10.5,16H17v1h-6.5V16z M7.5,15.75H9v1.5H7.5V15.75
 	z M10.5,12H17v1h-6.5V12z M7.5,11.75H9v1.5H7.5V11.75z M10.5,8H17v1h-6.5V8z M7.409,9.091l-0.5-0.5l0.5-0.5l0.5,0.5L9,7.5L9.5,8
 	L7.909,9.591L7.409,9.091z"
-              />
-            </svg>
-            <span
-              class="ProductMenuItemText-bbJshj kjMpVz"
-            >
-              Playbooks
-            </span>
-            <button
-              aria-label="Open in new tab"
-              class="OpenInNewTabButton-fKoVVp cLFfqU"
-            >
-              <svg
-                fill="currentColor"
-                height="16"
-                version="1.1"
-                viewBox="0 0 24 24"
-                width="16"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
                 />
               </svg>
-            </button>
-          </a>
-          <div
-            data-testid="product-menu-list"
-          />
-          <li
-            class="MenuGroup menu-divider"
-            role="separator"
-            style="display: none;"
-          />
-        </ul>
+              <span
+                class="ProductMenuItemText-bbJshj kjMpVz"
+              >
+                Playbooks
+              </span>
+              <button
+                aria-label="Open in new tab"
+                class="OpenInNewTabButton-fKoVVp cLFfqU"
+              >
+                <svg
+                  fill="currentColor"
+                  height="16"
+                  version="1.1"
+                  viewBox="0 0 24 24"
+                  width="16"
+                  xmlns="http://www.w3.org/2000/svg"
+                >
+                  <path
+                    d="M14,3V5H17.59L7.76,14.83L9.17,16.24L19,6.41V10H21V3M19,19H5V5H12V3H5C3.89,3 3,3.9 3,5V19A2,2 0 0,0 5,21H19A2,2 0 0,0 21,19V12H19V19Z"
+                  />
+                </svg>
+              </button>
+            </a>
+            <div
+              data-testid="product-menu-list"
+            />
+            <li
+              class="MenuGroup menu-divider"
+              role="separator"
+              style="display: none;"
+            />
+          </ul>
+        </div>
       </div>
     </div>
   </div>

--- a/webapp/channels/src/components/info_toast/info_toast.tsx
+++ b/webapp/channels/src/components/info_toast/info_toast.tsx
@@ -2,7 +2,7 @@
 // See LICENSE.txt for license information.
 
 import classNames from 'classnames';
-import React, {useEffect, useCallback} from 'react';
+import React, {useEffect, useCallback, useRef} from 'react';
 import {useIntl} from 'react-intl';
 import {CSSTransition} from 'react-transition-group';
 
@@ -25,6 +25,7 @@ type Props = {
 
 function InfoToast({content, onExited, className, position = DEFAULT_POSITION}: Props): JSX.Element {
     const {formatMessage} = useIntl();
+    const nodeRef = useRef<HTMLDivElement>(null);
 
     // Validate position and fallback to default if invalid
     const validatedPosition = VALID_POSITIONS.includes(position) ? position : DEFAULT_POSITION;
@@ -51,13 +52,17 @@ function InfoToast({content, onExited, className, position = DEFAULT_POSITION}: 
     return (
         <CSSTransition
             in={Boolean(content)}
+            nodeRef={nodeRef}
             classNames='toast'
             mountOnEnter={true}
             unmountOnExit={true}
             timeout={300}
             appear={true}
         >
-            <div className={toastContainerClassname}>
+            <div
+                ref={nodeRef}
+                className={toastContainerClassname}
+            >
                 {content.icon}
                 <span>{content.message}</span>
                 {content.undo && (

--- a/webapp/channels/src/components/mobile_sidebar_right/mobile_sidebar_right.tsx
+++ b/webapp/channels/src/components/mobile_sidebar_right/mobile_sidebar_right.tsx
@@ -22,6 +22,7 @@ const MobileRightDrawer = ({
 }: Props) => {
     const usageDeltas = useGetUsageDeltas();
     const sidebarRef = useRef<HTMLDivElement>(null);
+    const drawerRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (isOpen && sidebarRef.current) {
@@ -46,15 +47,18 @@ const MobileRightDrawer = ({
             <div className='nav-pills__container mobile-main-menu'>
                 <CSSTransition
                     in={isOpen}
+                    nodeRef={drawerRef}
                     enter={true}
                     exit={true}
                     mountOnEnter={true}
                     unmountOnExit={true}
                     timeout={TRANSITION_TIMEOUT}
                 >
-                    <MobileRightDrawerItems
-                        usageDeltaTeams={usageDeltas.teams.active}
-                    />
+                    <div ref={drawerRef}>
+                        <MobileRightDrawerItems
+                            usageDeltaTeams={usageDeltas.teams.active}
+                        />
+                    </div>
                 </CSSTransition>
             </div>
         </div>

--- a/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
+++ b/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_completed.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useEffect} from 'react';
+import React, {useEffect, useRef} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useSelector, useDispatch} from 'react-redux';
 import {CSSTransition} from 'react-transition-group';
@@ -130,6 +130,7 @@ const Completed = (props: Props): JSX.Element => {
     const {dismissAction} = props;
 
     const dispatch = useDispatch();
+    const wrapperRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         dispatch(getPrevTrialLicense());
@@ -155,10 +156,11 @@ const Completed = (props: Props): JSX.Element => {
         <>
             <CSSTransition
                 in={true}
+                nodeRef={wrapperRef}
                 timeout={150}
                 classNames='fade'
             >
-                <CompletedWrapper>
+                <CompletedWrapper ref={wrapperRef}>
                     <img
                         src={completedImg}
                         alt={'completed tasks image'}

--- a/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_popover.tsx
+++ b/webapp/channels/src/components/onboarding_tasklist/onboarding_tasklist_popover.tsx
@@ -4,7 +4,7 @@
 import {FloatingPortal} from '@floating-ui/react';
 import type {Placement} from '@floating-ui/react-dom';
 import {useFloating, offset as floatingOffset, autoUpdate} from '@floating-ui/react-dom';
-import React, {useLayoutEffect} from 'react';
+import React, {useLayoutEffect, useRef} from 'react';
 import {CSSTransition} from 'react-transition-group';
 import styled from 'styled-components';
 
@@ -75,6 +75,7 @@ export const TaskListPopover = ({
         })],
         whileElementsMounted: autoUpdate,
     });
+    const overlayRef = useRef<HTMLDivElement>(null);
 
     useLayoutEffect(() => {
         setReference(trigger);
@@ -94,9 +95,11 @@ export const TaskListPopover = ({
                 timeout={150}
                 classNames='fade'
                 in={isVisible}
+                nodeRef={overlayRef}
                 unmountOnExit={true}
             >
                 <Overlay
+                    ref={overlayRef}
                     onClick={onClick}
                     data-cy='onboarding-task-list-overlay'
                 />

--- a/webapp/channels/src/components/preparing_workspace/invite_members.tsx
+++ b/webapp/channels/src/components/preparing_workspace/invite_members.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState, useMemo, useEffect} from 'react';
+import React, {useState, useMemo, useEffect, useRef} from 'react';
 import {FormattedMessage, defineMessages, useIntl} from 'react-intl';
 import {CSSTransition} from 'react-transition-group';
 
@@ -41,6 +41,7 @@ const InviteMembers = (props: Props) => {
     const [showSkipButton, setShowSkipButton] = useState(false);
 
     const {formatMessage} = useIntl();
+    const nodeRef = useRef<HTMLDivElement>(null);
     let className = 'InviteMembers-body';
     if (props.className) {
         className += ' ' + props.className;
@@ -204,12 +205,16 @@ const InviteMembers = (props: Props) => {
     return (
         <CSSTransition
             in={props.show}
+            nodeRef={nodeRef}
             timeout={Animations.PAGE_SLIDE}
             classNames={mapAnimationReasonToClass('InviteMembers', props.transitionDirection)}
             mountOnEnter={true}
             unmountOnExit={true}
         >
-            <div className={className}>
+            <div
+                ref={nodeRef}
+                className={className}
+            >
                 <SingleColumnLayout style={{width: 547}}>
                     <PageLine
                         style={{

--- a/webapp/channels/src/components/preparing_workspace/launching_workspace.tsx
+++ b/webapp/channels/src/components/preparing_workspace/launching_workspace.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React, {useState, useEffect} from 'react';
+import React, {useState, useEffect, useRef} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useDispatch} from 'react-redux';
 import {CSSTransition} from 'react-transition-group';
@@ -35,6 +35,8 @@ export const LAUNCHING_WORKSPACE_FULLSCREEN_Z_INDEX = 1001;
 function LaunchingWorkspace(props: Props) {
     const [hasEntered, setHasEntered] = useState(false);
     const dispatch = useDispatch();
+    const bodyRef = useRef<HTMLDivElement>(null);
+    const fullscreenRef = useRef<HTMLDivElement>(null);
 
     useEffect(() => {
         if (hasEntered) {
@@ -58,7 +60,10 @@ function LaunchingWorkspace(props: Props) {
         bodyClass += ' LaunchingWorkspace-body--non-fullscreen';
     }
     const body = (
-        <div className={bodyClass}>
+        <div
+            ref={bodyRef}
+            className={bodyClass}
+        >
             <div className='LaunchingWorkspace__spinner'>
                 <img
                     src={loadingIcon}
@@ -84,6 +89,7 @@ function LaunchingWorkspace(props: Props) {
         content = (
             <CSSTransition
                 in={props.show && !hasEntered}
+                nodeRef={fullscreenRef}
                 timeout={TRANSITION_DURATION}
                 classNames={'LaunchingWorkspaceFullscreenWrapper'}
                 exit={true}
@@ -92,6 +98,7 @@ function LaunchingWorkspace(props: Props) {
                 unmountOnExit={true}
             >
                 <div
+                    ref={fullscreenRef}
                     className='LaunchingWorkspaceFullscreenWrapper-body'
                     style={{
                         zIndex: props.zIndex,
@@ -109,6 +116,7 @@ function LaunchingWorkspace(props: Props) {
         content = (
             <CSSTransition
                 in={props.show}
+                nodeRef={bodyRef}
                 timeout={Animations.PAGE_SLIDE}
                 classNames={mapAnimationReasonToClass('LaunchingWorkspace', props.transitionDirection)}
                 mountOnEnter={true}

--- a/webapp/channels/src/components/preparing_workspace/organization.tsx
+++ b/webapp/channels/src/components/preparing_workspace/organization.tsx
@@ -42,6 +42,7 @@ const Organization = (props: Props) => {
     const dispatch = useDispatch();
 
     const [triedNext, setTriedNext] = useState(false);
+    const nodeRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement>();
     const validation = teamNameToUrl(props.organization || '');
     const teamApiError = useRef<typeof TeamApiError | null>(null);
@@ -122,14 +123,19 @@ const Organization = (props: Props) => {
         className += ' ' + props.className;
     }
     return (
+
         <CSSTransition
             in={props.show}
+            nodeRef={nodeRef}
             timeout={Animations.PAGE_SLIDE}
             classNames={mapAnimationReasonToClass('Organization', props.transitionDirection)}
             mountOnEnter={true}
             unmountOnExit={true}
         >
-            <div className={className}>
+            <div
+                ref={nodeRef}
+                className={className}
+            >
                 <div className='Organization-right-col'>
                     <div className='Organization-form-wrapper'>
                         <div className='Organization__progress-path'>

--- a/webapp/channels/src/components/preparing_workspace/plugins.tsx
+++ b/webapp/channels/src/components/preparing_workspace/plugins.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useRef} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {CSSTransition} from 'react-transition-group';
 
@@ -32,6 +32,7 @@ type Props = PreparingWorkspacePageProps & {
 };
 const Plugins = (props: Props) => {
     const {formatMessage} = useIntl();
+    const nodeRef = useRef<HTMLDivElement>(null);
     let className = 'Plugins-body';
 
     if (props.className) {
@@ -55,12 +56,16 @@ const Plugins = (props: Props) => {
     return (
         <CSSTransition
             in={props.show}
+            nodeRef={nodeRef}
             timeout={Animations.PAGE_SLIDE}
             classNames={mapAnimationReasonToClass('Plugins', props.transitionDirection)}
             mountOnEnter={true}
             unmountOnExit={true}
         >
-            <div className={className}>
+            <div
+                ref={nodeRef}
+                className={className}
+            >
                 <SingleColumnLayout>
                     <PageLine
                         style={{

--- a/webapp/channels/src/components/preparing_workspace/progress.tsx
+++ b/webapp/channels/src/components/preparing_workspace/progress.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useRef} from 'react';
 import {CSSTransition} from 'react-transition-group';
 
 import {WizardSteps} from './steps';
@@ -15,7 +15,7 @@ type Props = {
     transitionSpeed: number;
 };
 
-export const Progress = (props: Props) => {
+export const Progress = React.forwardRef<HTMLDivElement, Props>((props, ref) => {
     // exclude transitioning out as a progress step
     const numSteps = props.stepOrder.length - 1;
     if (numSteps < 2) {
@@ -36,21 +36,33 @@ export const Progress = (props: Props) => {
         );
     });
 
-    return (<div className='PreparingWorkspaceProgress'>
-        <div className='PreparingWorkspaceProgress__circles'>{dots}</div>
-    </div>);
-};
+    return (
+        <div
+            ref={ref}
+            className='PreparingWorkspaceProgress'
+        >
+            <div className='PreparingWorkspaceProgress__circles'>{dots}</div>
+        </div>
+    );
+});
+Progress.displayName = 'Progress';
 
 export default function TransitionedProgress(props: Props) {
+    const nodeRef = useRef<HTMLDivElement>(null);
+
     return (
         <CSSTransition
             in={props.step !== WizardSteps.LaunchingWorkspace}
+            nodeRef={nodeRef}
             timeout={props.transitionSpeed}
             classNames={'OnboardingWizardProgress'}
             mountOnEnter={true}
             unmountOnExit={true}
         >
-            <Progress {...props}/>
+            <Progress
+                {...props}
+                ref={nodeRef}
+            />
         </CSSTransition>
     );
 }

--- a/webapp/channels/src/components/widgets/menu/menu_wrapper_animation.tsx
+++ b/webapp/channels/src/components/widgets/menu/menu_wrapper_animation.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import React from 'react';
+import React, {useRef} from 'react';
 import {CSSTransition} from 'react-transition-group';
 
 import {isMobile} from './is_mobile_view_hack';
@@ -17,6 +17,12 @@ type Props = {
  * @deprecated Use the "webapp/channels/src/components/menu" instead.
  */
 export default function MenuWrapperAnimation(props: Props) {
+    // The children are arbitrary, so there's no element of our own to hang a ref on. Without a
+    // nodeRef, CSSTransition falls back to findDOMNode, which React 18 warns about in StrictMode and
+    // React 19 removes. The wrapper is a static box, so the menu inside it still positions itself
+    // against .MenuWrapper.
+    const nodeRef = useRef<HTMLDivElement>(null);
+
     if (isMobile()) {
         if (props.show) {
             return props.children;
@@ -28,6 +34,7 @@ export default function MenuWrapperAnimation(props: Props) {
     return (
         <CSSTransition
             in={props.show}
+            nodeRef={nodeRef}
             classNames='MenuWrapperAnimation'
             enter={true}
             exit={true}
@@ -35,7 +42,9 @@ export default function MenuWrapperAnimation(props: Props) {
             unmountOnExit={true}
             timeout={ANIMATION_DURATION}
         >
-            {props.children}
+            <div ref={nodeRef}>
+                {props.children}
+            </div>
         </CSSTransition>
     );
 }

--- a/webapp/channels/src/components/widgets/modals/full_screen_modal.tsx
+++ b/webapp/channels/src/components/widgets/modals/full_screen_modal.tsx
@@ -74,6 +74,7 @@ class FullScreenModal extends React.PureComponent<Props> {
         return (
             <CSSTransition
                 in={this.props.show}
+                nodeRef={this.modal}
                 classNames='FullScreenModal'
                 mountOnEnter={true}
                 unmountOnExit={true}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

`Transition` and `CSSTransition` need to know which DOM node they are animating. When no `nodeRef` is given they fall back to `findDOMNode`, which React reports under `StrictMode` and removes outright in React 19. This was the most common problem the strict mode E2E run found, at 15 call sites.

Each call site now passes a `nodeRef`. Most were a one-line change because the component already rendered a single element that could take the ref. Three needed a little more:

- `MenuWrapperAnimation` and `MobileSidebarRight` render arbitrary children, so there was no element of their own to hang a ref on. Both now wrap the children in a plain `div`. The two snapshot files in this PR are that extra wrapper.
- `Progress` in the onboarding wizard is a function component that `TransitionedProgress` renders as the transition child, so it became a `forwardRef`.
- `AutoHeightSwitcher` used the `node` argument that `Transition` passes to `onEntered`. `react-transition-group` stops passing it once `nodeRef` is set, so the callback reads `wrapperRef.current` instead.

Found by running the E2E suite against a `MM_REACT_STRICT_MODE` build. The tooling for that is in #38235; this PR stands alone and does not depend on it.

#### Testing

The web app unit suite passes, including the two updated snapshots. The affected UI was exercised end to end by the Playwright and Cypress suites against a strict mode build, which reports no `findDOMNode` violations afterwards.

#### Release Note

```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a048f9-6875-7f39-b562-b4b4252e0959?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a048f9-6875-7f39-b562-b4b4252e0959&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes affect 15 user-facing transition components across multiple modules. Automated tests pass, but wrapper and ref changes may affect transition behavior in specific UI states.

**QA Recommendation:** Manual QA can be skipped because the unit, Playwright, and Cypress suites pass.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->