### PR TITLE
MM-70203: add plugin file action policy API

### DIFF
--- a/server/channels/app/plugin_api.go
+++ b/server/channels/app/plugin_api.go
@@ -1084,6 +1084,30 @@ func (api *PluginAPI) GetFile(fileID string) ([]byte, *model.AppError) {
 	return api.app.GetFile(api.ctx, fileID)
 }
 
+func (api *PluginAPI) HasPermissionToFileAction(sessionID, fileID, action string) bool {
+	if sessionID == "" || fileID == "" || !model.IsPermissionAction(action) {
+		return false
+	}
+
+	session, appErr := api.app.GetSessionById(api.ctx, sessionID)
+	if appErr != nil || session == nil || session.IsValid() != nil {
+		return false
+	}
+
+	session, appErr = api.app.GetSession(session.Token)
+	if appErr != nil || session == nil || session.Id != sessionID {
+		return false
+	}
+
+	fileInfo, appErr := api.app.Srv().getFileInfo(fileID)
+	if appErr != nil || fileInfo.ChannelId == "" {
+		return false
+	}
+
+	rctx := api.ctx.WithSession(session)
+	return api.app.HasPermissionToFileAction(rctx, session.UserId, session.Roles, fileInfo.ChannelId, action)
+}
+
 func (api *PluginAPI) UploadFile(data []byte, channelID string, filename string) (*model.FileInfo, *model.AppError) {
 	return api.app.UploadFile(api.ctx, data, channelID, filename)
 }

--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -798,20 +798,9 @@ func TestPluginAPIHasPermissionToFileAction(t *testing.T) {
 		model.SessionAttributesPropertyFieldIPAddress: "192.0.2.10",
 	}, model.GetMillis()))
 
-	fileInfo, appErr := th.App.DoUploadFile(
-		th.Context,
-		time.Now(),
-		th.BasicTeam.Id,
-		th.BasicChannel.Id,
-		th.BasicUser.Id,
-		"file-action-policy-test",
-		[]byte("test"),
-		true,
-	)
-	require.Nil(t, appErr)
+	fileInfo := th.CreateFileInfo(t, th.BasicUser.Id, "", th.BasicChannel.Id)
 	t.Cleanup(func() {
 		require.NoError(t, th.App.Srv().Store().FileInfo().PermanentDelete(th.Context, fileInfo.Id))
-		require.Nil(t, th.App.RemoveFile(fileInfo.Path))
 	})
 
 	mockAccessControl := &mocks.AccessControlServiceInterface{}

--- a/server/channels/app/plugin_api_test.go
+++ b/server/channels/app/plugin_api_test.go
@@ -759,6 +759,138 @@ func TestPluginAPIGetFile(t *testing.T) {
 	require.Nil(t, data)
 }
 
+func TestPluginAPIHasPermissionToFileAction(t *testing.T) {
+	th := Setup(t).InitBasic(t)
+	api := th.SetupPluginAPI()
+
+	fileActionAPI, ok := any(api).(interface {
+		HasPermissionToFileAction(sessionID, fileID, action string) bool
+	})
+	if !t.Run("method exposure", func(t *testing.T) {
+		require.True(t, ok, "PluginAPI must expose HasPermissionToFileAction(sessionID, fileID, action string) bool")
+	}) {
+		return
+	}
+
+	enableSessionAttributesCollection(t, th)
+	th.ConfigStore.SetReadOnlyFF(false)
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
+		cfg.FeatureFlags.PermissionPolicies = true
+	})
+	th.ConfigStore.SetReadOnlyFF(true)
+
+	activeSession, appErr := th.App.CreateSession(th.Context, &model.Session{
+		UserId:    th.BasicUser.Id,
+		ExpiresAt: model.GetMillis() + 100000,
+		Props:     model.StringMap{},
+	})
+	require.Nil(t, appErr)
+
+	expiredSession, appErr := th.App.CreateSession(th.Context, &model.Session{
+		UserId:    th.BasicUser.Id,
+		ExpiresAt: model.GetMillis() - 100000,
+		Props:     model.StringMap{},
+	})
+	require.Nil(t, appErr)
+
+	require.NoError(t, th.App.Srv().Store().SessionAttribute().Refresh(activeSession.Id, map[string]any{
+		model.SessionAttributesPropertyFieldIPAddress: "192.0.2.10",
+	}, model.GetMillis()))
+
+	fileInfo, appErr := th.App.DoUploadFile(
+		th.Context,
+		time.Now(),
+		th.BasicTeam.Id,
+		th.BasicChannel.Id,
+		th.BasicUser.Id,
+		"file-action-policy-test",
+		[]byte("test"),
+		true,
+	)
+	require.Nil(t, appErr)
+	t.Cleanup(func() {
+		require.NoError(t, th.App.Srv().Store().FileInfo().PermanentDelete(th.Context, fileInfo.Id))
+		require.Nil(t, th.App.RemoveFile(fileInfo.Path))
+	})
+
+	mockAccessControl := &mocks.AccessControlServiceInterface{}
+	th.App.Srv().ch.AccessControl = mockAccessControl
+	mockAccessControl.On("AccessEvaluation", mock.Anything, mock.MatchedBy(func(req model.AccessRequest) bool {
+		return req.Resource.ID == th.BasicChannel.Id &&
+			req.Action == model.AccessControlPolicyActionDownloadFileAttachment
+	})).Return(model.AccessDecision{Decision: false}, (*model.AppError)(nil)).Once()
+	mockAccessControl.On("AccessEvaluation", mock.Anything, mock.MatchedBy(func(req model.AccessRequest) bool {
+		return req.Resource.ID == th.BasicChannel.Id &&
+			req.Action == model.AccessControlPolicyActionUploadFileAttachment &&
+			req.Subject.Session[model.SessionAttributesPropertyFieldIPAddress] == "192.0.2.10"
+	})).Return(model.AccessDecision{Decision: true}, (*model.AppError)(nil)).Once()
+
+	tests := []struct {
+		name      string
+		sessionID string
+		fileID    string
+		action    string
+		expected  bool
+	}{
+		{
+			name:     "missing session",
+			fileID:   fileInfo.Id,
+			action:   model.AccessControlPolicyActionDownloadFileAttachment,
+			expected: false,
+		},
+		{
+			name:      "invalid session",
+			sessionID: model.NewId(),
+			fileID:    fileInfo.Id,
+			action:    model.AccessControlPolicyActionDownloadFileAttachment,
+			expected:  false,
+		},
+		{
+			name:      "expired session",
+			sessionID: expiredSession.Id,
+			fileID:    fileInfo.Id,
+			action:    model.AccessControlPolicyActionDownloadFileAttachment,
+			expected:  false,
+		},
+		{
+			name:      "unknown file",
+			sessionID: activeSession.Id,
+			fileID:    model.NewId(),
+			action:    model.AccessControlPolicyActionDownloadFileAttachment,
+			expected:  false,
+		},
+		{
+			name:      "invalid action",
+			sessionID: activeSession.Id,
+			fileID:    fileInfo.Id,
+			action:    "invalid-action",
+			expected:  false,
+		},
+		{
+			name:      "policy deny",
+			sessionID: activeSession.Id,
+			fileID:    fileInfo.Id,
+			action:    model.AccessControlPolicyActionDownloadFileAttachment,
+			expected:  false,
+		},
+		{
+			name:      "policy allow with session attributes",
+			sessionID: activeSession.Id,
+			fileID:    fileInfo.Id,
+			action:    model.AccessControlPolicyActionUploadFileAttachment,
+			expected:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, fileActionAPI.HasPermissionToFileAction(tt.sessionID, tt.fileID, tt.action))
+		})
+	}
+	mockAccessControl.AssertExpectations(t)
+}
+
 func TestPluginAPIGetFileInfos(t *testing.T) {
 	mainHelper.Parallel(t)
 	th := Setup(t).InitBasic(t)

--- a/server/public/plugin/api.go
+++ b/server/public/plugin/api.go
@@ -862,6 +862,12 @@ type API interface {
 	// Minimum server version: 5.8
 	GetFile(fileId string) ([]byte, *model.AppError)
 
+	// HasPermissionToFileAction evaluates the applicable policy for a session and file.
+	//
+	// @tag File
+	// Minimum server version: 11.7
+	HasPermissionToFileAction(sessionID, fileID, action string) bool
+
 	// GetFileLink gets the public link to a file by fileId.
 	//
 	// @tag File

--- a/server/public/plugin/api_timer_layer_generated.go
+++ b/server/public/plugin/api_timer_layer_generated.go
@@ -923,6 +923,13 @@ func (api *apiTimerLayer) GetFile(fileId string) ([]byte, *model.AppError) {
 	return _returnsA, _returnsB
 }
 
+func (api *apiTimerLayer) HasPermissionToFileAction(sessionID, fileID, action string) bool {
+	startTime := timePkg.Now()
+	_returnsA := api.apiImpl.HasPermissionToFileAction(sessionID, fileID, action)
+	api.recordTime(startTime, "HasPermissionToFileAction", true)
+	return _returnsA
+}
+
 func (api *apiTimerLayer) GetFileLink(fileId string) (string, *model.AppError) {
 	startTime := timePkg.Now()
 	_returnsA, _returnsB := api.apiImpl.GetFileLink(fileId)

--- a/server/public/plugin/client_rpc_generated.go
+++ b/server/public/plugin/client_rpc_generated.go
@@ -6006,6 +6006,36 @@ func (s *apiRPCServer) GetFile(args *Z_GetFileArgs, returns *Z_GetFileReturns) e
 	return nil
 }
 
+type Z_HasPermissionToFileActionArgs struct {
+	A string
+	B string
+	C string
+}
+
+type Z_HasPermissionToFileActionReturns struct {
+	A bool
+}
+
+func (g *apiRPCClient) HasPermissionToFileAction(sessionID, fileID, action string) bool {
+	_args := &Z_HasPermissionToFileActionArgs{sessionID, fileID, action}
+	_returns := &Z_HasPermissionToFileActionReturns{}
+	if err := g.client.Call("Plugin.HasPermissionToFileAction", _args, _returns); err != nil {
+		log.Printf("RPC call to HasPermissionToFileAction API failed: %s", err.Error())
+	}
+	return _returns.A
+}
+
+func (s *apiRPCServer) HasPermissionToFileAction(args *Z_HasPermissionToFileActionArgs, returns *Z_HasPermissionToFileActionReturns) error {
+	if hook, ok := s.impl.(interface {
+		HasPermissionToFileAction(sessionID, fileID, action string) bool
+	}); ok {
+		returns.A = hook.HasPermissionToFileAction(args.A, args.B, args.C)
+	} else {
+		return encodableError(fmt.Errorf("API HasPermissionToFileAction called but not implemented."))
+	}
+	return nil
+}
+
 type Z_GetFileLinkArgs struct {
 	A string
 }

--- a/server/public/plugin/plugintest/api.go
+++ b/server/public/plugin/plugintest/api.go
@@ -4176,6 +4176,24 @@ func (_m *API) HasPermissionToChannel(userID string, channelId string, permissio
 	return r0
 }
 
+// HasPermissionToFileAction provides a mock function with given fields: sessionID, fileID, action
+func (_m *API) HasPermissionToFileAction(sessionID string, fileID string, action string) bool {
+	ret := _m.Called(sessionID, fileID, action)
+
+	if len(ret) == 0 {
+		panic("no return value specified for HasPermissionToFileAction")
+	}
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func(string, string, string) bool); ok {
+		r0 = rf(sessionID, fileID, action)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
 // HasPermissionToTeam provides a mock function with given fields: userID, teamID, permission
 func (_m *API) HasPermissionToTeam(userID string, teamID string, permission *model.Permission) bool {
 	ret := _m.Called(userID, teamID, permission)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Backports the session-scoped Plugin API check for file actions to `release-11.11`.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-70203

#### Release Note
```release-note
Added a Plugin API method for session-scoped file action policy checks.
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-62298151-0e8a-47f5-9dee-f4dbd91f7959?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-62298151-0e8a-47f5-9dee-f4dbd91f7959&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

