### PR TITLE
MM-70501 - fix attribute masking resolver to support attributes

### DIFF
--- a/server/channels/app/access_control_masking.go
+++ b/server/channels/app/access_control_masking.go
@@ -129,7 +129,7 @@ func (r *appMaskingResolver) fieldToMaskingInfo(field *model.PropertyField) *mod
 		info.Access = model.MaskingFieldAccessSourceOnly
 	case model.PropertyAccessModeSharedOnly:
 		info.Access = model.MaskingFieldAccessSharedOnly
-		if field.Type == model.PropertyFieldTypeSelect || field.Type == model.PropertyFieldTypeMultiselect {
+		if field.Type.SupportsOptions() {
 			info.VisibleValues = extractVisibleOptionNames(field)
 		} else {
 			info.VisibleValues = r.app.getCallerTextValues(r.rctxWithCaller, r.callerID, field, r.cpaGroupID)

--- a/server/channels/app/access_control_masking_test.go
+++ b/server/channels/app/access_control_masking_test.go
@@ -1260,11 +1260,6 @@ func TestMaskSimulationPolicyLiteralsForCaller_CompoundOrPreserved(t *testing.T)
 // field's literals are option names, and the read path hands back the options at
 // or below the caller's own rank — so a caller must be able to name any of them
 // in a policy expression.
-//
-// Spelling the type list out as select/multiselect instead drops rank into the
-// text branch, where the caller's stored value is the option ID rather than its
-// name. Every option name then reads as hidden and no rank rule can be authored
-// by anyone, admins included.
 func TestAppMaskingResolver_SharedOnlyRank(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)

--- a/server/channels/app/access_control_masking_test.go
+++ b/server/channels/app/access_control_masking_test.go
@@ -1254,3 +1254,69 @@ func TestMaskSimulationPolicyLiteralsForCaller_CompoundOrPreserved(t *testing.T)
 	assert.Equal(t, blame.EvaluationTree.Expression, blame.Expression)
 	mockACS.AssertExpectations(t)
 }
+
+// TestAppMaskingResolver_SharedOnlyRank pins the resolver's options-vs-text split
+// to Type.SupportsOptions(), the same predicate maskConditionValues uses. A rank
+// field's literals are option names, and the read path hands back the options at
+// or below the caller's own rank — so a caller must be able to name any of them
+// in a policy expression.
+//
+// Spelling the type list out as select/multiselect instead drops rank into the
+// text branch, where the caller's stored value is the option ID rather than its
+// name. Every option name then reads as hidden and no rank rule can be authored
+// by anyone, admins included.
+func TestAppMaskingResolver_SharedOnlyRank(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+	th.App.Srv().SetLicense(model.NewTestLicenseSKU(model.LicenseShortSkuEnterprise))
+	rctx := request.TestContext(t)
+
+	cpaGroup, appErr := th.App.GetPropertyGroup(rctx, model.AccessControlPropertyGroupName)
+	require.Nil(t, appErr)
+
+	callerID := model.NewId()
+	optPublic, optSecret, optTopSecret := model.NewId(), model.NewId(), model.NewId()
+
+	// Store-level Create bypasses the CPA access-control hook, which admits only
+	// an installed plugin for protected fields. Reads still filter per caller.
+	fieldName := celSafeName()
+	field, err := th.Store.PropertyField().Create(&model.PropertyField{
+		GroupID:    cpaGroup.ID,
+		Name:       fieldName,
+		Type:       model.PropertyFieldTypeRank,
+		ObjectType: model.PropertyFieldObjectTypeUser,
+		TargetType: string(model.PropertyFieldTargetLevelSystem),
+		Attrs: model.StringInterface{
+			model.PropertyFieldAttributeOptions: []any{
+				map[string]any{"id": optPublic, "name": "Public", "rank": 1},
+				map[string]any{"id": optSecret, "name": "Secret", "rank": 2},
+				map[string]any{"id": optTopSecret, "name": "TopSecret", "rank": 3},
+			},
+			// shared_only requires protected (ValidatePropertyFieldAccessMode).
+			model.PropertyAttrsProtected:  true,
+			model.PropertyAttrsAccessMode: model.PropertyAccessModeSharedOnly,
+		},
+	})
+	require.NoError(t, err)
+
+	// The caller holds Secret, so the read path admits Secret and below.
+	_, err = th.Store.PropertyValue().Create(&model.PropertyValue{
+		TargetID:   callerID,
+		TargetType: model.PropertyValueTargetTypeUser,
+		GroupID:    cpaGroup.ID,
+		FieldID:    field.ID,
+		Value:      json.RawMessage(`"` + optSecret + `"`),
+	})
+	require.NoError(t, err)
+
+	resolver, appErr := newMaskingResolver(th.App, rctx, callerID)
+	require.Nil(t, appErr)
+
+	info, resolveErr := resolver.Resolve(fieldName)
+	require.NoError(t, resolveErr)
+	require.Equal(t, model.MaskingFieldAccessSharedOnly, info.Access)
+
+	assert.False(t, info.IsValueHidden("Secret"), "the caller's own rank must be nameable")
+	assert.False(t, info.IsValueHidden("Public"), "a rank below the caller's must be nameable")
+	assert.True(t, info.IsValueHidden("TopSecret"), "a rank above the caller's stays hidden")
+}


### PR DESCRIPTION
<!-- Summary and Release Note are required. Include Ticket Link and Screenshots as needed. -->

#### Summary
<!-- What does this PR do? Include QA steps if not covered in the ticket. -->
This PR patches an issue that was discovered while attempting to merge [enterprise PR-2289](https://github.com/mattermost/enterprise/pull/2289).  Rank attributes with `shared_only` access mode are unable to resolve literal value masking due to a missed condition check.  Attempting to create a policy with a literal value comparison, such as `user.attributes.clearance >= Secret` results in 400 errors, even in cases where the user submitting the policy has a clearance of `Secret` or higher.

In the `master` branch, this bug was already fixed incidentally as part of the channel attributes feature [PR-37755](https://github.com/mattermost/mattermost/pull/37755), but it still affects the current 11.11 release cut.  This PR looks to close that gap, which will also allow the enterprise PR above to be patched as well.   

The fix is a simple one-line change.  A small test was also added to verify the fix, as the original test that caught the issue currently lives in the `enterprise` PR.  The `master` branch already has its own test coverage as part of the channel attribute feature, so it's fine to just add this test for the v11.11 release branch.

#### Ticket Link
This was discovered as part of an attempt to cherrypick https://mattermost.atlassian.net/browse/MM-70501.
There is no specific Jira ticket associated with this issue.

#### Release Note
<!--
Write a release note if this PR includes any of:
* API or config changes.
* Schema migrations (added/dropped tables or columns, index changes, column type changes).
* User-visible behavior changes (UI, CLI, websocket).
* Deprecations, breaking changes, or compatibility notes.

The release-note block must always be present. Use past tense. Write NONE if none of the above apply. Newlines are stripped.

Example:
```release-note
Added new API endpoints POST /api/v4/foo and GET /api/v4/foo/:foo_id.
```

```release-note
NONE
```
-->
```release-note
Fixed an issue in which policies containing Rank attributes with 'shared-only' access mode were unable to be created by users.
```
