### PR TITLE
docs: add 10 missing legacy redirect entries to active-redirects.json

### DIFF
--- a/docs/site/sidebars/active-redirects.json
+++ b/docs/site/sidebars/active-redirects.json
@@ -2,7 +2,7 @@
   "_meta": {
     "maintained": "by hand",
     "note": "Legacy Sphinx URL redirects, originally bulk-extracted during the docs migration. Add new entries at the end of the array. `from` must be unique and must not contain an anchor; `to` should point at a page that exists, or the redirect silently dead-ends.",
-    "active": 747
+    "active": 757
   },
   "redirects": [
     {
@@ -2992,6 +2992,46 @@
     {
       "from": "/guides/administration",
       "to": "/administration-guide/administration-guide-index"
+    },
+    {
+      "from": "/preferences/manage-your-notifications",
+      "to": "/end-user-guide/preferences/manage-your-notifications"
+    },
+    {
+      "from": "/messaging/formatting-text",
+      "to": "/end-user-guide/collaborate/format-messages"
+    },
+    {
+      "from": "/configure/authentication-configuration-settings",
+      "to": "/administration-guide/configure/authentication-configuration-settings"
+    },
+    {
+      "from": "/comply/audit-log",
+      "to": "/administration-guide/comply/embedded-json-audit-log-schema"
+    },
+    {
+      "from": "/administration/compliance",
+      "to": "/administration-guide/comply/comply-index"
+    },
+    {
+      "from": "/configure/reporting-configuration-settings",
+      "to": "/administration-guide/configure/reporting-configuration-settings"
+    },
+    {
+      "from": "/install/software-hardware-requirements",
+      "to": "/deployment-guide/software-hardware-requirements"
+    },
+    {
+      "from": "/configure/site-configuration-settings",
+      "to": "/administration-guide/configure/site-configuration-settings"
+    },
+    {
+      "from": "/onboard/ad-ldap-groups-synchronization",
+      "to": "/administration-guide/onboard/ad-ldap-groups-synchronization"
+    },
+    {
+      "from": "/developer/bot-accounts",
+      "to": "/developers/integrate/reference/bot-accounts"
     }
   ]
 }


### PR DESCRIPTION
#### Summary

Adds 10 missing entries to `active-redirects.json` (`_meta.active` 747 → 757) so `docs.mattermost.com` no longer 404s on legacy Sphinx URLs still referenced by `mattermost.com/pl/*` shortlinks after the Docusaurus migration.

Nine target paths sit under legacy-IA prefixes the CFF already routes correctly (`preferences/`, `configure/`, `comply/`, `onboard/`, etc.); they just needed redirect-stub entries. The tenth (`/developer/bot-accounts`) also needs a companion CFF change in [`mattermost-platform/mattermost-iac-docs#11`](https://github.com/mattermost-platform/mattermost-iac-docs/pull/11) to route `/developer/*` (singular) through the legacy-IA branch — both must land for that one URL to resolve end-to-end.

Follow-up: [38319](https://github.com/mattermost/mattermost/pull/38319) fixes bugs in `check-external-links.mjs` that were masking these very 404s. That PR is stacked because its CI can only pass once this one deploys.

#### Release Note
```release-note
NONE
```