### PR TITLE
Hide the System Console Recaps page unless EnableAIRecaps is on

### DIFF
--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -4024,7 +4024,10 @@ const AdminDefinition: AdminDefinitionType = {
             recaps: {
                 url: 'site_config/recaps',
                 title: defineMessage({id: 'admin.sidebar.recaps', defaultMessage: 'Recaps'}),
-                isHidden: it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.SITE.AI_RECAPS)),
+                isHidden: it.any(
+                    it.not(it.userHasReadPermissionOnResource(RESOURCE_KEYS.SITE.AI_RECAPS)),
+                    it.configIsFalse('FeatureFlags', 'EnableAIRecaps'),
+                ),
                 schema: {
                     id: 'RecapSettings',
                     name: defineMessage({id: 'admin.site.recaps', defaultMessage: 'Recaps'}),

--- a/webapp/channels/src/components/admin_console/admin_definition_recaps.test.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition_recaps.test.tsx
@@ -1,0 +1,43 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {AdminConfig} from '@mattermost/types/config';
+
+import {RESOURCE_KEYS} from 'mattermost-redux/constants/permissions_sysconsole';
+
+import AdminDefinition from './admin_definition';
+import type {Check, ConsoleAccess} from './types';
+
+const readAccess = {
+    read: {
+        [RESOURCE_KEYS.SITE.AI_RECAPS]: true,
+    },
+    write: {},
+} as ConsoleAccess;
+
+const noAccess = {
+    read: {},
+    write: {},
+} as ConsoleAccess;
+
+function isHidden(config: Partial<AdminConfig>, access: ConsoleAccess = readAccess) {
+    const check = AdminDefinition.site.subsections.recaps.isHidden as Extract<Check, (...args: any[]) => boolean>;
+    return check(config, {}, {}, true, access);
+}
+
+describe('AdminDefinition - Recaps', () => {
+    test('hides Recaps when EnableAIRecaps is disabled', () => {
+        const mockConfig: Partial<AdminConfig> = {FeatureFlags: {EnableAIRecaps: false}};
+        expect(isHidden(mockConfig)).toBe(true);
+    });
+
+    test('shows Recaps when EnableAIRecaps is enabled and user has permission', () => {
+        const mockConfig: Partial<AdminConfig> = {FeatureFlags: {EnableAIRecaps: true}};
+        expect(isHidden(mockConfig)).toBe(false);
+    });
+
+    test('hides Recaps when user lacks permission even if the flag is enabled', () => {
+        const mockConfig: Partial<AdminConfig> = {FeatureFlags: {EnableAIRecaps: true}};
+        expect(isHidden(mockConfig, noAccess)).toBe(true);
+    });
+});

--- a/webapp/channels/src/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/admin_sidebar/__snapshots__/admin_sidebar.test.tsx.snap
@@ -1367,25 +1367,6 @@ c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V4z M20,4v5H4V4H20z M22,15v5c0,1.1-0.9,2-2,2H
                           </li>
                           <li
                             class="sidebar-section"
-                            data-testid="site.recaps"
-                          >
-                            <a
-                              class="sidebar-section-title"
-                              href="/admin_console/site_config/recaps"
-                              id="site_config/recaps"
-                            >
-                              <span
-                                class="sidebar-section-title__text"
-                              >
-                                Recaps
-                              </span>
-                            </a>
-                            <ul
-                              class="nav nav__sub-menu subsections"
-                            />
-                          </li>
-                          <li
-                            class="sidebar-section"
                             data-testid="site.file_sharing_downloads"
                           >
                             <a
@@ -3197,25 +3178,6 @@ c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V4z M20,4v5H4V4H20z M22,15v5c0,1.1-0.9,2-2,2H
                                 class="sidebar-section-title__text"
                               >
                                 Posts
-                              </span>
-                            </a>
-                            <ul
-                              class="nav nav__sub-menu subsections"
-                            />
-                          </li>
-                          <li
-                            class="sidebar-section"
-                            data-testid="site.recaps"
-                          >
-                            <a
-                              class="sidebar-section-title"
-                              href="/admin_console/site_config/recaps"
-                              id="site_config/recaps"
-                            >
-                              <span
-                                class="sidebar-section-title__text"
-                              >
-                                Recaps
                               </span>
                             </a>
                             <ul
@@ -5070,25 +5032,6 @@ c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V4z M20,4v5H4V4H20z M22,15v5c0,1.1-0.9,2-2,2H
                           </li>
                           <li
                             class="sidebar-section"
-                            data-testid="site.recaps"
-                          >
-                            <a
-                              class="sidebar-section-title"
-                              href="/admin_console/site_config/recaps"
-                              id="site_config/recaps"
-                            >
-                              <span
-                                class="sidebar-section-title__text"
-                              >
-                                Recaps
-                              </span>
-                            </a>
-                            <ul
-                              class="nav nav__sub-menu subsections"
-                            />
-                          </li>
-                          <li
-                            class="sidebar-section"
                             data-testid="site.file_sharing_downloads"
                           >
                             <a
@@ -6925,25 +6868,6 @@ c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V4z M20,4v5H4V4H20z M22,15v5c0,1.1-0.9,2-2,2H
                           </li>
                           <li
                             class="sidebar-section"
-                            data-testid="site.recaps"
-                          >
-                            <a
-                              class="sidebar-section-title"
-                              href="/admin_console/site_config/recaps"
-                              id="site_config/recaps"
-                            >
-                              <span
-                                class="sidebar-section-title__text"
-                              >
-                                Recaps
-                              </span>
-                            </a>
-                            <ul
-                              class="nav nav__sub-menu subsections"
-                            />
-                          </li>
-                          <li
-                            class="sidebar-section"
                             data-testid="site.file_sharing_downloads"
                           >
                             <a
@@ -8749,25 +8673,6 @@ c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V4z M20,4v5H4V4H20z M22,15v5c0,1.1-0.9,2-2,2H
                                 class="sidebar-section-title__text"
                               >
                                 Posts
-                              </span>
-                            </a>
-                            <ul
-                              class="nav nav__sub-menu subsections"
-                            />
-                          </li>
-                          <li
-                            class="sidebar-section"
-                            data-testid="site.recaps"
-                          >
-                            <a
-                              class="sidebar-section-title"
-                              href="/admin_console/site_config/recaps"
-                              id="site_config/recaps"
-                            >
-                              <span
-                                class="sidebar-section-title__text"
-                              >
-                                Recaps
                               </span>
                             </a>
                             <ul
@@ -10679,25 +10584,6 @@ c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V4z M20,4v5H4V4H20z M22,15v5c0,1.1-0.9,2-2,2H
                           </li>
                           <li
                             class="sidebar-section"
-                            data-testid="site.recaps"
-                          >
-                            <a
-                              class="sidebar-section-title"
-                              href="/admin_console/site_config/recaps"
-                              id="site_config/recaps"
-                            >
-                              <span
-                                class="sidebar-section-title__text"
-                              >
-                                Recaps
-                              </span>
-                            </a>
-                            <ul
-                              class="nav nav__sub-menu subsections"
-                            />
-                          </li>
-                          <li
-                            class="sidebar-section"
                             data-testid="site.file_sharing_downloads"
                           >
                             <a
@@ -12484,25 +12370,6 @@ c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V4z M20,4v5H4V4H20z M22,15v5c0,1.1-0.9,2-2,2H
                                 class="sidebar-section-title__text"
                               >
                                 Posts
-                              </span>
-                            </a>
-                            <ul
-                              class="nav nav__sub-menu subsections"
-                            />
-                          </li>
-                          <li
-                            class="sidebar-section"
-                            data-testid="site.recaps"
-                          >
-                            <a
-                              class="sidebar-section-title"
-                              href="/admin_console/site_config/recaps"
-                              id="site_config/recaps"
-                            >
-                              <span
-                                class="sidebar-section-title__text"
-                              >
-                                Recaps
                               </span>
                             </a>
                             <ul
@@ -14317,25 +14184,6 @@ c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V4z M20,4v5H4V4H20z M22,15v5c0,1.1-0.9,2-2,2H
                           </li>
                           <li
                             class="sidebar-section"
-                            data-testid="site.recaps"
-                          >
-                            <a
-                              class="sidebar-section-title"
-                              href="/admin_console/site_config/recaps"
-                              id="site_config/recaps"
-                            >
-                              <span
-                                class="sidebar-section-title__text"
-                              >
-                                Recaps
-                              </span>
-                            </a>
-                            <ul
-                              class="nav nav__sub-menu subsections"
-                            />
-                          </li>
-                          <li
-                            class="sidebar-section"
                             data-testid="site.file_sharing_downloads"
                           >
                             <a
@@ -16021,25 +15869,6 @@ c0,1.1,0.9,2,2,2h16c1.1,0,2-0.9,2-2V4z M20,4v5H4V4H20z M22,15v5c0,1.1-0.9,2-2,2H
                                 class="sidebar-section-title__text"
                               >
                                 Posts
-                              </span>
-                            </a>
-                            <ul
-                              class="nav nav__sub-menu subsections"
-                            />
-                          </li>
-                          <li
-                            class="sidebar-section"
-                            data-testid="site.recaps"
-                          >
-                            <a
-                              class="sidebar-section-title"
-                              href="/admin_console/site_config/recaps"
-                              id="site_config/recaps"
-                            >
-                              <span
-                                class="sidebar-section-title__text"
-                              >
-                                Recaps
                               </span>
                             </a>
                             <ul


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
The System Console Recaps page (`Site Configuration > Recaps`) was only hidden by `sysconsole_read_ai_recaps`. After the `#38058` permissions migration that grants that permission to `system_admin`, the page became visible even when `EnableAIRecaps` is off (the default).

This adds the same feature-flag check used by other unfinished console pages so Recaps stays hidden unless the flag is on.

**QA**
- With `EnableAIRecaps` off (default): System Console > Site Configuration does not list Recaps, and `/admin_console/site_config/recaps` does not render the settings page.
- With `EnableAIRecaps` on and `sysconsole_read_ai_recaps`: Recaps appears and the settings page loads.

#### Release Note
```release-note
Hid the System Console Recaps page unless the EnableAIRecaps feature flag is enabled.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a06c59-6b98-741f-8147-97a2fdbfd0dd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a06c59-6b98-741f-8147-97a2fdbfd0dd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change affects Recaps visibility and authorization checks. Automated tests cover the enabled and disabled feature-flag states, with limited impact outside the admin console.
**QA Recommendation:** Manual QA can be skipped. Automated coverage validates the affected paths.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->