### PR TITLE
[MM-70524] Fix advanced text editor issue with rootID

### DIFF
--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
@@ -299,6 +299,30 @@ describe('components/avanced_text_editor/advanced_text_editor', () => {
         expect(screen.getByPlaceholderText('Write to Other Channel')).toHaveValue('a different draft');
     });
 
+    it('should mount when rootId is omitted, as plugins may do via window.Components', () => {
+        // Plugins reach AdvancedTextEditor through the untyped window.Components bridge, so
+        // TypeScript cannot enforce the required rootId prop. Omitting it used to compare
+        // draft.rootId ('') against undefined forever and throw React error #301.
+        const {rootId: _unusedRootId, ...propsWithoutRootId} = baseProps;
+
+        renderWithContext(
+            <AdvancedTextEditor
+                {...(propsWithoutRootId as unknown as Props)}
+            />,
+            mergeObjects(initialState, {
+                entities: {
+                    roles: {
+                        roles: {
+                            user_roles: {permissions: [Permissions.CREATE_POST]},
+                        },
+                    },
+                },
+            }),
+        );
+
+        expect(screen.getByTestId('post_textbox')).toBeInTheDocument();
+    });
+
     it('should submit a destination-owned draft while the textbox still holds the previous channel value', async () => {
         const sourceDraft = 'stale draft from the source channel';
         const destinationMessage = 'new message composed for the destination channel';

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
@@ -304,12 +304,12 @@ describe('components/avanced_text_editor/advanced_text_editor', () => {
         // TypeScript cannot enforce the required rootId prop. An undefined rootId used to
         // mismatch the draft's '' on every render pass, throwing React error #301 on mount
         // and, once mounted, leaving the post-submit draft reset silently dropped.
-        const {rootId: _unusedRootId, ...propsWithoutRootId} = baseProps;
         const message = 'a message sent from a composer without a rootId';
 
         renderWithContext(
             <AdvancedTextEditor
-                {...(propsWithoutRootId as unknown as Props)}
+                {...baseProps}
+                rootId={undefined as unknown as string}
             />,
             mergeObjects(initialState, {
                 entities: {

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
@@ -299,11 +299,13 @@ describe('components/avanced_text_editor/advanced_text_editor', () => {
         expect(screen.getByPlaceholderText('Write to Other Channel')).toHaveValue('a different draft');
     });
 
-    it('should mount when rootId is omitted, as plugins may do via window.Components', () => {
+    it('should mount and send when rootId is omitted, as plugins may do via window.Components', async () => {
         // Plugins reach AdvancedTextEditor through the untyped window.Components bridge, so
-        // TypeScript cannot enforce the required rootId prop. Omitting it used to compare
-        // draft.rootId ('') against undefined forever and throw React error #301.
+        // TypeScript cannot enforce the required rootId prop. An undefined rootId used to
+        // mismatch the draft's '' on every render pass, throwing React error #301 on mount
+        // and, once mounted, leaving the post-submit draft reset silently dropped.
         const {rootId: _unusedRootId, ...propsWithoutRootId} = baseProps;
+        const message = 'a message sent from a composer without a rootId';
 
         renderWithContext(
             <AdvancedTextEditor
@@ -320,7 +322,24 @@ describe('components/avanced_text_editor/advanced_text_editor', () => {
             }),
         );
 
-        expect(screen.getByTestId('post_textbox')).toBeInTheDocument();
+        const textbox = screen.getByTestId('post_textbox');
+
+        // SuggestionBox listens to onInput, not onChange.
+        fireEvent.input(textbox, {target: {value: message}});
+        expect(textbox).toHaveValue(message);
+
+        await act(async () => {
+            fireEvent.click(screen.getByTestId('SendMessageButton'));
+        });
+
+        expect(mockedOnSubmit).toHaveBeenCalledWith(
+            channelId,
+            '',
+            expect.objectContaining({message, channelId, rootId: ''}),
+            expect.anything(),
+            undefined,
+        );
+        expect(textbox).toHaveValue('');
     });
 
     it('should submit a destination-owned draft while the textbox still holds the previous channel value', async () => {

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -125,7 +125,7 @@ export type Props = {
 const AdvancedTextEditor = ({
     location,
     channelId,
-    rootId,
+    rootId: rootIdProp,
     postId,
     isThreadView = false,
     placeholder,
@@ -133,6 +133,11 @@ const AdvancedTextEditor = ({
     afterSubmit,
     storageKey,
 }: Props) => {
+    // rootId is typed as required, but plugins reach this component through the untyped
+    // window.Components bridge and may omit it. Every draft carries '' rather than undefined
+    // for a non-thread composer, so an undefined prop desyncs the id comparisons below.
+    const rootId = rootIdProp ?? '';
+
     const {formatMessage} = useIntl();
 
     const dispatch = useDispatch();
@@ -242,10 +247,7 @@ const AdvancedTextEditor = ({
     const codeBlockOnCtrlEnter = useSelector((state: GlobalState) => getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'code_block_ctrl_enter', true));
     const isDMOrGMRemote = isChannelShared && (channelType === Constants.DM_CHANNEL || channelType === Constants.GM_CHANNEL);
 
-    // Compared against draftFromStore rather than the props because it is the value being
-    // assigned, so the condition is always false on the next pass. Comparing the raw props
-    // re-renders forever if a caller omits rootId, since the selector stores it as ''.
-    if (draft.channelId !== draftFromStore.channelId || draft.rootId !== draftFromStore.rootId) {
+    if (draft.channelId !== channelId || draft.rootId !== rootId) {
         setDraft(draftFromStore);
     }
 

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.tsx
@@ -242,7 +242,10 @@ const AdvancedTextEditor = ({
     const codeBlockOnCtrlEnter = useSelector((state: GlobalState) => getBool(state, Preferences.CATEGORY_ADVANCED_SETTINGS, 'code_block_ctrl_enter', true));
     const isDMOrGMRemote = isChannelShared && (channelType === Constants.DM_CHANNEL || channelType === Constants.GM_CHANNEL);
 
-    if (draft.channelId !== channelId || draft.rootId !== rootId) {
+    // Compared against draftFromStore rather than the props because it is the value being
+    // assigned, so the condition is always false on the next pass. Comparing the raw props
+    // re-renders forever if a caller omits rootId, since the selector stores it as ''.
+    if (draft.channelId !== draftFromStore.channelId || draft.rootId !== draftFromStore.rootId) {
         setDraft(draftFromStore);
     }
 


### PR DESCRIPTION
#### Summary

`AdvancedTextEditor` breaks when `rootId` is omitted. Plugins reach the component through the untyped `window.Components` bridge, so TypeScript cannot enforce the required prop, and the Agents RHS composer hit this on 11.11.

A non-thread composer always carries `''` rather than `undefined`: `makeGetDraft` defaults the argument to `''`, and `AdvancedCreatePost` passes `rootId={''}` explicitly. An `undefined` prop therefore never matches the draft it gets compared against, which breaks two things:

- **On mount** — the render-time draft sync added in #37928 compares `draft.rootId` (`''`) against the prop (`undefined`), so it calls `setDraft` on every pass and throws React error #301.
- **On send** — `useSubmit` passes the raw prop as the `rootId` routing argument to `onSubmit`, and builds its post-submit draft reset from the same raw props. The `handleDraftChange` guard from #37928 compares that reset's `rootId` (`undefined`) against the local draft's (`''`), reads it as a stale callback from a channel the user has left, and drops it. The message posts, but the composer never clears and can be sent again.

#### Fix

Normalize once at the component boundary: `const rootId = rootIdProp ?? '';`

This is an identity function for every non-nullish input, so all three in-tree callers are untouched — `AdvancedCreatePost` already passes `''`, `AdvancedCreateComment` passes a post id, and `EditPost` passes `post.root_id`. The only inputs it rewrites are `undefined`/`null`, which currently throw on mount, so there is no working behavior to change. `''` is also not a new value downstream; it is what the center-channel composer has always passed, so every consumer below this component is already exercised with it.

Normalizing here rather than at the comparison site leaves the render-time sync from #37928 byte-identical, and covers both failures instead of only the crash.

#### Tests

`advanced_text_editor`: a composer rendered without `rootId` mounts, submits to the correct channel with a normalized `''` root, and clears afterwards.

The test was confirmed to fail in both directions before the fix — React error #301 with no fix at all, and `onSubmit` receiving `undefined` as its `rootId` argument if only the mount crash is addressed.

#### QA steps

- Open the Agents RHS against a build without the plugin-side workaround from mattermost/mattermost-plugin-agents#1016. It should render, and sending a message should clear the composer.
- Regression check on #37928: `/msg <user>` then type and send, Cmd+K between two DMs then send, and draft persistence across a channel switch. Messages must land in the channel shown in the composer.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-70524

#### Release Note

```release-note
NONE
```