### PR TITLE
Make PerformanceReporterController and PermissionSystemSchemeSettings safe to remount

### DIFF
--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/permission_system_scheme_settings.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_system_scheme_settings/permission_system_scheme_settings.tsx
@@ -118,9 +118,11 @@ export class PermissionSystemSchemeSettings extends React.PureComponent<Props, S
         }
     }
 
-    UNSAFE_componentWillReceiveProps(nextProps: Props) {
-        if (!this.state.loaded && this.rolesNeeded.every((roleName) => nextProps.roles[roleName])) {
-            this.loadRolesIntoState(nextProps);
+    componentDidUpdate() {
+        // The roles requested on mount arrive asynchronously, so keep waiting for them until
+        // they're all in props. Guarded by `loaded` so the setState can't loop.
+        if (!this.state.loaded && this.rolesNeeded.every((roleName) => this.props.roles[roleName])) {
+            this.loadRolesIntoState(this.props);
         }
     }
 

--- a/webapp/channels/src/components/root/performance_reporter_controller.tsx
+++ b/webapp/channels/src/components/root/performance_reporter_controller.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-import {useEffect, useRef} from 'react';
+import {useEffect} from 'react';
 import {useStore} from 'react-redux';
 
 import {Client4} from 'mattermost-redux/client';
@@ -14,16 +14,12 @@ import type {GlobalState} from 'types/store';
 export default function PerformanceReporterController() {
     const store = useStore<GlobalState>();
 
-    const reporter = useRef<PerformanceReporter>();
-
     useEffect(() => {
-        reporter.current = new PerformanceReporter(Client4, store, DesktopAppAPI);
-        reporter.current.observe();
+        const reporter = new PerformanceReporter(Client4, store, DesktopAppAPI);
+        reporter.observe();
 
-        // There's no way to clean up web-vitals, so continue to assume that this component won't ever be unmounted
         return () => {
-            // eslint-disable-next-line no-console
-            console.error('PerformanceReporterController - Component unmounted or store changed');
+            reporter.disconnect();
         };
     }, [store]);
 

--- a/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.test.ts
@@ -357,6 +357,24 @@ describe.skip('PerformanceReporter', () => {
     });
 });
 
+describe('PerformanceReporter.disconnect', () => {
+    test('should stop reporting web vitals once disconnected', () => {
+        const {reporter, sendBeacon} = newTestReporter();
+        reporter.observe();
+
+        const onCLSCallback = (onCLS as jest.Mock).mock.calls.at(-1)[0];
+
+        reporter.disconnect();
+
+        // web-vitals has no way to unregister a callback, so a reporter left behind by an unmounted
+        // component keeps being handed metrics after it has been disconnected.
+        onCLSCallback({name: 'CLS', value: 100});
+        reporter.maybeSendReport();
+
+        expect(sendBeacon).not.toHaveBeenCalled();
+    });
+});
+
 describe('PerformanceReporter.sendReport content-type', () => {
     const sampleReport = {
         version: '0.1.0' as const,
@@ -419,8 +437,6 @@ class TestPerformanceReporter extends PerformanceReporter {
     public sendBeacon: jest.Mock = jest.fn(() => true);
     public reportPeriodBase = 10;
     public reportPeriodJitter = 0;
-
-    public disconnect = super.disconnect;
 
     public handleObservations = jest.fn(super.handleObservations);
 

--- a/webapp/channels/src/utils/performance_telemetry/reporter.ts
+++ b/webapp/channels/src/utils/performance_telemetry/reporter.ts
@@ -80,6 +80,7 @@ export default class PerformanceReporter {
 
     private observer: PerformanceObserver;
     private reportTimeout: number | undefined;
+    private disconnected = false;
 
     // These values are protected instead of private so that they can be modified by unit tests
     protected reportPeriodBase = 60 * 1000;
@@ -170,9 +171,12 @@ export default class PerformanceReporter {
     }
 
     /**
-     * This method is for testing only because we can't clean up the callbacks registered with web-vitals.
+     * web-vitals has no way to unregister a callback, so a disconnected reporter has to keep
+     * ignoring the metrics it still receives rather than stop receiving them.
      */
-    protected disconnect() {
+    public disconnect() {
+        this.disconnected = true;
+
         removeEventListener('visibilitychange', this.handleVisibilityChange);
 
         clearTimeout(this.reportTimeout);
@@ -181,6 +185,7 @@ export default class PerformanceReporter {
         this.observer.disconnect();
 
         this.desktopOffListener?.();
+        this.desktopOffListener = undefined;
     }
 
     protected handleObservations(list: PerformanceObserverEntryList) {
@@ -244,6 +249,10 @@ export default class PerformanceReporter {
     }
 
     private handleWebVital(metric: Metric) {
+        if (this.disconnected) {
+            return;
+        }
+
         let labels: Record<string, string> | undefined;
 
         if (isLCPMetric(metric)) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Two components that misbehave when React mounts them more than once. `StrictMode` provokes this deliberately by mounting, unmounting and remounting on the first render, and React 19's reusable state will do it for real.

**`PerformanceReporterController` could not be unmounted.** Its effect created a `PerformanceReporter` and never tore it down, so a remount left the previous reporter's `PerformanceObserver` running and its web-vitals callbacks registered, and metrics were reported twice. The effect now disconnects on cleanup. `PerformanceReporter.disconnect` is public, clears its report timeout, drops the desktop listener and sets a `disconnected` flag, because web-vitals has no way to unregister a callback — a disconnected reporter has to ignore the metrics it still receives rather than stop receiving them. Covered by a new unit test.

**`PermissionSystemSchemeSettings` used `UNSAFE_componentWillReceiveProps`** to copy roles into state as they arrived from an async fetch. That is `componentDidUpdate` work; it is now there, guarded by the existing `loaded` flag so the `setState` cannot loop.

Found by running the E2E suite against a `MM_REACT_STRICT_MODE` build. The tooling for that is in #38235; this PR stands alone and does not depend on it.

#### Testing

New unit test asserts a disconnected `PerformanceReporter` stops reporting web vitals it is still handed. The rest of the web app unit suite passes. Both components were exercised end to end against a strict mode build, which reports no violations from them afterwards.

#### Release Note

```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a048f9-6875-7f39-b562-b4b4252e0959?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a048f9-6875-7f39-b562-b4b4252e0959&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Changes affect shared performance telemetry and permission settings lifecycle behavior. Automated tests cover the disconnected reporter path, but other remount and role-loading paths may regress.

**QA Recommendation:** Skip manual QA. The automated suite and Strict Mode validation provide sufficient coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->