### PR TITLE
Add ways for plugin to create permissions and roles

### DIFF
--- a/server/channels/api4/permission.go
+++ b/server/channels/api4/permission.go
@@ -12,7 +12,28 @@ import (
 )
 
 func (api *API) InitPermissions() {
+	api.BaseRoutes.Permissions.Handle("", api.APISessionRequired(getPluginPermissions)).Methods(http.MethodGet)
 	api.BaseRoutes.Permissions.Handle("/ancillary", api.APISessionRequired(appendAncillaryPermissionsPost)).Methods(http.MethodPost)
+}
+
+func getPluginPermissions(c *Context, w http.ResponseWriter, r *http.Request) {
+	if !c.App.SessionHasPermissionTo(*c.AppContext.Session(), model.PermissionSysconsoleReadUserManagementPermissions) {
+		c.SetPermissionError(model.PermissionSysconsoleReadUserManagementPermissions)
+		return
+	}
+
+	permissions, appErr := c.App.GetPluginPermissions()
+	if appErr != nil {
+		c.Err = appErr
+		return
+	}
+	if permissions == nil {
+		permissions = []*model.PluginPermission{}
+	}
+
+	if err := json.NewEncoder(w).Encode(permissions); err != nil {
+		c.Logger.Warn("Error while writing response", mlog.Err(err))
+	}
 }
 
 func appendAncillaryPermissionsPost(c *Context, w http.ResponseWriter, r *http.Request) {

--- a/server/channels/api4/permissions_test.go
+++ b/server/channels/api4/permissions_test.go
@@ -13,6 +13,44 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 )
 
+func TestGetPluginPermissions(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+	t.Cleanup(model.ResetPluginPermissionRegistryForTest)
+
+	pluginID := "com.example.api"
+	appErr := th.App.RegisterPluginPermission(th.Context, pluginID, &model.PluginPermission{
+		Id:          "manage_thing",
+		Name:        "Manage thing",
+		Description: "Allows managing things",
+		Scope:       model.PermissionScopeSystem,
+	})
+	require.Nil(t, appErr)
+
+	t.Run("forbidden for regular user", func(t *testing.T) {
+		_, resp, err := th.Client.GetPluginPermissions(context.Background())
+		require.Error(t, err)
+		CheckForbiddenStatus(t, resp)
+	})
+
+	t.Run("system admin can list registered permissions", func(t *testing.T) {
+		permissions, _, err := th.SystemAdminClient.GetPluginPermissions(context.Background())
+		require.NoError(t, err)
+		require.NotEmpty(t, permissions)
+
+		var found *model.PluginPermission
+		for _, p := range permissions {
+			if p.PermissionId == model.PluginPermissionId(pluginID, "manage_thing") {
+				found = p
+				break
+			}
+		}
+		require.NotNil(t, found)
+		assert.Equal(t, "Manage thing", found.Name)
+		assert.Equal(t, model.PermissionScopeSystem, found.Scope)
+	})
+}
+
 func TestGetAncillaryPermissions(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)

--- a/server/channels/app/plugin.go
+++ b/server/channels/app/plugin.go
@@ -122,6 +122,11 @@ func (ch *Channels) syncPluginsActiveState() {
 				defer wg.Done()
 
 				deactivated := pluginsEnvironment.Deactivate(plugin.Manifest.Id)
+				if deactivated {
+					if appErr := New(ServerConnector(ch)).SetPluginPermissionsActive(plugin.Manifest.Id, false); appErr != nil {
+						ch.srv.Log().Warn("Failed to deactivate plugin permissions", mlog.String("plugin_id", plugin.Manifest.Id), mlog.Err(appErr))
+					}
+				}
 				if deactivated && plugin.Manifest.HasClient() {
 					message := model.NewWebSocketEvent(model.WebsocketEventPluginDisabled, "", "", "", nil, "")
 					message.Add("manifest", plugin.Manifest.ClientManifest())
@@ -150,6 +155,12 @@ func (ch *Channels) syncPluginsActiveState() {
 					if err := ch.notifyPluginEnabled(updatedManifest); err != nil {
 						logger.Error("Failed to notify cluster on plugin enable", mlog.Err(err))
 					}
+					if appErr := New(ServerConnector(ch)).RegisterManifestPluginRBAC(request.EmptyContext(ch.srv.Log()), updatedManifest); appErr != nil {
+						logger.Warn("Failed to register plugin permissions and roles from manifest", mlog.Err(appErr))
+					}
+					if appErr := ch.setPluginPermissionsActive(pluginID, true); appErr != nil {
+						logger.Warn("Failed to activate plugin permissions", mlog.Err(appErr))
+					}
 				}
 			}(plugin)
 		}
@@ -170,6 +181,7 @@ func (a *App) InitPlugins(rctx request.CTX, pluginDir, webappPluginDir string) {
 }
 
 func (ch *Channels) initPlugins(rctx request.CTX, pluginDir, webappPluginDir string) {
+	ch.loadPluginPermissionCatalog()
 	// Acquiring lock manually, as plugins might be disabled. See GetPluginsEnvironment.
 	defer func() {
 		ch.srv.Platform().SetPluginsEnvironment(ch)
@@ -494,6 +506,9 @@ func (ch *Channels) disablePlugin(id string) *model.AppError {
 		cfg.PluginSettings.PluginStates[id] = &model.PluginState{Enable: false}
 	})
 	ch.unregisterPluginCommands(id)
+	if appErr := ch.setPluginPermissionsActive(id, false); appErr != nil {
+		ch.srv.Log().Warn("Failed to deactivate plugin permissions", mlog.String("plugin_id", id), mlog.Err(appErr))
+	}
 
 	// This call will implicitly invoke SyncPluginsActiveState which will deactivate disabled plugins.
 	if _, _, err := ch.cfgSvc.SaveConfig(ch.cfgSvc.Config(), true); err != nil {

--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -30,13 +30,17 @@ type PluginAPI struct {
 }
 
 func NewPluginAPI(a *App, rctx request.CTX, manifest *model.Manifest) *PluginAPI {
-	return &PluginAPI{
+	api := &PluginAPI{
 		id:       manifest.Id,
 		manifest: manifest,
 		ctx:      rctx,
 		app:      a,
 		logger:   a.Log().Sugar(mlog.String("plugin_id", manifest.Id)),
 	}
+	if appErr := a.RegisterManifestPluginRBAC(rctx, manifest); appErr != nil {
+		api.logger.Warn("Failed to register plugin permissions and roles from manifest", "error", appErr.Error())
+	}
+	return api
 }
 
 func (api *PluginAPI) checkLDAPLicense() error {
@@ -1258,6 +1262,26 @@ func (api *PluginAPI) HasPermissionToTeam(userID, teamID string, permission *mod
 func (api *PluginAPI) HasPermissionToChannel(userID, channelID string, permission *model.Permission) bool {
 	ok, _ := api.app.HasPermissionToChannel(api.ctx, userID, channelID, permission)
 	return ok
+}
+
+func (api *PluginAPI) RegisterPermission(permission *model.PluginPermission) *model.AppError {
+	return api.app.RegisterPluginPermission(api.ctx, api.id, permission)
+}
+
+func (api *PluginAPI) RegisterRole(role *model.PluginRole) (*model.Role, *model.AppError) {
+	return api.app.RegisterPluginRole(api.ctx, api.id, role)
+}
+
+func (api *PluginAPI) PatchPluginRole(name string, patch *model.RolePatch) (*model.Role, *model.AppError) {
+	return api.app.PatchPluginRole(api.ctx, api.id, name, patch)
+}
+
+func (api *PluginAPI) AssignPluginRole(userID, roleName string) (*model.User, *model.AppError) {
+	return api.app.AssignPluginRole(api.ctx, api.id, userID, roleName)
+}
+
+func (api *PluginAPI) RemovePluginRole(userID, roleName string) (*model.User, *model.AppError) {
+	return api.app.RemovePluginRole(api.ctx, api.id, userID, roleName)
 }
 
 func (api *PluginAPI) RolesGrantPermission(roleNames []string, permissionId string) bool {

--- a/server/channels/app/plugin_install.go
+++ b/server/channels/app/plugin_install.go
@@ -583,6 +583,10 @@ func (ch *Channels) removePluginLocally(id string) *model.AppError {
 	pluginsEnvironment.Deactivate(id)
 	pluginsEnvironment.RemovePlugin(id)
 	ch.unregisterPluginCommands(id)
+	if appErr := ch.purgePluginRBAC(id); appErr != nil {
+		logger := ch.srv.Log().With(mlog.String("plugin_id", id))
+		logger.Warn("Failed to purge plugin permissions and roles", mlog.Err(appErr))
+	}
 
 	if err := os.RemoveAll(unpackedBundlePath); err != nil {
 		return model.NewAppError("removePlugin", "app.plugin.remove.app_error", nil, "", http.StatusInternalServerError).Wrap(err)

--- a/server/channels/app/plugin_permissions.go
+++ b/server/channels/app/plugin_permissions.go
@@ -1,0 +1,499 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"errors"
+	"net/http"
+	"slices"
+	"strings"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+	"github.com/mattermost/mattermost/server/v8/channels/store"
+)
+
+func (ch *Channels) loadPluginPermissionCatalog() {
+	if ch.srv == nil || ch.srv.Store() == nil {
+		return
+	}
+	permissions, err := ch.srv.Store().Role().GetPluginPermissions()
+	if err != nil {
+		ch.srv.Log().Warn("Failed to load plugin permission catalog", mlog.Err(err))
+		return
+	}
+	for _, p := range permissions {
+		model.RegisterPluginPermissionInMemory(p)
+	}
+}
+
+func (a *App) LoadPluginPermissionCatalog() {
+	a.ch.loadPluginPermissionCatalog()
+}
+
+func (a *App) RegisterManifestPluginRBAC(rctx request.CTX, manifest *model.Manifest) *model.AppError {
+	if manifest == nil {
+		return nil
+	}
+	for _, p := range manifest.Permissions {
+		if p == nil {
+			continue
+		}
+		if appErr := a.RegisterPluginPermission(rctx, manifest.Id, &model.PluginPermission{
+			Id:           p.Id,
+			Name:         p.Name,
+			Description:  p.Description,
+			Scope:        p.Scope,
+			DefaultRoles: p.DefaultRoles,
+		}); appErr != nil {
+			return appErr
+		}
+	}
+	for _, r := range manifest.Roles {
+		if r == nil {
+			continue
+		}
+		if _, appErr := a.RegisterPluginRole(rctx, manifest.Id, &model.PluginRole{
+			Name:        r.Name,
+			DisplayName: r.DisplayName,
+			Description: r.Description,
+			Permissions: r.Permissions,
+		}); appErr != nil {
+			return appErr
+		}
+	}
+	return nil
+}
+
+func (a *App) RegisterPluginPermission(rctx request.CTX, pluginID string, permission *model.PluginPermission) *model.AppError {
+	if permission == nil {
+		return model.NewAppError("RegisterPluginPermission", "app.plugin.permission.invalid.app_error", nil, "permission is nil", http.StatusBadRequest)
+	}
+	if !model.IsValidPluginId(pluginID) {
+		return model.NewAppError("RegisterPluginPermission", "app.plugin.permission.invalid.app_error", nil, "invalid plugin id", http.StatusBadRequest)
+	}
+	if !model.IsValidPluginPermissionLocalID(permission.Id) {
+		return model.NewAppError("RegisterPluginPermission", "app.plugin.permission.invalid.app_error", nil, "invalid permission id", http.StatusBadRequest)
+	}
+	if strings.TrimSpace(permission.Name) == "" {
+		return model.NewAppError("RegisterPluginPermission", "app.plugin.permission.invalid.app_error", nil, "name is required", http.StatusBadRequest)
+	}
+	if !model.IsValidPluginPermissionScope(permission.Scope) {
+		return model.NewAppError("RegisterPluginPermission", "app.plugin.permission.invalid.app_error", nil, "invalid scope", http.StatusBadRequest)
+	}
+
+	permissionID := model.PluginPermissionId(pluginID, permission.Id)
+	if _, _, ok := model.SplitPluginPermissionId(permissionID); !ok {
+		return model.NewAppError("RegisterPluginPermission", "app.plugin.permission.invalid.app_error", nil, "invalid namespaced permission id", http.StatusBadRequest)
+	}
+
+	existing, err := a.Srv().Store().Role().GetPluginPermission(pluginID, permission.Id)
+	var nfErr *store.ErrNotFound
+	isNew := errors.As(err, &nfErr)
+	if err != nil && !isNew {
+		return model.NewAppError("RegisterPluginPermission", "app.plugin.permission.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	if isNew {
+		count, countErr := a.Srv().Store().Role().GetPluginPermissionsByPlugin(pluginID)
+		if countErr != nil {
+			return model.NewAppError("RegisterPluginPermission", "app.plugin.permission.save.app_error", nil, "", http.StatusInternalServerError).Wrap(countErr)
+		}
+		if len(count) >= model.MaxPluginPermissionsPerPlugin {
+			return model.NewAppError("RegisterPluginPermission", "app.plugin.permission.limit.app_error", nil, "", http.StatusBadRequest)
+		}
+	}
+
+	for _, roleName := range permission.DefaultRoles {
+		if !model.IsValidRoleName(roleName) || !model.IsBuiltInRole(roleName) {
+			return model.NewAppError("RegisterPluginPermission", "app.plugin.permission.invalid.app_error", nil, "invalid default role "+roleName, http.StatusBadRequest)
+		}
+	}
+
+	toSave := &model.PluginPermission{
+		PluginId:        pluginID,
+		Id:              permission.Id,
+		PermissionId:    permissionID,
+		Name:            permission.Name,
+		Description:     permission.Description,
+		Scope:           permission.Scope,
+		DefaultRoles:    append([]string(nil), permission.DefaultRoles...),
+		Active:          true,
+		DefaultsApplied: existing != nil && existing.DefaultsApplied,
+	}
+
+	if err := a.Srv().Store().Role().SavePluginPermission(toSave); err != nil {
+		return model.NewAppError("RegisterPluginPermission", "app.plugin.permission.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+
+	saved, err := a.Srv().Store().Role().GetPluginPermission(pluginID, permission.Id)
+	if err != nil {
+		return model.NewAppError("RegisterPluginPermission", "app.plugin.permission.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	saved.Active = true
+	model.RegisterPluginPermissionInMemory(saved)
+
+	if appErr := a.ensurePluginPermissionOnSystemAdmin(rctx, saved.PermissionId); appErr != nil {
+		return appErr
+	}
+
+	if !saved.DefaultsApplied {
+		if appErr := a.applyPluginPermissionDefaults(rctx, saved); appErr != nil {
+			return appErr
+		}
+		if err := a.Srv().Store().Role().MarkPluginPermissionDefaultsApplied(pluginID, permission.Id); err != nil {
+			return model.NewAppError("RegisterPluginPermission", "app.plugin.permission.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		}
+		saved.DefaultsApplied = true
+		model.RegisterPluginPermissionInMemory(saved)
+	}
+
+	permission.PermissionId = saved.PermissionId
+	permission.PluginId = pluginID
+	permission.Active = true
+	return nil
+}
+
+func (a *App) ensurePluginPermissionOnSystemAdmin(rctx request.CTX, permissionID string) *model.AppError {
+	role, appErr := a.GetRoleByName(rctx, model.SystemAdminRoleId)
+	if appErr != nil {
+		return appErr
+	}
+	if slices.Contains(role.Permissions, permissionID) {
+		return nil
+	}
+	role.Permissions = append(role.Permissions, permissionID)
+	updated, appErr := a.UpdateRole(role)
+	if appErr != nil {
+		return appErr
+	}
+	return a.sendUpdatedRoleEvent(updated)
+}
+
+func (a *App) applyPluginPermissionDefaults(rctx request.CTX, permission *model.PluginPermission) *model.AppError {
+	for _, roleName := range permission.DefaultRoles {
+		if roleName == model.SystemAdminRoleId {
+			continue
+		}
+		role, appErr := a.GetRoleByName(rctx, roleName)
+		if appErr != nil {
+			return appErr
+		}
+		if slices.Contains(role.Permissions, permission.PermissionId) {
+			continue
+		}
+		role.Permissions = append(role.Permissions, permission.PermissionId)
+		updated, appErr := a.UpdateRole(role)
+		if appErr != nil {
+			return appErr
+		}
+		if appErr := a.sendUpdatedRoleEvent(updated); appErr != nil {
+			return appErr
+		}
+	}
+	return nil
+}
+
+func (a *App) SetPluginPermissionsActive(pluginID string, active bool) *model.AppError {
+	if err := a.Srv().Store().Role().SetPluginPermissionsActive(pluginID, active); err != nil {
+		return model.NewAppError("SetPluginPermissionsActive", "app.plugin.permission.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	model.SetPluginPermissionsActiveInMemory(pluginID, active)
+	return nil
+}
+
+func (a *App) GetPluginPermissions() ([]*model.PluginPermission, *model.AppError) {
+	permissions, err := a.Srv().Store().Role().GetPluginPermissions()
+	if err != nil {
+		return nil, model.NewAppError("GetPluginPermissions", "app.plugin.permission.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	nameByID := map[string]string{}
+	if plugins, appErr := a.GetPlugins(); appErr == nil {
+		for _, p := range plugins.Active {
+			nameByID[p.Id] = p.Name
+		}
+		for _, p := range plugins.Inactive {
+			nameByID[p.Id] = p.Name
+		}
+	}
+	for _, p := range permissions {
+		p.PluginName = nameByID[p.PluginId]
+	}
+	return permissions, nil
+}
+
+func (a *App) RegisterPluginRole(rctx request.CTX, pluginID string, pluginRole *model.PluginRole) (*model.Role, *model.AppError) {
+	if pluginRole == nil {
+		return nil, model.NewAppError("RegisterPluginRole", "app.plugin.role.invalid.app_error", nil, "role is nil", http.StatusBadRequest)
+	}
+	if !model.IsValidPluginId(pluginID) {
+		return nil, model.NewAppError("RegisterPluginRole", "app.plugin.role.invalid.app_error", nil, "invalid plugin id", http.StatusBadRequest)
+	}
+	if !model.IsValidPluginRoleLocalName(pluginRole.Name) {
+		return nil, model.NewAppError("RegisterPluginRole", "app.plugin.role.invalid.app_error", nil, "invalid role name", http.StatusBadRequest)
+	}
+	if strings.TrimSpace(pluginRole.DisplayName) == "" {
+		return nil, model.NewAppError("RegisterPluginRole", "app.plugin.role.invalid.app_error", nil, "display name is required", http.StatusBadRequest)
+	}
+
+	existingOwnership, err := a.Srv().Store().Role().GetPluginRoleOwnership(pluginID, pluginRole.Name)
+	var nfErr *store.ErrNotFound
+	isNew := errors.As(err, &nfErr)
+	if err != nil && !isNew {
+		return nil, model.NewAppError("RegisterPluginRole", "app.plugin.role.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	if isNew {
+		owned, countErr := a.Srv().Store().Role().GetPluginRoleOwnershipsByPlugin(pluginID)
+		if countErr != nil {
+			return nil, model.NewAppError("RegisterPluginRole", "app.plugin.role.save.app_error", nil, "", http.StatusInternalServerError).Wrap(countErr)
+		}
+		if len(owned) >= model.MaxPluginRolesPerPlugin {
+			return nil, model.NewAppError("RegisterPluginRole", "app.plugin.role.limit.app_error", nil, "", http.StatusBadRequest)
+		}
+	}
+
+	permissions, appErr := a.namespacePluginRolePermissions(pluginID, pluginRole.Permissions)
+	if appErr != nil {
+		return nil, appErr
+	}
+
+	roleName := model.PluginRoleName(pluginID, pluginRole.Name)
+	if existingOwnership != nil {
+		roleName = existingOwnership.RoleName
+	}
+
+	displayName := model.PluginRoleNameI18nKey(roleName)
+	description := model.PluginRoleDescriptionI18nKey(roleName)
+	if pluginRole.DisplayName != "" {
+		displayName = pluginRole.DisplayName
+	}
+	if pluginRole.Description != "" {
+		description = pluginRole.Description
+	}
+
+	existingRole, getErr := a.GetRoleByName(rctx, roleName)
+	if getErr != nil && getErr.StatusCode != http.StatusNotFound {
+		return nil, getErr
+	}
+
+	if existingRole != nil {
+		existingRole.DeleteAt = 0
+		existingRole.DisplayName = displayName
+		existingRole.Description = description
+		if isNew {
+			existingRole.Permissions = permissions
+		}
+		updated, updateErr := a.UpdateRole(existingRole)
+		if updateErr != nil {
+			return nil, updateErr
+		}
+		if err := a.Srv().Store().Role().SavePluginRoleOwnership(&model.PluginRoleOwnership{
+			PluginId:  pluginID,
+			LocalName: pluginRole.Name,
+			RoleName:  roleName,
+		}); err != nil {
+			return nil, model.NewAppError("RegisterPluginRole", "app.plugin.role.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+		}
+		return updated, nil
+	}
+
+	created, createErr := a.CreateRole(&model.Role{
+		Name:        roleName,
+		DisplayName: displayName,
+		Description: description,
+		Permissions: permissions,
+	})
+	if createErr != nil {
+		return nil, createErr
+	}
+	if err := a.Srv().Store().Role().SavePluginRoleOwnership(&model.PluginRoleOwnership{
+		PluginId:  pluginID,
+		LocalName: pluginRole.Name,
+		RoleName:  roleName,
+	}); err != nil {
+		return nil, model.NewAppError("RegisterPluginRole", "app.plugin.role.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	return created, nil
+}
+
+func (a *App) namespacePluginRolePermissions(pluginID string, permissions []string) ([]string, *model.AppError) {
+	out := make([]string, 0, len(permissions))
+	for _, p := range permissions {
+		namespaced := p
+		if owner, _, ok := model.SplitPluginPermissionId(p); ok {
+			if owner != pluginID {
+				return nil, model.NewAppError("RegisterPluginRole", "app.plugin.role.invalid.app_error", nil, "permission does not belong to this plugin", http.StatusBadRequest)
+			}
+		} else {
+			if !model.IsValidPluginPermissionLocalID(p) {
+				return nil, model.NewAppError("RegisterPluginRole", "app.plugin.role.invalid.app_error", nil, "invalid permission "+p, http.StatusBadRequest)
+			}
+			namespaced = model.PluginPermissionId(pluginID, p)
+		}
+		if !model.IsRegisteredPluginPermission(namespaced) {
+			return nil, model.NewAppError("RegisterPluginRole", "app.plugin.role.invalid.app_error", nil, "unknown plugin permission "+p, http.StatusBadRequest)
+		}
+		registered := model.GetRegisteredPluginPermission(namespaced)
+		if registered == nil || registered.PluginId != pluginID {
+			return nil, model.NewAppError("RegisterPluginRole", "app.plugin.role.invalid.app_error", nil, "permission does not belong to this plugin", http.StatusBadRequest)
+		}
+		out = append(out, namespaced)
+	}
+	return out, nil
+}
+
+func (a *App) PatchPluginRole(rctx request.CTX, pluginID, localName string, patch *model.RolePatch) (*model.Role, *model.AppError) {
+	ownership, err := a.Srv().Store().Role().GetPluginRoleOwnership(pluginID, localName)
+	if err != nil {
+		var nfErr *store.ErrNotFound
+		if errors.As(err, &nfErr) {
+			return nil, model.NewAppError("PatchPluginRole", "app.plugin.role.not_found.app_error", nil, "", http.StatusNotFound).Wrap(err)
+		}
+		return nil, model.NewAppError("PatchPluginRole", "app.plugin.role.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	role, appErr := a.GetRoleByName(rctx, ownership.RoleName)
+	if appErr != nil {
+		return nil, appErr
+	}
+	if patch != nil && patch.Permissions != nil {
+		namespaced, nsErr := a.namespacePluginRolePermissions(pluginID, *patch.Permissions)
+		if nsErr != nil {
+			return nil, nsErr
+		}
+		patch.Permissions = &namespaced
+	}
+	return a.PatchRole(role, patch)
+}
+
+func (a *App) AssignPluginRole(rctx request.CTX, pluginID, userID, localName string) (*model.User, *model.AppError) {
+	ownership, err := a.Srv().Store().Role().GetPluginRoleOwnership(pluginID, localName)
+	if err != nil {
+		var nfErr *store.ErrNotFound
+		if errors.As(err, &nfErr) {
+			return nil, model.NewAppError("AssignPluginRole", "app.plugin.role.not_found.app_error", nil, "", http.StatusNotFound).Wrap(err)
+		}
+		return nil, model.NewAppError("AssignPluginRole", "app.plugin.role.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	user, appErr := a.GetUser(userID)
+	if appErr != nil {
+		return nil, appErr
+	}
+	roles := user.GetRoles()
+	if slices.Contains(roles, ownership.RoleName) {
+		return user, nil
+	}
+	roles = append(roles, ownership.RoleName)
+	return a.UpdateUserRolesWithUser(rctx, user, strings.Join(roles, " "), true)
+}
+
+func (a *App) RemovePluginRole(rctx request.CTX, pluginID, userID, localName string) (*model.User, *model.AppError) {
+	ownership, err := a.Srv().Store().Role().GetPluginRoleOwnership(pluginID, localName)
+	if err != nil {
+		var nfErr *store.ErrNotFound
+		if errors.As(err, &nfErr) {
+			return nil, model.NewAppError("RemovePluginRole", "app.plugin.role.not_found.app_error", nil, "", http.StatusNotFound).Wrap(err)
+		}
+		return nil, model.NewAppError("RemovePluginRole", "app.plugin.role.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	user, appErr := a.GetUser(userID)
+	if appErr != nil {
+		return nil, appErr
+	}
+	roles := user.GetRoles()
+	filtered := make([]string, 0, len(roles))
+	for _, role := range roles {
+		if role != ownership.RoleName {
+			filtered = append(filtered, role)
+		}
+	}
+	if len(filtered) == len(roles) {
+		return user, nil
+	}
+	return a.UpdateUserRolesWithUser(rctx, user, strings.Join(filtered, " "), true)
+}
+
+func (a *App) PurgePluginRBAC(rctx request.CTX, pluginID string) *model.AppError {
+	permissions, err := a.Srv().Store().Role().GetPluginPermissionsByPlugin(pluginID)
+	if err != nil {
+		return model.NewAppError("PurgePluginRBAC", "app.plugin.permission.get.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	permissionIDs := make([]string, 0, len(permissions))
+	for _, p := range permissions {
+		permissionIDs = append(permissionIDs, p.PermissionId)
+	}
+
+	if len(permissionIDs) > 0 {
+		if appErr := a.stripPermissionsFromAllRoles(permissionIDs); appErr != nil {
+			return appErr
+		}
+	}
+
+	ownerships, err := a.Srv().Store().Role().GetPluginRoleOwnershipsByPlugin(pluginID)
+	if err != nil {
+		return model.NewAppError("PurgePluginRBAC", "app.plugin.role.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	for _, ownership := range ownerships {
+		role, getErr := a.GetRoleByName(rctx, ownership.RoleName)
+		if getErr != nil {
+			if getErr.StatusCode == http.StatusNotFound {
+				continue
+			}
+			return getErr
+		}
+		if _, delErr := a.DeleteRole(role.Id); delErr != nil {
+			return delErr
+		}
+	}
+
+	if err := a.Srv().Store().Role().DeletePluginRoleOwnerships(pluginID); err != nil {
+		return model.NewAppError("PurgePluginRBAC", "app.plugin.role.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	if err := a.Srv().Store().Role().DeletePluginPermissions(pluginID); err != nil {
+		return model.NewAppError("PurgePluginRBAC", "app.plugin.permission.save.app_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	}
+	model.UnregisterPluginPermissionsInMemory(pluginID)
+	return nil
+}
+
+func (a *App) stripPermissionsFromAllRoles(permissionIDs []string) *model.AppError {
+	remove := make(map[string]bool, len(permissionIDs))
+	for _, id := range permissionIDs {
+		remove[id] = true
+	}
+	roles, appErr := a.GetAllRoles()
+	if appErr != nil {
+		return appErr
+	}
+	for _, role := range roles {
+		filtered := make([]string, 0, len(role.Permissions))
+		changed := false
+		for _, p := range role.Permissions {
+			if remove[p] {
+				changed = true
+				continue
+			}
+			filtered = append(filtered, p)
+		}
+		if !changed {
+			continue
+		}
+		role.Permissions = filtered
+		updated, updateErr := a.UpdateRole(role)
+		if updateErr != nil {
+			return updateErr
+		}
+		if sendErr := a.sendUpdatedRoleEvent(updated); sendErr != nil {
+			return sendErr
+		}
+	}
+	return nil
+}
+
+func (ch *Channels) setPluginPermissionsActive(pluginID string, active bool) *model.AppError {
+	return New(ServerConnector(ch)).SetPluginPermissionsActive(pluginID, active)
+}
+
+func (ch *Channels) purgePluginRBAC(pluginID string) *model.AppError {
+	return New(ServerConnector(ch)).PurgePluginRBAC(request.EmptyContext(ch.srv.Log()), pluginID)
+}

--- a/server/channels/app/plugin_permissions_test.go
+++ b/server/channels/app/plugin_permissions_test.go
@@ -1,0 +1,163 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+)
+
+func TestRegisterPluginPermission(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+	t.Cleanup(model.ResetPluginPermissionRegistryForTest)
+
+	pluginID := "com.example.plugin"
+	permission := &model.PluginPermission{
+		Id:           "manage_thing",
+		Name:         "Manage thing",
+		Description:  "Allows managing things",
+		Scope:        model.PermissionScopeChannel,
+		DefaultRoles: []string{model.ChannelAdminRoleId},
+	}
+
+	appErr := th.App.RegisterPluginPermission(th.Context, pluginID, permission)
+	require.Nil(t, appErr)
+	require.Equal(t, model.PluginPermissionId(pluginID, "manage_thing"), permission.PermissionId)
+
+	assert.True(t, model.IsRegisteredPluginPermission(permission.PermissionId))
+
+	systemAdmin, appErr := th.App.GetRoleByName(th.Context, model.SystemAdminRoleId)
+	require.Nil(t, appErr)
+	assert.Contains(t, systemAdmin.Permissions, permission.PermissionId)
+
+	channelAdmin, appErr := th.App.GetRoleByName(th.Context, model.ChannelAdminRoleId)
+	require.Nil(t, appErr)
+	assert.Contains(t, channelAdmin.Permissions, permission.PermissionId)
+
+	t.Run("second register does not reapply defaults", func(t *testing.T) {
+		channelAdmin.Permissions = sliceWithout(channelAdmin.Permissions, permission.PermissionId)
+		_, appErr = th.App.UpdateRole(channelAdmin)
+		require.Nil(t, appErr)
+
+		appErr = th.App.RegisterPluginPermission(th.Context, pluginID, permission)
+		require.Nil(t, appErr)
+
+		channelAdmin, appErr = th.App.GetRoleByName(th.Context, model.ChannelAdminRoleId)
+		require.Nil(t, appErr)
+		assert.NotContains(t, channelAdmin.Permissions, permission.PermissionId)
+	})
+
+	t.Run("rejects core permission collision via local id", func(t *testing.T) {
+		appErr := th.App.RegisterPluginPermission(th.Context, pluginID, &model.PluginPermission{
+			Id:    "Manage_System",
+			Name:  "Nope",
+			Scope: model.PermissionScopeSystem,
+		})
+		require.NotNil(t, appErr)
+	})
+
+	t.Run("rejects invalid scope", func(t *testing.T) {
+		appErr := th.App.RegisterPluginPermission(th.Context, pluginID, &model.PluginPermission{
+			Id:    "other_thing",
+			Name:  "Other",
+			Scope: model.PermissionScopePlaybook,
+		})
+		require.NotNil(t, appErr)
+	})
+}
+
+func TestRegisterPluginRoleAndAssignment(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+	t.Cleanup(model.ResetPluginPermissionRegistryForTest)
+
+	pluginID := "com.example.roles"
+	appErr := th.App.RegisterPluginPermission(th.Context, pluginID, &model.PluginPermission{
+		Id:    "manage_thing",
+		Name:  "Manage thing",
+		Scope: model.PermissionScopeSystem,
+	})
+	require.Nil(t, appErr)
+
+	role, appErr := th.App.RegisterPluginRole(th.Context, pluginID, &model.PluginRole{
+		Name:        "admin",
+		DisplayName: "Thing Admin",
+		Description: "Administer things",
+		Permissions: []string{"manage_thing"},
+	})
+	require.Nil(t, appErr)
+	require.Equal(t, model.PluginRoleName(pluginID, "admin"), role.Name)
+	assert.Contains(t, role.Permissions, model.PluginPermissionId(pluginID, "manage_thing"))
+
+	user, appErr := th.App.AssignPluginRole(th.Context, pluginID, th.BasicUser.Id, "admin")
+	require.Nil(t, appErr)
+	assert.Contains(t, user.GetRoles(), role.Name)
+	assert.True(t, th.App.HasPermissionTo(th.BasicUser.Id, &model.Permission{Id: model.PluginPermissionId(pluginID, "manage_thing")}))
+
+	user, appErr = th.App.RemovePluginRole(th.Context, pluginID, th.BasicUser.Id, "admin")
+	require.Nil(t, appErr)
+	assert.NotContains(t, user.GetRoles(), role.Name)
+
+	t.Run("cannot put another plugin's permission on the role", func(t *testing.T) {
+		other := "com.example.other"
+		require.Nil(t, th.App.RegisterPluginPermission(th.Context, other, &model.PluginPermission{
+			Id:    "manage_thing",
+			Name:  "Other",
+			Scope: model.PermissionScopeSystem,
+		}))
+		_, appErr := th.App.RegisterPluginRole(th.Context, pluginID, &model.PluginRole{
+			Name:        "admin",
+			DisplayName: "Thing Admin",
+			Permissions: []string{model.PluginPermissionId(other, "manage_thing")},
+		})
+		require.NotNil(t, appErr)
+	})
+}
+
+func TestPurgePluginRBAC(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+	t.Cleanup(model.ResetPluginPermissionRegistryForTest)
+
+	pluginID := "com.example.purge"
+	permission := &model.PluginPermission{
+		Id:           "manage_thing",
+		Name:         "Manage thing",
+		Scope:        model.PermissionScopeChannel,
+		DefaultRoles: []string{model.ChannelAdminRoleId},
+	}
+	require.Nil(t, th.App.RegisterPluginPermission(th.Context, pluginID, permission))
+	role, appErr := th.App.RegisterPluginRole(th.Context, pluginID, &model.PluginRole{
+		Name:        "admin",
+		DisplayName: "Thing Admin",
+		Permissions: []string{"manage_thing"},
+	})
+	require.Nil(t, appErr)
+
+	require.Nil(t, th.App.PurgePluginRBAC(th.Context, pluginID))
+	assert.False(t, model.IsRegisteredPluginPermission(permission.PermissionId))
+
+	channelAdmin, appErr := th.App.GetRoleByName(th.Context, model.ChannelAdminRoleId)
+	require.Nil(t, appErr)
+	assert.NotContains(t, channelAdmin.Permissions, permission.PermissionId)
+
+	deleted, appErr := th.App.GetRoleByName(th.Context, role.Name)
+	require.Nil(t, appErr)
+	assert.NotEqual(t, int64(0), deleted.DeleteAt)
+}
+
+func sliceWithout(in []string, drop string) []string {
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if v != drop {
+			out = append(out, v)
+		}
+	}
+	return out
+}

--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -425,3 +425,5 @@ channels/db/migrations/postgres/000214_drop_channelmembers_autotranslation.down.
 channels/db/migrations/postgres/000214_drop_channelmembers_autotranslation.up.sql
 channels/db/migrations/postgres/000215_drop_channelmembers_autotranslation_column.down.sql
 channels/db/migrations/postgres/000215_drop_channelmembers_autotranslation_column.up.sql
+channels/db/migrations/postgres/000216_create_plugin_permissions.down.sql
+channels/db/migrations/postgres/000216_create_plugin_permissions.up.sql

--- a/server/channels/db/migrations/postgres/000216_create_plugin_permissions.down.sql
+++ b/server/channels/db/migrations/postgres/000216_create_plugin_permissions.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS PluginRoles;
+DROP TABLE IF EXISTS PluginPermissions;

--- a/server/channels/db/migrations/postgres/000216_create_plugin_permissions.up.sql
+++ b/server/channels/db/migrations/postgres/000216_create_plugin_permissions.up.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS PluginPermissions (
+    PluginId         VARCHAR(190)  NOT NULL,
+    LocalId          VARCHAR(64)   NOT NULL,
+    PermissionId     VARCHAR(255)  NOT NULL,
+    Name             VARCHAR(128)  NOT NULL,
+    Description      VARCHAR(1024) NOT NULL DEFAULT '',
+    Scope            VARCHAR(32)   NOT NULL,
+    DefaultRoles     TEXT          NOT NULL DEFAULT '',
+    Active           BOOLEAN       NOT NULL DEFAULT TRUE,
+    DefaultsApplied  BOOLEAN       NOT NULL DEFAULT FALSE,
+    CreateAt         BIGINT        NOT NULL,
+    UpdateAt         BIGINT        NOT NULL,
+    PRIMARY KEY (PluginId, LocalId)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pluginpermissions_permissionid ON PluginPermissions (PermissionId);
+
+CREATE TABLE IF NOT EXISTS PluginRoles (
+    PluginId  VARCHAR(190) NOT NULL,
+    LocalName VARCHAR(32)  NOT NULL,
+    RoleName  VARCHAR(64)  NOT NULL,
+    CreateAt  BIGINT       NOT NULL,
+    PRIMARY KEY (PluginId, LocalName)
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_pluginroles_rolename ON PluginRoles (RoleName);

--- a/server/channels/store/retrylayer/retrylayer.go
+++ b/server/channels/store/retrylayer/retrylayer.go
@@ -12541,6 +12541,48 @@ func (s *RetryLayerRoleStore) Delete(roleID string) (*model.Role, error) {
 
 }
 
+func (s *RetryLayerRoleStore) DeletePluginPermissions(pluginID string) error {
+
+	tries := 0
+	for {
+		err := s.RoleStore.DeletePluginPermissions(pluginID)
+		if err == nil {
+			return nil
+		}
+		if !isRepeatableError(err) {
+			return err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
+func (s *RetryLayerRoleStore) DeletePluginRoleOwnerships(pluginID string) error {
+
+	tries := 0
+	for {
+		err := s.RoleStore.DeletePluginRoleOwnerships(pluginID)
+		if err == nil {
+			return nil
+		}
+		if !isRepeatableError(err) {
+			return err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerRoleStore) Get(roleID string) (*model.Role, error) {
 
 	tries := 0
@@ -12625,6 +12667,132 @@ func (s *RetryLayerRoleStore) GetByNames(names []string) ([]*model.Role, error) 
 
 }
 
+func (s *RetryLayerRoleStore) GetPluginPermission(pluginID string, localID string) (*model.PluginPermission, error) {
+
+	tries := 0
+	for {
+		result, err := s.RoleStore.GetPluginPermission(pluginID, localID)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
+func (s *RetryLayerRoleStore) GetPluginPermissions() ([]*model.PluginPermission, error) {
+
+	tries := 0
+	for {
+		result, err := s.RoleStore.GetPluginPermissions()
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
+func (s *RetryLayerRoleStore) GetPluginPermissionsByPlugin(pluginID string) ([]*model.PluginPermission, error) {
+
+	tries := 0
+	for {
+		result, err := s.RoleStore.GetPluginPermissionsByPlugin(pluginID)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
+func (s *RetryLayerRoleStore) GetPluginRoleOwnership(pluginID string, localName string) (*model.PluginRoleOwnership, error) {
+
+	tries := 0
+	for {
+		result, err := s.RoleStore.GetPluginRoleOwnership(pluginID, localName)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
+func (s *RetryLayerRoleStore) GetPluginRoleOwnershipsByPlugin(pluginID string) ([]*model.PluginRoleOwnership, error) {
+
+	tries := 0
+	for {
+		result, err := s.RoleStore.GetPluginRoleOwnershipsByPlugin(pluginID)
+		if err == nil {
+			return result, nil
+		}
+		if !isRepeatableError(err) {
+			return result, err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
+func (s *RetryLayerRoleStore) MarkPluginPermissionDefaultsApplied(pluginID string, localID string) error {
+
+	tries := 0
+	for {
+		err := s.RoleStore.MarkPluginPermissionDefaultsApplied(pluginID, localID)
+		if err == nil {
+			return nil
+		}
+		if !isRepeatableError(err) {
+			return err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerRoleStore) PermanentDeleteAll() error {
 
 	tries := 0
@@ -12667,6 +12835,48 @@ func (s *RetryLayerRoleStore) Save(role *model.Role) (*model.Role, error) {
 
 }
 
+func (s *RetryLayerRoleStore) SavePluginPermission(permission *model.PluginPermission) error {
+
+	tries := 0
+	for {
+		err := s.RoleStore.SavePluginPermission(permission)
+		if err == nil {
+			return nil
+		}
+		if !isRepeatableError(err) {
+			return err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
+func (s *RetryLayerRoleStore) SavePluginRoleOwnership(ownership *model.PluginRoleOwnership) error {
+
+	tries := 0
+	for {
+		err := s.RoleStore.SavePluginRoleOwnership(ownership)
+		if err == nil {
+			return nil
+		}
+		if !isRepeatableError(err) {
+			return err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
 func (s *RetryLayerRoleStore) SavePreservingUnknownPermissions(role *model.Role) (*model.Role, error) {
 
 	tries := 0
@@ -12682,6 +12892,27 @@ func (s *RetryLayerRoleStore) SavePreservingUnknownPermissions(role *model.Role)
 		if tries >= 3 {
 			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
 			return result, err
+		}
+		timepkg.Sleep(100 * timepkg.Millisecond)
+	}
+
+}
+
+func (s *RetryLayerRoleStore) SetPluginPermissionsActive(pluginID string, active bool) error {
+
+	tries := 0
+	for {
+		err := s.RoleStore.SetPluginPermissionsActive(pluginID, active)
+		if err == nil {
+			return nil
+		}
+		if !isRepeatableError(err) {
+			return err
+		}
+		tries++
+		if tries >= 3 {
+			err = errors.Wrap(err, "giving up after 3 consecutive repeatable transaction failures")
+			return err
 		}
 		timepkg.Sleep(100 * timepkg.Millisecond)
 	}

--- a/server/channels/store/sqlstore/role_store.go
+++ b/server/channels/store/sqlstore/role_store.go
@@ -522,3 +522,199 @@ func (s *SqlRoleStore) ChannelRolesUnderTeamRole(roleName string) ([]*model.Role
 
 	return roles, nil
 }
+
+type dbPluginPermission struct {
+	PluginId        string
+	LocalId         string
+	PermissionId    string
+	Name            string
+	Description     string
+	Scope           string
+	DefaultRoles    string
+	Active          bool
+	DefaultsApplied bool
+	CreateAt        int64
+	UpdateAt        int64
+}
+
+func (p dbPluginPermission) ToModel() *model.PluginPermission {
+	return &model.PluginPermission{
+		PluginId:        p.PluginId,
+		Id:              p.LocalId,
+		PermissionId:    p.PermissionId,
+		Name:            p.Name,
+		Description:     p.Description,
+		Scope:           p.Scope,
+		DefaultRoles:    strings.Fields(p.DefaultRoles),
+		Active:          p.Active,
+		DefaultsApplied: p.DefaultsApplied,
+		CreateAt:        p.CreateAt,
+		UpdateAt:        p.UpdateAt,
+	}
+}
+
+func (s *SqlRoleStore) SavePluginPermission(permission *model.PluginPermission) error {
+	now := model.GetMillis()
+	if permission.CreateAt == 0 {
+		permission.CreateAt = now
+	}
+	permission.UpdateAt = now
+
+	builder := s.getQueryBuilder().
+		Insert("PluginPermissions").
+		Columns("PluginId", "LocalId", "PermissionId", "Name", "Description", "Scope", "DefaultRoles", "Active", "DefaultsApplied", "CreateAt", "UpdateAt").
+		Values(
+			permission.PluginId,
+			permission.Id,
+			permission.PermissionId,
+			permission.Name,
+			permission.Description,
+			permission.Scope,
+			strings.Join(permission.DefaultRoles, " "),
+			permission.Active,
+			permission.DefaultsApplied,
+			permission.CreateAt,
+			permission.UpdateAt,
+		).
+		SuffixExpr(sq.Expr("ON CONFLICT (PluginId, LocalId) DO UPDATE SET Name = EXCLUDED.Name, Description = EXCLUDED.Description, Scope = EXCLUDED.Scope, DefaultRoles = EXCLUDED.DefaultRoles, Active = EXCLUDED.Active, UpdateAt = EXCLUDED.UpdateAt"))
+
+	if _, err := s.GetMaster().ExecBuilder(builder); err != nil {
+		return errors.Wrapf(err, "failed to save plugin permission plugin=%s id=%s", permission.PluginId, permission.Id)
+	}
+	return nil
+}
+
+func (s *SqlRoleStore) GetPluginPermission(pluginID, localID string) (*model.PluginPermission, error) {
+	query := s.getQueryBuilder().
+		Select("PluginId", "LocalId", "PermissionId", "Name", "Description", "Scope", "DefaultRoles", "Active", "DefaultsApplied", "CreateAt", "UpdateAt").
+		From("PluginPermissions").
+		Where(sq.Eq{"PluginId": pluginID, "LocalId": localID})
+
+	var dbPerm dbPluginPermission
+	if err := s.GetReplica().GetBuilder(&dbPerm, query); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, store.NewErrNotFound("PluginPermission", pluginID+":"+localID)
+		}
+		return nil, errors.Wrapf(err, "failed to get plugin permission plugin=%s id=%s", pluginID, localID)
+	}
+	return dbPerm.ToModel(), nil
+}
+
+func (s *SqlRoleStore) pluginPermissionsSelect() sq.SelectBuilder {
+	return s.getQueryBuilder().
+		Select("PluginId", "LocalId", "PermissionId", "Name", "Description", "Scope", "DefaultRoles", "Active", "DefaultsApplied", "CreateAt", "UpdateAt").
+		From("PluginPermissions")
+}
+
+func (s *SqlRoleStore) GetPluginPermissions() ([]*model.PluginPermission, error) {
+	var dbPerms []dbPluginPermission
+	if err := s.GetReplica().SelectBuilder(&dbPerms, s.pluginPermissionsSelect()); err != nil {
+		return nil, errors.Wrap(err, "failed to get plugin permissions")
+	}
+	out := make([]*model.PluginPermission, 0, len(dbPerms))
+	for _, p := range dbPerms {
+		out = append(out, p.ToModel())
+	}
+	return out, nil
+}
+
+func (s *SqlRoleStore) GetPluginPermissionsByPlugin(pluginID string) ([]*model.PluginPermission, error) {
+	query := s.pluginPermissionsSelect().Where(sq.Eq{"PluginId": pluginID})
+	var dbPerms []dbPluginPermission
+	if err := s.GetReplica().SelectBuilder(&dbPerms, query); err != nil {
+		return nil, errors.Wrapf(err, "failed to get plugin permissions plugin=%s", pluginID)
+	}
+	out := make([]*model.PluginPermission, 0, len(dbPerms))
+	for _, p := range dbPerms {
+		out = append(out, p.ToModel())
+	}
+	return out, nil
+}
+
+func (s *SqlRoleStore) SetPluginPermissionsActive(pluginID string, active bool) error {
+	builder := s.getQueryBuilder().
+		Update("PluginPermissions").
+		Set("Active", active).
+		Set("UpdateAt", model.GetMillis()).
+		Where(sq.Eq{"PluginId": pluginID})
+	if _, err := s.GetMaster().ExecBuilder(builder); err != nil {
+		return errors.Wrapf(err, "failed to set plugin permissions active plugin=%s", pluginID)
+	}
+	return nil
+}
+
+func (s *SqlRoleStore) DeletePluginPermissions(pluginID string) error {
+	builder := s.getQueryBuilder().
+		Delete("PluginPermissions").
+		Where(sq.Eq{"PluginId": pluginID})
+	if _, err := s.GetMaster().ExecBuilder(builder); err != nil {
+		return errors.Wrapf(err, "failed to delete plugin permissions plugin=%s", pluginID)
+	}
+	return nil
+}
+
+func (s *SqlRoleStore) MarkPluginPermissionDefaultsApplied(pluginID, localID string) error {
+	builder := s.getQueryBuilder().
+		Update("PluginPermissions").
+		Set("DefaultsApplied", true).
+		Set("UpdateAt", model.GetMillis()).
+		Where(sq.Eq{"PluginId": pluginID, "LocalId": localID})
+	if _, err := s.GetMaster().ExecBuilder(builder); err != nil {
+		return errors.Wrapf(err, "failed to mark plugin permission defaults applied plugin=%s id=%s", pluginID, localID)
+	}
+	return nil
+}
+
+func (s *SqlRoleStore) SavePluginRoleOwnership(ownership *model.PluginRoleOwnership) error {
+	if ownership.CreateAt == 0 {
+		ownership.CreateAt = model.GetMillis()
+	}
+	builder := s.getQueryBuilder().
+		Insert("PluginRoles").
+		Columns("PluginId", "LocalName", "RoleName", "CreateAt").
+		Values(ownership.PluginId, ownership.LocalName, ownership.RoleName, ownership.CreateAt).
+		SuffixExpr(sq.Expr("ON CONFLICT (PluginId, LocalName) DO NOTHING"))
+	if _, err := s.GetMaster().ExecBuilder(builder); err != nil {
+		return errors.Wrapf(err, "failed to save plugin role ownership plugin=%s name=%s", ownership.PluginId, ownership.LocalName)
+	}
+	return nil
+}
+
+func (s *SqlRoleStore) GetPluginRoleOwnership(pluginID, localName string) (*model.PluginRoleOwnership, error) {
+	query := s.getQueryBuilder().
+		Select("PluginId", "LocalName", "RoleName", "CreateAt").
+		From("PluginRoles").
+		Where(sq.Eq{"PluginId": pluginID, "LocalName": localName})
+
+	var ownership model.PluginRoleOwnership
+	if err := s.GetReplica().GetBuilder(&ownership, query); err != nil {
+		if err == sql.ErrNoRows {
+			return nil, store.NewErrNotFound("PluginRole", pluginID+":"+localName)
+		}
+		return nil, errors.Wrapf(err, "failed to get plugin role ownership plugin=%s name=%s", pluginID, localName)
+	}
+	return &ownership, nil
+}
+
+func (s *SqlRoleStore) GetPluginRoleOwnershipsByPlugin(pluginID string) ([]*model.PluginRoleOwnership, error) {
+	query := s.getQueryBuilder().
+		Select("PluginId", "LocalName", "RoleName", "CreateAt").
+		From("PluginRoles").
+		Where(sq.Eq{"PluginId": pluginID})
+
+	var ownerships []*model.PluginRoleOwnership
+	if err := s.GetReplica().SelectBuilder(&ownerships, query); err != nil {
+		return nil, errors.Wrapf(err, "failed to get plugin role ownerships plugin=%s", pluginID)
+	}
+	return ownerships, nil
+}
+
+func (s *SqlRoleStore) DeletePluginRoleOwnerships(pluginID string) error {
+	builder := s.getQueryBuilder().
+		Delete("PluginRoles").
+		Where(sq.Eq{"PluginId": pluginID})
+	if _, err := s.GetMaster().ExecBuilder(builder); err != nil {
+		return errors.Wrapf(err, "failed to delete plugin role ownerships plugin=%s", pluginID)
+	}
+	return nil
+}

--- a/server/channels/store/store.go
+++ b/server/channels/store/store.go
@@ -906,6 +906,19 @@ type RoleStore interface {
 	// ChannelRolesUnderTeamRole returns all of the non-deleted roles that are affected by updates to the
 	// given role.
 	ChannelRolesUnderTeamRole(roleName string) ([]*model.Role, error)
+
+	SavePluginPermission(permission *model.PluginPermission) error
+	GetPluginPermission(pluginID, localID string) (*model.PluginPermission, error)
+	GetPluginPermissions() ([]*model.PluginPermission, error)
+	GetPluginPermissionsByPlugin(pluginID string) ([]*model.PluginPermission, error)
+	SetPluginPermissionsActive(pluginID string, active bool) error
+	DeletePluginPermissions(pluginID string) error
+	MarkPluginPermissionDefaultsApplied(pluginID, localID string) error
+
+	SavePluginRoleOwnership(ownership *model.PluginRoleOwnership) error
+	GetPluginRoleOwnership(pluginID, localName string) (*model.PluginRoleOwnership, error)
+	GetPluginRoleOwnershipsByPlugin(pluginID string) ([]*model.PluginRoleOwnership, error)
+	DeletePluginRoleOwnerships(pluginID string) error
 }
 
 type SchemeStore interface {

--- a/server/channels/store/storetest/mocks/RoleStore.go
+++ b/server/channels/store/storetest/mocks/RoleStore.go
@@ -135,6 +135,42 @@ func (_m *RoleStore) Delete(roleID string) (*model.Role, error) {
 	return r0, r1
 }
 
+// DeletePluginPermissions provides a mock function with given fields: pluginID
+func (_m *RoleStore) DeletePluginPermissions(pluginID string) error {
+	ret := _m.Called(pluginID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeletePluginPermissions")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(pluginID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// DeletePluginRoleOwnerships provides a mock function with given fields: pluginID
+func (_m *RoleStore) DeletePluginRoleOwnerships(pluginID string) error {
+	ret := _m.Called(pluginID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeletePluginRoleOwnerships")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string) error); ok {
+		r0 = rf(pluginID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Get provides a mock function with given fields: roleID
 func (_m *RoleStore) Get(roleID string) (*model.Role, error) {
 	ret := _m.Called(roleID)
@@ -255,6 +291,174 @@ func (_m *RoleStore) GetByNames(names []string) ([]*model.Role, error) {
 	return r0, r1
 }
 
+// GetPluginPermission provides a mock function with given fields: pluginID, localID
+func (_m *RoleStore) GetPluginPermission(pluginID string, localID string) (*model.PluginPermission, error) {
+	ret := _m.Called(pluginID, localID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPluginPermission")
+	}
+
+	var r0 *model.PluginPermission
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, string) (*model.PluginPermission, error)); ok {
+		return rf(pluginID, localID)
+	}
+	if rf, ok := ret.Get(0).(func(string, string) *model.PluginPermission); ok {
+		r0 = rf(pluginID, localID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.PluginPermission)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(pluginID, localID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetPluginPermissions provides a mock function with no fields
+func (_m *RoleStore) GetPluginPermissions() ([]*model.PluginPermission, error) {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPluginPermissions")
+	}
+
+	var r0 []*model.PluginPermission
+	var r1 error
+	if rf, ok := ret.Get(0).(func() ([]*model.PluginPermission, error)); ok {
+		return rf()
+	}
+	if rf, ok := ret.Get(0).(func() []*model.PluginPermission); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.PluginPermission)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetPluginPermissionsByPlugin provides a mock function with given fields: pluginID
+func (_m *RoleStore) GetPluginPermissionsByPlugin(pluginID string) ([]*model.PluginPermission, error) {
+	ret := _m.Called(pluginID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPluginPermissionsByPlugin")
+	}
+
+	var r0 []*model.PluginPermission
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) ([]*model.PluginPermission, error)); ok {
+		return rf(pluginID)
+	}
+	if rf, ok := ret.Get(0).(func(string) []*model.PluginPermission); ok {
+		r0 = rf(pluginID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.PluginPermission)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(pluginID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetPluginRoleOwnership provides a mock function with given fields: pluginID, localName
+func (_m *RoleStore) GetPluginRoleOwnership(pluginID string, localName string) (*model.PluginRoleOwnership, error) {
+	ret := _m.Called(pluginID, localName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPluginRoleOwnership")
+	}
+
+	var r0 *model.PluginRoleOwnership
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, string) (*model.PluginRoleOwnership, error)); ok {
+		return rf(pluginID, localName)
+	}
+	if rf, ok := ret.Get(0).(func(string, string) *model.PluginRoleOwnership); ok {
+		r0 = rf(pluginID, localName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.PluginRoleOwnership)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string) error); ok {
+		r1 = rf(pluginID, localName)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetPluginRoleOwnershipsByPlugin provides a mock function with given fields: pluginID
+func (_m *RoleStore) GetPluginRoleOwnershipsByPlugin(pluginID string) ([]*model.PluginRoleOwnership, error) {
+	ret := _m.Called(pluginID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetPluginRoleOwnershipsByPlugin")
+	}
+
+	var r0 []*model.PluginRoleOwnership
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string) ([]*model.PluginRoleOwnership, error)); ok {
+		return rf(pluginID)
+	}
+	if rf, ok := ret.Get(0).(func(string) []*model.PluginRoleOwnership); ok {
+		r0 = rf(pluginID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*model.PluginRoleOwnership)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string) error); ok {
+		r1 = rf(pluginID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MarkPluginPermissionDefaultsApplied provides a mock function with given fields: pluginID, localID
+func (_m *RoleStore) MarkPluginPermissionDefaultsApplied(pluginID string, localID string) error {
+	ret := _m.Called(pluginID, localID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for MarkPluginPermissionDefaultsApplied")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(pluginID, localID)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // PermanentDeleteAll provides a mock function with no fields
 func (_m *RoleStore) PermanentDeleteAll() error {
 	ret := _m.Called()
@@ -303,6 +507,42 @@ func (_m *RoleStore) Save(role *model.Role) (*model.Role, error) {
 	return r0, r1
 }
 
+// SavePluginPermission provides a mock function with given fields: permission
+func (_m *RoleStore) SavePluginPermission(permission *model.PluginPermission) error {
+	ret := _m.Called(permission)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SavePluginPermission")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*model.PluginPermission) error); ok {
+		r0 = rf(permission)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// SavePluginRoleOwnership provides a mock function with given fields: ownership
+func (_m *RoleStore) SavePluginRoleOwnership(ownership *model.PluginRoleOwnership) error {
+	ret := _m.Called(ownership)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SavePluginRoleOwnership")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*model.PluginRoleOwnership) error); ok {
+		r0 = rf(ownership)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SavePreservingUnknownPermissions provides a mock function with given fields: role
 func (_m *RoleStore) SavePreservingUnknownPermissions(role *model.Role) (*model.Role, error) {
 	ret := _m.Called(role)
@@ -331,6 +571,24 @@ func (_m *RoleStore) SavePreservingUnknownPermissions(role *model.Role) (*model.
 	}
 
 	return r0, r1
+}
+
+// SetPluginPermissionsActive provides a mock function with given fields: pluginID, active
+func (_m *RoleStore) SetPluginPermissionsActive(pluginID string, active bool) error {
+	ret := _m.Called(pluginID, active)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetPluginPermissionsActive")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, bool) error); ok {
+		r0 = rf(pluginID, active)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // NewRoleStore creates a new instance of RoleStore. It also registers a testing interface on the mock and a cleanup function to assert the mocks expectations.

--- a/server/channels/store/storetest/role_store.go
+++ b/server/channels/store/storetest/role_store.go
@@ -24,6 +24,7 @@ func TestRoleStore(t *testing.T, rctx request.CTX, ss store.Store, s SqlStore) {
 	t.Run("GetNames", func(t *testing.T) { testRoleStoreGetByNames(t, rctx, ss) })
 	t.Run("Delete", func(t *testing.T) { testRoleStoreDelete(t, rctx, ss) })
 	t.Run("PermanentDeleteAll", func(t *testing.T) { testRoleStorePermanentDeleteAll(t, rctx, ss) })
+	t.Run("PluginPermissions", func(t *testing.T) { testRoleStorePluginPermissions(t, rctx, ss) })
 	t.Run("LowerScopedChannelSchemeRoles_AllChannelSchemeRoles", func(t *testing.T) { testRoleStoreLowerScopedChannelSchemeRoles(t, rctx, ss) })
 	t.Run("ChannelHigherScopedPermissionsBlankTeamSchemeChannelGuest", func(t *testing.T) {
 		testRoleStoreChannelHigherScopedPermissionsBlankTeamSchemeChannelGuest(t, rctx, ss, s)
@@ -691,4 +692,60 @@ func testRoleStoreChannelHigherScopedPermissionsBlankTeamSchemeChannelGuest(t *t
 	require.NoError(t, err)
 
 	require.Equal(t, len(roleMapBefore), len(roleMapAfter))
+}
+
+func testRoleStorePluginPermissions(t *testing.T, rctx request.CTX, ss store.Store) {
+	pluginID := "com.example.store"
+	perm := &model.PluginPermission{
+		PluginId:     pluginID,
+		Id:           "manage_thing",
+		PermissionId: model.PluginPermissionId(pluginID, "manage_thing"),
+		Name:         "Manage thing",
+		Description:  "desc",
+		Scope:        model.PermissionScopeSystem,
+		DefaultRoles: []string{model.ChannelAdminRoleId},
+		Active:       true,
+	}
+
+	require.NoError(t, ss.Role().SavePluginPermission(perm))
+
+	got, err := ss.Role().GetPluginPermission(pluginID, "manage_thing")
+	require.NoError(t, err)
+	assert.Equal(t, perm.PermissionId, got.PermissionId)
+	assert.Equal(t, []string{model.ChannelAdminRoleId}, got.DefaultRoles)
+	assert.False(t, got.DefaultsApplied)
+
+	perm.Name = "Manage thing updated"
+	require.NoError(t, ss.Role().SavePluginPermission(perm))
+	got, err = ss.Role().GetPluginPermission(pluginID, "manage_thing")
+	require.NoError(t, err)
+	assert.Equal(t, "Manage thing updated", got.Name)
+
+	require.NoError(t, ss.Role().MarkPluginPermissionDefaultsApplied(pluginID, "manage_thing"))
+	got, err = ss.Role().GetPluginPermission(pluginID, "manage_thing")
+	require.NoError(t, err)
+	assert.True(t, got.DefaultsApplied)
+
+	require.NoError(t, ss.Role().SetPluginPermissionsActive(pluginID, false))
+	got, err = ss.Role().GetPluginPermission(pluginID, "manage_thing")
+	require.NoError(t, err)
+	assert.False(t, got.Active)
+
+	ownership := &model.PluginRoleOwnership{
+		PluginId:  pluginID,
+		LocalName: "admin",
+		RoleName:  model.PluginRoleName(pluginID, "admin"),
+	}
+	require.NoError(t, ss.Role().SavePluginRoleOwnership(ownership))
+	gotOwn, err := ss.Role().GetPluginRoleOwnership(pluginID, "admin")
+	require.NoError(t, err)
+	assert.Equal(t, ownership.RoleName, gotOwn.RoleName)
+
+	require.NoError(t, ss.Role().DeletePluginRoleOwnerships(pluginID))
+	_, err = ss.Role().GetPluginRoleOwnership(pluginID, "admin")
+	require.Error(t, err)
+
+	require.NoError(t, ss.Role().DeletePluginPermissions(pluginID))
+	_, err = ss.Role().GetPluginPermission(pluginID, "manage_thing")
+	require.Error(t, err)
 }

--- a/server/channels/store/timerlayer/timerlayer.go
+++ b/server/channels/store/timerlayer/timerlayer.go
@@ -9939,6 +9939,38 @@ func (s *TimerLayerRoleStore) Delete(roleID string) (*model.Role, error) {
 	return result, err
 }
 
+func (s *TimerLayerRoleStore) DeletePluginPermissions(pluginID string) error {
+	start := time.Now()
+
+	err := s.RoleStore.DeletePluginPermissions(pluginID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RoleStore.DeletePluginPermissions", success, elapsed)
+	}
+	return err
+}
+
+func (s *TimerLayerRoleStore) DeletePluginRoleOwnerships(pluginID string) error {
+	start := time.Now()
+
+	err := s.RoleStore.DeletePluginRoleOwnerships(pluginID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RoleStore.DeletePluginRoleOwnerships", success, elapsed)
+	}
+	return err
+}
+
 func (s *TimerLayerRoleStore) Get(roleID string) (*model.Role, error) {
 	start := time.Now()
 
@@ -10003,6 +10035,102 @@ func (s *TimerLayerRoleStore) GetByNames(names []string) ([]*model.Role, error) 
 	return result, err
 }
 
+func (s *TimerLayerRoleStore) GetPluginPermission(pluginID string, localID string) (*model.PluginPermission, error) {
+	start := time.Now()
+
+	result, err := s.RoleStore.GetPluginPermission(pluginID, localID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RoleStore.GetPluginPermission", success, elapsed)
+	}
+	return result, err
+}
+
+func (s *TimerLayerRoleStore) GetPluginPermissions() ([]*model.PluginPermission, error) {
+	start := time.Now()
+
+	result, err := s.RoleStore.GetPluginPermissions()
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RoleStore.GetPluginPermissions", success, elapsed)
+	}
+	return result, err
+}
+
+func (s *TimerLayerRoleStore) GetPluginPermissionsByPlugin(pluginID string) ([]*model.PluginPermission, error) {
+	start := time.Now()
+
+	result, err := s.RoleStore.GetPluginPermissionsByPlugin(pluginID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RoleStore.GetPluginPermissionsByPlugin", success, elapsed)
+	}
+	return result, err
+}
+
+func (s *TimerLayerRoleStore) GetPluginRoleOwnership(pluginID string, localName string) (*model.PluginRoleOwnership, error) {
+	start := time.Now()
+
+	result, err := s.RoleStore.GetPluginRoleOwnership(pluginID, localName)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RoleStore.GetPluginRoleOwnership", success, elapsed)
+	}
+	return result, err
+}
+
+func (s *TimerLayerRoleStore) GetPluginRoleOwnershipsByPlugin(pluginID string) ([]*model.PluginRoleOwnership, error) {
+	start := time.Now()
+
+	result, err := s.RoleStore.GetPluginRoleOwnershipsByPlugin(pluginID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RoleStore.GetPluginRoleOwnershipsByPlugin", success, elapsed)
+	}
+	return result, err
+}
+
+func (s *TimerLayerRoleStore) MarkPluginPermissionDefaultsApplied(pluginID string, localID string) error {
+	start := time.Now()
+
+	err := s.RoleStore.MarkPluginPermissionDefaultsApplied(pluginID, localID)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RoleStore.MarkPluginPermissionDefaultsApplied", success, elapsed)
+	}
+	return err
+}
+
 func (s *TimerLayerRoleStore) PermanentDeleteAll() error {
 	start := time.Now()
 
@@ -10035,6 +10163,38 @@ func (s *TimerLayerRoleStore) Save(role *model.Role) (*model.Role, error) {
 	return result, err
 }
 
+func (s *TimerLayerRoleStore) SavePluginPermission(permission *model.PluginPermission) error {
+	start := time.Now()
+
+	err := s.RoleStore.SavePluginPermission(permission)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RoleStore.SavePluginPermission", success, elapsed)
+	}
+	return err
+}
+
+func (s *TimerLayerRoleStore) SavePluginRoleOwnership(ownership *model.PluginRoleOwnership) error {
+	start := time.Now()
+
+	err := s.RoleStore.SavePluginRoleOwnership(ownership)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RoleStore.SavePluginRoleOwnership", success, elapsed)
+	}
+	return err
+}
+
 func (s *TimerLayerRoleStore) SavePreservingUnknownPermissions(role *model.Role) (*model.Role, error) {
 	start := time.Now()
 
@@ -10049,6 +10209,22 @@ func (s *TimerLayerRoleStore) SavePreservingUnknownPermissions(role *model.Role)
 		s.Root.Metrics.ObserveStoreMethodDuration("RoleStore.SavePreservingUnknownPermissions", success, elapsed)
 	}
 	return result, err
+}
+
+func (s *TimerLayerRoleStore) SetPluginPermissionsActive(pluginID string, active bool) error {
+	start := time.Now()
+
+	err := s.RoleStore.SetPluginPermissionsActive(pluginID, active)
+
+	elapsed := float64(time.Since(start)) / float64(time.Second)
+	if s.Root.Metrics != nil {
+		success := "false"
+		if err == nil {
+			success = "true"
+		}
+		s.Root.Metrics.ObserveStoreMethodDuration("RoleStore.SetPluginPermissionsActive", success, elapsed)
+	}
+	return err
 }
 
 func (s *TimerLayerScheduledPostStore) CreateScheduledPost(rctx request.CTX, scheduledPost *model.ScheduledPost) (*model.ScheduledPost, error) {

--- a/server/i18n/en.json
+++ b/server/i18n/en.json
@@ -8189,6 +8189,22 @@
     "translation": "Plugin is not installed."
   },
   {
+    "id": "app.plugin.permission.get.app_error",
+    "translation": "Unable to get plugin permissions."
+  },
+  {
+    "id": "app.plugin.permission.invalid.app_error",
+    "translation": "Invalid plugin permission."
+  },
+  {
+    "id": "app.plugin.permission.limit.app_error",
+    "translation": "Plugin has reached the maximum number of permissions."
+  },
+  {
+    "id": "app.plugin.permission.save.app_error",
+    "translation": "Unable to save plugin permission."
+  },
+  {
     "id": "app.plugin.reattach.app_error",
     "translation": "Failed to reattach plugin"
   },
@@ -8203,6 +8219,22 @@
   {
     "id": "app.plugin.restart.app_error",
     "translation": "Unable to restart plugin on upgrade."
+  },
+  {
+    "id": "app.plugin.role.invalid.app_error",
+    "translation": "Invalid plugin role."
+  },
+  {
+    "id": "app.plugin.role.limit.app_error",
+    "translation": "Plugin has reached the maximum number of roles."
+  },
+  {
+    "id": "app.plugin.role.not_found.app_error",
+    "translation": "Plugin role not found."
+  },
+  {
+    "id": "app.plugin.role.save.app_error",
+    "translation": "Unable to save plugin role."
   },
   {
     "id": "app.plugin.seek.app_error",

--- a/server/public/model/client4.go
+++ b/server/public/model/client4.go
@@ -7791,6 +7791,15 @@ func (c *Client4) GetAncillaryPermissions(ctx context.Context, subsectionPermiss
 	return DecodeJSONFromResponse[[]string](r)
 }
 
+func (c *Client4) GetPluginPermissions(ctx context.Context) ([]*PluginPermission, *Response, error) {
+	r, err := c.doAPIGet(ctx, c.permissionsRoute(), "")
+	if err != nil {
+		return nil, BuildResponse(r), err
+	}
+	defer closeBody(r)
+	return DecodeJSONFromResponse[[]*PluginPermission](r)
+}
+
 func (c *Client4) GetUsersWithInvalidEmails(ctx context.Context, page, perPage int) ([]*User, *Response, error) {
 	values := url.Values{}
 	values.Set("page", strconv.Itoa(page))

--- a/server/public/model/manifest.go
+++ b/server/public/model/manifest.go
@@ -219,6 +219,13 @@ type Manifest struct {
 	// provide your settings schema.
 	SettingsSchema *PluginSettingsSchema `json:"settings_schema,omitempty" yaml:"settings_schema,omitempty"`
 
+	// Permissions declared by the plugin. Registered on activate and granted onto default_roles
+	// the first time each permission is seen. IDs are namespaced as "{pluginID}:{id}".
+	Permissions []*ManifestPermission `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+
+	// Roles declared by the plugin. Registered on activate as plugin-owned custom roles.
+	Roles []*ManifestRole `json:"roles,omitempty" yaml:"roles,omitempty"`
+
 	// Plugins can store any kind of data in Props to allow other plugins to use it.
 	Props map[string]any `json:"props,omitempty" yaml:"props,omitempty"`
 }
@@ -352,6 +359,67 @@ func (m *Manifest) IsValid() error {
 		}
 	}
 
+	if err := m.validatePermissions(); err != nil {
+		return err
+	}
+	if err := m.validateRoles(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (m *Manifest) validatePermissions() error {
+	if len(m.Permissions) > MaxPluginPermissionsPerPlugin {
+		return fmt.Errorf("plugin may register at most %d permissions", MaxPluginPermissionsPerPlugin)
+	}
+	seen := make(map[string]bool, len(m.Permissions))
+	for _, p := range m.Permissions {
+		if p == nil {
+			return errors.New("invalid empty permission")
+		}
+		if !IsValidPluginPermissionLocalID(p.Id) {
+			return fmt.Errorf("invalid permission id %q", p.Id)
+		}
+		if seen[p.Id] {
+			return fmt.Errorf("duplicate permission id %q", p.Id)
+		}
+		seen[p.Id] = true
+		if strings.TrimSpace(p.Name) == "" {
+			return fmt.Errorf("permission %q is missing a name", p.Id)
+		}
+		if !IsValidPluginPermissionScope(p.Scope) {
+			return fmt.Errorf("permission %q has invalid scope %q", p.Id, p.Scope)
+		}
+		for _, role := range p.DefaultRoles {
+			if !IsValidRoleName(role) || !IsBuiltInRole(role) {
+				return fmt.Errorf("permission %q has invalid default role %q", p.Id, role)
+			}
+		}
+	}
+	return nil
+}
+
+func (m *Manifest) validateRoles() error {
+	if len(m.Roles) > MaxPluginRolesPerPlugin {
+		return fmt.Errorf("plugin may register at most %d roles", MaxPluginRolesPerPlugin)
+	}
+	seen := make(map[string]bool, len(m.Roles))
+	for _, r := range m.Roles {
+		if r == nil {
+			return errors.New("invalid empty role")
+		}
+		if !IsValidPluginRoleLocalName(r.Name) {
+			return fmt.Errorf("invalid role name %q", r.Name)
+		}
+		if seen[r.Name] {
+			return fmt.Errorf("duplicate role name %q", r.Name)
+		}
+		seen[r.Name] = true
+		if strings.TrimSpace(r.DisplayName) == "" {
+			return fmt.Errorf("role %q is missing a display name", r.Name)
+		}
+	}
 	return nil
 }
 

--- a/server/public/model/plugin_permission.go
+++ b/server/public/model/plugin_permission.go
@@ -1,0 +1,235 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+const (
+	// PluginPermissionIDSeparator namespaces a plugin-owned permission as "{pluginID}:{localID}".
+	PluginPermissionIDSeparator = ":"
+
+	// PluginRoleNamePrefix is prepended to the hashed plugin-id segment of a plugin-owned role name.
+	PluginRoleNamePrefix = "p"
+
+	MaxPluginPermissionsPerPlugin = 32
+	MaxPluginRolesPerPlugin       = 8
+
+	MaxPluginPermissionLocalIDLength = 64
+	MaxPluginRoleLocalNameLength     = 32
+
+	pluginRoleNameHashLength = 16
+)
+
+var pluginPermissionLocalIDRe = regexp.MustCompile(`^[a-z0-9]+(_[a-z0-9]+)*$`)
+
+// PluginPermission is a permission registered by a plugin. PermissionId is the namespaced
+// ID stored on roles ("{pluginID}:{localID}"). Id is the plugin-local identifier.
+type PluginPermission struct {
+	PluginId       string   `json:"plugin_id"`
+	PluginName     string   `json:"plugin_name,omitempty"`
+	Id             string   `json:"id"`
+	PermissionId   string   `json:"permission_id"`
+	Name           string   `json:"name"`
+	Description    string   `json:"description"`
+	Scope          string   `json:"scope"`
+	DefaultRoles   []string `json:"default_roles,omitempty"`
+	Active         bool     `json:"active"`
+	DefaultsApplied bool    `json:"-"`
+	CreateAt       int64    `json:"create_at,omitempty"`
+	UpdateAt       int64    `json:"update_at,omitempty"`
+}
+
+// PluginRoleOwnership maps a plugin-owned role's local name to the Roles.Name used in assignments.
+type PluginRoleOwnership struct {
+	PluginId  string `json:"plugin_id"`
+	RoleName  string `json:"role_name"`
+	LocalName string `json:"local_name"`
+	CreateAt  int64  `json:"create_at,omitempty"`
+}
+
+// PluginRole is the plugin API payload for registering a custom role.
+type PluginRole struct {
+	Name        string   `json:"name"`
+	DisplayName string   `json:"display_name"`
+	Description string   `json:"description,omitempty"`
+	Permissions []string `json:"permissions,omitempty"`
+}
+
+// ManifestPermission is a permission declared in plugin.json.
+type ManifestPermission struct {
+	Id           string   `json:"id" yaml:"id"`
+	Name         string   `json:"name" yaml:"name"`
+	Description  string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Scope        string   `json:"scope" yaml:"scope"`
+	DefaultRoles []string `json:"default_roles,omitempty" yaml:"default_roles,omitempty"`
+}
+
+// ManifestRole is a role declared in plugin.json.
+type ManifestRole struct {
+	Name        string   `json:"name" yaml:"name"`
+	DisplayName string   `json:"display_name" yaml:"display_name"`
+	Description string   `json:"description,omitempty" yaml:"description,omitempty"`
+	Permissions []string `json:"permissions,omitempty" yaml:"permissions,omitempty"`
+}
+
+func PluginPermissionId(pluginID, localID string) string {
+	return pluginID + PluginPermissionIDSeparator + localID
+}
+
+func SplitPluginPermissionId(permissionID string) (pluginID, localID string, ok bool) {
+	pluginID, localID, found := strings.Cut(permissionID, PluginPermissionIDSeparator)
+	if !found || !IsValidPluginId(pluginID) || !IsValidPluginPermissionLocalID(localID) {
+		return "", "", false
+	}
+	return pluginID, localID, true
+}
+
+func IsValidPluginPermissionLocalID(id string) bool {
+	if id == "" || len(id) > MaxPluginPermissionLocalIDLength {
+		return false
+	}
+	return pluginPermissionLocalIDRe.MatchString(id)
+}
+
+func IsValidPluginRoleLocalName(name string) bool {
+	if name == "" || len(name) > MaxPluginRoleLocalNameLength {
+		return false
+	}
+	return pluginPermissionLocalIDRe.MatchString(name)
+}
+
+func IsValidPluginPermissionScope(scope string) bool {
+	switch scope {
+	case PermissionScopeSystem, PermissionScopeTeam, PermissionScopeChannel:
+		return true
+	default:
+		return false
+	}
+}
+
+// PluginRoleName returns the Roles.Name for a plugin-owned role. Role names are limited to
+// [a-z0-9_] and 64 characters, so the plugin ID is hashed rather than inlined.
+func PluginRoleName(pluginID, localName string) string {
+	sum := sha256.Sum256([]byte(pluginID))
+	return fmt.Sprintf("%s%s_%s", PluginRoleNamePrefix, hex.EncodeToString(sum[:])[:pluginRoleNameHashLength], localName)
+}
+
+func PluginPermissionNameI18nKey(permissionID string) string {
+	return "admin.permissions.permission." + permissionID + ".name"
+}
+
+func PluginPermissionDescriptionI18nKey(permissionID string) string {
+	return "admin.permissions.permission." + permissionID + ".description"
+}
+
+func PluginRoleNameI18nKey(roleName string) string {
+	return "admin.permissions.roles." + roleName + ".name"
+}
+
+func PluginRoleDescriptionI18nKey(roleName string) string {
+	return "admin.permissions.roles." + roleName + ".description"
+}
+
+func PluginPermissionGroupI18nKey(pluginID string) string {
+	return "admin.permissions.groups." + pluginID + ".name"
+}
+
+// pluginPermissionRegistry is the overlay consulted by UnknownPermissions so plugin
+// permission IDs remain valid while a plugin is disabled.
+var pluginPermissionRegistry sync.RWMutex
+var pluginPermissionsByID = map[string]*PluginPermission{}
+
+func RegisterPluginPermissionInMemory(p *PluginPermission) {
+	if p == nil || p.PermissionId == "" {
+		return
+	}
+	copy := *p
+	if p.DefaultRoles != nil {
+		copy.DefaultRoles = append([]string(nil), p.DefaultRoles...)
+	}
+	pluginPermissionRegistry.Lock()
+	pluginPermissionsByID[p.PermissionId] = &copy
+	pluginPermissionRegistry.Unlock()
+}
+
+func UnregisterPluginPermissionsInMemory(pluginID string) {
+	pluginPermissionRegistry.Lock()
+	defer pluginPermissionRegistry.Unlock()
+	for id, p := range pluginPermissionsByID {
+		if p.PluginId == pluginID {
+			delete(pluginPermissionsByID, id)
+		}
+	}
+}
+
+func SetPluginPermissionsActiveInMemory(pluginID string, active bool) {
+	pluginPermissionRegistry.Lock()
+	defer pluginPermissionRegistry.Unlock()
+	for _, p := range pluginPermissionsByID {
+		if p.PluginId == pluginID {
+			p.Active = active
+		}
+	}
+}
+
+func GetRegisteredPluginPermission(permissionID string) *PluginPermission {
+	pluginPermissionRegistry.RLock()
+	defer pluginPermissionRegistry.RUnlock()
+	p := pluginPermissionsByID[permissionID]
+	if p == nil {
+		return nil
+	}
+	copy := *p
+	if p.DefaultRoles != nil {
+		copy.DefaultRoles = append([]string(nil), p.DefaultRoles...)
+	}
+	return &copy
+}
+
+func IsRegisteredPluginPermission(permissionID string) bool {
+	pluginPermissionRegistry.RLock()
+	defer pluginPermissionRegistry.RUnlock()
+	_, ok := pluginPermissionsByID[permissionID]
+	return ok
+}
+
+func AllRegisteredPluginPermissions() []*PluginPermission {
+	pluginPermissionRegistry.RLock()
+	defer pluginPermissionRegistry.RUnlock()
+	out := make([]*PluginPermission, 0, len(pluginPermissionsByID))
+	for _, p := range pluginPermissionsByID {
+		copy := *p
+		if p.DefaultRoles != nil {
+			copy.DefaultRoles = append([]string(nil), p.DefaultRoles...)
+		}
+		out = append(out, &copy)
+	}
+	return out
+}
+
+func CountRegisteredPluginPermissions(pluginID string) int {
+	pluginPermissionRegistry.RLock()
+	defer pluginPermissionRegistry.RUnlock()
+	n := 0
+	for _, p := range pluginPermissionsByID {
+		if p.PluginId == pluginID {
+			n++
+		}
+	}
+	return n
+}
+
+// ResetPluginPermissionRegistryForTest clears the in-memory catalog. Tests only.
+func ResetPluginPermissionRegistryForTest() {
+	pluginPermissionRegistry.Lock()
+	pluginPermissionsByID = map[string]*PluginPermission{}
+	pluginPermissionRegistry.Unlock()
+}

--- a/server/public/model/plugin_permission_test.go
+++ b/server/public/model/plugin_permission_test.go
@@ -1,0 +1,139 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package model
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPluginPermissionId(t *testing.T) {
+	id := PluginPermissionId("com.mattermost.boards", "manage_board")
+	assert.Equal(t, "com.mattermost.boards:manage_board", id)
+
+	pluginID, localID, ok := SplitPluginPermissionId(id)
+	require.True(t, ok)
+	assert.Equal(t, "com.mattermost.boards", pluginID)
+	assert.Equal(t, "manage_board", localID)
+
+	_, _, ok = SplitPluginPermissionId("manage_system")
+	assert.False(t, ok)
+
+	_, _, ok = SplitPluginPermissionId("com.mattermost.boards:Manage_Board")
+	assert.False(t, ok)
+}
+
+func TestIsValidPluginPermissionLocalID(t *testing.T) {
+	assert.True(t, IsValidPluginPermissionLocalID("manage_board"))
+	assert.True(t, IsValidPluginPermissionLocalID("view"))
+	assert.False(t, IsValidPluginPermissionLocalID(""))
+	assert.False(t, IsValidPluginPermissionLocalID("Manage_Board"))
+	assert.False(t, IsValidPluginPermissionLocalID("_leading"))
+	assert.False(t, IsValidPluginPermissionLocalID("trailing_"))
+	assert.False(t, IsValidPluginPermissionLocalID("double__underscore"))
+}
+
+func TestPluginRoleName(t *testing.T) {
+	name := PluginRoleName("com.mattermost.boards", "admin")
+	assert.True(t, IsValidRoleName(name))
+	assert.LessOrEqual(t, len(name), RoleNameMaxLength)
+
+	other := PluginRoleName("com.mattermost.playbooks", "admin")
+	assert.NotEqual(t, name, other, "different plugins must not share a role name")
+}
+
+func TestPluginPermissionRegistry(t *testing.T) {
+	t.Cleanup(ResetPluginPermissionRegistryForTest)
+	ResetPluginPermissionRegistryForTest()
+
+	p := &PluginPermission{
+		PluginId:     "com.example.plugin",
+		Id:           "manage_thing",
+		PermissionId: PluginPermissionId("com.example.plugin", "manage_thing"),
+		Name:         "Manage thing",
+		Scope:        PermissionScopeSystem,
+		Active:       true,
+	}
+	RegisterPluginPermissionInMemory(p)
+
+	assert.True(t, IsRegisteredPluginPermission(p.PermissionId))
+	got := GetRegisteredPluginPermission(p.PermissionId)
+	require.NotNil(t, got)
+	assert.Equal(t, p.Name, got.Name)
+
+	SetPluginPermissionsActiveInMemory("com.example.plugin", false)
+	got = GetRegisteredPluginPermission(p.PermissionId)
+	require.NotNil(t, got)
+	assert.False(t, got.Active)
+	assert.True(t, IsRegisteredPluginPermission(p.PermissionId), "inactive permissions stay known")
+
+	UnregisterPluginPermissionsInMemory("com.example.plugin")
+	assert.False(t, IsRegisteredPluginPermission(p.PermissionId))
+}
+
+func TestUnknownPermissionsIncludesPluginCatalog(t *testing.T) {
+	t.Cleanup(ResetPluginPermissionRegistryForTest)
+	ResetPluginPermissionRegistryForTest()
+
+	permissionID := PluginPermissionId("com.example.plugin", "manage_thing")
+	RegisterPluginPermissionInMemory(&PluginPermission{
+		PluginId:     "com.example.plugin",
+		Id:           "manage_thing",
+		PermissionId: permissionID,
+		Name:         "Manage thing",
+		Scope:        PermissionScopeSystem,
+	})
+
+	role := &Role{
+		Name:        "custom_role",
+		DisplayName: "Custom",
+		Permissions: []string{PermissionCreatePost.Id, permissionID, "not_a_real_permission"},
+	}
+	assert.Equal(t, []string{"not_a_real_permission"}, role.UnknownPermissions())
+}
+
+func TestManifestValidatePermissionsAndRoles(t *testing.T) {
+	base := func() *Manifest {
+		return &Manifest{Id: "com.example.plugin", Name: "Example"}
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		m := base()
+		m.Permissions = []*ManifestPermission{{
+			Id: "manage_thing", Name: "Manage thing", Scope: PermissionScopeChannel,
+			DefaultRoles: []string{ChannelAdminRoleId},
+		}}
+		m.Roles = []*ManifestRole{{Name: "admin", DisplayName: "Thing Admin", Permissions: []string{"manage_thing"}}}
+		require.NoError(t, m.IsValid())
+	})
+
+	t.Run("invalid permission id", func(t *testing.T) {
+		m := base()
+		m.Permissions = []*ManifestPermission{{Id: "Bad-Id", Name: "X", Scope: PermissionScopeSystem}}
+		require.Error(t, m.IsValid())
+	})
+
+	t.Run("invalid scope", func(t *testing.T) {
+		m := base()
+		m.Permissions = []*ManifestPermission{{Id: "manage_thing", Name: "X", Scope: PermissionScopePlaybook}}
+		require.Error(t, m.IsValid())
+	})
+
+	t.Run("duplicate permission", func(t *testing.T) {
+		m := base()
+		m.Permissions = []*ManifestPermission{
+			{Id: "manage_thing", Name: "X", Scope: PermissionScopeSystem},
+			{Id: "manage_thing", Name: "Y", Scope: PermissionScopeSystem},
+		}
+		require.Error(t, m.IsValid())
+	})
+
+	t.Run("invalid role name", func(t *testing.T) {
+		m := base()
+		m.Roles = []*ManifestRole{{Name: "Bad Role", DisplayName: "X"}}
+		require.Error(t, m.IsValid())
+	})
+}

--- a/server/public/model/role.go
+++ b/server/public/model/role.go
@@ -829,7 +829,7 @@ func (r *Role) IsValidWithoutId() error {
 }
 
 // UnknownPermissions returns the permissions on the role that are not present in
-// AllPermissions or DeprecatedPermissions (see MM-68830).
+// AllPermissions, DeprecatedPermissions, or the plugin permission catalog (see MM-68830).
 func (r *Role) UnknownPermissions() []string {
 	check := func(perms []*Permission, permission string) bool {
 		for _, p := range perms {
@@ -842,7 +842,7 @@ func (r *Role) UnknownPermissions() []string {
 
 	var unknown []string
 	for _, permission := range r.Permissions {
-		if !check(AllPermissions, permission) && !check(DeprecatedPermissions, permission) {
+		if !check(AllPermissions, permission) && !check(DeprecatedPermissions, permission) && !IsRegisteredPluginPermission(permission) {
 			unknown = append(unknown, permission)
 		}
 	}

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -1035,6 +1035,44 @@ type API interface {
 	// Minimum server version: 5.3
 	HasPermissionToChannel(userID, channelId string, permission *model.Permission) bool
 
+	// RegisterPermission registers a permission owned by this plugin. Id is a local identifier
+	// (for example "manage_board"); the server namespaces it as "{pluginID}:{id}". Name and
+	// Description are English defaults used as translation fallbacks. DefaultRoles, if set, are
+	// applied only the first time the permission is registered.
+	//
+	// @tag Permission
+	// Minimum server version: 11.10
+	RegisterPermission(permission *model.PluginPermission) *model.AppError
+
+	// RegisterRole registers a custom role owned by this plugin. Name is a local identifier;
+	// the server stores a namespaced Roles.Name. Permissions must be this plugin's permissions
+	// (local ids or already-namespaced ids). Subsequent calls update display metadata and do
+	// not clobber admin-edited permissions.
+	//
+	// @tag Permission
+	// Minimum server version: 11.10
+	RegisterRole(role *model.PluginRole) (*model.Role, *model.AppError)
+
+	// PatchPluginRole updates a role previously registered by this plugin.
+	//
+	// @tag Permission
+	// Minimum server version: 11.10
+	PatchPluginRole(name string, patch *model.RolePatch) (*model.Role, *model.AppError)
+
+	// AssignPluginRole assigns a role owned by this plugin to a user.
+	//
+	// @tag Permission
+	// @tag User
+	// Minimum server version: 11.10
+	AssignPluginRole(userID, roleName string) (*model.User, *model.AppError)
+
+	// RemovePluginRole removes a role owned by this plugin from a user.
+	//
+	// @tag Permission
+	// @tag User
+	// Minimum server version: 11.10
+	RemovePluginRole(userID, roleName string) (*model.User, *model.AppError)
+
 	// RolesGrantPermission check if the specified roles grant the specified permission
 	//
 	// Minimum server version: 6.3

--- a/server/public/plugin/api_timer_layer_generated.go
+++ b/server/public/plugin/api_timer_layer_generated.go
@@ -1097,6 +1097,41 @@ func (api *apiTimerLayer) HasPermissionToChannel(userID, channelId string, permi
 	return _returnsA
 }
 
+func (api *apiTimerLayer) RegisterPermission(permission *model.PluginPermission) *model.AppError {
+	startTime := timePkg.Now()
+	_returnsA := api.apiImpl.RegisterPermission(permission)
+	api.recordTime(startTime, "RegisterPermission", _returnsA == nil)
+	return _returnsA
+}
+
+func (api *apiTimerLayer) RegisterRole(role *model.PluginRole) (*model.Role, *model.AppError) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := api.apiImpl.RegisterRole(role)
+	api.recordTime(startTime, "RegisterRole", _returnsB == nil)
+	return _returnsA, _returnsB
+}
+
+func (api *apiTimerLayer) PatchPluginRole(name string, patch *model.RolePatch) (*model.Role, *model.AppError) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := api.apiImpl.PatchPluginRole(name, patch)
+	api.recordTime(startTime, "PatchPluginRole", _returnsB == nil)
+	return _returnsA, _returnsB
+}
+
+func (api *apiTimerLayer) AssignPluginRole(userID, roleName string) (*model.User, *model.AppError) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := api.apiImpl.AssignPluginRole(userID, roleName)
+	api.recordTime(startTime, "AssignPluginRole", _returnsB == nil)
+	return _returnsA, _returnsB
+}
+
+func (api *apiTimerLayer) RemovePluginRole(userID, roleName string) (*model.User, *model.AppError) {
+	startTime := timePkg.Now()
+	_returnsA, _returnsB := api.apiImpl.RemovePluginRole(userID, roleName)
+	api.recordTime(startTime, "RemovePluginRole", _returnsB == nil)
+	return _returnsA, _returnsB
+}
+
 func (api *apiTimerLayer) RolesGrantPermission(roleNames []string, permissionId string) bool {
 	startTime := timePkg.Now()
 	_returnsA := api.apiImpl.RolesGrantPermission(roleNames, permissionId)

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -6708,6 +6708,153 @@ func (s *apiRPCServer) HasPermissionToChannel(args *Z_HasPermissionToChannelArgs
 	return nil
 }
 
+type Z_RegisterPermissionArgs struct {
+	A *model.PluginPermission
+}
+
+type Z_RegisterPermissionReturns struct {
+	A *model.AppError
+}
+
+func (g *apiRPCClient) RegisterPermission(permission *model.PluginPermission) *model.AppError {
+	_args := &Z_RegisterPermissionArgs{permission}
+	_returns := &Z_RegisterPermissionReturns{}
+	if err := g.client.Call("Plugin.RegisterPermission", _args, _returns); err != nil {
+		log.Printf("RPC call to RegisterPermission API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) RegisterPermission(args *Z_RegisterPermissionArgs, returns *Z_RegisterPermissionReturns) error {
+	if hook, ok := s.impl.(interface {
+		RegisterPermission(permission *model.PluginPermission) *model.AppError
+	}); ok {
+		returns.A = hook.RegisterPermission(args.A)
+	} else {
+		return encodableError(fmt.Errorf("API RegisterPermission called but not implemented."))
+	}
+	return nil
+}
+
+type Z_RegisterRoleArgs struct {
+	A *model.PluginRole
+}
+
+type Z_RegisterRoleReturns struct {
+	A *model.Role
+	B *model.AppError
+}
+
+func (g *apiRPCClient) RegisterRole(role *model.PluginRole) (*model.Role, *model.AppError) {
+	_args := &Z_RegisterRoleArgs{role}
+	_returns := &Z_RegisterRoleReturns{}
+	if err := g.client.Call("Plugin.RegisterRole", _args, _returns); err != nil {
+		log.Printf("RPC call to RegisterRole API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) RegisterRole(args *Z_RegisterRoleArgs, returns *Z_RegisterRoleReturns) error {
+	if hook, ok := s.impl.(interface {
+		RegisterRole(role *model.PluginRole) (*model.Role, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.RegisterRole(args.A)
+	} else {
+		return encodableError(fmt.Errorf("API RegisterRole called but not implemented."))
+	}
+	return nil
+}
+
+type Z_PatchPluginRoleArgs struct {
+	A string
+	B *model.RolePatch
+}
+
+type Z_PatchPluginRoleReturns struct {
+	A *model.Role
+	B *model.AppError
+}
+
+func (g *apiRPCClient) PatchPluginRole(name string, patch *model.RolePatch) (*model.Role, *model.AppError) {
+	_args := &Z_PatchPluginRoleArgs{name, patch}
+	_returns := &Z_PatchPluginRoleReturns{}
+	if err := g.client.Call("Plugin.PatchPluginRole", _args, _returns); err != nil {
+		log.Printf("RPC call to PatchPluginRole API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) PatchPluginRole(args *Z_PatchPluginRoleArgs, returns *Z_PatchPluginRoleReturns) error {
+	if hook, ok := s.impl.(interface {
+		PatchPluginRole(name string, patch *model.RolePatch) (*model.Role, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.PatchPluginRole(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("API PatchPluginRole called but not implemented."))
+	}
+	return nil
+}
+
+type Z_AssignPluginRoleArgs struct {
+	A string
+	B string
+}
+
+type Z_AssignPluginRoleReturns struct {
+	A *model.User
+	B *model.AppError
+}
+
+func (g *apiRPCClient) AssignPluginRole(userID, roleName string) (*model.User, *model.AppError) {
+	_args := &Z_AssignPluginRoleArgs{userID, roleName}
+	_returns := &Z_AssignPluginRoleReturns{}
+	if err := g.client.Call("Plugin.AssignPluginRole", _args, _returns); err != nil {
+		log.Printf("RPC call to AssignPluginRole API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) AssignPluginRole(args *Z_AssignPluginRoleArgs, returns *Z_AssignPluginRoleReturns) error {
+	if hook, ok := s.impl.(interface {
+		AssignPluginRole(userID, roleName string) (*model.User, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.AssignPluginRole(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("API AssignPluginRole called but not implemented."))
+	}
+	return nil
+}
+
+type Z_RemovePluginRoleArgs struct {
+	A string
+	B string
+}
+
+type Z_RemovePluginRoleReturns struct {
+	A *model.User
+	B *model.AppError
+}
+
+func (g *apiRPCClient) RemovePluginRole(userID, roleName string) (*model.User, *model.AppError) {
+	_args := &Z_RemovePluginRoleArgs{userID, roleName}
+	_returns := &Z_RemovePluginRoleReturns{}
+	if err := g.client.Call("Plugin.RemovePluginRole", _args, _returns); err != nil {
+		log.Printf("RPC call to RemovePluginRole API failed: %s", err.Error())
+	}
+	return _returns.A, _returns.B
+}
+
+func (s *apiRPCServer) RemovePluginRole(args *Z_RemovePluginRoleArgs, returns *Z_RemovePluginRoleReturns) error {
+	if hook, ok := s.impl.(interface {
+		RemovePluginRole(userID, roleName string) (*model.User, *model.AppError)
+	}); ok {
+		returns.A, returns.B = hook.RemovePluginRole(args.A, args.B)
+	} else {
+		return encodableError(fmt.Errorf("API RemovePluginRole called but not implemented."))
+	}
+	return nil
+}
+
 type Z_RolesGrantPermissionArgs struct {
 	A []string
 	B string

--- a/server/public/plugin/plugintest/api.go
+++ b/server/public/plugin/plugintest/api.go
@@ -114,6 +114,38 @@ func (_m *API) AddUserToChannel(channelId string, userID string, asUserId string
 	return r0, r1
 }
 
+// AssignPluginRole provides a mock function with given fields: userID, roleName
+func (_m *API) AssignPluginRole(userID string, roleName string) (*model.User, *model.AppError) {
+	ret := _m.Called(userID, roleName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for AssignPluginRole")
+	}
+
+	var r0 *model.User
+	var r1 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, string) (*model.User, *model.AppError)); ok {
+		return rf(userID, roleName)
+	}
+	if rf, ok := ret.Get(0).(func(string, string) *model.User); ok {
+		r0 = rf(userID, roleName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.User)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string) *model.AppError); ok {
+		r1 = rf(userID, roleName)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // CheckAccessControlExpression provides a mock function with given fields: actingUserID, resourceType, expression
 func (_m *API) CheckAccessControlExpression(actingUserID string, resourceType string, expression string) ([]model.CELExpressionError, *model.AppError) {
 	ret := _m.Called(actingUserID, resourceType, expression)
@@ -4748,6 +4780,38 @@ func (_m *API) PatchChannelMembersNotifications(members []*model.ChannelMemberId
 	return r0
 }
 
+// PatchPluginRole provides a mock function with given fields: name, patch
+func (_m *API) PatchPluginRole(name string, patch *model.RolePatch) (*model.Role, *model.AppError) {
+	ret := _m.Called(name, patch)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PatchPluginRole")
+	}
+
+	var r0 *model.Role
+	var r1 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, *model.RolePatch) (*model.Role, *model.AppError)); ok {
+		return rf(name, patch)
+	}
+	if rf, ok := ret.Get(0).(func(string, *model.RolePatch) *model.Role); ok {
+		r0 = rf(name, patch)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Role)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, *model.RolePatch) *model.AppError); ok {
+		r1 = rf(name, patch)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // PermanentDeleteBot provides a mock function with given fields: botUserId
 func (_m *API) PermanentDeleteBot(botUserId string) *model.AppError {
 	ret := _m.Called(botUserId)
@@ -5027,6 +5091,26 @@ func (_m *API) RegisterCommand(command *model.Command) error {
 	return r0
 }
 
+// RegisterPermission provides a mock function with given fields: permission
+func (_m *API) RegisterPermission(permission *model.PluginPermission) *model.AppError {
+	ret := _m.Called(permission)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RegisterPermission")
+	}
+
+	var r0 *model.AppError
+	if rf, ok := ret.Get(0).(func(*model.PluginPermission) *model.AppError); ok {
+		r0 = rf(permission)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.AppError)
+		}
+	}
+
+	return r0
+}
+
 // RegisterPluginForSharedChannels provides a mock function with given fields: opts
 func (_m *API) RegisterPluginForSharedChannels(opts model.RegisterPluginOpts) (string, error) {
 	ret := _m.Called(opts)
@@ -5085,6 +5169,38 @@ func (_m *API) RegisterPropertyGroup(name string) (*model.PropertyGroup, error) 
 	return r0, r1
 }
 
+// RegisterRole provides a mock function with given fields: role
+func (_m *API) RegisterRole(role *model.PluginRole) (*model.Role, *model.AppError) {
+	ret := _m.Called(role)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RegisterRole")
+	}
+
+	var r0 *model.Role
+	var r1 *model.AppError
+	if rf, ok := ret.Get(0).(func(*model.PluginRole) (*model.Role, *model.AppError)); ok {
+		return rf(role)
+	}
+	if rf, ok := ret.Get(0).(func(*model.PluginRole) *model.Role); ok {
+		r0 = rf(role)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.Role)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(*model.PluginRole) *model.AppError); ok {
+		r1 = rf(role)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
+}
+
 // RemovePlugin provides a mock function with given fields: id
 func (_m *API) RemovePlugin(id string) *model.AppError {
 	ret := _m.Called(id)
@@ -5103,6 +5219,38 @@ func (_m *API) RemovePlugin(id string) *model.AppError {
 	}
 
 	return r0
+}
+
+// RemovePluginRole provides a mock function with given fields: userID, roleName
+func (_m *API) RemovePluginRole(userID string, roleName string) (*model.User, *model.AppError) {
+	ret := _m.Called(userID, roleName)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemovePluginRole")
+	}
+
+	var r0 *model.User
+	var r1 *model.AppError
+	if rf, ok := ret.Get(0).(func(string, string) (*model.User, *model.AppError)); ok {
+		return rf(userID, roleName)
+	}
+	if rf, ok := ret.Get(0).(func(string, string) *model.User); ok {
+		r0 = rf(userID, roleName)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*model.User)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(string, string) *model.AppError); ok {
+		r1 = rf(userID, roleName)
+	} else {
+		if ret.Get(1) != nil {
+			r1 = ret.Get(1).(*model.AppError)
+		}
+	}
+
+	return r0, r1
 }
 
 // RemoveReaction provides a mock function with given fields: reaction

--- a/server/public/pluginapi/client.go
+++ b/server/public/pluginapi/client.go
@@ -24,6 +24,7 @@ type Client struct {
 	KV            KVService
 	Log           LogService
 	Mail          MailService
+	Permission    PermissionService
 	Plugin        PluginService
 	Post          PostService
 	Property      PropertyService
@@ -56,6 +57,7 @@ func NewClient(api plugin.API, driver plugin.Driver) *Client {
 		KV:            KVService{api: api},
 		Log:           LogService{api: api},
 		Mail:          MailService{api: api},
+		Permission:    PermissionService{api: api},
 		Plugin:        PluginService{api: api},
 		Post:          PostService{api: api},
 		Property:      PropertyService{api: api},

--- a/server/public/pluginapi/permission.go
+++ b/server/public/pluginapi/permission.go
@@ -1,0 +1,50 @@
+package pluginapi
+
+import (
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/plugin"
+)
+
+// PermissionService exposes methods to register plugin-owned permissions and roles.
+type PermissionService struct {
+	api plugin.API
+}
+
+// Register registers a permission owned by this plugin.
+//
+// Minimum server version: 11.10
+func (s *PermissionService) Register(permission *model.PluginPermission) error {
+	return normalizeAppErr(s.api.RegisterPermission(permission))
+}
+
+// RegisterRole registers a custom role owned by this plugin.
+//
+// Minimum server version: 11.10
+func (s *PermissionService) RegisterRole(role *model.PluginRole) (*model.Role, error) {
+	r, appErr := s.api.RegisterRole(role)
+	return r, normalizeAppErr(appErr)
+}
+
+// PatchRole updates a role previously registered by this plugin.
+//
+// Minimum server version: 11.10
+func (s *PermissionService) PatchRole(name string, patch *model.RolePatch) (*model.Role, error) {
+	r, appErr := s.api.PatchPluginRole(name, patch)
+	return r, normalizeAppErr(appErr)
+}
+
+// AssignRole assigns a role owned by this plugin to a user.
+//
+// Minimum server version: 11.10
+func (s *PermissionService) AssignRole(userID, roleName string) (*model.User, error) {
+	u, appErr := s.api.AssignPluginRole(userID, roleName)
+	return u, normalizeAppErr(appErr)
+}
+
+// RemoveRole removes a role owned by this plugin from a user.
+//
+// Minimum server version: 11.10
+func (s *PermissionService) RemoveRole(userID, roleName string) (*model.User, error) {
+	u, appErr := s.api.RemovePluginRole(userID, roleName)
+	return u, normalizeAppErr(appErr)
+}

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_group.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_group.tsx
@@ -12,6 +12,7 @@ import {PermissionsScope} from 'utils/constants';
 import PermissionCheckbox from './permission_checkbox';
 import PermissionDescription from './permission_description';
 import PermissionRow from './permission_row';
+import {getPluginPermissionGroup} from './plugin_permission_catalog';
 import type {AdditionalValues, Permission, Permissions} from './permissions_tree/types';
 import {groupRolesStrings} from './strings/groups';
 
@@ -281,7 +282,15 @@ export default class PermissionGroup extends React.PureComponent<Props, State> {
             classes += ' combined';
         }
         const additionalValuesProp = additionalValues?.[id] ? additionalValues[id] : undefined;
-        const name = groupRolesStrings[id] ? <FormattedMessage {...groupRolesStrings[id].name}/> : id;
+        const pluginGroup = getPluginPermissionGroup(id);
+        const name = groupRolesStrings[id] ? (
+            <FormattedMessage {...groupRolesStrings[id].name}/>
+        ) : (
+            <FormattedMessage
+                id={`admin.permissions.groups.${id}.name`}
+                defaultMessage={pluginGroup?.pluginName || id}
+            />
+        );
         let description: React.JSX.Element | string = '';
         if (groupRolesStrings[id]) {
             description = (

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_row.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permission_row.tsx
@@ -9,6 +9,7 @@ import type {Role} from '@mattermost/types/roles';
 
 import PermissionCheckbox from './permission_checkbox';
 import PermissionDescription from './permission_description';
+import {getPluginPermission} from './plugin_permission_catalog';
 import {permissionRolesStrings} from './strings/permissions';
 
 type Props = {
@@ -41,13 +42,28 @@ const PermissionRow = ({
         onChange(id);
     }, [readOnly, onChange, id]);
 
-    const name = permissionRolesStrings[id] ? <FormattedMessage {...permissionRolesStrings[id].name}/> : id;
+    const pluginPermission = getPluginPermission(id);
+    const name = permissionRolesStrings[id] ? (
+        <FormattedMessage {...permissionRolesStrings[id].name}/>
+    ) : (
+        <FormattedMessage
+            id={`admin.permissions.permission.${id}.name`}
+            defaultMessage={pluginPermission?.name || id}
+        />
+    );
     let description: React.JSX.Element | string = '';
     if (permissionRolesStrings[id]) {
         description = (
             <FormattedMessage
                 {...permissionRolesStrings[id].description}
                 values={additionalValues}
+            />
+        );
+    } else if (pluginPermission?.description) {
+        description = (
+            <FormattedMessage
+                id={`admin.permissions.permission.${id}.description`}
+                defaultMessage={pluginPermission.description}
             />
         );
     }

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.test.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.test.tsx
@@ -3,6 +3,9 @@
 
 import React from 'react';
 
+import type {PluginPermission} from '@mattermost/types/plugins';
+
+import {Client4} from 'mattermost-redux/client';
 import GeneralConstants from 'mattermost-redux/constants/general';
 
 import PermissionsTree from 'components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree';
@@ -11,6 +14,8 @@ import {renderWithContext} from 'tests/react_testing_utils';
 import {LicenseSkus} from 'utils/constants';
 
 import type {Group, Permission} from './types';
+
+import {setPluginPermissionCatalog} from '../plugin_permission_catalog';
 
 jest.mock('components/admin_console/permission_schemes_settings/permission_group', () => {
     return jest.fn(() => <div data-testid='permission-group'/>);
@@ -50,6 +55,13 @@ describe('components/admin_console/permission_schemes_settings/permission_tree',
 
     beforeEach(() => {
         PermissionGroup.mockClear();
+        setPluginPermissionCatalog([]);
+        jest.spyOn(Client4, 'getPluginPermissions').mockResolvedValue([]);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+        setPluginPermissionCatalog([]);
     });
 
     test('should match snapshot on default data', () => {
@@ -184,6 +196,42 @@ describe('components/admin_console/permission_schemes_settings/permission_tree',
         expect(groups[7].id).toStrictEqual('integrations');
         expect(groups[8].id).toStrictEqual('manage_shared_channels');
         expect(groups[9].id).toStrictEqual('custom_groups');
+    });
+
+    test('should append plugin permission groups for the current scope', () => {
+        const pluginPermissions: PluginPermission[] = [
+            {
+                plugin_id: 'com.example.plugin',
+                plugin_name: 'Example',
+                id: 'manage_thing',
+                permission_id: 'com.example.plugin:manage_thing',
+                name: 'Manage thing',
+                description: 'Allows managing things',
+                scope: 'channel_scope',
+                active: true,
+            },
+            {
+                plugin_id: 'com.example.plugin',
+                plugin_name: 'Example',
+                id: 'manage_system_thing',
+                permission_id: 'com.example.plugin:manage_system_thing',
+                name: 'Manage system thing',
+                description: 'Allows managing system things',
+                scope: 'system_scope',
+                active: true,
+            },
+        ];
+        jest.spyOn(Client4, 'getPluginPermissions').mockResolvedValue(pluginPermissions);
+        setPluginPermissionCatalog(pluginPermissions);
+
+        renderWithContext(
+            <PermissionsTree {...defaultProps}/>,
+        );
+
+        const groups = PermissionGroup.mock.calls[0][0].permissions as Array<Group | Permission>;
+        const pluginGroup = groups.find((group) => group.id === 'com.example.plugin');
+        expect(pluginGroup).toBeDefined();
+        expect(pluginGroup!.permissions).toEqual(['com.example.plugin:manage_thing']);
     });
 
     describe('should show playbook permissions', () => {

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.tsx
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permissions_tree/permissions_tree.tsx
@@ -7,6 +7,7 @@ import {FormattedMessage} from 'react-intl';
 import type {ClientConfig, ClientLicense} from '@mattermost/types/config';
 import type {Role} from '@mattermost/types/roles';
 
+import {Client4} from 'mattermost-redux/client';
 import GeneralConstants from 'mattermost-redux/constants/general';
 import Permissions from 'mattermost-redux/constants/permissions';
 
@@ -21,6 +22,7 @@ import type {AdditionalValues, Group} from './types';
 import EditPostTimeLimitButton from '../edit_post_time_limit_button';
 import EditPostTimeLimitModal from '../edit_post_time_limit_modal';
 import PermissionGroup from '../permission_group';
+import {getPluginPermissionGroups, setPluginPermissionCatalog} from '../plugin_permission_catalog';
 
 type Props = {
     scope: string;
@@ -206,6 +208,8 @@ export default class PermissionsTree extends React.PureComponent<Props, State> {
     updateGroups = () => {
         const {config, scope, license, role} = this.props;
 
+        this.groups = this.groups.filter((group) => !group.fromPlugin);
+
         const teamsGroup = this.groups[0];
         const publicChannelsGroup = this.groups[1];
         const privateChannelsGroup = this.groups[2];
@@ -345,6 +349,20 @@ export default class PermissionsTree extends React.PureComponent<Props, State> {
 
             return true;
         });
+
+        for (const pluginGroup of getPluginPermissionGroups()) {
+            const permissions = pluginGroup.permissions.
+                filter((permission) => permission.scope === scope).
+                map((permission) => permission.permission_id);
+            if (!permissions.length) {
+                continue;
+            }
+            this.groups.push({
+                id: pluginGroup.pluginId,
+                permissions,
+                fromPlugin: true,
+            });
+        }
     };
 
     openPostTimeLimitModal = () => {
@@ -355,11 +373,26 @@ export default class PermissionsTree extends React.PureComponent<Props, State> {
         this.setState({editTimeLimitModalIsVisible: false});
     };
 
+    componentDidMount() {
+        this.loadPluginPermissions();
+    }
+
     componentDidUpdate(prevProps: Props) {
         if (this.props.config !== prevProps.config || this.props.license !== prevProps.license) {
             this.updateGroups();
         }
     }
+
+    loadPluginPermissions = async () => {
+        try {
+            const permissions = await Client4.getPluginPermissions();
+            setPluginPermissionCatalog(permissions);
+            this.updateGroups();
+            this.forceUpdate();
+        } catch {
+            // Built-in permissions still render if the catalog cannot be loaded.
+        }
+    };
 
     toggleGroup = (ids: string[]) => {
         if (this.props.readOnly) {

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/permissions_tree/types.ts
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/permissions_tree/types.ts
@@ -14,6 +14,7 @@ export type Group = {
     id: string;
     permissions: Array<Permission | string>;
     isVisible?: (license?: ClientLicense) => boolean;
+    fromPlugin?: boolean;
 };
 
 export type AdditionalValues = Record<string, Record<string, any>>;

--- a/webapp/channels/src/components/admin_console/permission_schemes_settings/plugin_permission_catalog.ts
+++ b/webapp/channels/src/components/admin_console/permission_schemes_settings/plugin_permission_catalog.ts
@@ -1,0 +1,51 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {PluginPermission} from '@mattermost/types/plugins';
+
+import {PermissionsScope} from 'utils/constants';
+
+export type PluginPermissionGroup = {
+    pluginId: string;
+    pluginName: string;
+    permissions: PluginPermission[];
+};
+
+let catalog: PluginPermission[] = [];
+
+export function setPluginPermissionCatalog(permissions: PluginPermission[]) {
+    catalog = (permissions || []).filter((p) => p.active !== false);
+    for (const permission of catalog) {
+        (PermissionsScope as Record<string, string>)[permission.permission_id] = permission.scope;
+    }
+}
+
+export function getPluginPermission(permissionId: string): PluginPermission | undefined {
+    return catalog.find((p) => p.permission_id === permissionId);
+}
+
+export function getPluginPermissionGroup(pluginId: string): PluginPermissionGroup | undefined {
+    const permissions = catalog.filter((p) => p.plugin_id === pluginId);
+    if (!permissions.length) {
+        return undefined;
+    }
+    return {
+        pluginId,
+        pluginName: permissions[0].plugin_name || pluginId,
+        permissions,
+    };
+}
+
+export function getPluginPermissionGroups(): PluginPermissionGroup[] {
+    const byPlugin = new Map<string, PluginPermission[]>();
+    for (const permission of catalog) {
+        const list = byPlugin.get(permission.plugin_id) || [];
+        list.push(permission);
+        byPlugin.set(permission.plugin_id, list);
+    }
+    return [...byPlugin.entries()].map(([pluginId, permissions]) => ({
+        pluginId,
+        pluginName: permissions[0].plugin_name || pluginId,
+        permissions,
+    }));
+}

--- a/webapp/platform/client/src/client4.ts
+++ b/webapp/platform/client/src/client4.ts
@@ -111,6 +111,7 @@ import type {MfaSecret} from '@mattermost/types/mfa';
 import type {
     ClientPluginManifest,
     PluginManifest,
+    PluginPermission,
     PluginsResponse,
     PluginStatus,
 } from '@mattermost/types/plugins';
@@ -4818,6 +4819,13 @@ export default class Client4 {
         return this.doFetch<string[]>(
             `${this.getPermissionsRoute()}/ancillary`,
             {method: 'post', body: JSON.stringify(subsectionPermissions)},
+        );
+    };
+
+    getPluginPermissions = () => {
+        return this.doFetch<PluginPermission[]>(
+            `${this.getPermissionsRoute()}`,
+            {method: 'get'},
         );
     };
 

--- a/webapp/platform/types/src/plugins.ts
+++ b/webapp/platform/types/src/plugins.ts
@@ -25,9 +25,39 @@ export type PluginManifest = {
     webapp?: PluginManifestWebapp;
     settings_schema?: PluginSettingsSchema;
     props?: Record<string, any>;
+    permissions?: PluginManifestPermission[];
+    roles?: PluginManifestRole[];
 };
 
 export type PluginRedux = PluginManifest & {active: boolean};
+
+export type PluginPermission = {
+    plugin_id: string;
+    plugin_name?: string;
+    id: string;
+    permission_id: string;
+    name: string;
+    description: string;
+    scope: string;
+    default_roles?: string[];
+    active: boolean;
+    create_at?: number;
+};
+
+export type PluginManifestPermission = {
+    id: string;
+    name: string;
+    description?: string;
+    scope: string;
+    default_roles?: string[];
+};
+
+export type PluginManifestRole = {
+    name: string;
+    display_name: string;
+    description?: string;
+    permissions?: string[];
+};
 
 export type PluginManifestServer = {
     executables?: {


### PR DESCRIPTION
#### Summary
PoC to allow plugins to create their own permissions and roles.

Mainly intended for "Products as plugins" within Mattermost.

#### Ticket Link
NONE

#### Screenshots
TBD

#### Release Note
```release-note
Add APIs for plugins to register permissions and roles
```
