### PR TITLE
docs: fix incorrect GPO policy name for desktop auto-updater

### DIFF
--- a/docs/main/deployment-guide/desktop/desktop-msi-installer-and-group-policy-install.mdx
+++ b/docs/main/deployment-guide/desktop/desktop-msi-installer-and-group-policy-install.mdx
@@ -85,7 +85,7 @@ The following group policies are available supporting a state option of Not Conf
 > <td>Update Notifications</td>
 > <td>If disabled, in-app update notifications are not shown.</td>
 > <td>v5.1 or later</td>
-> <td><code>EnableAutoUpdates</code></td>
+> <td><code>EnableAutoUpdater</code></td>
 > </tr>
 > </tbody>
 > </table>
@@ -154,7 +154,7 @@ From desktop v6.0, users can run multiple Mattermost workspaces at the same time
 - On Windows, seed the approved list using the `DefaultServerList` Group Policy.
 - For scripted installs, seed `config.json` on first run to include multiple entries in the `teams` array. See the [Silent Windows desktop distribution](/deployment-guide/desktop/silent-windows-desktop-distribution) documentation for details.
 - To prevent users from adding or removing workspaces, use the existing `EnableServerManagement` Group Policy.
-- Disable `EnableAutoUpdates` to turn off update notifications.
+- Disable `EnableAutoUpdater` to turn off update notifications.
 
 ### Verify group policy settings have been applied
 

--- a/docs/main/deployment-guide/desktop/desktop-troubleshooting.mdx
+++ b/docs/main/deployment-guide/desktop/desktop-troubleshooting.mdx
@@ -43,7 +43,7 @@ If you're not seeing in-app update notifications when new versions are available
 3.  **Verify update notifications are enabled**:
     - On Windows: Go to **… \> File \> Settings** and ensure **Automatically check for updates** is enabled.
     - On macOS: Go to **Mattermost \> Settings** and ensure **Automatically check for updates** is enabled.
-4.  **Check Group Policy settings** (Enterprise deployments): Your system administrator may have disabled update notifications via the `EnableAutoUpdates` Group Policy. Contact your IT department for clarification.
+4.  **Check Group Policy settings** (Enterprise deployments): Your system administrator may have disabled update notifications via the `EnableAutoUpdater` Group Policy. Contact your IT department for clarification.
 5.  **Version previously skipped**: If you selected **Skip This Version** for the current release, manually check for updates to see it again.
 
 ## Update required screen


### PR DESCRIPTION
#### Summary

The desktop Group Policy that controls in-app update notifications is `EnableAutoUpdater`, but the docs referred to it as `EnableAutoUpdates`. Administrators following these instructions would look for a policy that doesn't exist.

Renames the policy in the group policy reference table and the multi-view deployment notes in `desktop-msi-installer-and-group-policy-install.mdx`, and in the update-notification troubleshooting step in `desktop-troubleshooting.mdx`.

Ports [mattermost/docs#9164](https://github.com/mattermost/docs/pull/9164) to the monorepo docs.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes update documentation only. They do not affect application behavior or shared code.

**QA Recommendation:** Skip manual QA. Verify the corrected policy name in the affected documentation files.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->