### PR TITLE
Remove the remaining string refs

### DIFF
--- a/webapp/channels/src/components/add_groups_to_channel_modal/add_groups_to_channel_modal.tsx
+++ b/webapp/channels/src/components/add_groups_to_channel_modal/add_groups_to_channel_modal.tsx
@@ -188,7 +188,7 @@ export class AddGroupsToChannelModal extends React.PureComponent<Props, State> {
         return (
             <div
                 key={option.id}
-                ref={isSelected ? this.selectedItemRef : option.id}
+                ref={isSelected ? this.selectedItemRef : undefined}
                 className={'more-modal__row clickable ' + rowSelected}
                 onClick={() => onAdd(option)}
                 onMouseMove={() => (onMouseMove ? onMouseMove(option) : undefined)}

--- a/webapp/channels/src/components/add_groups_to_team_modal/add_groups_to_team_modal.tsx
+++ b/webapp/channels/src/components/add_groups_to_team_modal/add_groups_to_team_modal.tsx
@@ -200,7 +200,7 @@ export class AddGroupsToTeamModal extends React.PureComponent<Props, State> {
         return (
             <div
                 key={option.id}
-                ref={isSelected ? this.selectedItemRef : option.id}
+                ref={isSelected ? this.selectedItemRef : undefined}
                 className={'more-modal__row clickable ' + rowSelected}
                 onClick={() => onAdd(option)}
                 onMouseMove={() => onMouseMove(option)}

--- a/webapp/channels/src/components/add_users_to_team_modal/add_users_to_team_modal.tsx
+++ b/webapp/channels/src/components/add_users_to_team_modal/add_users_to_team_modal.tsx
@@ -176,7 +176,7 @@ export class AddUsersToTeamModal extends React.PureComponent<Props, State> {
         return (
             <div
                 key={option.id}
-                ref={isSelected ? this.selectedItemRef : option.id}
+                ref={isSelected ? this.selectedItemRef : undefined}
                 className={'more-modal__row ' + (blocked ? 'more-modal__row--disabled' : 'clickable ') + rowSelected}
                 aria-disabled={blocked}
                 onClick={blocked ? undefined : () => onAdd(option)}

--- a/webapp/channels/src/components/admin_console/system_roles/system_role/add_users_to_role_modal/add_users_to_role_modal.tsx
+++ b/webapp/channels/src/components/admin_console/system_roles/system_role/add_users_to_role_modal/add_users_to_role_modal.tsx
@@ -120,7 +120,6 @@ export class AddUsersToRoleModal extends React.PureComponent<Props, State> {
         return (
             <div
                 key={option.id}
-                ref={isSelected ? 'selected' : option.id}
                 className={'more-modal__row clickable ' + rowSelected}
                 onClick={() => onAdd(option)}
                 onMouseMove={() => onMouseMove(option)}

--- a/webapp/channels/src/components/channel_selector_modal/channel_selector_modal.tsx
+++ b/webapp/channels/src/components/channel_selector_modal/channel_selector_modal.tsx
@@ -204,7 +204,7 @@ export class ChannelSelectorModal extends React.PureComponent<Props, State> {
         return (
             <div
                 key={option.id}
-                ref={isSelected ? this.selectedItemRef : option.id}
+                ref={isSelected ? this.selectedItemRef : undefined}
                 className={'more-modal__row clickable ' + rowSelected}
                 onClick={() => onAdd(option)}
                 onMouseMove={() => onMouseMove(option)}

--- a/webapp/channels/src/components/file_preview/file_progress_preview.tsx
+++ b/webapp/channels/src/components/file_preview/file_progress_preview.tsx
@@ -75,7 +75,6 @@ export default class FileProgressPreview extends React.PureComponent<Props> {
 
         return (
             <div
-                ref={clientId}
                 key={clientId}
                 className='file-preview post-image__column'
                 data-client-id={clientId}

--- a/webapp/channels/src/components/multiselect/multiselect_list.tsx
+++ b/webapp/channels/src/components/multiselect/multiselect_list.tsx
@@ -139,7 +139,7 @@ export default class MultiSelectList<T extends Value> extends React.PureComponen
 
         return (
             <div
-                ref={isSelected ? this.selectedItemRef : null}
+                ref={isSelected ? this.selectedItemRef : undefined}
                 className={rowSelected}
                 key={'multiselectoption' + option.value}
                 onClick={() => add(option)}

--- a/webapp/channels/src/components/multiselect/multiselect_list.tsx
+++ b/webapp/channels/src/components/multiselect/multiselect_list.tsx
@@ -139,7 +139,7 @@ export default class MultiSelectList<T extends Value> extends React.PureComponen
 
         return (
             <div
-                ref={isSelected ? this.selectedItemRef : option.value}
+                ref={isSelected ? this.selectedItemRef : null}
                 className={rowSelected}
                 key={'multiselectoption' + option.value}
                 onClick={() => add(option)}

--- a/webapp/channels/src/components/team_selector_modal/team_selector_modal.tsx
+++ b/webapp/channels/src/components/team_selector_modal/team_selector_modal.tsx
@@ -168,7 +168,7 @@ export class TeamSelectorModal extends React.PureComponent<Props, State> {
         return (
             <div
                 key={option.id}
-                ref={isSelected ? this.selectedItemRef : option.id}
+                ref={isSelected ? this.selectedItemRef : undefined}
                 className={'more-modal__row clickable ' + rowSelected}
                 onClick={() => onAdd(option)}
                 onMouseMove={() => onMouseMove(option)}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

String refs are deprecated, reported under `StrictMode`, and removed in React 19. Eight were left in the web app and none of them was doing anything.

Six are selector modal rows following the same pattern, `ref={isSelected ? this.selectedItemRef : option.id}`. Only the selected row's ref is ever read, to scroll it into view; the unselected rows were assigning a string ref that nothing looked up. Those now pass `undefined`.

The other two are `FileProgressPreview`, which set `ref={clientId}` next to an identical `key`, and `AddUsersToRoleModal`, which set `ref={isSelected ? 'selected' : option.id}` and never read either. Both refs are removed.

Found by running the E2E suite against a `MM_REACT_STRICT_MODE` build. The tooling for that is in #38235; this PR stands alone and does not depend on it.

#### Testing

The web app unit suite passes. The selector modals and file upload previews were exercised end to end against a strict mode build, which reports no string ref violations afterwards.

#### Release Note

```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a048f9-6875-7f39-b562-b4b4252e0959?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a048f9-6875-7f39-b562-b4b4252e0959&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes span several selector and preview components, but only remove deprecated string refs or pass `undefined` for unselected rows. Automated and end-to-end tests cover the affected flows.
**QA Recommendation:** Manual QA can be skipped.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->