### PR TITLE
docs: add 6 missing legacy redirect entries to active-redirects.json

### DIFF
--- a/docs/site/sidebars/active-redirects.json
+++ b/docs/site/sidebars/active-redirects.json
@@ -2,7 +2,7 @@
   "_meta": {
     "maintained": "by hand",
     "note": "Legacy Sphinx URL redirects, originally bulk-extracted during the docs migration. Add new entries at the end of the array. `from` must be unique and must not contain an anchor; `to` should point at a page that exists, or the redirect silently dead-ends.",
-    "active": 741
+    "active": 747
   },
   "redirects": [
     {
@@ -2968,6 +2968,30 @@
     {
       "from": "/deployment-guide/server/trouble-postgres",
       "to": "/deployment-guide/server/prepare-database"
+    },
+    {
+      "from": "/about/cloud-subscriptions",
+      "to": "/product-overview/cloud-subscriptions"
+    },
+    {
+      "from": "/collaborate/format-messages",
+      "to": "/end-user-guide/collaborate/format-messages"
+    },
+    {
+      "from": "/configure/environment-configuration-settings",
+      "to": "/administration-guide/configure/environment-configuration-settings"
+    },
+    {
+      "from": "/deployment/admin-roles",
+      "to": "/administration-guide/onboard/delegated-granular-administration"
+    },
+    {
+      "from": "/deployment/ldap-group-sync",
+      "to": "/administration-guide/onboard/ad-ldap-groups-synchronization"
+    },
+    {
+      "from": "/guides/administration",
+      "to": "/administration-guide/administration-guide-index"
     }
   ]
 }


### PR DESCRIPTION
#### Summary

Six legacy Sphinx URLs are still linked from the Mattermost webapp (per the failing `check-external-links` job in [Web App CI #11397](https://github.com/mattermost/mattermost/actions/runs/33785169507/job/100749169949)) but they had no corresponding entry in `docs/site/sidebars/active-redirects.json`, so `@docusaurus/plugin-client-redirects` emitted no stub for them and every cold request 404s at `docs.mattermost.com`.

Targets are taken from the equivalent redirects in the old Sphinx repo's `source/redirects.py` (which is what the migration extraction should have captured in the first place), verified to resolve to real MDX pages under `docs/main/`:

| From | To |
|---|---|
| `/about/cloud-subscriptions` | `/product-overview/cloud-subscriptions` |
| `/collaborate/format-messages` | `/end-user-guide/collaborate/format-messages` |
| `/configure/environment-configuration-settings` | `/administration-guide/configure/environment-configuration-settings` |
| `/deployment/admin-roles` | `/administration-guide/onboard/delegated-granular-administration` |
| `/deployment/ldap-group-sync` | `/administration-guide/onboard/ad-ldap-groups-synchronization` |
| `/guides/administration` | `/administration-guide/administration-guide-index` |

Bumps `_meta.active` from 741 to 747. Validated locally: JSON parses, all `from` values are unique, every `to` resolves to an existing `.mdx` file.

Full docs-URL resolution on the CDN (rescuing the many legacy `.html`-suffixed URLs still baked into deployed webapps) is handled by a companion CloudFront Function PR in the docs IaC repo. This PR closes the gap for the 6 URLs whose `from` path was never in the redirect map to begin with.

#### Release Note
```release-note
NONE
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change only updates redirect metadata. It does not affect application logic or critical flows.
**QA Recommendation:** Skip manual QA. Automated validation covers JSON validity, unique paths, and target resolution.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->