### PR TITLE
docs: unescape HTML entities inside markdown code spans

### DIFF
--- a/docs/main/administration-guide/configure/smtp-email.mdx
+++ b/docs/main/administration-guide/configure/smtp-email.mdx
@@ -146,7 +146,7 @@ If an SMTP connection test in the System Console for a self-hosted Mattermost de
   220 mail.example.com NO UCE ESMTP
   ```
 
-  Then type something like `HELO &lt;your mail server domain&gt;`. If the command works you should see something like:
+  Then type something like `HELO <your mail server domain>`. If the command works you should see something like:
 
   ``` text
   250-mail.example.com NO UCE

--- a/docs/main/administration-guide/manage/admin/abac-system-wide-policies.mdx
+++ b/docs/main/administration-guide/manage/admin/abac-system-wide-policies.mdx
@@ -61,7 +61,7 @@ Simple Mode is ideal for simple and straightforward access control scenarios. Ea
 </TabItem>
 <TabItem value="advanced-mode" label="Advanced Mode">
 
-Advanced Mode is ideal for complex access control scenarios that require CEL syntax to combine multiple conditions with logical operators that support rules like `user.&lt;attribute&gt; == &lt;value&gt;`, using `&&` / `||` (and/or) for multiple conditions, and `()` to group conditions. The CEL Expression Editor provides real-time syntax validation and feedback, as well as context-aware autocomplete for attributes, operators, and attribute values.
+Advanced Mode is ideal for complex access control scenarios that require CEL syntax to combine multiple conditions with logical operators that support rules like `user.<attribute> == <value>`, using `&&` / `||` (and/or) for multiple conditions, and `()` to group conditions. The CEL Expression Editor provides real-time syntax validation and feedback, as well as context-aware autocomplete for attributes, operators, and attribute values.
 
     You can also start defining rules in Simple Mode and then switch to Advanced Mode to refine the rules further as needed. However, you'll be blocked from switching from Advanced back to Simple Mode if one of the following are true:
 
@@ -69,7 +69,7 @@ Advanced Mode is ideal for complex access control scenarios that require CEL syn
     - Nested logic/grouping (parentheses) are present.
     - Unsupported operators or expressions are detected.
 
-    The syntax structure is `user.&lt;attribute&gt; &lt;operator&gt; &lt;value&gt;`.
+    The syntax structure is `user.<attribute> <operator> <value>`.
 
     As you type, autocompletes show available attributes. As you select attributes, autocomplete suggests appropriate CEL operators. After selecting an operator, when attribute values are pre-defined, autocomplete suggests values to choose from. Mattermost will explicitly indicate issues such as missing operators, incorrect syntax, or incomplete conditions.
 

--- a/docs/main/administration-guide/manage/admin/generating-support-packet.mdx
+++ b/docs/main/administration-guide/manage/admin/generating-support-packet.mdx
@@ -95,13 +95,13 @@ The following cluster-wide files are located in the root directory of the Suppor
 
 The following node-specific files are located in node subdirectories:
 
-- `&lt;node-id&gt;/mattermost.log` (Mattermost logs for each node)
-- `&lt;node-id&gt;/audit.log` (Mattermost audit logs for each node)
-- `&lt;node-id&gt;/ldap.log` (AD/LDAP logs for each node)
-- `&lt;node-id&gt;/notifications.log` (notifications logs for each node)
-- `&lt;node-id&gt;/cpu.prof` ([Go performance metrics](#go-performance-metrics) for each node)
-- `&lt;node-id&gt;/heap.prof` ([Go performance metrics](#go-performance-metrics) for each node)
-- `&lt;node-id&gt;/goroutines` ([Go performance metrics](#go-performance-metrics) for each node)
+- `<node-id>/mattermost.log` (Mattermost logs for each node)
+- `<node-id>/audit.log` (Mattermost audit logs for each node)
+- `<node-id>/ldap.log` (AD/LDAP logs for each node)
+- `<node-id>/notifications.log` (notifications logs for each node)
+- `<node-id>/cpu.prof` ([Go performance metrics](#go-performance-metrics) for each node)
+- `<node-id>/heap.prof` ([Go performance metrics](#go-performance-metrics) for each node)
+- `<node-id>/goroutines` ([Go performance metrics](#go-performance-metrics) for each node)
 
 ### Diagnostics highlights
 
@@ -140,13 +140,13 @@ From v10.11, Support Packets include PostgreSQL database schema dump information
 
 **Cluster-specific files (in node subdirectories):**
 
-- `&lt;node-id&gt;/mattermost.log` (Mattermost logs for each node)
-- `&lt;node-id&gt;/audit.log` (Mattermost audit logs for each node)
-- `&lt;node-id&gt;/ldap.log` (AD/LDAP logs for each node)
-- `&lt;node-id&gt;/notifications.log` (notifications logs for each node)
-- `&lt;node-id&gt;/cpu.prof` ([Go performance metrics](#go-performance-metrics) for each node)
-- `&lt;node-id&gt;/heap.prof` ([Go performance metrics](#go-performance-metrics) for each node)
-- `&lt;node-id&gt;/goroutines` ([Go performance metrics](#go-performance-metrics) for each node)
+- `<node-id>/mattermost.log` (Mattermost logs for each node)
+- `<node-id>/audit.log` (Mattermost audit logs for each node)
+- `<node-id>/ldap.log` (AD/LDAP logs for each node)
+- `<node-id>/notifications.log` (notifications logs for each node)
+- `<node-id>/cpu.prof` ([Go performance metrics](#go-performance-metrics) for each node)
+- `<node-id>/heap.prof` ([Go performance metrics](#go-performance-metrics) for each node)
+- `<node-id>/goroutines` ([Go performance metrics](#go-performance-metrics) for each node)
 
 The following additional plugin diagnostic data is included in the generated Support Packet when the plugin is enabled and operational:
 
@@ -183,13 +183,13 @@ Support packet file organization has been improved to make it easier to identify
 
 **Cluster-specific files (in node subdirectories):**
 
-- `&lt;node-id&gt;/mattermost.log` (Mattermost logs for each node)
-- `&lt;node-id&gt;/audit.log` (Mattermost audit logs for each node)
-- `&lt;node-id&gt;/ldap.log` (AD/LDAP logs for each node)
-- `&lt;node-id&gt;/notifications.log` (notifications logs for each node)
-- `&lt;node-id&gt;/cpu.prof` ([Go performance metrics](#go-performance-metrics) for each node)
-- `&lt;node-id&gt;/heap.prof` ([Go performance metrics](#go-performance-metrics) for each node)
-- `&lt;node-id&gt;/goroutines` ([Go performance metrics](#go-performance-metrics) for each node)
+- `<node-id>/mattermost.log` (Mattermost logs for each node)
+- `<node-id>/audit.log` (Mattermost audit logs for each node)
+- `<node-id>/ldap.log` (AD/LDAP logs for each node)
+- `<node-id>/notifications.log` (notifications logs for each node)
+- `<node-id>/cpu.prof` ([Go performance metrics](#go-performance-metrics) for each node)
+- `<node-id>/heap.prof` ([Go performance metrics](#go-performance-metrics) for each node)
+- `<node-id>/goroutines` ([Go performance metrics](#go-performance-metrics) for each node)
 
 The following additional plugin diagnostic data is included in the generated support packet when the plugin is enabled and operational:
 

--- a/docs/main/administration-guide/onboard/bulk-loading-data.mdx
+++ b/docs/main/administration-guide/onboard/bulk-loading-data.mdx
@@ -63,7 +63,7 @@ Next, zip it by running the `zip -r data.zip data.jsonl` command.
 
 From Mattermost v9.5, the mmctl bulk import process command in [local mode](/administration-guide/manage/mmctl-command-line-tool#local-mode) supports processing an import file without uploading it to the server.
 
-Run `mmctl import process --bypass-upload &lt;file&gt;.zip --local` to start your import and enable the Mattermost server to read from the file directly.
+Run `mmctl import process --bypass-upload <file>.zip --local` to start your import and enable the Mattermost server to read from the file directly.
 
 ### Not using mmctl local mode
 

--- a/docs/main/administration-guide/onboard/sso-google.mdx
+++ b/docs/main/administration-guide/onboard/sso-google.mdx
@@ -19,7 +19,7 @@ The [Google People API](https://developers.google.com/people) has replaced the G
 2.  Select **Credentials** in the left-hand sidebar.
 3.  Select **Create Credentials**, then select **OAuth client ID**.
 4.  Select the **Web application** as the application type.
-5.  Enter `Mattermost-&lt;your-company-name&gt;` as the **Name**, replacing `&lt;your-company-name&gt;` with the name of your organization.
+5.  Enter `Mattermost-<your-company-name>` as the **Name**, replacing `<your-company-name>` with the name of your organization.
 6.  Under **Authorized redirect URIs**, select **Add URL**, then enter `&#123;your-mattermost-url&#125;/signup/google/complete`. For example: `http://localhost:8065/signup/google/complete`.
 7.  Select **Create**.
 8.  Copy and paste the **Your Client ID** and **Your Client Secret** values to a temporary location. You will enter these values in the Mattermost System Console.

--- a/docs/main/administration-guide/onboard/sso-saml-adfs-msws2016.mdx
+++ b/docs/main/administration-guide/onboard/sso-saml-adfs-msws2016.mdx
@@ -46,11 +46,11 @@ If you would like to set up encryption for your SAML connection, select **Browse
 
 > ![image](/images/SSO-SAML-ADFS_add-new-relying-party-trust_005.png)
 
-6.  On the **Configure URL** screen, select **Enable Support for the SAML 2.0 WebSSO protocol**, then enter the **SAML 2.0 SSO service URL** in the following format:`https://&lt;your-mattermost-url&gt;/login/sso/saml` where `&lt;your-mattermost-url&gt;` should typically match the [Mattermost Site URL](/administration-guide/configure/environment-configuration-settings#site-url).
+6.  On the **Configure URL** screen, select **Enable Support for the SAML 2.0 WebSSO protocol**, then enter the **SAML 2.0 SSO service URL** in the following format:`https://<your-mattermost-url>/login/sso/saml` where `<your-mattermost-url>` should typically match the [Mattermost Site URL](/administration-guide/configure/environment-configuration-settings#site-url).
 
     > ![image](/images/SSO-SAML-ADFS_add-new-relying-party-trust_006.png)
 
-7.  On the **Configure Identifiers** screen, enter the **Relying party trust identifier**. This identifies the claims being requested. The **SAML 2.0 SSO service URL** format should be `https://&lt;your-mattermost-url&gt;/login/sso/saml` where `&lt;your-mattermost-url&gt;` matches your [Mattermost Site URL](/administration-guide/configure/environment-configuration-settings#site-url). Then choose **Next**.
+7.  On the **Configure Identifiers** screen, enter the **Relying party trust identifier**. This identifies the claims being requested. The **SAML 2.0 SSO service URL** format should be `https://<your-mattermost-url>/login/sso/saml` where `<your-mattermost-url>` matches your [Mattermost Site URL](/administration-guide/configure/environment-configuration-settings#site-url). Then choose **Next**.
 
     > ![image](/images/SSO-SAML-ADFS_add-new-relying-party-trust_007.png)
     >
@@ -117,9 +117,9 @@ Select **Pass through all claim values**, then select **Finish**.
 7.  Select **Finish** to create the claim rule, then select **OK** to finish creating rules.
 8.  Open Windows PowerShell as an administrator, then run the following command:
 
-> `Set-ADFSRelyingPartyTrust -TargetName &lt;display-name&gt; -SamlResponseSignature "MessageAndAssertion"`
+> `Set-ADFSRelyingPartyTrust -TargetName <display-name> -SamlResponseSignature "MessageAndAssertion"`
 
-where `&lt;display-name&gt;`is the name you specified in step 4 when you added a relying party trust. In this example, `&lt;display-name&gt;` would be `mattermost`.
+where `<display-name>`is the name you specified in step 4 when you added a relying party trust. In this example, `<display-name>` would be `mattermost`.
 
 This action adds the signature to SAML messages, making verification successful.
 

--- a/docs/main/administration-guide/onboard/sso-saml-adfs.mdx
+++ b/docs/main/administration-guide/onboard/sso-saml-adfs.mdx
@@ -49,11 +49,11 @@ However, if you would like to set up encryption for your SAML connection, select
 
 > ![image](/images/adfs_7_configure_certificate_encryption.png)
 
-7.  On the **Configure URL** screen, select **Enable Support for the SAML 2.0 WebSSO protocol**, then enter the **SAML 2.0 SSO service URL**, similar to `https://&lt;your-mattermost-url&gt;/login/sso/saml` where `&lt;your-mattermost-url&gt;` should typically match the [Mattermost Site URL](/administration-guide/configure/environment-configuration-settings#site-url).
+7.  On the **Configure URL** screen, select **Enable Support for the SAML 2.0 WebSSO protocol**, then enter the **SAML 2.0 SSO service URL**, similar to `https://<your-mattermost-url>/login/sso/saml` where `<your-mattermost-url>` should typically match the [Mattermost Site URL](/administration-guide/configure/environment-configuration-settings#site-url).
 
     > ![image](/images/adfs_8_configure_url.png)
 
-8.  On the **Configure Identifiers** screen, enter the **Relying party trust identifier** (also known as the **Identity Provider Issuer URL**) of the form `https://&lt;your-idp-url&gt;/adfs/services/trust`, then click **Add**.
+8.  On the **Configure Identifiers** screen, enter the **Relying party trust identifier** (also known as the **Identity Provider Issuer URL**) of the form `https://<your-idp-url>/adfs/services/trust`, then click **Add**.
 
     > ![image](/images/adfs_9_configure_identifiers.png)
 
@@ -118,9 +118,9 @@ Select **Pass through all claim values**, then select **Finish**.
 7.  Select **Finish** to create the claim rule, then select **OK** to finish creating rules.
 8.  Open Windows PowerShell as an administrator, then run the following command:
 
-> `Set-ADFSRelyingPartyTrust -TargetName &lt;display-name&gt; -SamlResponseSignature "MessageAndAssertion"`
+> `Set-ADFSRelyingPartyTrust -TargetName <display-name> -SamlResponseSignature "MessageAndAssertion"`
 
-where `&lt;display-name&gt;` is the name you specified in step 4 when adding a relying party trust. In this example, `&lt;display-name&gt;` would be `mattermost`.
+where `<display-name>` is the name you specified in step 4 when adding a relying party trust. In this example, `<display-name>` would be `mattermost`.
 
 This action adds the signature to SAML messages, making verification successful.
 

--- a/docs/main/administration-guide/onboard/sso-saml-entraid.mdx
+++ b/docs/main/administration-guide/onboard/sso-saml-entraid.mdx
@@ -45,9 +45,9 @@ This page provides guidance on configuring SAML with Microsoft Entra ID for Matt
 9. In the **Mattermost** enterprise application settings, select **Manage > Single sign-on**, then select **SAML** under **Select a single sign-on method**.
 10. Select **Edit** in the **Basic SAML Configuration** section, then set the fields below and select **Save**:
 
-    - **Identifier (Entity ID)**: `https://&lt;your-mattermost-url&gt;`
-    - **Reply URL (Assertion Consumer Service URL)**: `https://&lt;your-mattermost-url&gt;/login/sso/saml`
-    - **Sign on URL**: `https://&lt;your-mattermost-url&gt;/login`
+    - **Identifier (Entity ID)**: `https://<your-mattermost-url>`
+    - **Reply URL (Assertion Consumer Service URL)**: `https://<your-mattermost-url>/login/sso/saml`
+    - **Sign on URL**: `https://<your-mattermost-url>/login`
 
 11. Select **Edit** in the **Attributes & Claims** section, then configure the required claim and additional claims as described below.
 
@@ -128,14 +128,14 @@ This page provides guidance on configuring SAML with Microsoft Entra ID for Matt
 
 1.  In the Mattermost **System Console**, select **Authentication \> SAML 2.0**.
 2.  Set **Enable Login With SAML 2.0** to **True**.
-3.  Set **Identity Provider Metadata URL**: `https://login.microsoftonline.com/&lt;your-tenant-id&gt;/federationmetadata/2007-06/federationmetadata.xml?appid=&lt;your-app-id&gt;`
+3.  Set **Identity Provider Metadata URL**: `https://login.microsoftonline.com/<your-tenant-id>/federationmetadata/2007-06/federationmetadata.xml?appid=<your-app-id>`
 4.  Select **Get SAML Metadata From IdP** to verify that the SAML metadata can be retrieved successfully.
-5.  Set **SAML SSO URL**: `https://login.microsoftonline.com/&lt;your-tenant-id&gt;/saml2`
-6.  Set **Identity Provider Issuer URL** (trailing slash is required): `https://sts.windows.net/&lt;your-tenant-id&gt;/`
+5.  Set **SAML SSO URL**: `https://login.microsoftonline.com/<your-tenant-id>/saml2`
+6.  Set **Identity Provider Issuer URL** (trailing slash is required): `https://sts.windows.net/<your-tenant-id>/`
 7.  Choose the **Identity Provider Public Certificate** file from step 13 of **Set up an enterprise app for Mattermost SSO in Entra ID** then upload.
 8.  Set **Verify Signature** to **True**.
-9.  Set **Service Provider Login URL**: `https://&lt;your-mattermost-url&gt;/login/sso/saml`
-10. Set **Service Provider Identifier**: `https://&lt;your-mattermost-url&gt;`
+9.  Set **Service Provider Login URL**: `https://<your-mattermost-url>/login/sso/saml`
+10. Set **Service Provider Identifier**: `https://<your-mattermost-url>`
 11. Set **Enable Encryption** to **True**.
 12. Choose your **Service Provider Private Key** file then upload. If you used the Bash script referenced in the **Before you begin** section, this is the `mattermost-x509.key` file.
 13. Choose your **Service Provider Public Certificate** then upload. If you used the Bash script referenced in the **Before you begin** section, this is the `mattermost-x509.crt` file.

--- a/docs/main/administration-guide/onboard/sso-saml-okta.mdx
+++ b/docs/main/administration-guide/onboard/sso-saml-okta.mdx
@@ -31,7 +31,7 @@ See the [supported SAML encryption methods](/administration-guide/configure/auth
 
 6.  Enter **SAML Settings**, including:
 
-> - **Single sign on URL:** `https://&lt;your-mattermost-url&gt;/login/sso/saml` where `https://&lt;your-mattermost-url&gt;` should typically match the [Mattermost Site URL](/administration-guide/configure/environment-configuration-settings#site-url).
+> - **Single sign on URL:** `https://<your-mattermost-url>/login/sso/saml` where `https://<your-mattermost-url>` should typically match the [Mattermost Site URL](/administration-guide/configure/environment-configuration-settings#site-url).
 >
 > - **Audience URI:** For instance, `mattermost`
 >

--- a/docs/main/administration-guide/onboard/sso-saml-onelogin.mdx
+++ b/docs/main/administration-guide/onboard/sso-saml-onelogin.mdx
@@ -36,9 +36,9 @@ See the [supported SAML encryption methods](/administration-guide/configure/auth
 >
 > > - **RelayState**: leave blank
 > > - **Audience**: leave blank
-> > - **Recipient**: `https://&lt;your-mattermost-url&gt;/login/sso/saml` where `https://&lt;your-mattermost-url&gt;` should typically match the [Mattermost Site URL](/administration-guide/configure/environment-configuration-settings#site-url).
-> > - **ACS (Consumer) URL Validator**: `https:\/\/&lt;your-mattermost-url&gt;\/login\/sso\/saml`
-> > - **ACS (Consumer) URL**: `https://&lt;your-mattermost-url&gt;/login/sso/saml`
+> > - **Recipient**: `https://<your-mattermost-url>/login/sso/saml` where `https://<your-mattermost-url>` should typically match the [Mattermost Site URL](/administration-guide/configure/environment-configuration-settings#site-url).
+> > - **ACS (Consumer) URL Validator**: `https:\/\/<your-mattermost-url>\/login\/sso\/saml`
+> > - **ACS (Consumer) URL**: `https://<your-mattermost-url>/login/sso/saml`
 >
 > ![In OneLogin, select the Configuration tab to configure the SSO integration with required values.](/images/onelogin_3_configuration_1.png)
 >
@@ -140,7 +140,7 @@ See the [supported SAML encryption methods](/administration-guide/configure/auth
 2.  Configure Mattermost to verify the signature.
 
 > 1.  In the **Verify Signature** field, select **True**.
-> 2.  In the **Service Provider Login URL**, enter `https//&lt;your-mattermost-url&gt;/login/sso/saml`.
+> 2.  In the **Service Provider Login URL**, enter `https//<your-mattermost-url>/login/sso/saml`.
 >
 > ![On the System Console SAML page, enable the Verify Signature option by setting it to true, then enter your specific Service Provider Login URL based on your Mattermost URL](/images/okta_11_mattermost_verification.png)
 

--- a/docs/main/administration-guide/onboard/sso-saml-onelogin.mdx
+++ b/docs/main/administration-guide/onboard/sso-saml-onelogin.mdx
@@ -140,7 +140,7 @@ See the [supported SAML encryption methods](/administration-guide/configure/auth
 2.  Configure Mattermost to verify the signature.
 
 > 1.  In the **Verify Signature** field, select **True**.
-> 2.  In the **Service Provider Login URL**, enter `https//<your-mattermost-url>/login/sso/saml`.
+> 2.  In the **Service Provider Login URL**, enter `https://<your-mattermost-url>/login/sso/saml`.
 >
 > ![On the System Console SAML page, enable the Verify Signature option by setting it to true, then enter your specific Service Provider Login URL based on your Mattermost URL](/images/okta_11_mattermost_verification.png)
 

--- a/docs/main/administration-guide/scale/collect-performance-metrics.mdx
+++ b/docs/main/administration-guide/scale/collect-performance-metrics.mdx
@@ -60,7 +60,7 @@ Once you set this up, run `docker-compose` as described in [Dockprom Repository]
 
 You can also use our [Mattermost Performance Monitoring v2](https://grafana.com/grafana/dashboards/15582-mattermost-performance-monitoring-v2/) dashboard by simply importing it into Grafana.
 
-1.  Open Grafana (`&lt;localhost&gt;:3000` by default) and then log into it.
+1.  Open Grafana (`<localhost>:3000` by default) and then log into it.
 2.  Once you log in, go to the **Plus** <img src={useBaseUrl('/img/ui/plus_F0415.svg')} alt="The Plus icon provides access to channel and direct message functionality." className="theme-icon" /> icon on the left sidebar, and then select **Import**.
 3.  Enter the dashboard ID (`15582`) in the **Grafana.com Dashboard** field, and then select **Load** to fetch the dashboard.
 

--- a/docs/main/administration-guide/scale/deploy-grafana-loki-for-centralized-logging.mdx
+++ b/docs/main/administration-guide/scale/deploy-grafana-loki-for-centralized-logging.mdx
@@ -261,7 +261,7 @@ Replace `<LOKI_HOST>` with the IP address or hostname of your monitoring server,
 
 ## Step 4: Add Loki as a data source in Grafana
 
-1.  Log in to Grafana (default: `http://&lt;monitoring-server&gt;:3000`).
+1.  Log in to Grafana (default: `http://<monitoring-server>:3000`).
 2.  Navigate to **Administration \> Data Sources \> Add data source**.
 3.  Select **Loki** from the list.
 4.  Configure the connection:

--- a/docs/main/administration-guide/scale/deploy-prometheus-grafana-for-performance-monitoring.mdx
+++ b/docs/main/administration-guide/scale/deploy-prometheus-grafana-for-performance-monitoring.mdx
@@ -58,13 +58,13 @@ While Prometheus and Grafana may be installed on the same server as Mattermost, 
           - targets: ["<hostname1>:<port>", "<hostname2>:<port>"]
     ```
 
-3.  Replace the `&lt;hostname1&gt;:&lt;port&gt;` parameter with your Mattermost host IP address and port to scrape the data. It connects to `/metrics` using HTTP.
+3.  Replace the `<hostname1>:<port>` parameter with your Mattermost host IP address and port to scrape the data. It connects to `/metrics` using HTTP.
 
 4.  In the Mattermost System Console, go to **Environment \> Performance Monitoring** to set **Enable Performance Monitoring** to **true**, then specify the **Listen Address** (port-only, e.g., `8067`), and select **Save**. See our [Configuration Settings](/administration-guide/configure/environment-configuration-settings#performance-monitoring) documentation for details.
 
     ![Enable performance monitoring options in the System Console by going to Environment \> Performance Monitoring, then specifying a listen address.](/images/perf_monitoring_system_console.png)
 
-5.  To test that the server is running, go to `&lt;ip&gt;:&lt;port&gt;/metrics`.
+5.  To test that the server is running, go to `<ip>:<port>/metrics`.
 
 <Note>
 
@@ -73,7 +73,7 @@ A Mattermost Enterprise license is required to connect to `/metrics` using HTTP.
 </Note>
 
 6.  Finally, run `vi prometheus.yml` to finish configuring Prometheus. For starting the Prometheus service, read the [comprehensive guides provided by Prometheus](https://prometheus.io/docs/prometheus/latest/getting_started/).
-7.  Once the service has started, you can access the data in `&lt;localhost&gt;:&lt;port&gt;/graph`. While you can use the Prometheus service to create graphs, we'll focus on creating metric and analytics dashboards in Grafana.
+7.  Once the service has started, you can access the data in `<localhost>:<port>/graph`. While you can use the Prometheus service to create graphs, we'll focus on creating metric and analytics dashboards in Grafana.
 
 <Tip>
 

--- a/docs/main/administration-guide/scale/performance-monitoring-metrics.mdx
+++ b/docs/main/administration-guide/scale/performance-monitoring-metrics.mdx
@@ -236,9 +236,9 @@ A Mattermost Enterprise license is required to connect to `/metrics` using HTTP.
 
 If enabled, you can run the profiler by
 
-`go tool pprof http://localhost:&lt;port&gt;/debug/pprof/profile?seconds=&lt;duration&gt;`
+`go tool pprof http://localhost:<port>/debug/pprof/profile?seconds=<duration>`
 
-where you can replace `localhost` with the server name. The profiling reports are available at `&lt;ip&gt;:&lt;port&gt;`, which include:
+where you can replace `localhost` with the server name. The profiling reports are available at `<ip>:<port>`, which include:
 
 - `/debug/pprof/profile?seconds=30` for CPU profiling
 - `/debug/pprof/cmdline` for command line profiling

--- a/docs/main/administration-guide/upgrade/upgrade-mattermost-kubernetes-ha.mdx
+++ b/docs/main/administration-guide/upgrade/upgrade-mattermost-kubernetes-ha.mdx
@@ -85,7 +85,7 @@ This step involves updating the Mattermost Operator and Mattermost server to a n
 
 We recommend having a separate Mattermost custom resource. See the [Deploy Mattermost on Kubernetes](/deployment-guide/server/deploy-kubernetes) documentation for details.
 
-1.  In the separate resource, update the `version` field in your `mattermost-installation.yaml` file by replacing the `&lt;new-version-tag&gt;` with the specific version you are upgrading to:
+1.  In the separate resource, update the `version` field in your `mattermost-installation.yaml` file by replacing the `<new-version-tag>` with the specific version you are upgrading to:
 
 > ``` yaml
 > apiVersion: installation.mattermost.com/v1beta1

--- a/docs/main/deployment-guide/calls/calls-deployment-guide.mdx
+++ b/docs/main/deployment-guide/calls/calls-deployment-guide.mdx
@@ -323,7 +323,7 @@ Before moving to Step 1.5, confirm the following:
 
 - [ ] Every required server or VM has been created.
 - [ ] Every required server has the IP address or DNS name you plan to use later in configuration.
-- [ ] You have administrative access to every required server. (validate with `ssh &lt;user&gt;@<SERVER_IP>`)
+- [ ] You have administrative access to every required server. (validate with `ssh <user>@<SERVER_IP>`)
 
 ### 1.5 Network Configuration
 

--- a/docs/main/deployment-guide/calls/calls-offloader-setup.mdx
+++ b/docs/main/deployment-guide/calls/calls-offloader-setup.mdx
@@ -462,7 +462,7 @@ curl http://localhost:4545/version
 
 ### Connecting to Mattermost
 
-Configure the Mattermost Calls plugin to use the offloader service via **System Console > Plugins > Calls > Job service URL**, setting it to `http://&lt;offloader-host&gt;:4545`.
+Configure the Mattermost Calls plugin to use the offloader service via **System Console > Plugins > Calls > Job service URL**, setting it to `http://<offloader-host>:4545`.
 
 > [!NOTE]
 > The first time Mattermost connects to the offloader it will self-register and store its authentication key in the database, provided `API_SECURITY_ALLOWSELFREGISTRATION=true` is set (the default in the deployment script).

--- a/docs/main/deployment-guide/desktop/desktop-msi-installer-and-group-policy-install.mdx
+++ b/docs/main/deployment-guide/desktop/desktop-msi-installer-and-group-policy-install.mdx
@@ -221,7 +221,7 @@ Ensure the desktop app is closed before proceeding with a silent installation. B
 
 <Note>
 
-\- Replace `&lt;version&gt;` with the actual version number (e.g., `v6.3.0`). - From v6.1.0, the MSI installs per-machine by default, requiring administrator privileges.
+\- Replace `<version>` with the actual version number (e.g., `v6.3.0`). - From v6.1.0, the MSI installs per-machine by default, requiring administrator privileges.
 
 </Note>
 
@@ -231,8 +231,8 @@ From version v5.9.0 of the Mattermost desktop app, the following silent MSI inst
 
 Use the `APPLICATIONFOLDER` parameter to specify an installation directory for the MSI installation:
 
-- **Command Prompt:** `msiexec /i mattermost-desktop-v6.3.0-x64.msi APPLICATIONFOLDER="&lt;install directory&gt;"`
-- **PowerShell:** `Start-Process -FilePath "$env:systemroot\system32\msiexec.exe" -ArgumentList '/i mattermost-desktop-v6.3.0-x64.msi APPLICATIONFOLDER="&lt;install directory&gt;"'`
+- **Command Prompt:** `msiexec /i mattermost-desktop-v6.3.0-x64.msi APPLICATIONFOLDER="<install directory>"`
+- **PowerShell:** `Start-Process -FilePath "$env:systemroot\system32\msiexec.exe" -ArgumentList '/i mattermost-desktop-v6.3.0-x64.msi APPLICATIONFOLDER="<install directory>"'`
 
 Change this command as new versions of the Mattermost Desktop App are released.
 

--- a/docs/main/deployment-guide/desktop/desktop-troubleshooting.mdx
+++ b/docs/main/deployment-guide/desktop/desktop-troubleshooting.mdx
@@ -22,9 +22,9 @@ Organizations standardizing on Windows installations can choose between Windows 
 
 The location of the Mattermost desktop app configuration file depends on the platform where you're running Mattermost (and, in the case of macOS, how you've chosen to install the app):
 
-- Windows: `Users\&lt;username&gt;\AppData\Roaming\Mattermost`
-- macOS installer: `/Users/&lt;username&gt;/Library/Application Support/Mattermost`
-- macOS App Store: `/Users/&lt;username&gt;/Library/Containers/Mattermost.Desktop/Data/Library/Application Support/Mattermost` (via Finder: `~/Library/Application Support/Mattermost` as the extension is hidden)
+- Windows: `Users\<username>\AppData\Roaming\Mattermost`
+- macOS installer: `/Users/<username>/Library/Application Support/Mattermost`
+- macOS App Store: `/Users/<username>/Library/Containers/Mattermost.Desktop/Data/Library/Application Support/Mattermost` (via Finder: `~/Library/Application Support/Mattermost` as the extension is hidden)
 - Linux: `~/.config/Mattermost`
 
 <Note>

--- a/docs/main/deployment-guide/mobile/mobile-faq.mdx
+++ b/docs/main/deployment-guide/mobile/mobile-faq.mdx
@@ -246,7 +246,7 @@ The app checks for platform-specific configuration on app install. If no configu
 
 **Set up for iOS**
 
-1.  Create an `apple-app-site-association` file in the `.well-known` directory at the root of your server. It should be accessible by navigating to `https://&lt;your-site-name&gt;/.well-known/apple-app-site-association`. There should not be a file extension.
+1.  Create an `apple-app-site-association` file in the `.well-known` directory at the root of your server. It should be accessible by navigating to `https://<your-site-name>/.well-known/apple-app-site-association`. There should not be a file extension.
 2.  In order to handle deep links, paste the following `JSON` into the `apple-app-site-association` file. Make sure to place your app ID in the `appID` property:
 
 {/* */}
@@ -265,7 +265,7 @@ The app checks for platform-specific configuration on app install. If no configu
 
 3.  Add the associated domains entitlement to your app via the Apple developer portal.
 4.  Add an entitlement that specifies the domains your app supports via the Xcode entitlements manager.
-5.  Before installing the app with the new entitlement, make sure that you can view the contents of the `apple-app-site-association` file via a browser by navigating to `https://&lt;your-site-name&gt;/.well-known/apple-app-site-association`. The app will check for this file on install and, if found, will allow outside permalinks to open the app.
+5.  Before installing the app with the new entitlement, make sure that you can view the contents of the `apple-app-site-association` file via a browser by navigating to `https://<your-site-name>/.well-known/apple-app-site-association`. The app will check for this file on install and, if found, will allow outside permalinks to open the app.
 
 Official documentation for configuring deep linking on iOS can be found [here](https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html).
 

--- a/docs/main/deployment-guide/quick-start-evaluation.mdx
+++ b/docs/main/deployment-guide/quick-start-evaluation.mdx
@@ -54,7 +54,7 @@ On **Virtual Machine Settings** tab, configure the following:
 2.  **Public IP address:** Typically **create new**. You must set a **DNS prefix** (label) that is **globally unique** in Azure; it forms part of your URL. This DNS will allow public access to your workspace. It is important that you do not already have a matching DNS name within your Azure subscription, or your deployment may fail later in the process.
 3.  **Virtual network:** **Create new** with the suggested address space, or attach an existing VNet and subnet that meet the constraints. Using a new virtual network avoids collisions with overlapping address spaces in the same subscription.
 
-The portal may show a preview of your URL in the form `https://&lt;dns-label&gt;.&lt;region&gt;.cloudapp.azure.com`. That is the address you will use once TLS and Mattermost are ready.
+The portal may show a preview of your URL in the form `https://<dns-label>.<region>.cloudapp.azure.com`. That is the address you will use once TLS and Mattermost are ready.
 
 ## Step 4: Review and create
 
@@ -64,11 +64,11 @@ Review settings, accept any **Marketplace** terms if prompted, then select **Cre
 
 - In the Azure portal, open the **resource group** you used.
 
-- Open the **Public IP address** resource (often named `&lt;your-vm-name&gt;-ip` unless you changed it).
+- Open the **Public IP address** resource (often named `<your-vm-name>-ip` unless you changed it).
 
 - Under **Essentials**, note the **DNS name**. Your site URL is:
 
-  `https://&lt;dns-label&gt;.&lt;region&gt;.cloudapp.azure.com`
+  `https://<dns-label>.<region>.cloudapp.azure.com`
 
   Example: `https://myorg.eastus.cloudapp.azure.com`
 

--- a/docs/main/end-user-guide/collaborate/share-links.mdx
+++ b/docs/main/end-user-guide/collaborate/share-links.mdx
@@ -71,7 +71,7 @@ From Mattermost v10.11, [channel bookmarks](/end-user-guide/collaborate/manage-c
 
 Deep links must be formatted in Mattermost as follows:
 
-- Deep link to a team: `mattermost://<your-Mattermost-server-URL>/&lt;team-name&gt;`
-- Deep link to a channel: `mattermost://<your-Mattermost-server-URL>/&lt;team-name&gt;/channels/&lt;channel-name&gt;`
-- Deep link to a channel message or thread: `mattermost://<your-Mattermost-server-URL>/&lt;team-name&gt;/pl/&lt;post-id&gt;`
-- Deep link to a direct message: `mattermost://<your-Mattermost-server-URL>/&lt;team-name&gt;/messages/@&lt;user-name&gt;`
+- Deep link to a team: `mattermost://<your-Mattermost-server-URL>/<team-name>`
+- Deep link to a channel: `mattermost://<your-Mattermost-server-URL>/<team-name>/channels/<channel-name>`
+- Deep link to a channel message or thread: `mattermost://<your-Mattermost-server-URL>/<team-name>/pl/<post-id>`
+- Deep link to a direct message: `mattermost://<your-Mattermost-server-URL>/<team-name>/messages/@<user-name>`

--- a/docs/main/end-user-guide/project-management/migrate-to-boards.mdx
+++ b/docs/main/end-user-guide/project-management/migrate-to-boards.mdx
@@ -81,7 +81,7 @@ git clone https://github.com/mattermost/focalboard focalboard
 6.  Run `npm install`.
 7.  Change directory to `focalboard/import/notion`.
 8.  Run `npm install`.
-9.  From within the same folder, run `npx ts-node importNotion.ts -i &lt;path to the notion-export folder&gt; -o archive.boardarchive`.
+9.  From within the same folder, run `npx ts-node importNotion.ts -i <path to the notion-export folder> -o archive.boardarchive`.
 10. In Boards, open the board you want to use for the export.
 11. Select **Settings \> Import archive** and select `archive.boardarchive`.
 12. Select **Upload**.

--- a/docs/main/integrations-guide/incoming-webhooks.mdx
+++ b/docs/main/integrations-guide/incoming-webhooks.mdx
@@ -180,7 +180,7 @@ Mattermost automatically translates JSON payloads from Slack format:
 
 - `[https://mattermost.com/](https://mattermost.com/)` is rendered as a link.
 - `<https://mattermost.com/|Click here>` is rendered as linked text.
-- `&lt;userid&gt;` triggers a user mention.
+- `<userid>` triggers a user mention.
 - `<!channel>`, `<!here>`, or `<!all>` trigger channel-wide mentions.
 
 You can also send a direct message by overriding the channel name with `@username`, e.g., `"channel": "@jim"`.

--- a/docs/main/integrations-guide/jira.mdx
+++ b/docs/main/integrations-guide/jira.mdx
@@ -192,7 +192,7 @@ Use the `/jira issue create` slash command to create a Jira issue without leavin
 
 #### Transition Jira issues
 
-You can transition issues without leaving Mattermost by using the `/jira transition &lt;issue-key&gt; &lt;state&gt;` slash command. States and issue transitions are based on your Jira project workflow configuration. For example, `/jira transition EXT-20 done` transitions the issue key EXT-20 to a `done` state. Partial matches are supported. For example, running the `/jira transition EXT-20 in` slash command transitions the issue to an `in progress` state. However, if your Jira instance includes states of both `in review` and `in progress`, the Jira integration bot will prompt you to clarify which state you want.
+You can transition issues without leaving Mattermost by using the `/jira transition <issue-key> <state>` slash command. States and issue transitions are based on your Jira project workflow configuration. For example, `/jira transition EXT-20 done` transitions the issue key EXT-20 to a `done` state. Partial matches are supported. For example, running the `/jira transition EXT-20 in` slash command transitions the issue to an `in progress` state. However, if your Jira instance includes states of both `in review` and `in progress`, the Jira integration bot will prompt you to clarify which state you want.
 
 #### Assign Jira issues
 

--- a/docs/main/product-overview/desktop-app-changelog.mdx
+++ b/docs/main/product-overview/desktop-app-changelog.mdx
@@ -328,7 +328,7 @@ Mattermost Desktop App v6.0.0 contains low severity level security fixes. Upgrad
 
 - Sometimes the app will not restart after an auto-update. This is normal, and if this occurs the app can be safely launched manually.
 - Sometimes during installation you may see this message: ``Warning 1946. Property 'System.AppUserModel.ID' for shortcut 'Mattermost.Ink' could not be set``. This message can be safely ignored.
-- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/&lt;username&gt;/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/&lt;username&gt;/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
+- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/<username>/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/<username>/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
 - On Linux, a left-click on the Mattermost tray icon doesn't open the app window but opens the tray menu.
 - Crashes might be experienced in some Linux desktop clients due to an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the Mattermost system tray icon via Desktop Settings.
 
@@ -409,7 +409,7 @@ Mattermost Desktop App v6.0.0 contains low severity level security fixes. Upgrad
 
 - Sometimes the app will not restart after an auto-update. This is normal, and if this occurs the app can be safely launched manually.
 - Sometimes during installation you may see this message: ``Warning 1946. Property 'System.AppUserModel.ID' for shortcut 'Mattermost.Ink' could not be set``. This message can be safely ignored.
-- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/&lt;username&gt;/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/&lt;username&gt;/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
+- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/<username>/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/<username>/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
 - On Linux, a left-click on the Mattermost tray icon doesn't open the app window but opens the tray menu.
 - Crashes might be be experienced in some Linux desktop clients due to an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the Mattermost system tray icon via Desktop Settings.
 - On apps using GPO configurations, when adding a second server tab, it's possible to drag and drop tabs, but they'll jump back to the original position when releasing the mouse.
@@ -470,7 +470,7 @@ Mattermost Desktop App v5.12.0 contains a medium severity level security fix. Up
 
 - Sometimes the app will not restart after an auto-update. This is normal, and if this occurs the app can be safely launched manually.
 - Sometimes during installation you may see this message: ``Warning 1946. Property 'System.AppUserModel.ID' for shortcut 'Mattermost.Ink' could not be set``. This message can be safely ignored.
-- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/&lt;username&gt;/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/&lt;username&gt;/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
+- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/<username>/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/<username>/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
 - On Linux, a left-click on the Mattermost tray icon doesn't open the app window but opens the tray menu.
 - Crashes might be be experienced in some Linux desktop clients due to an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the Mattermost system tray icon via Desktop Settings.
 - On apps using GPO configurations, when adding a second server tab, it's possible to drag and drop tabs, but they'll jump back to the original position when releasing the mouse.
@@ -562,7 +562,7 @@ Mattermost Desktop App v5.11.0 contains a low severity level security fix. Upgra
 - Boards is not using the new Desktop API, causing issues in v5.11+. Users of v5.11 will need to upgrade their Boards plugin version to v9.1.0+ avoid the issue.
 - Sometimes the app will not restart after an auto-update. This is normal, and if this occurs the app can be safely launched manually.
 - Sometimes during installation you may see this message: ``Warning 1946. Property 'System.AppUserModel.ID' for shortcut 'Mattermost.Ink' could not be set``. This message can be safely ignored.
-- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/&lt;username&gt;/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/&lt;username&gt;/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
+- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/<username>/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/<username>/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
 - On Linux, a left-click on the Mattermost tray icon doesn't open the app window but opens the tray menu.
 - Crashes might be be experienced in some Linux desktop clients due to an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the Mattermost system tray icon via Desktop Settings.
 - On apps using GPO configurations, when adding a second server tab, it's possible to drag and drop tabs, but they'll jump back to the original position when releasing the mouse.
@@ -655,7 +655,7 @@ Mattermost Desktop App v5.10.0 contains a low severity level security fix. Upgra
 - Clicking on links does not put the Desktop app in the background to show the external browser.
 - Sometimes the app will not restart after an auto-update. This is normal, and if this occurs the app can be safely launched manually.
 - Sometimes during installation you may see this message: ``Warning 1946. Property 'System.AppUserModel.ID' for shortcut 'Mattermost.Ink' could not be set``. This message can be safely ignored.
-- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/&lt;username&gt;/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/&lt;username&gt;/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
+- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/<username>/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/<username>/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
 - On Linux, a left-click on the Mattermost tray icon doesn't open the app window but opens the tray menu.
 - Crashes might be be experienced in some Linux desktop clients due to an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the Mattermost system tray icon via Desktop Settings.
 - On apps using GPO configurations, when adding a second server tab, it's possible to drag and drop tabs, but they'll jump back to the original position when releasing the mouse.
@@ -739,7 +739,7 @@ v5.9.0 is the first Extended Support Release for the Desktop App. See more detai
 
 - Sometimes the app will not restart after an auto-update. This is normal, and if this occurs the app can be safely launched manually.
 - Sometimes during installation you may see this message: ``Warning 1946. Property 'System.AppUserModel.ID' for shortcut 'Mattermost.Ink' could not be set``. This message can be safely ignored.
-- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/&lt;username&gt;/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/&lt;username&gt;/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
+- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/<username>/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/<username>/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
 - On Linux, a left-click on the Mattermost tray icon doesn't open the app window but opens the tray menu.
 - Crashes might be be experienced in some Linux desktop clients due to an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the Mattermost system tray icon via Desktop Settings.
 - On apps using GPO configurations, when adding a second server tab, it's possible to drag and drop tabs, but they'll jump back to the original position when releasing the mouse.
@@ -807,7 +807,7 @@ Mattermost v5.8.0 contains low to medium severity level security fixes. Upgradin
 ### Known Issues
 
 - Desktop App Windows 10: The taskbar might not flash on receipt of a new message when the setting is enabled.
-- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/&lt;username&gt;/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/&lt;username&gt;/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
+- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/<username>/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/<username>/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
 - On Linux, a left-click on the Mattermost tray icon doesn't open the app window but opens the tray menu.
 - Crashes might be be experienced in some Linux desktop clients due to an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the Mattermost system tray icon via Desktop Settings.
 - On apps using GPO configurations, when adding a second server tab, it's possible to drag and drop tabs, but they'll jump back to the original position when releasing the mouse.
@@ -858,7 +858,7 @@ Mattermost v5.8.0 contains low to medium severity level security fixes. Upgradin
 
 - Error might be experienced when quitting v5.7 desktop app on macOS Ventura.
 - In the **Settings** modal, the search text in the **Check spelling** dropdown is not visible.
-- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/&lt;username&gt;/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/&lt;username&gt;/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
+- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/<username>/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/<username>/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
 - On Linux, a left-click on the Mattermost tray icon doesn't open the app window but opens the tray menu.
 - Crashes might be be experienced in some Linux desktop clients due to an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the Mattermost system tray icon via Desktop Settings.
 - On apps using GPO configurations, when adding a second server tab, it's possible to drag and drop tabs, but they'll jump back to the original position when releasing the mouse.
@@ -913,7 +913,7 @@ Mattermost v5.8.0 contains low to medium severity level security fixes. Upgradin
 
 ### Known Issues
 
-- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/&lt;username&gt;/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/&lt;username&gt;/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
+- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/<username>/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/<username>/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
 - On Linux, a left-click on the Mattermost tray icon doesn't open the app window but opens the tray menu.
 - Crashes might be be experienced in some Linux desktop clients due to an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the Mattermost system tray icon via Desktop Settings.
 - On apps using GPO configurations, when adding a second server tab, it's possible to drag and drop tabs, but they'll jump back to the original position when releasing the mouse.
@@ -971,7 +971,7 @@ Mattermost v5.5.0 contains a medium severity level security fix. Upgrading is hi
 ### Known Issues
 
 - Users are unable to login to Desktop app v5.5 on servers with subpaths.
-- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/&lt;username&gt;/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/&lt;username&gt;/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
+- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually delete their cache directory. For macOS it is located in `/Users/<username>/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost`, for Windows in `Users/<username>/AppData/Roaming/Mattermost` and for Linux in `~/config/Mattermost` (where `~` is the home directory).
 - On Linux, a left-click on the Mattermost tray icon doesn't open the app window but opens the tray menu.
 - Crashes might be be experienced in some Linux desktop clients due to an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the Mattermost system tray icon via Desktop Settings.
 - On apps using GPO configurations, when adding a second server tab, it's possible to drag and drop tabs, but they'll jump back to the original position when releasing the mouse.
@@ -1021,7 +1021,7 @@ Mattermost v5.5.0 contains a medium severity level security fix. Upgrading is hi
 
 - Mattermost is not detected in the **Add Server** screen if the server has plugins disabled.
 - When running "Run Diagnostics" from the **Help** menu, the app crashes.
-- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually remove their cache directory. For macOS it is located in `/Users/&lt;username&gt;/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost` and for Windows it is located in `Users/&lt;username&gt;/AppData/Roaming/Mattermost`.
+- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually remove their cache directory. For macOS it is located in `/Users/<username>/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost` and for Windows it is located in `Users/<username>/AppData/Roaming/Mattermost`.
 - On Linux, a left-click on the Mattermost tray icon doesn't open the app window but opens the tray menu.
 - Crashes might be be experienced in some Linux desktop clients due to an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the Mattermost system tray icon via Desktop Settings.
 - On apps using GPO configurations, when adding a second server tab, it's possible to drag and drop tabs, but they'll jump back to the original position when releasing the mouse.
@@ -1094,7 +1094,7 @@ Mattermost v5.3.0 contains a medium severity level security fix. Upgrading is hi
 
 ### Known Issues
 
-- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually remove their cache directory. For macOS it is located in `/Users/&lt;username&gt;/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost` and for Windows it is located in `Users/&lt;username&gt;/AppData/Roaming/Mattermost`.
+- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually remove their cache directory. For macOS it is located in `/Users/<username>/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost` and for Windows it is located in `Users/<username>/AppData/Roaming/Mattermost`.
 - On Linux, a left-click on the Mattermost tray icon doesn't open the app window but opens the tray menu.
 - Crashes might be be experienced in some Linux desktop clients due to an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the Mattermost system tray icon via Desktop Settings.
 - On apps using GPO configurations, when adding a second server tab, it's possible to drag and drop tabs, but they'll jump back to the original position when releasing the mouse.
@@ -1187,7 +1187,7 @@ Mattermost v5.3.0 contains a medium severity level security fix. Upgrading is hi
 
 ### Known Issues
 
-- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually remove their cache directory. For macOS it is located in `/Users/&lt;username&gt;/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost` and for Windows it is located in `Users/&lt;username&gt;/AppData/Roaming/Mattermost`.
+- Users seeing an endless "Loading..." screen when attempting to log in to the app may need to manually remove their cache directory. For macOS it is located in `/Users/<username>/Library/Containers/Mattermost/Data/Library/Application Support/Mattermost` and for Windows it is located in `Users/<username>/AppData/Roaming/Mattermost`.
 - On Linux, a left click on the tray icon doesn't open the app window but opens the tray menu.
 - Crashes might be be experienced in some Linux desktop clients. This is an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the system tray icon in the Desktop settings.
 - On apps using GPO configurations, when adding a second server tab, it's possible to drag and drop tabs, but they'll jump back to the original position when releasing the mouse.
@@ -1380,7 +1380,7 @@ Mattermost v5.0.0 contains a low level security fix. Upgrading is highly recomme
 #### Linux
 
 - Fixed the tray icon size on Linux.
-- Fixed an issue where pressing `Alt+&lt;somekey&gt;` could cause the menu bar to disable and overlap the top bar on Linux.
+- Fixed an issue where pressing `Alt+<somekey>` could cause the menu bar to disable and overlap the top bar on Linux.
 
 #### All Platforms
 
@@ -1392,7 +1392,7 @@ Mattermost v5.0.0 contains a low level security fix. Upgrading is highly recomme
 
 - Unread messages icon may be missing from the taskbar on Windows following 4.7.0 upgrade.
 - Crashes might be be experienced in some Linux desktop clients. This is an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the system tray icon in the Desktop settings.
-- On some Linux distros, a sandbox setting is preventing apps from opening links in the browser (see https://github.com/electron/electron/issues/17972#issuecomment-486927073). While this is fixed for most installers, it is not on the tgz. In this case manual intervention is required via `$ chmod 4755 &lt;installpath&gt;/chrome-sandbox`.
+- On some Linux distros, a sandbox setting is preventing apps from opening links in the browser (see https://github.com/electron/electron/issues/17972#issuecomment-486927073). While this is fixed for most installers, it is not on the tgz. In this case manual intervention is required via `$ chmod 4755 <installpath>/chrome-sandbox`.
 - Pressing Enter multiple times during Basic Authentication causes a crash.
 - On apps using GPO configurations, when adding a second server tab, it is possible to drag and drop tabs but they will jump back to the original position when releasing the mouse.
 
@@ -1504,7 +1504,7 @@ Mattermost v4.7.0 contains low to medium level security fixes. Upgrading is high
 - The `create_desktop_file.sh` script is removed from the .tar.gz release. As a workaround, it can be downloaded from [GitHub here](https://github.com/mattermost/desktop/blob/master/src/assets/linux/create_desktop_file.sh).
 - An error may occur when installing the MSI Installer on any Windows version.
 - Crashes might be be experienced in some Linux desktop clients. This is an upstream bug in the `libnotifyapp` library. A recommended workaround is to disable the system tray icon in the Desktop settings.
-- On some Linux distros, a sandbox setting is preventing apps from opening links in the browser (see https://github.com/electron/electron/issues/17972#issuecomment-486927073). While this is fixed for most installers, it is not on the tgz. In this case manual intervention is required via `$ chmod 4755 &lt;installpath&gt;/chrome-sandbox`.
+- On some Linux distros, a sandbox setting is preventing apps from opening links in the browser (see https://github.com/electron/electron/issues/17972#issuecomment-486927073). While this is fixed for most installers, it is not on the tgz. In this case manual intervention is required via `$ chmod 4755 <installpath>/chrome-sandbox`.
 - Pressing Enter multiple times during Basic Authentication causes a crash.
 - On apps using GPO configurations, when adding a second server tab, it is possible to drag and drop tabs but they will jump back to the original position when releasing the mouse.
 
@@ -1559,7 +1559,7 @@ Mattermost v4.7.0 contains low to medium level security fixes. Upgrading is high
 - Unlocking the Desktop App on macOS marks the currently viewed channel as read.
 - On Ubuntu, auto-focus is lost when using ALT+TAB to switch between windows.
 - Crashes might be be experienced in some Linux desktop clients. This is an upstream bug in the `libnotifyapp` library and a recommended workaround is to disable the system tray icon in the Desktop settings.
-- On some Linux distros, a sandbox setting is preventing apps from opening links in the browser (see https://github.com/electron/electron/issues/17972#issuecomment-486927073). While this is fixed for most installers, it is not on the tgz. In this case manual intervention is required via `$ chmod 4755 &lt;installpath&gt;/chrome-sandbox`.
+- On some Linux distros, a sandbox setting is preventing apps from opening links in the browser (see https://github.com/electron/electron/issues/17972#issuecomment-486927073). While this is fixed for most installers, it is not on the tgz. In this case manual intervention is required via `$ chmod 4755 <installpath>/chrome-sandbox`.
 - Pressing Enter multiple times during Basic Authentication causes a crash.
 - On apps using GPO configurations, when adding a second server tab, it is possible to drag and drop tabs but they will jump back to the original position when releasing the mouse.
 
@@ -1646,7 +1646,7 @@ Many thanks to all our contributors. In alphabetical order:
 - Double notifications are received on Ubuntu for at-mentions.
 - The current window frame and server tabs are not styled consistently with the rest of the OS in Windows 7 or Linux.
 - Crashes might be be experienced in some linux desktop clients. This is an upstream bug in the `libnotifyapp` library and a recommended workaround is to disable the system tray icon in the Desktop settings.
-- On some Linux distros, a sandbox setting is preventing apps from opening links in the browser (see https://github.com/electron/electron/issues/17972#issuecomment-486927073). While this is fixed for most installers, it is not on the tgz. In this case manual intervention is required via `$ chmod 4755 &lt;installpath&gt;/chrome-sandbox`.
+- On some Linux distros, a sandbox setting is preventing apps from opening links in the browser (see https://github.com/electron/electron/issues/17972#issuecomment-486927073). While this is fixed for most installers, it is not on the tgz. In this case manual intervention is required via `$ chmod 4755 <installpath>/chrome-sandbox`.
 - Pressing Enter multiple times during Basic Authentication causes a crash.
 - On apps using GPO configurations, when adding a second server tab, it is possible to drag and drop tabs but they will jump back to the original position when releasing the mouse.
 
@@ -1731,7 +1731,7 @@ Mattermost v4.4.0 contains low to medium level security fixes. [Upgrading](https
 - The current window frame and server tabs are not styled consistently with the rest of the OS in Windows 7 or Linux.
 - No notification on Windows if the app is closed on the channel where the message is posted.
 - Crashes might be be experienced in some linux desktop clients. This is an upstream bug in the `libnotifyapp` library and a recommended workaround is to disable the system tray icon in the Desktop settings.
-- On some Linux distros, a sandbox setting is preventing apps from opening links in the browser (see https://github.com/electron/electron/issues/17972#issuecomment-486927073). While this is fixed for most installers, it is not on the tgz. In this case manual intervention is required via `$ chmod 4755 &lt;installpath&gt;/chrome-sandbox`.
+- On some Linux distros, a sandbox setting is preventing apps from opening links in the browser (see https://github.com/electron/electron/issues/17972#issuecomment-486927073). While this is fixed for most installers, it is not on the tgz. In this case manual intervention is required via `$ chmod 4755 <installpath>/chrome-sandbox`.
 - Pressing Enter multiple times during Basic Authentication causes a crash.
 - The confirmation dialog from UAC names MSI installers with random numbers.
 - On apps using GPO configurations, when adding a second server tab, it is possible to drag and drop tabs but they will jump back to the original position when releasing the mouse.

--- a/docs/main/product-overview/mattermost-v10-changelog.mdx
+++ b/docs/main/product-overview/mattermost-v10-changelog.mdx
@@ -1305,7 +1305,7 @@ If you upgrade from a release earlier than v10.0, please read the other [Importa
  - Added full support for @mentions in the values of fields in [message attachments](https://developers.mattermost.com/integrate/reference/message-attachments/).
 
 #### Administration
- - Added a new URL parameter called ``permanent`` to ``DELETE /api/v4/posts/&lt;post-id&gt;``, and set ``permanent`` to ``true`` in order to permanently delete a post and its attachments.
+ - Added a new URL parameter called ``permanent`` to ``DELETE /api/v4/posts/<post-id>``, and set ``permanent`` to ``true`` in order to permanently delete a post and its attachments.
  - Added Connected Workspaces (Beta) administration page to the System Console when Connected Workspaces are [enabled](https://docs.mattermost.com/onboard/connected-workspaces.html#enable-connected-workflows) for the server.
  - Added a team selector to accept connection invite flow in Connected Workspaces.
  - Restricted activation and deactivation of LDAP-managed users through both the System Console UI and Mattermost API.
@@ -1314,7 +1314,7 @@ If you upgrade from a release earlier than v10.0, please read the other [Importa
  - Improved log messages for cluster communication.
  - Information about deleted rows from the Data Retention job are now logged.
  - License details to logs are now emitted when added or removed.
- - Added a new mmctl command, ``mmctl post delete &lt;post-id&gt;``, in order to permanently delete a post and its attachments.
+ - Added a new mmctl command, ``mmctl post delete <post-id>``, in order to permanently delete a post and its attachments.
 
 #### Performance
  - Added metrics to prometheus to check the mobile versions for each session daily.

--- a/docs/main/product-overview/mattermost-v11-changelog.mdx
+++ b/docs/main/product-overview/mattermost-v11-changelog.mdx
@@ -100,7 +100,7 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-10-is-now-availa
  - Added a new **Board Attributes** panel under **System Console > System Attributes** for managing the default attributes shown on every board, including the locked **Status** and **Assignee** fields. Available when the ``IntegratedBoards`` feature flag is enabled.
  - Added a "Revoke non-compliant tokens" action in **System Console > Integrations > Integration Management** that lets admins revoke existing personal access tokens that violate the configured **Maximum Personal Access Token Lifetime** (tokens that never expire or expire beyond the cap). Bot account tokens are exempt, and the number of affected tokens is shown for confirmation before revoking.
  - Added a discovery page for **Classification Markings** in the **System Console** so the feature is surfaced with an upgrade path on licenses below Enterprise when the ``ClassificationMarkings`` feature flag is enabled.
- - Added a **Session Attributes** management page under **System Console > System Attributes**, and made enabled session attributes selectable in Attribute-Based permission-policy editors (generating ``user.session.&lt;name>`` conditions). Requires Enterprise Advanced license.
+ - Added a **Session Attributes** management page under **System Console > System Attributes**, and made enabled session attributes selectable in Attribute-Based permission-policy editors (generating ``user.session.<name>`` conditions). Requires Enterprise Advanced license.
  - Added the ability to edit a team's name and description from the System Console **Team Configuration** page.
  - Added a Teams column to the System Console user data CSV export, listing each user's team memberships.
  - Team membership can now be controlled by [user attributes](https://docs.mattermost.com/administration-guide/manage/admin/attribute-based-access-control.html) (department, program, etc.) — private teams automatically enforce access rules, block non-qualifying joins, and remove ineligible members via sync; public teams use advisory mode, surfacing a "Recommended" tag to qualifying users without blocking anyone. Team admins and system admins can define per-team membership rules, configure auto-add, and trigger or monitor sync jobs directly from Team Settings and the System Console, with inline enforcement in the Invite People and Add Members modals.
@@ -133,7 +133,7 @@ See [this blog post](https://mattermost.com/blog/mattermost-v11-10-is-now-availa
  - Hard-coded a second plugin signing key from Mattermost.
 
 #### mmctl
- - Added the ability to send direct messages with ``mmctl`` using ``mmctl post create @username --message &lt;text>``.
+ - Added the ability to send direct messages with ``mmctl`` using ``mmctl post create @username --message <text>``.
  - Added new ``mmctl`` commands: ``job create`` to create jobs with type-specific options, ``job show`` to display job details, and ``job cancel`` to cancel running jobs.
  - Added a new ``--auto-add-users`` flag to the ``mmctl channel move`` command. The command now also lists the channel members that are missing from the destination team when a move is rejected.
  - Added a new ``mmctl channel users list`` command that lists the members of a channel (ID, username, email, and roles), with ``--page``, ``--per-page``, and ``--all`` pagination flags.

--- a/docs/main/product-overview/unsupported-legacy-releases.mdx
+++ b/docs/main/product-overview/unsupported-legacy-releases.mdx
@@ -886,7 +886,7 @@ See [this walkthrough video](https://www.youtube.com/watch?v=b1M2BGGF578&feature
     - Added two new configuration settings, ``MessageRetentionHours`` and ``FileRetentionHours``, in order to support setting your global retention time in hours. ``DataRetentionSettings.MessageRetentionDays`` and ``DataRetentionSettings.FileRetentionDays`` are deprecated but we will continue to use their value until you set something for their hours equivalent. If Days are set then the hours configuration must be 0 and if hours is set then the days config must be 0. We do not support hours for granular retention policies. Due to how our Elasticsearch indexes are stored, Data retention will now also remove elastic search indexes equal to the day of the retention cut-off time.
 
 ### API Changes
- - Added a new API endpoint ``POST /api/v4/posts/&lt;post ID&gt;/move``.
+ - Added a new API endpoint ``POST /api/v4/posts/<post ID>/move``.
  - Added ``UpdateChannelMembersNotifications`` plugin API.
  - Added plugin APIs and hooks for accessing the **Shared Channels** service via plugins.
  - Added a limit to the payload size of API endpoints passing in arrays.
@@ -1331,8 +1331,8 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
 ### API Changes
  - Added the ``X-Forwarded-For`` request header to the audit stream for all Rest API calls.
  - Added API endpoint ``POST /api/v4/user/login/desktop_login``. Modified OAuth/SAML flows to include ``desktop_login`` where applicable.
- - Added new API endpoint ``GET`` ``/api/v4/channels/&lt;channel-id&gt;/common_teams`` to fetch list of teams common between members of a group message.
- - Added new API endpoint ``POST`` ``/api/v4/channels/&lt;channel-id&gt;/convert_to_channel`` to convert a group message to a private channel.
+ - Added new API endpoint ``GET`` ``/api/v4/channels/<channel-id>/common_teams`` to fetch list of teams common between members of a group message.
+ - Added new API endpoint ``POST`` ``/api/v4/channels/<channel-id>/convert_to_channel`` to convert a group message to a private channel.
  - Added a new ``MessageHasBeenDeleted`` hook to the plugin API.
  - Moved the ``request`` package into the public shared folder.
 
@@ -2492,7 +2492,7 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
  - Added two new URL parameters to the ``GET /api/v4/groups`` endpoint to get the ``ChannelMemberCount`` for a group.
  - Added new API endpoints ``POST /api/v4/users/:user_id/posts/:post_id/ack`` and ``DELETE /api/v4/users/:user_id/posts/:post_id/ack``.
  - Added a new API endpoint ``POST /api/v4/groups/:group_id:/restore``.
- - Added an allowed value ``sort=display_name`` to ``GET /api/v4/users?in_group=&lt;groupid&gt;``.
+ - Added an allowed value ``sort=display_name`` to ``GET /api/v4/users?in_group=<groupid>``.
  - Added a new endpoint ``api/v4/cloud/products/selfhosted``.
  - A new API method ``RegisterCollectionAndTopic(collectionType, topicType string) (error)`` was added to the Plugin API and the following hooks. This API method is in beta, subject to change, and not covered by our backwards compatibility guarantee.
     - ``UserHasPermissionToCollection(c *Context, userID, collectionType, collectionId string, permission *model.Permission) (bool, error)``
@@ -3730,7 +3730,7 @@ Mattermost v6.4.0 contains low severity level security fixes. [Upgrading](https:
 ### Important Upgrade Notes
  - A new schema migration system has been introduced, so we strongly recommend backing up the database before updating the server to this version. The new migration system will run through all existing migrations to record them to a new table. This will only happen for the first run in order to migrate the application to the new system. The table where migration information is stored is called ``db_migrations``. Additionally, a ``db_lock`` table is used to prevent multiple installations from running migrations in parallel. Any downtime depends on how many records the database has and whether there are missing migrations in the schema. In case of an error while applying the migrations, please check this table first. If you encounter an issue please file [an Issue](https://github.com/mattermost/mattermost-server/issues) by including the failing migration name, database driver/version, and the server logs. 
  - On MySQL, if you encounter an error "Failed to apply database migrations" when upgrading to v6.4.0, it means that there is a mismatch between the table collation and the default database collation. You can manually fix this by changing the database collation with ``ALTER DATABASE <YOUR_DB_NAME> COLLATE = 'utf8mb4_general_ci',``. Then do the server upgrade again and the migration will be successful. 
- - It has been commonly observed on MySQL 8+ systems to have an error ``Error 1267: Illegal mix of collations`` when upgrading due to changing the default collation. This is caused by the database and the tables having different collations. If you get this error, please change the collations to have the same value with, for example, ``ALTER DATABASE <db_name> COLLATE = '&lt;collation&gt;'``.
+ - It has been commonly observed on MySQL 8+ systems to have an error ``Error 1267: Illegal mix of collations`` when upgrading due to changing the default collation. This is caused by the database and the tables having different collations. If you get this error, please change the collations to have the same value with, for example, ``ALTER DATABASE <db_name> COLLATE = '<collation>'``.
  - The new migration system requires the MySQL database user to have additional *EXECUTE*, *CREATE ROUTINE*, *ALTER ROUTINE* and *REFERENCES* privileges to run schema migrations.                   
 
 <Important>
@@ -4311,9 +4311,9 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
    2. Medium effort, medium downtime - This process will require SQL queries to be executed manually on the server. To avoid causing a table lock, a customer can choose to use the pt-online-schema-change tool for MySQL. For Postgres, the table locking is very minimal. The advantage is that since there are a lot of queries, the customer can take their own time to run individual queries during off-hours. All queries except #11 are safe to be executed this way. Then the usual method of (1) can be followed.
    3. High effort, low downtime - This process requires everything of (2), plus it tries to minimize the impact of query #11. We can do this by following step 2, and then starting v6 along with a running v5 server, and then monitor the application logs. As soon as the v6 application starts up, we need to bring down a v5 node. This minimizes the downtime to only a few seconds.
  - While trying to upgrade to a Mattermost version >= 6.0.x, you might encounter the following error: ``Failed to alter column type. It is likely you have invalid JSON values in the column. Please fix the values manually and run the migration again.`` This means that the particular column has some invalid JSON values which need to be fixed manually. A common fix that is known to work is to wipe out all \u0000 characters. Please follow these steps:
-   1. Check the affected values by: ``SELECT COUNT(*) FROM &lt;table&gt; WHERE &lt;column&gt; LIKE '%\u0000%';``
+   1. Check the affected values by: ``SELECT COUNT(*) FROM <table> WHERE <column> LIKE '%\u0000%';``
    2. If you get a count more than 0, check those values manually, and confirm they are okay to be removed.
-   3. Remove them by ``UPDATE &lt;table&gt; SET &lt;column&gt; = regexp_replace(&lt;column&gt;, '\\u0000', '', 'g') where &lt;column&gt; like '%\u0000%';``
+   3. Remove them by ``UPDATE <table> SET <column> = regexp_replace(<column>, '\\u0000', '', 'g') where <column> like '%\u0000%';``
    4. Then try to start Mattermost again.
  - Focalboard plugin has been renamed to Mattermost Boards, and v0.9.1 (released with Mattermost v6.0) is now enabled by default.
  - The advanced logging configuration schema changed. This is a breaking change relative to 5.x. See updated [documentation](https://docs.mattermost.com/comply/audit-log.html).
@@ -4731,7 +4731,7 @@ If you upgrade from a release earlier than v5.37, please read the other [Importa
  - Fixed an issue where admin advisor notifications were accidentally re-enabled in a previous release.
  - Fixed various bugs for the Collapsed Reply Threads (Beta) feature, including:
    - Fixed an issue where an error occurred while following a thread with no replies.
-   - Fixed an issue where ``reply_count`` of 0 was always returned for GET single Post on ``/posts/&lt;postid&gt;`` API.
+   - Fixed an issue where ``reply_count`` of 0 was always returned for GET single Post on ``/posts/<postid>`` API.
    - Fixed an issue where following a single message returned a status 500.
    - Fixed an issue where when replying in a thread after unfollowing it, the thread was not auto-followed again.
    - Fixed an issue where when enabling Collapsed Reply Threads, channels that had no new activity were showing as unread.
@@ -5565,7 +5565,7 @@ Multiple setting options were added to ``config.json``. Below is a list of the a
  - Added a new ``/users/&#123;user_id&#125;/teams/&#123;team_id&#125;/threads/mention_counts`` API endpoint.
  - Added a new ``GET /api/v4/cloud/subscription/stats`` API endpoint.
  - Added a new ``GET /api/v4/cloud/subscription/limitreached/invite`` API endpoint.
- - Added new ``PUT /api/v4/users/&lt;id&gt;/status/custom``, ``DELETE /api/v4/users/&lt;id&gt;/status/custom``, and ``DELETE /api/v4/users/&lt;id&gt;/status/custom/recent`` API endpoints.
+ - Added new ``PUT /api/v4/users/<id>/status/custom``, ``DELETE /api/v4/users/<id>/status/custom``, and ``DELETE /api/v4/users/<id>/status/custom/recent`` API endpoints.
  - The ``/api/v4/users/me/auth`` API endpoint can no longer be used to change passwords. This was a hidden feature that was not documented, but was nevertheless possible. We have removed this hidden feature.
  - Updated ``/users/&#123;user_id&#125;/teams/&#123;team_id&#125;/threads`` API to support the ``unread=true`` query parameter.
  - The ``/api/v4/users/&#123;user_id&#125;/teams/&#123;team_id&#125;/threads`` API endpoint now accepts "before" and "after" parameters instead of a page index.
@@ -6287,7 +6287,7 @@ Mattermost v5.27.0 contains a low level security fix. [Upgrading](https://docs.m
 
 ### Breaking Changes
  - In v5.26, Elasticsearch indexes needed to be recreated. Admins should re-index Elasticsearch using the **Purge index** and then **Index now** button so that all the changes will be included in the index. Systems may be left with a limited search during the indexing, so it should be done during a time when there is little to no activity because it may take several hours.
- - An ``EnableExperimentalGossipEncryption`` option was added under ``ClusterSettings``. If this is set to ``true``, and ``UseExperimentalGossip`` is also ``true``, all communication through the cluster using the gossip protocol will be encrypted. The encryption uses ``AES-256`` by default, and it is not kept configurable by design. However, if one wishes, they can set the value in Systems table manually for the ``ClusterEncryptionKey`` row. A key is a byte array converted to base64. It should be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256. To update the key, one can execute ``UPDATE Systems SET Value='&lt;value&gt;' WHERE Name='ClusterEncryptionKey';`` in MySQL and ``UPDATE systems SET value='&lt;value&gt;' WHERE name='ClusterEncryptionKey'`` for PostgreSQL. For any change in this config setting to take effect, the whole cluster must be shutdown first. Then the config change made, and then restarted. In a cluster, all servers either will completely use encryption or not. There cannot be any partial usage.
+ - An ``EnableExperimentalGossipEncryption`` option was added under ``ClusterSettings``. If this is set to ``true``, and ``UseExperimentalGossip`` is also ``true``, all communication through the cluster using the gossip protocol will be encrypted. The encryption uses ``AES-256`` by default, and it is not kept configurable by design. However, if one wishes, they can set the value in Systems table manually for the ``ClusterEncryptionKey`` row. A key is a byte array converted to base64. It should be either 16, 24, or 32 bytes to select AES-128, AES-192, or AES-256. To update the key, one can execute ``UPDATE Systems SET Value='<value>' WHERE Name='ClusterEncryptionKey';`` in MySQL and ``UPDATE systems SET value='<value>' WHERE name='ClusterEncryptionKey'`` for PostgreSQL. For any change in this config setting to take effect, the whole cluster must be shutdown first. Then the config change made, and then restarted. In a cluster, all servers either will completely use encryption or not. There cannot be any partial usage.
 
 <Important>
 
@@ -7166,7 +7166,7 @@ If you upgrade from a release earlier than 5.18, please read the other [Importan
  - Fixed an issue where the Menu help text was truncated in English for Do Not Disturb status.
  - Fixed an issue where the height and width parameters in inline images didn't work.
  - Fixed an issue where the day picker in after/before search didn't honor the user's timezone override.
- - Fixed an issue where editing a post and hitting ``&lt;enter&gt;`` in code block saved the post automatically instead of adding a newline.
+ - Fixed an issue where editing a post and hitting ``<enter>`` in code block saved the post automatically instead of adding a newline.
  - Fixed an issue where users were unable to close the Edit Channel Header modal when opened from the Intro Message.
  - Fixed an issue where opening the channel picker using CTRL+K and then focusing on the message box using CTRL+SHIFT+L did not close the channel picker.
  - Fixed an issue where the at-mention suggestions still highlighted the previous search but not the first suggestion in the list.
@@ -12485,7 +12485,7 @@ Many thanks to all our contributors. In alphabetical order:
 
 ### Bug Fixes
 
-- Fixed an error where a channel would no longer load after using a GitLab built-in Mattermost slash command `/project issue show &lt;number&gt;`
+- Fixed an error where a channel would no longer load after using a GitLab built-in Mattermost slash command `/project issue show <number>`
 - Outdated results in modal searches are now properly discarded
 - Fixed order of channels on the sidebar
 - Fixed search highlighting for wildcard searches and hashtags


### PR DESCRIPTION
#### Summary
- RST-to-MDX migration left &lt;/&gt; placeholders inside backticks, which rendered literally. Restore <placeholder> syntax in code spans only.
- We can see e.g. https://docs.mattermost.com/deployment-guide/quick-start-evaluation with `https://&lt;dns-label&gt;.&lt;region&gt;.cloudapp.azure.com`

#### Ticket Link
https://docs.mattermost.com/deployment-guide/quick-start-evaluation


#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** Changes affect documentation formatting only. They do not modify application behavior, APIs, authentication, data, or shared code.  
**QA Recommendation:** Manual QA is not required. Run automated documentation checks.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->