### PR TITLE
chore(ci): bump pr-test-analysis toolkit ref to pick up claude-code actions

### DIFF
--- a/.github/workflows/pr-test-analysis.yml
+++ b/.github/workflows/pr-test-analysis.yml
@@ -38,7 +38,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       (github.event.pull_request.draft == false &&
        github.event.pull_request.head.repo.full_name == 'mattermost/mattermost')
-    uses: mattermost/mattermost-test-automation-toolkit/.github/workflows/pr-test-analysis.yml@93d73f4f101e10dc03c7ed6b76b35eb5ff5babb7 # 2026-05-16
+    uses: mattermost/mattermost-test-automation-toolkit/.github/workflows/pr-test-analysis.yml@b51a481e3fe6332053be09800d59da1a8c3e3e2e # 2026-09-04
     with:
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       target_repo: mattermost/mattermost


### PR DESCRIPTION
#### Summary
Points at mattermost/mattermost-test-automation-toolkit b51a481e3fe6332053be09800d59da1a8c3e3e2e, which upgrades anthropics/claude-code-action from v1.0.70 → v1.0.210. v1.0.210 includes anthropics/claude-code-action#1580 (shipped in v1.0.188), which passes no-cache: true to oven-sh/setup-bun. The upstream setup-bun key is not ref-aware, so every second-and-subsequent run against the same PR ref hit a 409 on save, and @actions/cache treated the HTML error body as transient and burned ~20-30s on 5 retries plus emitted a noisy warning per PR push. Disabling the cache is a net wallclock win — the 35 MB Bun binary downloads in 2-3s. Refs:
- https://github.com/anthropics/claude-code-action/pull/1580
- https://github.com/anthropics/claude-code-action/issues/1252
- https://github.com/anthropics/claude-code-action/releases/tag/v1.0.210

#### Ticket Link
https://github.com/mattermost/mattermost/actions

#### Release Note

```release-note
NONE
```



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change updates one reusable workflow reference. It does not affect application logic, public APIs, authentication, data persistence, or user-facing flows.

**QA Recommendation:** Skip manual QA. Automated workflow validation is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->