### PR TITLE
Cherry-pick #38330: fix dead Cypress image fixture on release-11.7

### DIFF
--- a/e2e-tests/cypress/tests/fixtures/markdown/markdown_inline_images_1.md
+++ b/e2e-tests/cypress/tests/fixtures/markdown/markdown_inline_images_1.md
@@ -1,3 +1,3 @@
 ### In-line Images
 
-Mattermost/platform build status:  [![Build Status](https://docs.mattermost.com/_images/icon-76x76.png)](https://docs.mattermost.com/_images/icon-76x76.png)
+Mattermost/platform build status:  [![Build Status](https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png)](https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png)

--- a/e2e-tests/cypress/tests/integration/channels/files_and_attachments/image_link_preview_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/files_and_attachments/image_link_preview_spec.js
@@ -100,7 +100,7 @@ describe('Image Link Preview', () => {
         cy.visit(offTopicUrl);
 
         const markdownImageText = 'exampleImage';
-        const markdownImageSrc = 'https://docs.mattermost.com/_images/icon-76x76.png';
+        const markdownImageSrc = 'https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png';
         const markdownImageSrcEncoded = encodeURIComponent(markdownImageSrc); // Since the url preview will be encoded string
         const messageWithMarkdownImage = `![${markdownImageText}](${markdownImageSrc}) an image plus some text that has [a link](https://example.com/)`;
 

--- a/e2e-tests/cypress/tests/integration/channels/markdown/markdown_image_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/markdown/markdown_image_spec.js
@@ -44,11 +44,11 @@ describe('Markdown', () => {
                 should('have.class', 'markdown-inline-img').
                 and('have.class', 'markdown-inline-img--hover').
                 and('have.attr', 'alt', 'Build Status').
-                and('have.attr', 'src', `${baseUrl}/api/v4/image?url=https%3A%2F%2Fdocs.mattermost.com%2F_images%2Ficon-76x76.png`).
+                and('have.attr', 'src', `${baseUrl}/api/v4/image?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmattermost%2Fmattermost%2Fmaster%2Fe2e-tests%2Fcypress%2Ftests%2Ffixtures%2Fmattermost-icon_128x128.png`).
                 and((inlineImg) => {
-                    expect(inlineImg.height()).to.be.closeTo(76, 76);
+                    expect(inlineImg.height()).to.be.closeTo(128, 2);
                 }).
-                and('have.css', 'width', '76px');
+                and('have.css', 'width', '128px');
         });
     });
 

--- a/e2e-tests/cypress/tests/integration/channels/messaging/inline_markdown_image_link_open_link_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/inline_markdown_image_link_open_link_spec.js
@@ -21,7 +21,7 @@ describe('Messaging', () => {
 
     it('MM-T188 - Inline markdown image that is a link, opens the link', () => {
         const linkUrl = 'https://www.google.com';
-        const imageUrl = 'https://docs.mattermost.com/_images/icon-76x76.png';
+        const imageUrl = 'https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png';
         const label = 'Build Status';
         const baseUrl = Cypress.config('baseUrl');
 


### PR DESCRIPTION
#### Summary

Cherry-pick of #38330 to `release-11.7`.

The migration of `docs.mattermost.com` removed `/_images/icon-76x76.png`. Cypress specs on this release branch still use that URL, so the local image proxy returns the broken-image placeholder and the same two required tests fail on every run of #38314:

- `Markdown › with in-line images 1`
- `Messaging › MM-T188 - Inline markdown image that is a link, opens the link`

This test-only backport points all four references at the existing in-repository 128×128 Mattermost icon and updates the corresponding size assertions. It is kept separate from #38314 so the CI repair can be reviewed and merged independently; #38314 is temporarily stacked on this branch.

The upstream PR's full Cypress and Playwright suites pass. The replacement asset is present on this release branch and returns HTTP 200 from `raw.githubusercontent.com`; the old docs URL returns HTTP 404.

#### Release Note

```release-note
NONE
```
