### PR TITLE
Fix three e2e specs that load an inline image from a dead docs URL

### DIFF
--- a/e2e-tests/cypress/tests/fixtures/markdown/markdown_inline_images_1.md
+++ b/e2e-tests/cypress/tests/fixtures/markdown/markdown_inline_images_1.md
@@ -1,3 +1,3 @@
 ### In-line Images
 
-Mattermost/platform build status:  [![Build Status](https://docs.mattermost.com/_images/icon-76x76.png)](https://docs.mattermost.com/_images/icon-76x76.png)
+Mattermost/platform build status:  [![Build Status](https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png)](https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png)

--- a/e2e-tests/cypress/tests/integration/channels/files_and_attachments/image_link_preview_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/files_and_attachments/image_link_preview_spec.js
@@ -100,7 +100,7 @@ describe('Image Link Preview', () => {
         cy.visit(offTopicUrl);
 
         const markdownImageText = 'exampleImage';
-        const markdownImageSrc = 'https://docs.mattermost.com/_images/icon-76x76.png';
+        const markdownImageSrc = 'https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png';
         const markdownImageSrcEncoded = encodeURIComponent(markdownImageSrc); // Since the url preview will be encoded string
         const messageWithMarkdownImage = `![${markdownImageText}](${markdownImageSrc}) an image plus some text that has [a link](https://example.com/)`;
 

--- a/e2e-tests/cypress/tests/integration/channels/markdown/markdown_image_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/markdown/markdown_image_spec.js
@@ -30,6 +30,9 @@ describe('Markdown', () => {
 
     const baseUrl = Cypress.config('baseUrl');
 
+    // Must match the image linked from markdown/markdown_inline_images_1.md
+    const inlineImageUrl = 'https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png';
+
     it('with in-line images 1', () => {
         // #  Post markdown message
         cy.postMessageFromFile('markdown/markdown_inline_images_1.md');
@@ -44,11 +47,11 @@ describe('Markdown', () => {
                 should('have.class', 'markdown-inline-img').
                 and('have.class', 'markdown-inline-img--hover').
                 and('have.attr', 'alt', 'Build Status').
-                and('have.attr', 'src', `${baseUrl}/api/v4/image?url=https%3A%2F%2Fdocs.mattermost.com%2F_images%2Ficon-76x76.png`).
+                and('have.attr', 'src', `${baseUrl}/api/v4/image?url=${encodeURIComponent(inlineImageUrl)}`).
                 and((inlineImg) => {
-                    expect(inlineImg.height()).to.be.closeTo(76, 76);
+                    expect(inlineImg.height()).to.be.closeTo(128, 2);
                 }).
-                and('have.css', 'width', '76px');
+                and('have.css', 'width', '128px');
         });
     });
 

--- a/e2e-tests/cypress/tests/integration/channels/messaging/inline_markdown_image_link_open_link_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/inline_markdown_image_link_open_link_spec.js
@@ -21,7 +21,7 @@ describe('Messaging', () => {
 
     it('MM-T188 - Inline markdown image that is a link, opens the link', () => {
         const linkUrl = 'https://www.google.com';
-        const imageUrl = 'https://docs.mattermost.com/_images/icon-76x76.png';
+        const imageUrl = 'https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png';
         const label = 'Build Status';
         const baseUrl = Cypress.config('baseUrl');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Three Cypress specs load their inline markdown image from `https://docs.mattermost.com/_images/icon-76x76.png`. The docs site restructure moved that path (the image is now at `/images/icon-76x76.png`), so the old URL returns **HTTP 404**, the local image proxy serves a `broken-image` placeholder, and the specs fail deterministically on every branch:

- `Markdown › with in-line images 1` — `expected '<img.markdown-inline-img.broken-image>' to have class 'markdown-inline-img--hover'`
- `Messaging › MM-T188 - Inline markdown image that is a link, opens the link` — `src` is the `broken-image` static file instead of the proxied URL
- `Image Link Preview › MM-T2389` — same cause; fails locally, has been passing in CI

This is currently failing `e2e-test/cypress-full/enterprise` on unrelated PRs, including [#38312](https://github.com/mattermost/mattermost/pull/38312) (which was overridden by a maintainer) and [#38313](https://github.com/mattermost/mattermost/pull/38313).

Rather than chase the docs site's new path, this points the specs at `mattermost-icon_128x128.png`, a fixture already committed to this repo and reachable over `raw.githubusercontent.com`. That is the same approach the other tests in `markdown_image_spec.js` already take for `small-image.png`, and it stops these specs from depending on the docs website's URL layout.

The replacement image is 128x128 rather than 76x76, so `with in-line images 1` now asserts a 128px width. The hardcoded pre-encoded URL in that assertion is replaced with `encodeURIComponent` over a named constant so the spec and its fixture can't drift apart silently.

If reviewers would rather keep pointing at the docs site, the minimal alternative is dropping the underscore — `https://docs.mattermost.com/images/icon-76x76.png` returns 200 and would need no assertion changes.

**QA steps**

Verified locally against a server built from this branch with `ImageProxySettings.Enable=true` and `ImageProxyType=local`, running the three specs with `cypress run --browser electron`:

| Test | pristine `master` | this branch |
| --- | --- | --- |
| `Markdown › with in-line images 1` | fail | pass |
| `Messaging › MM-T188` | fail | pass |
| `Image Link Preview › MM-T2389` | fail | pass |
| other 5 tests in `markdown_image_spec.js` | pass | pass |
| `Image Link Preview › MM-T331` | pass | pass |

The two failures reproduced locally on pristine `master` with the exact error messages CI reported, confirming the fix is not vacuous.

`Image Link Preview › MM-T1447` fails identically before and after this change (`expected 348 to be close to 350 +/- 1`). It uploads local image fixtures and asserts a container width, never touching the docs URL — it is a 2px layout difference in this environment and passes in CI.

Full before/after runner output: [cypress_docs_image_url_before_after.log](https://cursor.com/artifacts/c/art-ea32fa21-0540-4d7b-96c0-f804331b9a71)

#### Release Note
```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a066b7-1bf4-7b96-8f3c-688222230193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a066b7-1bf4-7b96-8f3c-688222230193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes affect only Cypress fixtures and assertions for inline image tests. They do not modify shared utilities, production code, or critical user flows.

**QA Recommendation:** Manual QA is not required. Automated Cypress coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->