### PR TITLE
Enable React concurrent rendering by default

### DIFF
--- a/e2e-tests/playwright/lib/src/server/default_config.ts
+++ b/e2e-tests/playwright/lib/src/server/default_config.ts
@@ -817,7 +817,7 @@ const defaultServerConfig: AdminConfig = {
         MmBlocksEnabled: true,
         ClusterGracefulDrain: true,
         ChannelBookmarks: true,
-        EnableConcurrentReact: false,
+        EnableConcurrentReact: true,
         EnableMFIPluginSignaturePublicKey: true,
         RecurringScheduledPosts: false,
     },

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -225,7 +225,7 @@ func (f *FeatureFlags) SetDefaults() {
 
 	f.MmBlocksEnabled = true
 
-	f.EnableConcurrentReact = false
+	f.EnableConcurrentReact = true
 
 	f.EnableMFIPluginSignaturePublicKey = true
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

This is the first of a series of PRs splitting up the React 19 upgrade. It flips `EnableConcurrentReact` to default on, having landed the fixes over the past week that make concurrent rendering safe:

- #38175 — stop `trimResults` and `ChannelMentionProvider` mutating suggestion results, which breaks rendering when results arrive asynchronously under concurrent React.
- #38236 — pass a `nodeRef` at all 15 `Transition`/`CSSTransition` call sites so `react-transition-group` stops falling back to `findDOMNode`.
- #38237 — remove the last eight string refs, none of which was being read.
- #38238 — make `Tag` forward its ref, stop `isReadonly` and `connect`'s injected `dispatch` reaching DOM elements, and fix duplicate keys in the add-workspace menu.
- #38239 — make `PerformanceReporterController` and `PermissionSystemSchemeSettings` safe to remount, the former by tearing down its `PerformanceReporter` on cleanup, the latter by moving off `UNSAFE_componentWillReceiveProps`.
- #38240 — take react-bootstrap's fix for the last two unsafe lifecycles in `TabContent` and `Dropdown`, and stop `@mattermost/components` shipping a second copy of `react-dom`.

Concurrent rendering has been available behind this flag since the React 18 upgrade, and it is a prerequisite for React 19, which removes legacy mode entirely — there will be no `ReactDOM.render` to fall back to. The flag itself stays in place as a temporary escape hatch, and is only removed once React 19 lands and makes it unimplementable.

**On the failing checks**

Both failures are pre-existing breakage on `master`, not regressions from enabling concurrent rendering.

The three Cypress failures are caused by a docs-site restructure that landed earlier today, and reproduce identically on unrelated PRs running against current `master`. `Integrations › MM-T710` does a `cy.request()` against `docs.mattermost.com/messaging/managing-channels.html`, now 404; `Markdown › with in-line images 1` and `Messaging › MM-T188` both render `docs.mattermost.com/_images/icon-76x76.png`, now 404, so the `<img>` picks up `broken-image` and the placeholder `src`.

The Playwright failure is in the `ABAC file permissions` specs, which already fail or flake in four of the five most recent `master` runs. Every ABAC failure on this branch except the serial-skipped upload case passed on retest, and the two that stayed red also fail on an unrelated control PR built from the same `master`.

#### Release Note

```release-note
Enabled React concurrent rendering by default.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a066b7-1bf4-7b96-8f3c-688222230193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a066b7-1bf4-7b96-8f3c-688222230193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟠 Medium

**Regression Risk:** Enabling concurrent rendering by default changes behavior across React user-facing paths. Automated coverage reduces risk, but concurrent-rendering edge cases can still cause regressions.

**QA Recommendation:** Manual QA is not required. Rely on full automated coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->