### PR TITLE
Take react-bootstrap's lifecycle fix and stop shipping a second react-dom

### DIFF
--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -75,7 +75,7 @@
     "prop-types": "15.8.1",
     "react": "18.2.0",
     "react-beautiful-dnd": "13.1.1",
-    "react-bootstrap": "github:mattermost/react-bootstrap#797ff617540f59920f8fd90ec8ba536b78323154",
+    "react-bootstrap": "github:mattermost/react-bootstrap#d693ec8082954f0e6d3e826ca6161979b29001cd",
     "react-color": "2.19.3",
     "react-day-picker": "8.3.6",
     "react-dom": "18.2.0",

--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -75,7 +75,7 @@
     "prop-types": "15.8.1",
     "react": "18.2.0",
     "react-beautiful-dnd": "13.1.1",
-    "react-bootstrap": "github:mattermost/react-bootstrap#c17701564a6f240a14419d94369936c380f917e5",
+    "react-bootstrap": "github:mattermost/react-bootstrap#797ff617540f59920f8fd90ec8ba536b78323154",
     "react-color": "2.19.3",
     "react-day-picker": "8.3.6",
     "react-dom": "18.2.0",

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -123,7 +123,7 @@
         "prop-types": "15.8.1",
         "react": "18.2.0",
         "react-beautiful-dnd": "13.1.1",
-        "react-bootstrap": "github:mattermost/react-bootstrap#797ff617540f59920f8fd90ec8ba536b78323154",
+        "react-bootstrap": "github:mattermost/react-bootstrap#d693ec8082954f0e6d3e826ca6161979b29001cd",
         "react-color": "2.19.3",
         "react-day-picker": "8.3.6",
         "react-dom": "18.2.0",
@@ -23556,7 +23556,7 @@
     },
     "node_modules/react-bootstrap": {
       "version": "0.32.4",
-      "resolved": "git+ssh://git@github.com/mattermost/react-bootstrap.git#797ff617540f59920f8fd90ec8ba536b78323154",
+      "resolved": "git+ssh://git@github.com/mattermost/react-bootstrap.git#d693ec8082954f0e6d3e826ca6161979b29001cd",
       "integrity": "sha512-cfde04u5rHWxflLLbjktlUZDgqkTGcti/7RPH7ch7OR0pT4msXcxml9nR3ClM5fbiOnlkJLxIVYjfS9+K3JWkQ==",
       "hasInstallScript": true,
       "license": "MIT",
@@ -28672,7 +28672,7 @@
       "version": "11.11.0",
       "dependencies": {
         "@tippyjs/react": "4.2.6",
-        "react-bootstrap": "github:mattermost/react-bootstrap#797ff617540f59920f8fd90ec8ba536b78323154",
+        "react-bootstrap": "github:mattermost/react-bootstrap#d693ec8082954f0e6d3e826ca6161979b29001cd",
         "styled-components": "5.3.7"
       },
       "devDependencies": {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -123,7 +123,7 @@
         "prop-types": "15.8.1",
         "react": "18.2.0",
         "react-beautiful-dnd": "13.1.1",
-        "react-bootstrap": "github:mattermost/react-bootstrap#c17701564a6f240a14419d94369936c380f917e5",
+        "react-bootstrap": "github:mattermost/react-bootstrap#797ff617540f59920f8fd90ec8ba536b78323154",
         "react-color": "2.19.3",
         "react-day-picker": "8.3.6",
         "react-dom": "18.2.0",
@@ -23556,8 +23556,8 @@
     },
     "node_modules/react-bootstrap": {
       "version": "0.32.4",
-      "resolved": "git+ssh://git@github.com/mattermost/react-bootstrap.git#c17701564a6f240a14419d94369936c380f917e5",
-      "integrity": "sha512-FOdO69AE6NY0gAjCb5FRSPpmh+6+kUEp83Ss/eu8jtuHk3tB/JygupZgAeSPALNAo2svdg3DfnNo2VQd2+J0rw==",
+      "resolved": "git+ssh://git@github.com/mattermost/react-bootstrap.git#797ff617540f59920f8fd90ec8ba536b78323154",
+      "integrity": "sha512-cfde04u5rHWxflLLbjktlUZDgqkTGcti/7RPH7ch7OR0pT4msXcxml9nR3ClM5fbiOnlkJLxIVYjfS9+K3JWkQ==",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
@@ -28672,7 +28672,7 @@
       "version": "11.11.0",
       "dependencies": {
         "@tippyjs/react": "4.2.6",
-        "react-bootstrap": "github:mattermost/react-bootstrap#c17701564a6f240a14419d94369936c380f917e5",
+        "react-bootstrap": "github:mattermost/react-bootstrap#797ff617540f59920f8fd90ec8ba536b78323154",
         "styled-components": "5.3.7"
       },
       "devDependencies": {

--- a/webapp/platform/components/package.json
+++ b/webapp/platform/components/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@tippyjs/react": "4.2.6",
-    "react-bootstrap": "github:mattermost/react-bootstrap#c17701564a6f240a14419d94369936c380f917e5",
+    "react-bootstrap": "github:mattermost/react-bootstrap#797ff617540f59920f8fd90ec8ba536b78323154",
     "styled-components": "5.3.7"
   }
 }

--- a/webapp/platform/components/package.json
+++ b/webapp/platform/components/package.json
@@ -51,7 +51,7 @@
   },
   "dependencies": {
     "@tippyjs/react": "4.2.6",
-    "react-bootstrap": "github:mattermost/react-bootstrap#797ff617540f59920f8fd90ec8ba536b78323154",
+    "react-bootstrap": "github:mattermost/react-bootstrap#d693ec8082954f0e6d3e826ca6161979b29001cd",
     "styled-components": "5.3.7"
   }
 }

--- a/webapp/platform/components/rollup.config.js
+++ b/webapp/platform/components/rollup.config.js
@@ -13,6 +13,10 @@ const externals = [
     ...Object.keys(packagejson.peerDependencies || {}),
     'lodash/throttle',
     'react',
+
+    // react-dom is only a devDependency here, so without this it gets bundled into dist and the
+    // web app ends up running two copies of the renderer.
+    'react-dom',
     'mattermost-redux',
     'reselect',
 ];


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Two dependency-level problems, one commit each.

**A second copy of react-dom in the bundle.** `@mattermost/components` lists `react-dom` only as a devDependency and did not name it in its Rollup externals, so its `dist` carried a whole copy of the renderer. `react` was already external; this adds `react-dom` alongside it.

**react-bootstrap's last two unsafe lifecycles.** `TabContent` used `UNSAFE_componentWillReceiveProps` and `Dropdown` used `UNSAFE_componentWillUpdate`. React reports both under `StrictMode` and neither is safe to interrupt under concurrent rendering. Fixed in [mattermost/react-bootstrap#14](https://github.com/mattermost/react-bootstrap/pull/14), that needs to be merged before this one.

Found by running the E2E suite against a `MM_REACT_STRICT_MODE` build. The tooling for that is in #38235; this PR stands alone and does not depend on it.

#### Release Note

```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a048f9-6875-7f39-b562-b4b4252e0959?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a048f9-6875-7f39-b562-b4b4252e0959&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The changes affect shared dependency resolution and component bundling across multiple workspaces. No authentication, persistence, public API, or core business logic is affected.

**QA Recommendation:** Manual QA can be skipped when automated coverage passes.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->