### PR TITLE
Prepackage mattermost-plugin-agents v2.6.1

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -163,7 +163,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.8.0
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.11.1
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.6.0
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.6.1
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.4.0
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.7.0
@@ -178,7 +178,7 @@ PLUGIN_PACKAGES += mattermost-plugin-dataminr-v2.0.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.11.1%2B329b65c-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.6.0%2B7824854-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.6.1%2B0b1b771-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.4.0%2B4b7dd4b-fips
 endif
 


### PR DESCRIPTION
#### Summary

Updates the default prepackaged [mattermost-plugin-agents](https://github.com/mattermost/mattermost-plugin-agents) artifact from **2.6.0** to **2.6.1** ([release v2.6.1](https://github.com/mattermost/mattermost-plugin-agents/releases/tag/v2.6.1)) for the `master` branch.

Both prepackaged plugin lists are updated:
- non-FIPS: `mattermost-plugin-agents-v2.6.1`
- FIPS: `mattermost-plugin-agents-v2.6.1%2B0b1b771-fips` (`0b1b771` is the tagged release commit)

Bundles verified on `plugins.releases.mattermost.com`.

#### Release Note

```release-note
Prepackaged the Mattermost Agents plugin at version 2.6.1 instead of 2.6.0.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change updates package references in one Makefile. It does not affect application logic or critical flows.
**QA Recommendation:** Skip manual QA. Automated checks and bundle verification are sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->