### PR TITLE
MM-69706: remove the ChannelBookmarks feature flag compatibility shim

### DIFF
--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -155,8 +155,6 @@ type FeatureFlags struct {
 	// being unreachable.
 	ClusterGracefulDrain bool
 
-	ChannelBookmarks bool
-
 	// Enable React concurrent rendering
 	EnableConcurrentReact bool
 
@@ -226,8 +224,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.ChannelAttributes = false
 
 	f.MmBlocksEnabled = true
-
-	f.ChannelBookmarks = true
 
 	f.EnableConcurrentReact = false
 


### PR DESCRIPTION
#### Summary
Removes the `ChannelBookmarks` field from `FeatureFlags`, reverting the temporary compatibility shim added in #37368, now that the mobile guard has since merged: [mattermost-mobile#9916](https://github.com/mattermost/mattermost-mobile/pull/9916)/.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-69706

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** Removing a public `FeatureFlags` field can affect consumers that still reference `ChannelBookmarks`. The change is isolated and coordinated with the mobile guard merge.
**QA Recommendation:** Skip manual QA. Rely on automated tests and consumer build validation.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->