### PR TITLE
fix(e2e): repoint markdown image specs off the deleted docs.mattermost.com asset

### DIFF
--- a/e2e-tests/cypress/tests/fixtures/markdown/markdown_inline_images_1.md
+++ b/e2e-tests/cypress/tests/fixtures/markdown/markdown_inline_images_1.md
@@ -1,3 +1,3 @@
 ### In-line Images
 
-Mattermost/platform build status:  [![Build Status](https://docs.mattermost.com/_images/icon-76x76.png)](https://docs.mattermost.com/_images/icon-76x76.png)
+Mattermost/platform build status:  [![Build Status](https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png)](https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png)

--- a/e2e-tests/cypress/tests/integration/channels/files_and_attachments/image_link_preview_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/files_and_attachments/image_link_preview_spec.js
@@ -100,7 +100,7 @@ describe('Image Link Preview', () => {
         cy.visit(offTopicUrl);
 
         const markdownImageText = 'exampleImage';
-        const markdownImageSrc = 'https://docs.mattermost.com/_images/icon-76x76.png';
+        const markdownImageSrc = 'https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png';
         const markdownImageSrcEncoded = encodeURIComponent(markdownImageSrc); // Since the url preview will be encoded string
         const messageWithMarkdownImage = `![${markdownImageText}](${markdownImageSrc}) an image plus some text that has [a link](https://example.com/)`;
 

--- a/e2e-tests/cypress/tests/integration/channels/markdown/markdown_image_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/markdown/markdown_image_spec.js
@@ -44,11 +44,11 @@ describe('Markdown', () => {
                 should('have.class', 'markdown-inline-img').
                 and('have.class', 'markdown-inline-img--hover').
                 and('have.attr', 'alt', 'Build Status').
-                and('have.attr', 'src', `${baseUrl}/api/v4/image?url=https%3A%2F%2Fdocs.mattermost.com%2F_images%2Ficon-76x76.png`).
+                and('have.attr', 'src', `${baseUrl}/api/v4/image?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmattermost%2Fmattermost%2Fmaster%2Fe2e-tests%2Fcypress%2Ftests%2Ffixtures%2Fmattermost-icon_128x128.png`).
                 and((inlineImg) => {
-                    expect(inlineImg.height()).to.be.closeTo(76, 76);
+                    expect(inlineImg.height()).to.be.closeTo(128, 2);
                 }).
-                and('have.css', 'width', '76px');
+                and('have.css', 'width', '128px');
         });
     });
 

--- a/e2e-tests/cypress/tests/integration/channels/messaging/inline_markdown_image_link_open_link_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/inline_markdown_image_link_open_link_spec.js
@@ -21,7 +21,7 @@ describe('Messaging', () => {
 
     it('MM-T188 - Inline markdown image that is a link, opens the link', () => {
         const linkUrl = 'https://www.google.com';
-        const imageUrl = 'https://docs.mattermost.com/_images/icon-76x76.png';
+        const imageUrl = 'https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png';
         const label = 'Build Status';
         const baseUrl = Cypress.config('baseUrl');
 


### PR DESCRIPTION
#### Summary

`e2e-test/cypress-full/enterprise` has been failing on unrelated PRs (e.g. [#37913](https://github.com/mattermost/mattermost/pull/37913), [#38328](https://github.com/mattermost/mattermost/pull/38328)). This is infra, not those changes.

**Root cause:** docs.mattermost.com migrated from Sphinx to Docusaurus v3.10.1 (the 404 bodies in the CI reports are Docusaurus pages, `last-modified: Thu, 03 Sep 2026 15:24:40 GMT`). The migration removed the `/_images/` static asset path, so the icon four of our specs depend on is now gone:

```
$ curl -sIL -o /dev/null -w '%{http_code}\n' https://docs.mattermost.com/_images/icon-76x76.png
404
```

The image proxy fetch fails, the webapp falls back to the broken-image placeholder (`/static/files/e757928a47e7c419ddb8.png`), and the assertions blow up. This reproduces on every run, so retesting does not help:

| Spec | Failure |
|---|---|
| `markdown/markdown_image_spec.js` "with in-line images 1" | `expected '<img.markdown-inline-img.broken-image>' to have class 'markdown-inline-img--hover'` |
| `messaging/inline_markdown_image_link_open_link_spec.js` MM-T188 | `src` is `/static/files/e757928a47e7c419ddb8.png` instead of the proxy URL |
| `files_and_attachments/image_link_preview_spec.js` MM-T2389 | same image, not yet observed failing but will |
| `fixtures/markdown/markdown_inline_images_1.md` | shared fixture behind the first spec |

**Fix:** the icon is gone from the docs site entirely (I probed `/img/`, `/static/img/`, `/img/brand/` and `/assets/images/`, all 404), so rather than chase another docs URL these now point at an image we actually own: the in-repo fixture `mattermost-icon_128x128.png`, served over `raw.githubusercontent.com`. Several sibling specs in this same directory already use exactly that pattern (`small-image.png`, `image-small-height.png`, `png-image-file.png`), and it drops the dependency on the docs site's asset layout, which is what broke us here.

Size assertions move 76px to 128px to match the new fixture. 128px stays under the 350px `max-height` on `.markdown-inline-img` (`webapp/channels/src/sass/layout/_markdown.scss`), so it renders at natural size. I also tightened the height tolerance from `closeTo(76, 76)` to `closeTo(128, 2)` - the old one accepted anything from 0 to 152, so it would have happily passed on a zero-height broken image.

No bootstrap problem: `mattermost-icon_128x128.png` is already on `master`, so the raw URL resolves while this PR is still in review.

**Not fixed here (for the record, both unrelated to the above):**

- `builtin_commands/common_commands_2_spec.js` MM-T710 `/mute` hit a 404 on `https://docs.mattermost.com/messaging/managing-channels.html#naming-a-channel` (link lives in the server i18n string `api.command_channel_mute.no_channel.error`). Same migration, but the docs team has since put a `.html` -> extensionless 301 in place, and the assertion reads `allRequestResponses[0]['Request URL']`, so this one passes again as of now. Worth repointing the i18n links eventually, since we are relying on a compat redirect.
- `message_display_mode_colorize_username_spec.js` MM-T4984_2 is a genuine pre-existing flake, not infra. `generateColor()` in `webapp/channels/src/components/user_profile/utils.ts` hashes the username, then re-salts up to 10 times looking for contrast ratio >= 4.5. That filter collapses the output space onto a small set of passing colours, so two random `apiInitSetup` usernames colliding is a real probability. Separate fix.

#### Ticket Link

N/A - CI infra breakage from an external docs site migration.

#### Release Note

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** Changes are limited to E2E markdown image fixtures and assertions. No shared code, critical flow, API, or data logic is affected.  
**QA Recommendation:** Skip manual QA. Rely on the existing E2E coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->