### PR TITLE
Stop package-lock.json from losing its peer markers

### DIFF
--- a/.github/workflows/build-server-image.yml
+++ b/.github/workflows/build-server-image.yml
@@ -11,6 +11,7 @@ on:
       - server/build/buildenv-tag.sh
       - server/.go-version
       - .nvmrc
+      - mise.toml
       - .github/workflows/build-server-image.yml
   pull_request:
     paths:
@@ -19,6 +20,7 @@ on:
       - server/build/buildenv-tag.sh
       - server/.go-version
       - .nvmrc
+      - mise.toml
       - .github/workflows/build-server-image.yml
   workflow_dispatch:
 

--- a/.github/workflows/webapp-ci.yml
+++ b/.github/workflows/webapp-ci.yml
@@ -37,6 +37,38 @@ jobs:
         run: |
           npm run check
 
+  check-lockfile:
+    permissions:
+      contents: read
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    defaults:
+      run:
+        working-directory: webapp
+    steps:
+      - name: ci/checkout-repo
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: ci/setup-node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
+        with:
+          node-version-file: ".nvmrc"
+      - name: ci/check-lockfile
+        run: |
+          # `npm ci` accepts a lockfile that npm 10 has stripped of its "peer"
+          # markers, so it can't catch this. Regenerating and diffing can.
+          npm install --package-lock-only --ignore-scripts --no-audit --no-fund
+
+          if ! git diff --quiet -- package-lock.json; then
+            echo "::error file=webapp/package-lock.json::package-lock.json is not what the pinned npm generates"
+            echo "Regenerate it using the Node version in .nvmrc:"
+            echo "    cd webapp && npm install"
+            echo
+            git --no-pager diff -- package-lock.json
+            exit 1
+          fi
+
   check-i18n:
     permissions:
       contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,8 @@
 
+# Tracked, not ignored: mise.toml pins the Node this repo builds with, and
+# it is common to ignore mise.toml globally for personal use elsewhere.
+!mise.toml
+
 logs
 .DS_Store
 node_modules

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,15 @@
+# Toolchain for developers using mise. CI does not read this file -- it installs
+# Node from .nvmrc -- so this exists to give a working tree the same Node that
+# CI, the buildenv images and webapp/package.json "engines" all agree on.
+#
+# npm is deliberately absent: it ships with Node, and 24.11.1 carries exactly
+# the npm 11.6.2 that "engines" requires. Pinning Node exactly is therefore what
+# pins npm exactly, and it is the same npm every CI job gets. Naming npm here
+# too would add a second version to hold in step, with nothing enforcing the
+# pairing, so a stale entry could hand you an npm that ships with no Node.
+#
+# A Node bump moves this alongside .nvmrc, both server/build/Dockerfile.buildenv*,
+# "engines"/"packageManager" and webapp/package-lock.json. buildenv-tag.sh fails
+# when this and .nvmrc disagree.
+[tools]
+node = "24.11.1"

--- a/server/build/buildenv-tag.sh
+++ b/server/build/buildenv-tag.sh
@@ -5,7 +5,8 @@
 #
 # The tag comes from the Dockerfiles, since those are what actually determine
 # the image, and they are checked against .go-version and .nvmrc so the pins
-# cannot drift apart unnoticed.
+# cannot drift apart unnoticed. mise.toml pins Node for developers rather than
+# for the image, but it is checked here too, for the same reason.
 set -euo pipefail
 
 cd "$(dirname "${BASH_SOURCE[0]}")/../.."
@@ -25,6 +26,11 @@ satisfies() {
 
 go_version=$(cat server/.go-version)
 node_spec=$(cat .nvmrc)
+
+mise_version=$(awk -F'"' '$1 ~ /^node[[:space:]]*=[[:space:]]*$/ { print $2; exit }' mise.toml)
+[[ -n "${mise_version}" ]] || fail "mise.toml: no node pin"
+satisfies "${mise_version}" "${node_spec}" ||
+    fail "mise.toml: node is ${mise_version}, but .nvmrc says ${node_spec}"
 
 node_version=""
 for dockerfile in "${DOCKERFILES[@]}"; do

--- a/webapp/.npmrc
+++ b/webapp/.npmrc
@@ -1,1 +1,6 @@
 save-exact=true
+
+# Refuse to run under a toolchain that doesn't match "engines" in package.json.
+# Without this, npm only warns (EBADENGINE) and then rewrites package-lock.json
+# using the wrong npm's semantics -- npm 10 silently strips "peer" markers.
+engine-strict=true

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -46,8 +46,8 @@
         "webpack-dev-server": "5.2.2"
       },
       "engines": {
-        "node": "^24",
-        "npm": "^11"
+        "node": "24.11.1",
+        "npm": "11.6.2"
       }
     },
     "channels": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -2,8 +2,8 @@
   "name": "@mattermost/webapp",
   "private": true,
   "engines": {
-    "node": "^24",
-    "npm": "^11"
+    "node": "24.11.1",
+    "npm": "11.6.2"
   },
   "packageManager": "npm@11.6.2",
   "scripts": {

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -5,6 +5,7 @@
     "node": "^24",
     "npm": "^11"
   },
+  "packageManager": "npm@11.6.2",
   "scripts": {
     "postinstall": "patch-package && npm run build --workspace platform/types --workspace platform/client --workspace platform/shared --workspace platform/components",
     "build": "node scripts/build.mjs",


### PR DESCRIPTION
#### Summary

`webapp/package-lock.json` keeps losing its `"peer": true` markers, and someone keeps having to put them back by hand — 95f4687b6, 41367fa7b, 6fe07757b, and most recently #38488, reverting #38409. This makes that stop.

**Cause.** Regenerating today's lockfile under the two toolchains:

| toolchain | `"peer": true` count | diff vs. committed lockfile |
|---|---|---|
| Node 24.11.1 / **npm 11.6.2** (pinned in `.nvmrc` + `engines`) | 62 | **0 lines** — byte identical |
| Node 22.17.1 / **npm 10.9.2** | 2 | 78 lines |

The npm 10 diff is exactly 95f4687b6 in reverse. The committed lockfile is correct; npm 10 corrupts it. `engines` already says `node ^24 / npm ^11`, but npm only warns:

```
npm warn EBADENGINE   required: { node: '^24', npm: '^11' }
npm warn EBADENGINE   current: { node: 'v22.17.1', npm: '10.9.2' }
up to date in 1s
```

…and rewrites the lockfile anyway. `webapp/Makefile`'s `node_modules` target runs a bare `npm install` whenever `CI` is unset, so `make run`, `make test` and `make check-style` all trigger it. The damage lands in whatever PR the developer happened to be working on, which is why it shows up in unrelated feature PRs (`0fa2713b5`, `d9c1388461`, `b1e444274f` each dropped the count to 2 or 3, and #38409 — a System Console feature PR — dropped it to 2 again while this PR was open).

**Fix, in five parts:**

1. **`engine-strict=true` in `webapp/.npmrc`** turns that warning into a hard error, so the wrong npm stops instead of quietly corrupting the lockfile.
2. **Exact `engines`** — `node 24.11.1 / npm 11.6.2` instead of `^24 / ^11`, matching `.nvmrc`. A range makes `engine-strict` mean "some npm 11"; an exact pin makes it mean "the npm this lockfile was generated with", which is the property the lockfile actually depends on.
3. **A `check-lockfile` CI job** regenerates the lockfile with the pinned toolchain and diffs it, covering lockfiles that arrive by another route — forks, bots, merge resolution, `--engine-strict=false`.
4. **`packageManager`** records the npm that pairs with the pinned Node.
5. **`mise.toml`** gives mise users that same Node without a second pin to keep in step; `buildenv-tag.sh` fails when it and `.nvmrc` disagree.

`npm ci` cannot serve as the backstop here: handed a lockfile with the peer markers stripped, npm 11's `npm ci` reports `added 1949 packages` and exits 0. It only checks that `package.json` and the lockfile agree on versions.

#### Release Note
```release-note
NONE
```
