### PR TITLE
Fix content extraction of text files that are not valid UTF-8

### DIFF
--- a/server/channels/app/file.go
+++ b/server/channels/app/file.go
@@ -1741,6 +1741,11 @@ func (a *App) ExtractContentFromFileInfo(rctx request.CTX, fileInfo *model.FileI
 		if len(text) > maxContentExtractionSize {
 			text = text[0:maxContentExtractionSize]
 		}
+		// The Content column is UTF-8, and the database rejects anything else.
+		// The truncation above cuts at a byte offset and can split a rune, and
+		// an extractor can return bytes that are not valid UTF-8 to begin with,
+		// so drop what cannot be stored rather than losing the whole document.
+		text = strings.ToValidUTF8(text, "")
 		if storeErr := a.Srv().Store().FileInfo().SetContent(rctx, fileInfo.Id, text); storeErr != nil {
 			return errors.Wrap(storeErr, "failed to save the extracted file content")
 		}

--- a/server/channels/app/file.go
+++ b/server/channels/app/file.go
@@ -1334,7 +1334,9 @@ func (a *App) SetFileSearchableContent(rctx request.CTX, fileID string, data str
 		return appErr
 	}
 
-	err := a.Srv().Store().FileInfo().SetContent(rctx, fileInfo.Id, data)
+	// The Content column is UTF-8, and the database rejects anything else. The
+	// data comes from a plugin, so it carries no guarantee of being valid.
+	err := a.Srv().Store().FileInfo().SetContent(rctx, fileInfo.Id, strings.ToValidUTF8(data, ""))
 	if err != nil {
 		var nfErr *store.ErrNotFound
 		switch {

--- a/server/platform/services/docextractor/plain.go
+++ b/server/platform/services/docextractor/plain.go
@@ -4,10 +4,14 @@
 package docextractor
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"golang.org/x/text/encoding/charmap"
 )
 
 type plainExtractor struct{}
@@ -51,6 +55,32 @@ func (pe *plainExtractor) Extract(_ context.Context, filename string, r io.ReadS
 		}
 	}
 
-	text, _ := io.ReadAll(r)
-	return string(runes[0:total]) + string(text), nil
+	text, err := io.ReadAll(io.MultiReader(bytes.NewReader(runes[0:total]), r))
+	if err != nil {
+		return "", err
+	}
+	return toUTF8(text), nil
+}
+
+// toUTF8 converts the file content to UTF-8. Text files are not necessarily
+// encoded in UTF-8 (a CSV exported on a German Windows machine is usually
+// Latin-1, for example), while the extracted text ends up in a UTF-8 database
+// column, which rejects any other byte sequence. Content that is already valid
+// UTF-8 is kept as it is; anything else is read as Windows-1252, which is the
+// common case for the files that reach this extractor and which maps every
+// byte, so the result is always valid UTF-8. Transcoding rather than dropping
+// the file keeps the text searchable, which is the point of the extraction.
+func toUTF8(text []byte) string {
+	if utf8.Valid(text) {
+		return string(text)
+	}
+
+	decoded, err := charmap.Windows1252.NewDecoder().Bytes(text)
+	if err != nil {
+		// Windows-1252 has no undecodable byte, so this is unreachable today,
+		// but dropping what cannot be decoded still beats failing the
+		// extraction if that ever changes.
+		return strings.ToValidUTF8(string(text), "")
+	}
+	return string(decoded)
 }

--- a/server/platform/services/docextractor/plain_test.go
+++ b/server/platform/services/docextractor/plain_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 )
@@ -51,4 +52,48 @@ func TestBigBinaryFile(t *testing.T) {
 	extractedText, err := extractor.Extract(context.Background(), "test.bin", bytes.NewReader(content), 0)
 	require.NoError(t, err)
 	require.Equal(t, "", extractedText)
+}
+
+func TestPlainLatin1File(t *testing.T) {
+	extractor := plainExtractor{}
+	// "Straße Müller äöü" encoded as ISO-8859-1, as produced by a spreadsheet
+	// exporting a CSV on a German Windows machine.
+	content := []byte("Stra\xdfe M\xfcller \xe4\xf6\xfc\n")
+	extractedText, err := extractor.Extract(context.Background(), "test.csv", bytes.NewReader(content), 0)
+	require.NoError(t, err)
+	require.True(t, utf8.ValidString(extractedText), "extracted text must be valid UTF-8, got %q", extractedText)
+	require.Equal(t, "Straße Müller äöü\n", extractedText)
+}
+
+func TestPlainLatin1AfterAsciiHeader(t *testing.T) {
+	extractor := plainExtractor{}
+	// Only the first 1024 bytes are inspected before the file is accepted, so
+	// make sure the non UTF-8 bytes show up after that boundary.
+	content := append(bytes.Repeat([]byte("a"), 1100), []byte("M\xfcller\n")...)
+	extractedText, err := extractor.Extract(context.Background(), "test.csv", bytes.NewReader(content), 0)
+	require.NoError(t, err)
+	require.True(t, utf8.ValidString(extractedText), "extracted text must be valid UTF-8")
+	require.Equal(t, string(bytes.Repeat([]byte("a"), 1100))+"Müller\n", extractedText)
+}
+
+func TestPlainMixedEncodingFile(t *testing.T) {
+	extractor := plainExtractor{}
+	// A file that is UTF-8 in one place and Latin-1 in another cannot be read
+	// correctly as either, but the extractor still has to return valid UTF-8.
+	content := append([]byte("Straße "), bytes.Repeat([]byte("a"), 1100)...)
+	content = append(content, []byte("M\xfcller\n")...)
+	extractedText, err := extractor.Extract(context.Background(), "test.txt", bytes.NewReader(content), 0)
+	require.NoError(t, err)
+	require.True(t, utf8.ValidString(extractedText), "extracted text must be valid UTF-8")
+	require.Contains(t, extractedText, "Müller")
+}
+
+func TestPlainUTF8AfterAsciiHeader(t *testing.T) {
+	extractor := plainExtractor{}
+	// The first 1024 bytes carry no hint that the file is UTF-8, which must not
+	// turn the rest of it into mojibake.
+	content := append(bytes.Repeat([]byte("a"), 1100), []byte("Müller\n")...)
+	extractedText, err := extractor.Extract(context.Background(), "test.txt", bytes.NewReader(content), 0)
+	require.NoError(t, err)
+	require.Equal(t, string(content), extractedText)
 }


### PR DESCRIPTION
#### Summary

Text files that are not valid UTF-8 can never be indexed, and the extraction job keeps retrying them.

`plainExtractor` is the catch-all extractor: its `Match` returns true for every file. It reads the first 1024 bytes, checks that each decoded rune is graphic or whitespace, and then returns the raw bytes of the whole file. A Latin-1 file passes that check, because an invalid byte sequence decodes to U+FFFD, which is itself a graphic character. The raw bytes then reach the `Content` column, which is UTF-8, and the write is rejected:

```
failed to save the extracted file content: failed to update FileInfo content with id=...: pq: invalid byte sequence for encoding "UTF8": 0xe4 0x6c 0x6c (22021)
```

The file's content stays empty, so it is never searchable, and the hourly catch-up job selects exactly the files whose content is empty. Every affected file is downloaded and run through the extractors again on every run for the next 24 hours, about 24 times, and the job reports errors the whole time. On the instance where this was found the error count kept climbing as new exports were uploaded. The trigger was an ordinary German CSV export (`0xe4` is a-umlaut in Latin-1).

The same error was reported in #18735, which was closed in a sweep of older issues rather than fixed.

**Two commits:**

1. `plainExtractor` keeps content that is already valid UTF-8 exactly as it is, and reads anything else as Windows-1252. That covers the single byte encodings these files actually use, and Windows-1252 maps every byte, so the extractor always returns valid UTF-8. Transcoding rather than stripping the offending bytes keeps the content searchable, which is the point of extraction: a Latin-1 `Müller` is indexed as `Müller`, not as `M?ller` and not dropped. No new dependency; `golang.org/x/text` is already a direct one.

   Sniffing the encoding (`golang.org/x/net/html/charset`) was the first thing I tried, and it is worse here: it decides from the first 1024 bytes only, so a UTF-8 document whose first kilobyte happens to be plain ASCII is classified as Windows-1252 and every later `ü` is stored as `Ã¼`. That trades a loud failure on rare files for silent corruption of common ones. Deciding on the whole content avoids it, and the content is fully read either way. `TestPlainUTF8AfterAsciiHeader` guards against that regression.

   The same commit guards the extracted text in `ExtractContentFromFileInfo`, where it is truncated to `maxContentExtractionSize` at a byte offset. That can split a rune and turn a perfectly valid UTF-8 document into a rejected write, and it applies to every extractor, not just this one.

2. `SetFileSearchableContent`, the plugin-facing API, writes caller-supplied text into the same column with the same lack of a guarantee. Same guard.

I considered sanitizing in the store layer instead, which would close the class in one place. I did not, because it is not one place: `SearchFileInfoStore.SetContent` forwards the same string to the search engine after the SQL write, so sanitizing in `SqlFileInfoStore` would keep invalid bytes flowing to Elasticsearch/Bleve. The app layer is where the content is complete and has a single owner.

**QA steps**

Upload a text file saved in Latin-1, for example a CSV containing `M\xfcller`. Before this change the server logs `failed to save the extracted file content: ... invalid byte sequence for encoding "UTF8"`, the file's content stays empty so search never finds it, and the extraction job picks it up again every hour for a day. After the change the content is stored as UTF-8 and searching for `Müller` finds the file.

Verified against Postgres 16: the raw extractor output is rejected with the error above, the new output is stored as `Müller;Bahnhofstraße 1` and matches a full text search for `müller`.

#### Ticket Link

Fixes: https://github.com/mattermost/mattermost/issues/18735

#### Release Note

```release-note
Fixed content extraction for text files that are not encoded in UTF-8 (for example CSV exports in Latin-1). Their content was never indexed and the extraction job kept retrying them; they are now converted to UTF-8 and made searchable.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes affect file extraction and database persistence across multiple modules. Automated tests cover key encoding cases, but uncommon file encodings may still pose regression risk.
**QA Recommendation:** Manual QA is not required. Run automated tests and verify indexing for non-UTF-8 text files.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->