### PR TITLE
Fix props, refs and keys that React was warning about

### DIFF
--- a/webapp/channels/src/components/channel_header_menu/channel_header_menu.tsx
+++ b/webapp/channels/src/components/channel_header_menu/channel_header_menu.tsx
@@ -62,8 +62,6 @@ export default function ChannelHeaderMenu({dmUser, gmMembers, isMobile, archived
     const isChannelBookmarksEnabled = useSelector(getIsChannelBookmarksEnabled);
     const isChannelAutotranslated = useSelector((state: GlobalState) => (channel?.id ? isChannelAutotranslatedSelector(state, channel.id) : false));
 
-    const isReadonly = false;
-
     if (!channel) {
         return null;
     }
@@ -181,7 +179,6 @@ export default function ChannelHeaderMenu({dmUser, gmMembers, isMobile, archived
                     isFavorite={isFavorite}
                     isMobile={isMobile || false}
                     isDefault={isDefault}
-                    isReadonly={isReadonly}
                     isLicensedForLDAPGroups={isLicensedForLDAPGroups}
                     isChannelBookmarksEnabled={isChannelBookmarksEnabled}
                     isChannelAutotranslated={isChannelAutotranslated}

--- a/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_public_private_menu.tsx
+++ b/webapp/channels/src/components/channel_header_menu/channel_header_menu_items/channel_header_public_private_menu.tsx
@@ -37,7 +37,6 @@ interface Props extends Menu.FirstMenuItemProps {
     channel: Channel;
     user: UserProfile;
     isMuted: boolean;
-    isReadonly: boolean;
     isDefault: boolean;
     isMobile: boolean;
     isFavorite: boolean;

--- a/webapp/channels/src/components/channel_settings_modal/share_channel_with_workspaces/add_workspace_dropdown.tsx
+++ b/webapp/channels/src/components/channel_settings_modal/share_channel_with_workspaces/add_workspace_dropdown.tsx
@@ -97,10 +97,11 @@ export default function AddWorkspaceDropdown({
                     disabled={true}
                 />
             )}
+            {/* A remote cluster is keyed on (remote_id, name), so remote_id alone can repeat here. */}
             {!loading && available.map((rc) => (
                 <Menu.Item
-                    key={rc.remote_id}
-                    id={`${MENU_ID}-item-${rc.remote_id}`}
+                    key={`${rc.remote_id}-${rc.name}`}
+                    id={`${MENU_ID}-item-${rc.remote_id}-${rc.name}`}
                     labels={<span>{rc.display_name || rc.name}</span>}
                     onClick={() => handleSelect(rc)}
                 />

--- a/webapp/channels/src/components/suggestion/search_channel_suggestion/index.ts
+++ b/webapp/channels/src/components/suggestion/search_channel_suggestion/index.ts
@@ -25,8 +25,4 @@ const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {
     };
 };
 
-// A null mapDispatchToProps makes react-redux inject `dispatch`, which this component forwards
-// into the rest props that SuggestionContainer spreads onto its <li>.
-const mapDispatchToProps = () => ({});
-
-export default connect(mapStateToProps, mapDispatchToProps, null, {forwardRef: true})(SearchChannelSuggestion);
+export default connect(mapStateToProps, null, null, {forwardRef: true})(SearchChannelSuggestion);

--- a/webapp/channels/src/components/suggestion/search_channel_suggestion/index.ts
+++ b/webapp/channels/src/components/suggestion/search_channel_suggestion/index.ts
@@ -25,4 +25,8 @@ const mapStateToProps = (state: GlobalState, ownProps: OwnProps) => {
     };
 };
 
-export default connect(mapStateToProps, null, null, {forwardRef: true})(SearchChannelSuggestion);
+// A null mapDispatchToProps makes react-redux inject `dispatch`, which this component forwards
+// into the rest props that SuggestionContainer spreads onto its <li>.
+const mapDispatchToProps = () => ({});
+
+export default connect(mapStateToProps, mapDispatchToProps, null, {forwardRef: true})(SearchChannelSuggestion);

--- a/webapp/channels/src/components/suggestion/suggestion.tsx
+++ b/webapp/channels/src/components/suggestion/suggestion.tsx
@@ -36,6 +36,10 @@ const SuggestionContainer = React.forwardRef<HTMLLIElement, SuggestionProps<unkn
 
     Reflect.deleteProperty(otherProps, 'item');
 
+    // Suggestions are usually connected, and a connect() without mapDispatchToProps injects a
+    // `dispatch` prop that the suggestion then forwards here along with the rest of its props.
+    Reflect.deleteProperty(otherProps, 'dispatch');
+
     const handleClick = useCallback((e: React.MouseEvent) => {
         e.preventDefault();
 

--- a/webapp/channels/src/components/widgets/tag/tag.tsx
+++ b/webapp/channels/src/components/widgets/tag/tag.tsx
@@ -127,7 +127,7 @@ const TagText = styled.span`
     text-overflow: ellipsis;
 `;
 
-const Tag = React.forwardRef<HTMLDivElement, Props>(({
+const Tag = React.forwardRef<HTMLElement, Props>(({
     variant,
     onClick,
     className,
@@ -157,7 +157,10 @@ const Tag = React.forwardRef<HTMLDivElement, Props>(({
     return (
         <TagWrapper
             {...rest}
-            ref={ref}
+
+            // TagWrapper renders a div or a button, but styled-components types
+            // its ref as one or the other, never HTMLElement.
+            ref={ref as React.Ref<HTMLDivElement>}
             as={element}
             uppercase={uppercase}
             onClick={onClick}

--- a/webapp/channels/src/components/widgets/tag/tag.tsx
+++ b/webapp/channels/src/components/widgets/tag/tag.tsx
@@ -127,7 +127,7 @@ const TagText = styled.span`
     text-overflow: ellipsis;
 `;
 
-const Tag = ({
+const Tag = React.forwardRef<HTMLDivElement, Props>(({
     variant,
     onClick,
     className,
@@ -136,7 +136,7 @@ const Tag = ({
     size = 'xs',
     uppercase = false,
     ...rest
-}: Props) => {
+}, ref) => {
     const Icon = iconName ? glyphMap[iconName] : null;
     const element = onClick ? 'button' : 'div';
 
@@ -157,6 +157,7 @@ const Tag = ({
     return (
         <TagWrapper
             {...rest}
+            ref={ref}
             as={element}
             uppercase={uppercase}
             onClick={onClick}
@@ -166,6 +167,7 @@ const Tag = ({
             <TagText>{text}</TagText>
         </TagWrapper>
     );
-};
+});
+Tag.displayName = 'Tag';
 
 export default memo(Tag);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Four unrelated one-file fixes, each for something React complains about at a component boundary. They are separate commits.

**`Tag` could not take a ref.** `WithTooltip` puts a ref on its child so it can position the popover against it. `Tag` is a function component, so the ref went nowhere and React warned. It is now a `forwardRef`.

**`isReadonly` reached a DOM element.** `ChannelHeaderMenu` passed a hardcoded `const isReadonly = false` into `ChannelHeaderPublicPrivateMenu`, which spread its props onto an `<li>`. Nothing read the prop, so both the prop and its declaration are gone.

**`connect`'s injected `dispatch` reached a DOM element.** A `connect()` without `mapDispatchToProps` injects a `dispatch` prop. Suggestions forward their remaining props to `SuggestionContainer`, which spreads them onto its `<li>`, so `dispatch` landed on the DOM. `SuggestionContainer` now strips it, which covers every connected suggestion rather than one at a time.

**Duplicate React keys in the add-workspace menu.** It keyed each entry on `rc.remote_id`, but a remote cluster is identified by `(remote_id, name)`, so a repeated `remote_id` produced duplicate keys. Both the key and the element id now use the pair.

Found by running the E2E suite against a `MM_REACT_STRICT_MODE` build, though these warnings are not strict-mode specific — React reports them in any development build. The tooling is in #38235; this PR stands alone and does not depend on it.

#### Testing

The web app unit suite passes. All four areas were exercised end to end against a strict mode build, which reports none of these warnings afterwards.

#### Release Note

```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a048f9-6875-7f39-b562-b4b4252e0959?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a048f9-6875-7f39-b562-b4b4252e0959&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The changes are isolated to React component boundaries and menu identifiers. No critical flows or data logic are affected.

**QA Recommendation:** Manual QA can be skipped because unit and strict-mode end-to-end tests pass.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->