### PR TITLE
[MM-70505] Backport NewTransportForInternalConnections to release-11.8

### DIFF
--- a/server/public/shared/httpservice/client_test.go
+++ b/server/public/shared/httpservice/client_test.go
@@ -95,6 +95,39 @@ func TestHTTPClient(t *testing.T) {
 	})
 }
 
+func TestNewTransportForInternalConnections(t *testing.T) {
+	// httptest servers listen on a loopback address, which is a reserved range.
+	mockHTTP := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer mockHTTP.Close()
+
+	u, err := url.Parse(mockHTTP.URL)
+	require.NoError(t, err)
+	host := u.Hostname()
+
+	t.Run("blocks reserved IP ranges when the allowlist is empty", func(t *testing.T) {
+		c := NewHTTPClient(NewTransportForInternalConnections(false, ""))
+		_, err := c.Get(mockHTTP.URL)
+		require.IsType(t, &url.Error{}, err)
+		require.Contains(t, err.(*url.Error).Err.Error(), "address forbidden")
+	})
+
+	t.Run("allows a host named in the allowlist", func(t *testing.T) {
+		c := NewHTTPClient(NewTransportForInternalConnections(false, host))
+		resp, err := c.Get(mockHTTP.URL)
+		require.NoError(t, err)
+		resp.Body.Close()
+	})
+
+	t.Run("allows a CIDR range named in the allowlist", func(t *testing.T) {
+		c := NewHTTPClient(NewTransportForInternalConnections(false, "127.0.0.0/8 ::1/128"))
+		resp, err := c.Get(mockHTTP.URL)
+		require.NoError(t, err)
+		resp.Body.Close()
+	})
+}
+
 func TestHTTPClientWithProxy(t *testing.T) {
 	proxy := createProxyServer()
 	defer proxy.Close()

--- a/server/public/shared/httpservice/httpservice.go
+++ b/server/public/shared/httpservice/httpservice.go
@@ -71,6 +71,58 @@ func (h *HTTPServiceImpl) MakeClient(trustURLs bool) *http.Client {
 	}
 }
 
+// isAllowedInternalHost reports whether host appears verbatim in a
+// space/comma-separated AllowedUntrustedInternalConnections value.
+func isAllowedInternalHost(host, allowedUntrustedInternalConnections string) bool {
+	return slices.Contains(strings.FieldsFunc(allowedUntrustedInternalConnections, splitFields), host)
+}
+
+// checkInternalIP returns nil if ip may be dialed, or an error if it is a
+// reserved-range or self-assigned IP not covered by a CIDR entry in the
+// space/comma-separated AllowedUntrustedInternalConnections value.
+func checkInternalIP(ip net.IP, allowedUntrustedInternalConnections string) error {
+	reservedIP := IsReservedIP(ip)
+
+	ownIP, err := IsOwnIP(ip)
+	if err != nil {
+		// If there is an error getting the self-assigned IPs, default to the secure option
+		return fmt.Errorf("unable to determine if IP is own IP: %w", err)
+	}
+
+	// If it's not a reserved IP and it's not self-assigned IP, accept the IP
+	if !reservedIP && !ownIP {
+		return nil
+	}
+
+	// Otherwise it needs to be explicitly added to AllowedUntrustedInternalConnections
+	for _, allowed := range strings.FieldsFunc(allowedUntrustedInternalConnections, splitFields) {
+		if _, ipRange, err := net.ParseCIDR(allowed); err == nil && ipRange.Contains(ip) {
+			return nil
+		}
+	}
+
+	if reservedIP {
+		return fmt.Errorf("IP %s is in a reserved range and not in AllowedUntrustedInternalConnections", ip)
+	}
+	return fmt.Errorf("IP %s is a self-assigned IP and not in AllowedUntrustedInternalConnections", ip)
+}
+
+// NewTransportForInternalConnections returns a transport that applies the same
+// AllowedUntrustedInternalConnections filtering as MakeTransport, but takes the
+// allowlist as a static value instead of reading it from a config service. It is
+// for callers that have the allowlist string but not an HTTPService.
+func NewTransportForInternalConnections(insecure bool, allowedUntrustedInternalConnections string) *MattermostTransport {
+	allowHost := func(host string) bool {
+		return isAllowedInternalHost(host, allowedUntrustedInternalConnections)
+	}
+
+	allowIP := func(ip net.IP) error {
+		return checkInternalIP(ip, allowedUntrustedInternalConnections)
+	}
+
+	return NewTransport(insecure, allowHost, allowIP)
+}
+
 func (h *HTTPServiceImpl) MakeTransport(trustURLs bool) *MattermostTransport {
 	insecure := h.configService.Config().ServiceSettings.EnableInsecureOutgoingConnections != nil && *h.configService.Config().ServiceSettings.EnableInsecureOutgoingConnections
 
@@ -78,38 +130,14 @@ func (h *HTTPServiceImpl) MakeTransport(trustURLs bool) *MattermostTransport {
 		return NewTransport(insecure, nil, nil)
 	}
 
+	// The allowlist is read inside the closures so a long-lived client picks up
+	// config changes on each dial.
 	allowHost := func(host string) bool {
-		if h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections == nil {
-			return false
-		}
-		return slices.Contains(strings.FieldsFunc(*h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections, splitFields), host)
+		return isAllowedInternalHost(host, model.SafeDereference(h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections))
 	}
 
 	allowIP := func(ip net.IP) error {
-		reservedIP := IsReservedIP(ip)
-
-		ownIP, err := IsOwnIP(ip)
-		if err != nil {
-			// If there is an error getting the self-assigned IPs, default to the secure option
-			return fmt.Errorf("unable to determine if IP is own IP: %w", err)
-		}
-
-		// If it's not a reserved IP and it's not self-assigned IP, accept the IP
-		if !reservedIP && !ownIP {
-			return nil
-		}
-
-		// In the case it's the self-assigned IP, enforce that it needs to be explicitly added to the AllowedUntrustedInternalConnections
-		for _, allowed := range strings.FieldsFunc(model.SafeDereference(h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections), splitFields) {
-			if _, ipRange, err := net.ParseCIDR(allowed); err == nil && ipRange.Contains(ip) {
-				return nil
-			}
-		}
-
-		if reservedIP {
-			return fmt.Errorf("IP %s is in a reserved range and not in AllowedUntrustedInternalConnections", ip)
-		}
-		return fmt.Errorf("IP %s is a self-assigned IP and not in AllowedUntrustedInternalConnections", ip)
+		return checkInternalIP(ip, model.SafeDereference(h.configService.Config().ServiceSettings.AllowedUntrustedInternalConnections))
 	}
 
 	return NewTransport(insecure, allowHost, allowIP)


### PR DESCRIPTION
#### Summary
Backport of the `NewTransportForInternalConnections` httpservice helper (already present on release-11.9+) so the MM-70505 enterprise cherry-pick (mattermost/enterprise#2293) compiles against this branch. Minimal, self-contained: just the function and its test.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70505

#### Release Note
```release-note
NONE
```