### PR TITLE
fix(check-external-links): follow 301s, route GET-fallback through the loop, skip Zendesk

### DIFF
--- a/docs/site/sidebars/active-redirects.json
+++ b/docs/site/sidebars/active-redirects.json
@@ -2,7 +2,7 @@
   "_meta": {
     "maintained": "by hand",
     "note": "Legacy Sphinx URL redirects, originally bulk-extracted during the docs migration. Add new entries at the end of the array. `from` must be unique and must not contain an anchor; `to` should point at a page that exists, or the redirect silently dead-ends.",
-    "active": 747
+    "active": 757
   },
   "redirects": [
     {
@@ -2992,6 +2992,46 @@
     {
       "from": "/guides/administration",
       "to": "/administration-guide/administration-guide-index"
+    },
+    {
+      "from": "/preferences/manage-your-notifications",
+      "to": "/end-user-guide/preferences/manage-your-notifications"
+    },
+    {
+      "from": "/messaging/formatting-text",
+      "to": "/end-user-guide/collaborate/format-messages"
+    },
+    {
+      "from": "/configure/authentication-configuration-settings",
+      "to": "/administration-guide/configure/authentication-configuration-settings"
+    },
+    {
+      "from": "/comply/audit-log",
+      "to": "/administration-guide/comply/embedded-json-audit-log-schema"
+    },
+    {
+      "from": "/administration/compliance",
+      "to": "/administration-guide/comply/comply-index"
+    },
+    {
+      "from": "/configure/reporting-configuration-settings",
+      "to": "/administration-guide/configure/reporting-configuration-settings"
+    },
+    {
+      "from": "/install/software-hardware-requirements",
+      "to": "/deployment-guide/software-hardware-requirements"
+    },
+    {
+      "from": "/configure/site-configuration-settings",
+      "to": "/administration-guide/configure/site-configuration-settings"
+    },
+    {
+      "from": "/onboard/ad-ldap-groups-synchronization",
+      "to": "/administration-guide/onboard/ad-ldap-groups-synchronization"
+    },
+    {
+      "from": "/developer/bot-accounts",
+      "to": "/developers/integrate/reference/bot-accounts"
     }
   ]
 }

--- a/webapp/scripts/check-external-links.mjs
+++ b/webapp/scripts/check-external-links.mjs
@@ -17,6 +17,13 @@ const ROOT_DOMAIN_PATTERN = /^https?:\/\/(www\.)?mattermost\.com\/?$/;
 /** Marketing forms; often slow or block bot User-Agents — not reliable to verify in CI. */
 const FORMS_MATTERMOST_PATTERN = /^https?:\/\/forms\.mattermost\.com\//i;
 
+// Hosts whose bot-management (Cloudflare TLS fingerprint checks etc.) rejects
+// non-browser clients regardless of User-Agent spoofing, so we can't validate
+// them from CI.
+const UNCRAWLABLE_HOSTS = new Set([
+    'support.mattermost.com', // Zendesk fronted by Cloudflare bot mgmt
+]);
+
 const SOURCE_EXTENSIONS = ['.ts', '.tsx', '.js', '.jsx'];
 
 const DIRECTORIES_TO_SCAN = [
@@ -195,10 +202,8 @@ function processResponse(originalUrl, response) {
         return {url: originalUrl, status, ok: true};
     }
 
-    if (status === 301) {
-        return {url: originalUrl, status, ok: true};
-    }
-
+    // Follow every 3xx (including 301) to its final destination. Short-circuiting
+    // 301s as "OK" hides real 404s at the chain's end
     if (isRedirect) {
         return {url: originalUrl, status, redirect: true};
     }
@@ -215,7 +220,14 @@ function processResponse(originalUrl, response) {
 }
 
 function shouldSkipUrlCheck(url) {
-    return PUSH_SERVER_PATTERN.test(url) || FORMS_MATTERMOST_PATTERN.test(url);
+    if (PUSH_SERVER_PATTERN.test(url) || FORMS_MATTERMOST_PATTERN.test(url)) {
+        return true;
+    }
+    try {
+        return UNCRAWLABLE_HOSTS.has(new URL(url).hostname);
+    } catch {
+        return false;
+    }
 }
 
 async function checkUrls(urls, concurrency = 5, silentProgress = false) {

--- a/webapp/scripts/check-external-links.mjs
+++ b/webapp/scripts/check-external-links.mjs
@@ -149,21 +149,22 @@ async function checkUrlWithRedirects(originalUrl) {
     let currentUrl = originalUrl;
 
     for (let redirectCount = 0; redirectCount <= MAX_REDIRECTS; redirectCount++) {
-        const response = await fetch(currentUrl, {
+        let response = await fetch(currentUrl, {
             method: 'HEAD',
             redirect: 'manual',
             headers: FETCH_HEADERS,
             signal: AbortSignal.timeout(10000),
         });
 
+        // Some origins reject HEAD; retry with GET and let the outer loop
+        // handle any 3xx the GET returns so we still follow the chain.
         if (response.status === 405 || response.status === 403) {
-            const getResponse = await fetch(currentUrl, {
+            response = await fetch(currentUrl, {
                 method: 'GET',
                 redirect: 'manual',
                 headers: FETCH_HEADERS,
                 signal: AbortSignal.timeout(10000),
             });
-            return processResponse(originalUrl, getResponse);
         }
 
         const result = processResponse(originalUrl, response);

--- a/webapp/scripts/check-external-links.mjs
+++ b/webapp/scripts/check-external-links.mjs
@@ -159,6 +159,7 @@ async function checkUrlWithRedirects(originalUrl) {
         // Some origins reject HEAD; retry with GET and let the outer loop
         // handle any 3xx the GET returns so we still follow the chain.
         if (response.status === 405 || response.status === 403) {
+            await response.body?.cancel();
             response = await fetch(currentUrl, {
                 method: 'GET',
                 redirect: 'manual',
@@ -167,23 +168,30 @@ async function checkUrlWithRedirects(originalUrl) {
             });
         }
 
-        const result = processResponse(originalUrl, response);
+        // Always release the response body — HEAD leaves it null (safe no-op),
+        // but the GET fallback returns real bodies we never read. Leaving them
+        // open pins sockets in undici's pool until finalization.
+        try {
+            const result = processResponse(originalUrl, response);
 
-        if (!result.redirect) {
-            return result;
+            if (!result.redirect) {
+                return result;
+            }
+
+            const location = response.headers.get('location');
+            if (!location) {
+                return {
+                    url: originalUrl,
+                    status: response.status,
+                    ok: false,
+                    error: 'Redirect without Location header',
+                };
+            }
+
+            currentUrl = new URL(location, currentUrl).href;
+        } finally {
+            await response.body?.cancel();
         }
-
-        const location = response.headers.get('location');
-        if (!location) {
-            return {
-                url: originalUrl,
-                status: response.status,
-                ok: false,
-                error: 'Redirect without Location header',
-            };
-        }
-
-        currentUrl = new URL(location, currentUrl).href;
     }
 
     return {


### PR DESCRIPTION
#### Summary

Fixes three bugs in the CI external-link checker. **Stacked on top of [#38318](https://github.com/mattermost/mattermost/pull/38318)** — its CI can only pass once #38318 merges and the docs site redeploys, because the checker starts detecting real 404s (which are exactly what #38318 fixes).

**Bugs fixed:**

1. **Follow 301s in `processResponse`.** Previously 301 responses were short-circuited as "OK" without following the redirect. This masked real 404s at the end of `/pl/*` shortlink chains and let genuinely-broken URLs slip through CI unnoticed.

2. **Route GET-fallback responses through the redirect loop.** When HEAD returned 405/403 we retried with GET, but returned the GET result directly, bypassing the outer loop's `Location` handling. Combined with fix 1, a GET-returned 3xx would come back as `{redirect: true}` and be reported as broken with no error text. `response` is now reassigned in the fallback branch so the same downstream code processes it.

3. **Skip `support.mattermost.com`** via a new `UNCRAWLABLE_HOSTS` set. Zendesk fronts these URLs with Cloudflare bot management that inspects TLS fingerprints (JA3/JA4) and rejects non-browser clients regardless of `User-Agent` spoofing, so they always false-positive. Four URLs affected (contact form, ThreadAutoFollow help, browser/desktop log-collection articles) — all valid in a browser.

#### Merge order

1. [done] Merge and deploy [#38318](https://github.com/mattermost/mattermost/pull/38318) — puts the redirect stubs in S3.
2. [done] Merge and deploy [mattermost-platform/mattermost-iac-docs#11](https://github.com/mattermost-platform/mattermost-iac-docs/pull/11) — CFF handles `/developer/*` correctly.
3. [done] Rebase this PR on master. CI should now pass (all 12 previously-hidden 404s resolve).

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Redirect handling changes affect shared CI link-checking paths, including 301 responses and GET fallbacks. The blast radius is limited to CI validation, and rollback is straightforward.
**QA Recommendation:** Skip manual QA if automated tests provide full coverage. Verify the redirect-checker tests before merge.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->