### PR TITLE
MM-69944: scope received_group to group readers

### DIFF
--- a/server/channels/app/group.go
+++ b/server/channels/app/group.go
@@ -144,6 +144,28 @@ func (a *App) isUniqueToUsernames(val string) *model.AppError {
 	return nil
 }
 
+func (a *App) publishReceivedGroupEvent(group *model.Group) *model.AppError {
+	groupJSON, jsonErr := json.Marshal(group)
+	if jsonErr != nil {
+		return model.NewAppError("publishReceivedGroupEvent", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(jsonErr)
+	}
+
+	messageWs := model.NewWebSocketEvent(model.WebsocketEventReceivedGroup, "", "", "", nil, "")
+	messageWs.Add("group", string(groupJSON))
+
+	if !group.AllowReference {
+		restrictBroadcastToGroupReaders(messageWs.GetBroadcast())
+	}
+	a.Publish(messageWs)
+
+	return nil
+}
+
+func restrictBroadcastToGroupReaders(broadcast *model.WebsocketBroadcast) {
+	broadcast.RequiredPermissions = []string{model.PermissionSysconsoleReadUserManagementGroups.Id}
+	broadcast.ContainsSensitiveData = true
+}
+
 func (a *App) CreateGroupWithUserIds(group *model.GroupWithUserIds) (*model.Group, *model.AppError) {
 	if appErr := a.isUniqueToUsernames(group.GetName()); appErr != nil {
 		appErr.Where = "CreateGroupWithUserIds"
@@ -167,18 +189,16 @@ func (a *App) CreateGroupWithUserIds(group *model.GroupWithUserIds) (*model.Grou
 		}
 	}
 
-	messageWs := model.NewWebSocketEvent(model.WebsocketEventReceivedGroup, "", "", "", nil, "")
 	count, err := a.Srv().Store().Group().GetMemberCount(newGroup.Id)
 	if err != nil {
 		return nil, model.NewAppError("CreateGroupWithUserIds", "app.group.id.app_error", nil, "", http.StatusBadRequest).Wrap(err)
 	}
 	newGroup.MemberCount = new(int(count))
-	groupJSON, jsonErr := json.Marshal(newGroup)
-	if jsonErr != nil {
-		return nil, model.NewAppError("CreateGroupWithUserIds", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(jsonErr)
+
+	if appErr := a.publishReceivedGroupEvent(newGroup); appErr != nil {
+		appErr.Where = "CreateGroupWithUserIds"
+		return nil, appErr
 	}
-	messageWs.Add("group", string(groupJSON))
-	a.Publish(messageWs)
 
 	return newGroup, nil
 }
@@ -212,14 +232,11 @@ func (a *App) UpdateGroup(group *model.Group) (*model.Group, *model.AppError) {
 	}
 
 	updatedGroup.MemberCount = new(int(count))
-	messageWs := model.NewWebSocketEvent(model.WebsocketEventReceivedGroup, "", "", "", nil, "")
 
-	groupJSON, err := json.Marshal(updatedGroup)
-	if err != nil {
-		return nil, model.NewAppError("UpdateGroup", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	if appErr := a.publishReceivedGroupEvent(updatedGroup); appErr != nil {
+		appErr.Where = "UpdateGroup"
+		return nil, appErr
 	}
-	messageWs.Add("group", string(groupJSON))
-	a.Publish(messageWs)
 
 	return updatedGroup, nil
 }
@@ -243,14 +260,10 @@ func (a *App) DeleteGroup(groupID string) (*model.Group, *model.AppError) {
 
 	deletedGroup.MemberCount = new(int(count))
 
-	messageWs := model.NewWebSocketEvent(model.WebsocketEventReceivedGroup, "", "", "", nil, "")
-
-	groupJSON, err := json.Marshal(deletedGroup)
-	if err != nil {
-		return nil, model.NewAppError("DeleteGroup", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	if appErr := a.publishReceivedGroupEvent(deletedGroup); appErr != nil {
+		appErr.Where = "DeleteGroup"
+		return nil, appErr
 	}
-	messageWs.Add("group", string(groupJSON))
-	a.Publish(messageWs)
 
 	return deletedGroup, nil
 }
@@ -274,14 +287,10 @@ func (a *App) RestoreGroup(groupID string) (*model.Group, *model.AppError) {
 
 	restoredGroup.MemberCount = new(int(count))
 
-	messageWs := model.NewWebSocketEvent(model.WebsocketEventReceivedGroup, "", "", "", nil, "")
-
-	groupJSON, err := json.Marshal(restoredGroup)
-	if err != nil {
-		return nil, model.NewAppError("RestoreGroup", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(err)
+	if appErr := a.publishReceivedGroupEvent(restoredGroup); appErr != nil {
+		appErr.Where = "RestoreGroup"
+		return nil, appErr
 	}
-	messageWs.Add("group", string(groupJSON))
-	a.Publish(messageWs)
 
 	return restoredGroup, nil
 }

--- a/server/channels/app/group_test.go
+++ b/server/channels/app/group_test.go
@@ -4,12 +4,17 @@
 package app
 
 import (
+	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/i18n"
+	"github.com/mattermost/mattermost/server/v8/channels/app/platform"
+	"github.com/mattermost/mattermost/server/v8/channels/testlib"
 )
 
 // TestGetGroup tests basic group retrieval and verifies that ViewUsersRestrictions
@@ -517,4 +522,222 @@ func TestUserIsInAdminRoleGroup(t *testing.T) {
 	actual, err = th.App.UserIsInAdminRoleGroup(th.BasicUser.Id, th.BasicTeam.Id, model.GroupSyncableTypeTeam)
 	require.Nil(t, err)
 	require.False(t, actual)
+}
+
+func TestPublishReceivedGroupEvent(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t)
+
+	testCluster := &testlib.FakeClusterInterface{}
+	th.Server.Platform().SetCluster(testCluster)
+	defer th.Server.Platform().SetCluster(nil)
+
+	capturePublishedGroup := func(t *testing.T, publish func()) *model.WebSocketEvent {
+		t.Helper()
+		testCluster.ClearMessages()
+		publish()
+
+		events := selectReceivedGroupEvents(t, testCluster)
+		require.Len(t, events, 1)
+		return events[0]
+	}
+
+	t.Run("broadcast scope follows allow_reference", func(t *testing.T) {
+		testCases := []struct {
+			name           string
+			allowReference bool
+			restricted     bool
+		}{
+			{"non-referenceable group is restricted to group readers", false, true},
+			{"referenceable group is broadcast to everyone", true, false},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				group := &model.Group{
+					Id:             model.NewId(),
+					DisplayName:    "dn_" + model.NewId(),
+					Source:         model.GroupSourceLdap,
+					AllowReference: tc.allowReference,
+				}
+
+				ev := capturePublishedGroup(t, func() {
+					require.Nil(t, th.App.publishReceivedGroupEvent(group))
+				})
+
+				if tc.restricted {
+					assertBroadcastRestricted(t, ev)
+				} else {
+					assertBroadcastUnrestricted(t, ev)
+				}
+			})
+		}
+	})
+
+	t.Run("gate is applied through the real mutation paths", func(t *testing.T) {
+		newGroupFixture := func(t *testing.T, allowReference bool) *model.Group {
+			t.Helper()
+			id := model.NewId()
+			group, appErr := th.App.CreateGroup(&model.Group{
+				DisplayName:    "dn_" + id,
+				Name:           new("name" + id),
+				Source:         model.GroupSourceLdap,
+				RemoteId:       new(model.NewId()),
+				AllowReference: allowReference,
+			})
+			require.Nil(t, appErr)
+			return group
+		}
+
+		t.Run("CreateGroupWithUserIds", func(t *testing.T) {
+			id := model.NewId()
+			ev := capturePublishedGroup(t, func() {
+				_, appErr := th.App.CreateGroupWithUserIds(&model.GroupWithUserIds{
+					Group: model.Group{
+						DisplayName:    "dn_" + id,
+						Name:           new("name" + id),
+						Source:         model.GroupSourceCustom,
+						AllowReference: false,
+					},
+				})
+				require.Nil(t, appErr)
+			})
+			assertRestrictedGroupEvent(t, ev)
+		})
+
+		t.Run("UpdateGroup", func(t *testing.T) {
+			group := newGroupFixture(t, false)
+			group.DisplayName = "dn_" + model.NewId()
+
+			ev := capturePublishedGroup(t, func() {
+				_, appErr := th.App.UpdateGroup(group)
+				require.Nil(t, appErr)
+			})
+			assertRestrictedGroupEvent(t, ev)
+		})
+
+		t.Run("UpdateGroup leaves a referenceable group unrestricted", func(t *testing.T) {
+			group := newGroupFixture(t, true)
+			group.DisplayName = "dn_" + model.NewId()
+
+			ev := capturePublishedGroup(t, func() {
+				_, appErr := th.App.UpdateGroup(group)
+				require.Nil(t, appErr)
+			})
+			assertBroadcastUnrestricted(t, ev)
+		})
+
+		t.Run("DeleteGroup", func(t *testing.T) {
+			group := newGroupFixture(t, false)
+
+			ev := capturePublishedGroup(t, func() {
+				_, appErr := th.App.DeleteGroup(group.Id)
+				require.Nil(t, appErr)
+			})
+			assertRestrictedGroupEvent(t, ev)
+		})
+
+		t.Run("RestoreGroup", func(t *testing.T) {
+			group := newGroupFixture(t, false)
+			_, appErr := th.App.DeleteGroup(group.Id)
+			require.Nil(t, appErr)
+
+			ev := capturePublishedGroup(t, func() {
+				_, appErr := th.App.RestoreGroup(group.Id)
+				require.Nil(t, appErr)
+			})
+			assertRestrictedGroupEvent(t, ev)
+		})
+	})
+}
+
+func selectReceivedGroupEvents(t *testing.T, cluster *testlib.FakeClusterInterface) []*model.WebSocketEvent {
+	t.Helper()
+
+	var events []*model.WebSocketEvent
+	for _, msg := range cluster.SelectMessages(func(msg *model.ClusterMessage) bool {
+		return msg.Event == model.ClusterEventPublish
+	}) {
+		ev, err := model.WebSocketEventFromJSON(bytes.NewReader(msg.Data))
+		require.NoError(t, err)
+		if ev.EventType() == model.WebsocketEventReceivedGroup {
+			events = append(events, ev)
+		}
+	}
+
+	return events
+}
+
+func assertBroadcastUnrestricted(t *testing.T, ev *model.WebSocketEvent) {
+	t.Helper()
+
+	require.Empty(t, ev.GetBroadcast().RequiredPermissions)
+	require.False(t, ev.GetBroadcast().ContainsSensitiveData)
+}
+
+func assertBroadcastRestricted(t *testing.T, ev *model.WebSocketEvent) {
+	t.Helper()
+
+	require.Equal(t, []string{model.PermissionSysconsoleReadUserManagementGroups.Id}, ev.GetBroadcast().RequiredPermissions)
+	require.True(t, ev.GetBroadcast().ContainsSensitiveData)
+}
+
+func assertRestrictedGroupEvent(t *testing.T, ev *model.WebSocketEvent) {
+	t.Helper()
+
+	assertBroadcastRestricted(t, ev)
+
+	groupJSON, ok := ev.GetData()["group"].(string)
+	require.True(t, ok)
+
+	var group *model.Group
+	require.NoError(t, json.Unmarshal([]byte(groupJSON), &group))
+	require.False(t, group.AllowReference)
+	require.NotNil(t, group.MemberCount)
+}
+
+func TestReceivedGroupEventDelivery(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	connForRoles := func(t *testing.T, user *model.User, roles string) *platform.WebConn {
+		t.Helper()
+
+		session, appErr := th.App.CreateSession(th.Context, &model.Session{UserId: user.Id, Roles: roles})
+		require.Nil(t, appErr)
+
+		wc := &platform.WebConn{
+			Platform: th.Server.Platform(),
+			Suite:    th.App,
+			UserId:   user.Id,
+			T:        i18n.T,
+		}
+		wc.SetConnectionID(model.NewId())
+		wc.SetSession(session)
+		wc.SetSessionToken(session.Token)
+		wc.SetSessionExpiresAt(session.ExpiresAt)
+
+		return wc
+	}
+
+	restricted := model.NewWebSocketEvent(model.WebsocketEventReceivedGroup, "", "", "", nil, "")
+	restrictBroadcastToGroupReaders(restricted.GetBroadcast())
+
+	testCases := []struct {
+		description string
+		user        *model.User
+		roles       string
+		expected    bool
+	}{
+		{"system manager holding no manage_system", th.BasicUser2, model.SystemUserRoleId + " " + model.SystemManagerRoleId, true},
+		{"system admin", th.SystemAdminUser, model.SystemUserRoleId + " " + model.SystemAdminRoleId, true},
+		{"regular user", th.BasicUser, model.SystemUserRoleId, false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.description, func(t *testing.T) {
+			wc := connForRoles(t, tc.user, tc.roles)
+			require.Equal(t, tc.expected, wc.ShouldSendEvent(restricted))
+		})
+	}
 }


### PR DESCRIPTION
#### Summary
`received_group` WebSocket event scope fixed.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-69944

#### Release Note
```release-note
`received_group` WebSocket event scope fixed
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change updates shared WebSocket publishing logic and permission-based delivery. Automated tests cover the main mutation and access-control paths, but incorrect filtering could affect event visibility.

**QA Recommendation:** Manual QA is not required. Automated test coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->