### PR TITLE
Restore the webapp node_modules cache read-only in E2E prep-deps

### DIFF
--- a/.github/workflows/e2e-tests-cypress-template.yml
+++ b/.github/workflows/e2e-tests-cypress-template.yml
@@ -247,6 +247,8 @@ jobs:
       - name: ci/setup-webapp-node-modules
         if: steps.probe.outputs.cache-hit != 'true'
         uses: ./.github/actions/webapp-setup
+        with:
+          read-only: "true"
       # Read-only restore of the registry cache warmed daily from master, so the
       # install below refetches as little as possible.
       - name: ci/restore-npm-cache

--- a/.github/workflows/e2e-tests-playwright-template.yml
+++ b/.github/workflows/e2e-tests-playwright-template.yml
@@ -181,6 +181,8 @@ jobs:
           fetch-depth: 1
       - name: ci/setup-webapp-node-modules
         uses: ./.github/actions/webapp-setup
+        with:
+          read-only: "true"
       - name: ci/cache-playwright-deps
         # Caches node_modules + the rolled-up @mattermost/playwright-lib dist
         # so workers don't re-run rollup on every job.


### PR DESCRIPTION
#### Summary

`webapp-setup` defaults to read-write: it uses `actions/cache`, which saves at post-job whenever the exact key missed. The `prep-deps` jobs in the Cypress and Playwright templates were the only two call sites still relying on that default — every other caller (`webapp-ci.yml`, `e2e-tests-check.yml`, and the E2E workers) already passes `read-only: "true"`.

The consequence is that any PR whose `webapp/package-lock.json` misses `node-modules-Linux-<hash>` writes a fresh entry, and that entry is ~3.7 GB — the largest single item in a 10 GB budget that is already evicting continuously. One lockfile-touching PR displaces a lot of what other jobs depend on, and the entry it leaves behind is keyed on a lockfile no other branch reads.

Pass `read-only: "true"` at both sites. `webapp-ci-cache-warm.yml` becomes the sole writer of the key, which is what the surrounding design already assumes.

This is safe at both sites: `webapp-setup` builds the platform packages on either cache path (`make node_modules` on a miss, `npm run postinstall` on a hit), so Cypress still gets the `@mattermost/eslint-plugin` symlink target and Playwright still gets the built `@mattermost/{client,types}` its `file:` deps and rollup postinstall resolve against.

The tradeoff: on a key miss these jobs now run `make node_modules` without saving the result, so a PR that changes the webapp lockfile repeats that install on each run rather than paying it once. That is the same tradeoff the E2E caches already make — warm from master, never write from PRs.

#### Release Note
```release-note
NONE
```
