### PR TITLE
[Docs Revamp Feedback] Match landing page titles to the TOC, and keep the sidebar on persona pages

### DIFF
--- a/docs/main/administration-guide/configure/configuration-settings.mdx
+++ b/docs/main/administration-guide/configure/configuration-settings.mdx
@@ -1,5 +1,5 @@
 ---
-title: "Configuration settings"
+title: "System Console settings"
 ---
 import useBaseUrl from '@docusaurus/useBaseUrl';
 

--- a/docs/main/administration-guide/configure/configure-index.mdx
+++ b/docs/main/administration-guide/configure/configure-index.mdx
@@ -4,7 +4,7 @@ sidebar_label: "Configure"
 ---
 Configuration covers everything you set before and after your server is running: the System Console settings themselves, the subsystems Mattermost connects to, and the capabilities you turn on for your users.
 
-## System Console settings reference
+## System Console settings
 
 - [System Console settings](/administration-guide/configure/configuration-settings) - Every System Console setting, one page per section, with its `config.json` key and environment variable.
 - [Store configuration in your database](/administration-guide/configure/configuration-in-your-database) - Store configuration in your Mattermost database rather than as a JSON file.

--- a/docs/main/administration-guide/manage/admin/server-maintenance.mdx
+++ b/docs/main/administration-guide/manage/admin/server-maintenance.mdx
@@ -1,11 +1,11 @@
 ---
-title: "Server maintenance"
+title: "Manage Mattermost"
 ---
 Running Mattermost day to day: who has access to what, the tools you operate the server with, your license and billing, the notices your users see, and getting your data out.
 
-## Users and access
+## Access control
 
-- [Users and access](/administration-guide/manage/admin/user-management) - Permissions, roles, user attributes, team and channel membership, and attribute-based access control.
+- [Access control](/administration-guide/manage/admin/user-management) - Permissions, roles, user attributes, team and channel membership, and attribute-based access control.
 
 ## Server operations
 

--- a/docs/main/administration-guide/manage/admin/user-management.mdx
+++ b/docs/main/administration-guide/manage/admin/user-management.mdx
@@ -1,13 +1,17 @@
 ---
-title: "User management"
+title: "Access control"
 ---
 Who can do what in a workspace that's already running: the roles and permissions you grant, the attributes you record about people, and the policies that decide which teams and channels they can reach.
 
-- [User attributes](/administration-guide/manage/admin/user-attributes) - Define custom attributes on user profiles.
 - [Manage team and channel members](/administration-guide/manage/team-channel-members) - Add, remove, and change the roles of members.
 - [Advanced permissions](/administration-guide/onboard/advanced-permissions) - Customize what each role is allowed to do.
-- [Advanced permissions: backend infrastructure](/administration-guide/onboard/advanced-permissions-backend-infrastructure) - How the permissions system is structured.
+  - [Advanced permissions: backend infrastructure](/administration-guide/onboard/advanced-permissions-backend-infrastructure) - How the permissions system is structured.
 - [Delegated granular administration](/administration-guide/onboard/delegated-granular-administration) - Grant admin access to part of the System Console.
 - [Attribute-based access control](/administration-guide/manage/admin/attribute-based-access-control) - Grant access based on user attributes rather than membership lists.
+  - [User attributes](/administration-guide/manage/admin/user-attributes) - Define the custom attributes that access rules are written against.
+  - [System-wide attribute-based access policies](/administration-guide/manage/admin/abac-system-wide-policies) - Organization-wide policies System Admins assign to teams and channels.
+  - [Team membership policies](/administration-guide/manage/admin/abac-team-membership) - Control who can join a team.
+  - [Team channel policies](/administration-guide/manage/admin/abac-team-channel-policies) - Channel membership policies Team Admins manage from Team Settings.
+  - [Channel-specific access rules](/administration-guide/manage/admin/abac-channel-access-rules) - Access rules Channel Admins manage from Channel Settings.
 
 Setting up authentication and creating accounts in the first place is covered in [onboard users](/administration-guide/onboard/onboard-index), including [guest accounts](/administration-guide/onboard/guest-accounts).

--- a/docs/main/for/administrator.mdx
+++ b/docs/main/for/administrator.mdx
@@ -2,6 +2,7 @@
 title: "For Administrators"
 description: "Start here if you configure and operate Mattermost for your organization."
 slug: /for/administrator
+displayed_sidebar: documentation
 hide_table_of_contents: true
 ---
 

--- a/docs/main/for/air-gapped-operator.mdx
+++ b/docs/main/for/air-gapped-operator.mdx
@@ -2,6 +2,7 @@
 title: "For Air-Gapped Operators"
 description: "Start here if you deploy and operate Mattermost in network-isolated enclaves."
 slug: /for/air-gapped-operator
+displayed_sidebar: documentation
 hide_table_of_contents: true
 ---
 

--- a/docs/main/for/compliance-officer.mdx
+++ b/docs/main/for/compliance-officer.mdx
@@ -2,6 +2,7 @@
 title: "For Compliance Officers"
 description: "Start here if you collect audit evidence, respond to audits, and map regulatory mandates to Mattermost configuration."
 slug: /for/compliance-officer
+displayed_sidebar: documentation
 hide_table_of_contents: true
 ---
 

--- a/docs/main/for/developer.mdx
+++ b/docs/main/for/developer.mdx
@@ -2,6 +2,7 @@
 title: "For Developers and Integrators"
 description: "Start here if you build plugins, use the REST API, or integrate Mattermost with other systems."
 slug: /for/developer
+displayed_sidebar: documentation
 hide_table_of_contents: true
 ---
 

--- a/docs/main/for/end-user.mdx
+++ b/docs/main/for/end-user.mdx
@@ -2,6 +2,7 @@
 title: "For End Users"
 description: "Start here if you use Mattermost day to day."
 slug: /for/end-user
+displayed_sidebar: documentation
 hide_table_of_contents: true
 ---
 

--- a/docs/main/for/security-architect.mdx
+++ b/docs/main/for/security-architect.mdx
@@ -2,6 +2,7 @@
 title: "For Security Architects"
 description: "Start here if you evaluate Mattermost for regulated, classified, or DISC environments."
 slug: /for/security-architect
+displayed_sidebar: documentation
 hide_table_of_contents: true
 ---
 

--- a/docs/main/for/sre.mdx
+++ b/docs/main/for/sre.mdx
@@ -2,6 +2,7 @@
 title: "For SREs and Platform Operators"
 description: "Start here if you own deploy, scale, observability, and disaster recovery for Mattermost."
 slug: /for/sre
+displayed_sidebar: documentation
 hide_table_of_contents: true
 ---
 

--- a/docs/main/for/sre.mdx
+++ b/docs/main/for/sre.mdx
@@ -15,9 +15,9 @@ You own Mattermost's deployment, scaling, and operations. This page is a curated
 ## Start here
 
 <CardGrid columns={3} cards={[
-  {title: 'Scaling architecture', to: '/deployment-guide/scale/scaling-for-enterprise', description: 'Scaling, HA, Redis, Enterprise search.'},
+  {title: 'Size your deployment', to: '/deployment-guide/deployment-architecture', description: 'Pick a scale tier and get an architecture and bill of materials.'},
+  {title: 'Prepare your Mattermost Server environment', to: '/deployment-guide/server/preparations', description: 'Database, file storage, network, reverse proxy, and TLS.'},
   {title: 'Install on Kubernetes', to: '/deployment-guide/server/deploy-kubernetes', description: 'Mattermost Operator + Helm chart + custom resources.'},
-  {title: 'Backup and DR', to: '/deployment-guide/backup-disaster-recovery', description: 'Backup strategy, retention, restore drills.'},
 ]} />
 
 ## Common tasks
@@ -28,7 +28,7 @@ You own Mattermost's deployment, scaling, and operations. This page is a curated
   {title: 'Air-gapped deployment overview', to: '/deployment-guide/air-gapped-operations/quick-start-runbook', description: 'Deploy Mattermost in a network-isolated enclave.'},
   {title: 'Calls operations (RTCD)', to: '/deployment-guide/calls/calls-deployment-guide', description: 'RTCD, Offloader, Calls on Kubernetes, metrics.'},
   {title: 'Prometheus and Grafana', to: '/administration-guide/scale/deploy-prometheus-grafana-for-performance-monitoring', description: 'Scrape configs, dashboards, alert rules.'},
-  {title: 'Active/Passive on AWS', to: '/deployment-guide/disaster-recovery-aws', description: 'Cross-region failover topology.'},
+  {title: 'Backup and DR', to: '/deployment-guide/backup-disaster-recovery', description: 'Backup strategy, retention, restore drills.'},
 ]} />
 
 ## Other personas

--- a/docs/main/index.mdx
+++ b/docs/main/index.mdx
@@ -13,7 +13,7 @@ The secure, self-hosted collaboration platform for defense, intelligence, securi
 
 <CardGrid columns={4} cards={[
   {title: 'For End Users', to: '/for/end-user', description: 'Messaging, Playbooks, Calls, Boards — day-to-day collaboration.'},
-  {title: 'For Administrators', to: '/for/administrator', description: 'User provisioning, SSO, RBAC, configuration, billing.'},
+  {title: 'For Administrators', to: '/for/administrator', description: 'User provisioning, SSO, ABAC, configuration, billing.'},
   {title: 'For Developers', to: '/for/developer', description: 'Plugins, the REST API, webhooks, slash commands.'},
   {title: 'For Security Architects', to: '/for/security-architect', description: 'Compliance frameworks, FIPS, audit logging, hardening.'},
 ]} />

--- a/docs/site/scripts/gen-documentation-sidebar.mjs
+++ b/docs/site/scripts/gen-documentation-sidebar.mjs
@@ -375,7 +375,7 @@ const DEPLOYMENT_HIDDEN = new Set([]);
 const ADMIN_CONFIGURE_GROUPS = {
   settingsReference: {
     // Ordered to follow the System Console's own left-hand nav.
-    label: 'System Console settings reference',
+    label: 'System Console settings',
     landing: 'configuration-settings',
     items: [
       'site-configuration-settings',


### PR DESCRIPTION
#### Summary

Follow-up to the docs revamp feedback. Five small fixes, all in `docs/`:

1. **Overview page: RBAC → ABAC.** The "For Administrators" card on the home page listed RBAC; it now says ABAC.
2. **Access control index page matches the TOC.** 
3. **"System Console settings reference" → "System Console settings"** in the sidebar. 
4. **Persona landing pages keep the left sidebar.** 
5. **"Server maintenance" → "Manage Mattermost".** 

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Multiple documentation pages and sidebar configuration changes could cause incorrect navigation, ordering, or nesting. The changes do not modify application behavior, URLs, authentication, or data handling.  
**QA Recommendation:** Perform targeted manual QA of persona sidebars, Access Control navigation, and SRE card ordering.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->