### PR TITLE
Warm the Playwright deps cache from master and prefer it over the artifact

### DIFF
--- a/.github/actions/pack-playwright-build/action.yml
+++ b/.github/actions/pack-playwright-build/action.yml
@@ -1,0 +1,50 @@
+name: "Pack Playwright build output artifact"
+description: >
+  Tar everything Playwright needs that is compiled from our own source — the
+  rolled-up lib/dist and the built @mattermost/{client,types} output — and upload
+  it as a run-scoped artifact for this run's workers.
+
+  These are deliberately not cached. Both are derived from first-party source
+  rather than from a lockfile, so caching them would drag lib/src and the
+  platform sources into the deps key: 18.6% of master commits touch one of those,
+  against 1.4% for the Playwright lockfile alone. Keying ~275 MB of dependencies
+  on our own edit rate is the churn this split exists to avoid, and prep-deps
+  builds both every run regardless, so there is nothing to warm.
+
+  The container mounts the repo, so the workers already have the sources. What
+  they lack is the tsc and rollup output, which is all this carries.
+
+inputs:
+  fips:
+    description: >
+      Whether this is a FIPS-edition run. e2e-tests-ci.yml invokes the playwright
+      template twice per workflow run — once per edition — and artifact names are
+      run-scoped, so the two invocations would otherwise collide. Must match the
+      unpack step.
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    # -C so the archive holds paths relative to the workspace, letting unpack
+    # extract straight into it.
+    - name: ci/pack-playwright-build
+      shell: bash
+      run: |
+        set -euo pipefail
+        tar -czf "${RUNNER_TEMP}/playwright-build.tgz" -C "${GITHUB_WORKSPACE}" \
+          e2e-tests/playwright/lib/dist \
+          webapp/platform/client/lib \
+          webapp/platform/types/lib
+    - name: ci/upload-playwright-build
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: e2e-playwright-build${{ inputs.fips == 'true' && '-fips' || '' }}
+        path: ${{ runner.temp }}/playwright-build.tgz
+        # Only ever consumed by workers in the same run.
+        retention-days: 1
+        if-no-files-found: error
+        # The tarball is already gzipped; re-compressing it in the zip wrapper
+        # costs CPU for no gain.
+        compression-level: 0

--- a/.github/actions/pack-playwright-deps/action.yml
+++ b/.github/actions/pack-playwright-deps/action.yml
@@ -1,0 +1,47 @@
+name: "Pack Playwright deps artifact"
+description: >
+  The producing half of the artifact transport for the Playwright dependencies:
+  tars the node_modules, the lib workspace's node_modules, and the chromium build
+  just installed by prep-deps, and uploads them as a run-scoped artifact for this
+  run's workers to unpack.
+
+  This is the fallback path, reached only when restore-playwright-deps found the
+  cache key cold. It is not a cache — the artifact is scoped to one run, costs
+  the shared Actions cache nothing, and is retained for a day. It must produce
+  the payload restore-playwright-deps would otherwise have restored, since the
+  workers accept either.
+
+inputs:
+  fips:
+    description: >
+      Whether this is a FIPS-edition run. e2e-tests-ci.yml invokes the playwright
+      template twice per workflow run — once per edition — and artifact names are
+      run-scoped, so the two invocations would otherwise collide. Must match the
+      unpack step.
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    # -C so the archives hold paths relative to their extraction root, letting
+    # unpack extract straight into the workspace and HOME.
+    - name: ci/pack-playwright-deps
+      shell: bash
+      run: |
+        set -euo pipefail
+        tar -czf "${RUNNER_TEMP}/playwright-node-modules.tgz" -C "${GITHUB_WORKSPACE}" e2e-tests/playwright/node_modules e2e-tests/playwright/lib/node_modules
+        tar -czf "${RUNNER_TEMP}/playwright-browsers.tgz" -C "${HOME}" .cache/ms-playwright
+    - name: ci/upload-playwright-deps
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: e2e-playwright-deps${{ inputs.fips == 'true' && '-fips' || '' }}
+        path: |
+          ${{ runner.temp }}/playwright-node-modules.tgz
+          ${{ runner.temp }}/playwright-browsers.tgz
+        # Only ever consumed by workers in the same run.
+        retention-days: 1
+        if-no-files-found: error
+        # The tarballs are already gzipped; re-compressing them in the zip
+        # wrapper costs CPU for no gain.
+        compression-level: 0

--- a/.github/actions/restore-playwright-deps/action.yml
+++ b/.github/actions/restore-playwright-deps/action.yml
@@ -1,0 +1,64 @@
+name: "Restore Playwright deps cache"
+description: >
+  The Actions-cache transport for the Playwright dependencies — node_modules, the
+  lib workspace's node_modules, and the chromium build — keyed on the Playwright
+  lockfile alone.
+
+  The payload is exactly what the lockfile determines, which is what keeps this
+  key stable: nothing built from our own source rides in it, so editing lib/src
+  or a platform type cannot invalidate ~275 MB of dependencies. Those build
+  outputs ship separately, via pack/unpack-playwright-build.
+
+  This is the fast path, taken whenever the key is warm. Read-only, as
+  e2e-ci-cache-warm-playwright-deps.yml is the only writer of the key, so PR and
+  merge runs never write to the Actions cache.
+
+  When the key is cold the template falls back to the artifact transport instead
+  — pack-playwright-deps into unpack-playwright-deps — which must land the same
+  payload in the same paths, so the two transports are interchangeable.
+
+inputs:
+  lookup-only:
+    description: "Probe whether the key exists without downloading the entry."
+    required: false
+    default: "false"
+  fail-on-cache-miss:
+    description: "Fail the step when the exact key is absent."
+    required: false
+    default: "false"
+
+outputs:
+  cache-hit:
+    description: "true on an exact-key hit"
+    value: ${{ steps.restore.outputs.cache-hit }}
+  key:
+    description: "The computed cache key"
+    value: ${{ steps.key.outputs.key }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: ci/compute-playwright-deps-key
+      id: key
+      shell: bash
+      run: echo "key=e2e-playwright-deps-${{ runner.os }}-${{ hashFiles('e2e-tests/playwright/package-lock.json') }}" >> "${GITHUB_OUTPUT}"
+    - name: ci/restore-playwright-deps
+      id: restore
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      # No restore-keys. The workers are the only consumer that downloads this
+      # entry, and they use it as-is with no install step to reconcile a
+      # near-miss, so an older node_modules would silently run the suite against
+      # the wrong dependencies. Exact key or nothing, with the artifact covering
+      # the nothing.
+      #
+      # A fuzzy match would not help the installers either: npm ci deletes
+      # node_modules before installing. Their warm start is ~/.npm, which
+      # restore-e2e-npm-cache does restore with restore-keys.
+      with:
+        path: |
+          e2e-tests/playwright/node_modules
+          e2e-tests/playwright/lib/node_modules
+          ~/.cache/ms-playwright
+        key: ${{ steps.key.outputs.key }}
+        lookup-only: ${{ inputs.lookup-only }}
+        fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}

--- a/.github/actions/unpack-playwright-build/action.yml
+++ b/.github/actions/unpack-playwright-build/action.yml
@@ -1,0 +1,32 @@
+name: "Unpack Playwright build output artifact"
+description: >
+  Download and extract this run's artifact from pack-playwright-build, putting
+  the rolled-up lib/dist and the built @mattermost/{client,types} output where
+  the workers resolve them — the latter through the file: symlinks in the
+  Playwright node_modules.
+
+  Runs on every worker, on both the cache-hit and cache-miss deps paths, since
+  this content ships only by artifact and is in neither the deps cache nor the
+  checkout.
+
+inputs:
+  fips:
+    description: >
+      Whether this is a FIPS-edition run. Must match the pack step so the correct
+      artifact is downloaded.
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: ci/download-playwright-build
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      with:
+        name: e2e-playwright-build${{ inputs.fips == 'true' && '-fips' || '' }}
+        path: ${{ runner.temp }}
+    - name: ci/unpack-playwright-build
+      shell: bash
+      run: |
+        set -euo pipefail
+        tar -xzf "${RUNNER_TEMP}/playwright-build.tgz" -C "${GITHUB_WORKSPACE}"

--- a/.github/actions/unpack-playwright-deps/action.yml
+++ b/.github/actions/unpack-playwright-deps/action.yml
@@ -1,0 +1,33 @@
+name: "Unpack Playwright deps artifact"
+description: >
+  The consuming half of the artifact transport for the Playwright dependencies:
+  downloads this run's artifact from pack-playwright-deps and extracts the
+  node_modules, the lib workspace's node_modules, and the chromium build into
+  place.
+
+  Runs on a worker only when restore-playwright-deps found the cache key cold,
+  and must leave the same paths populated that a cache restore would have, so the
+  steps that follow cannot tell which transport ran.
+
+inputs:
+  fips:
+    description: >
+      Whether this is a FIPS-edition run. Must match the pack step so the correct
+      artifact is downloaded.
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: ci/download-playwright-deps
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      with:
+        name: e2e-playwright-deps${{ inputs.fips == 'true' && '-fips' || '' }}
+        path: ${{ runner.temp }}
+    - name: ci/unpack-playwright-deps
+      shell: bash
+      run: |
+        set -euo pipefail
+        tar -xzf "${RUNNER_TEMP}/playwright-node-modules.tgz" -C "${GITHUB_WORKSPACE}"
+        tar -xzf "${RUNNER_TEMP}/playwright-browsers.tgz" -C "${HOME}"

--- a/.github/workflows/e2e-ci-cache-warm-playwright-deps.yml
+++ b/.github/workflows/e2e-ci-cache-warm-playwright-deps.yml
@@ -1,0 +1,100 @@
+# Warms the Playwright dependencies cache (node_modules, the lib workspace's
+# node_modules, and chromium) from master. This workflow is the only writer of
+# the key, so PR and merge runs never write to the Actions cache; they restore it
+# read-only via .github/actions/restore-playwright-deps.
+#
+# Until this workflow has warmed a given key, runs on that tree fall back to the
+# run-scoped artifact built by prep-deps in e2e-tests-playwright-template.yml.
+name: "E2E Cache Warm: Playwright deps"
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # Daily 3am UTC — after the webapp node_modules and E2E npm registry caches warm at 1am
+  # Warm as soon as the key's only input lands on master, so the merge run and
+  # subsequent PRs hit the cache instead of paying for the artifact fallback all
+  # day. The schedule is the backstop.
+  push:
+    branches:
+      - master
+    paths:
+      - "e2e-tests/playwright/package-lock.json"
+  workflow_dispatch:
+
+# Keep manual, scheduled and push-triggered runs from racing to save the same key.
+concurrency:
+  group: e2e-ci-cache-warm-playwright-deps
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: write # required to save the Actions cache
+
+jobs:
+  warm:
+    name: Warm Playwright deps cache
+    runs-on: ubuntu-24.04
+    # workflow_dispatch can target any branch. Warming from one would write a
+    # branch-scoped entry keyed on that branch's lockfile — quota spent on a key
+    # no other branch can read, which is the churn this workflow exists to avoid.
+    if: github.ref == 'refs/heads/master'
+    # Bound a hung run so it can't hold the concurrency group for the default
+    # 6-hour timeout and block subsequent warm runs.
+    timeout-minutes: 30
+    steps:
+      - name: Checkout mattermost project
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - name: ci/probe-playwright-deps
+        id: deps
+        uses: ./.github/actions/restore-playwright-deps
+        with:
+          lookup-only: "true"
+      # Ahead of webapp-setup so its install benefits too, and so cache/restore
+      # never untars ~/.npm on top of entries npm has already written this job.
+      - name: ci/restore-npm-cache
+        if: steps.deps.outputs.cache-hit != 'true'
+        uses: ./.github/actions/restore-e2e-npm-cache
+      # npm ci below typechecks lib/src against the @mattermost/{client,types}
+      # output, so those have to be built even though the cache does not carry
+      # them.
+      - name: ci/setup-webapp-node-modules
+        if: steps.deps.outputs.cache-hit != 'true'
+        uses: ./.github/actions/webapp-setup
+        with:
+          read-only: "true"
+      # Skip the browser download here; the next step installs chromium alone.
+      - name: ci/install-playwright-deps
+        if: steps.deps.outputs.cache-hit != 'true'
+        working-directory: e2e-tests/playwright
+        env:
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
+        run: npm ci
+      - name: ci/install-playwright-chromium
+        if: steps.deps.outputs.cache-hit != 'true'
+        working-directory: e2e-tests/playwright
+        run: npx playwright install chromium
+      # Must stay in sync with restore-playwright-deps and pack-playwright-deps.
+      # lib/dist is deliberately absent: it is built from our source, ships by
+      # artifact, and would otherwise force lib/src into this key.
+      - name: ci/save-playwright-deps
+        if: steps.deps.outputs.cache-hit != 'true'
+        uses: actions/cache/save@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        with:
+          path: |
+            e2e-tests/playwright/node_modules
+            e2e-tests/playwright/lib/node_modules
+            ~/.cache/ms-playwright
+          key: ${{ steps.deps.outputs.key }}
+      # This job is the sole writer of the key, so its summary is where "is
+      # warming actually working?" gets answered.
+      - name: ci/report-warm-outcome
+        env:
+          CACHE_HIT: ${{ steps.deps.outputs.cache-hit }}
+          CACHE_KEY: ${{ steps.deps.outputs.key }}
+        run: |
+          if [ "${CACHE_HIT}" = "true" ]; then
+            echo "Playwright deps: \`${CACHE_KEY}\` already warm; nothing new to save." >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "Playwright deps: saved \`${CACHE_KEY}\`." >> "${GITHUB_STEP_SUMMARY}"
+          fi

--- a/.github/workflows/e2e-tests-playwright-template.yml
+++ b/.github/workflows/e2e-tests-playwright-template.yml
@@ -163,15 +163,20 @@ jobs:
           echo "workers=$(jq -nc --argjson n "${INPUT_WORKERS}" '[range(1; $n+1)]')" >> $GITHUB_OUTPUT
           echo "start_time=$(date +%s)" >> $GITHUB_OUTPUT
 
-  # Install webapp node_modules once via the shared webapp-setup action, then
-  # workers restore the same stable cache. The node_modules cache is keyed only
-  # on webapp/package-lock.json and is shared with webapp-ci.yml jobs.
+  # Decide how workers get their deps, and bridge the gap when they can't use the
+  # cache. On a hit this job is just a checkout and a metadata lookup; workers
+  # restore the warmed entry directly and nothing is uploaded. On a miss — a PR
+  # touching the lockfile, lib/src or the platform packages, or a master commit
+  # that landed before the warm workflow ran — this job installs once and ships a
+  # run-scoped artifact as a stop-gap until the next warm populates the key.
   prep-deps:
     name: prep-deps
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     permissions:
       contents: read
+    outputs:
+      cache-hit: ${{ steps.deps.outputs.cache-hit }}
     steps:
       - name: ci/checkout-repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -179,41 +184,69 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 1
+      # A real restore, not a lookup-only probe: prep-deps needs node_modules
+      # present to build lib/dist below, on the hit path as well as the miss
+      # path. The verdict still becomes the job output the workers branch on.
+      - name: ci/restore-playwright-deps
+        id: deps
+        uses: ./.github/actions/restore-playwright-deps
+      # Which transport a run took is otherwise only legible from which steps
+      # below were skipped. Reporting the key alongside the verdict is what makes
+      # a miss diagnosable: a lockfile drift reads as an unexpected key rather
+      # than an unexplained miss.
+      - name: ci/report-playwright-deps-transport
+        env:
+          CACHE_HIT: ${{ steps.deps.outputs.cache-hit }}
+          CACHE_KEY: ${{ steps.deps.outputs.key }}
+        run: |
+          if [ "${CACHE_HIT}" = "true" ]; then
+            echo "Playwright deps: cache **hit** on \`${CACHE_KEY}\` — workers restore it directly from the Actions cache." >> "${GITHUB_STEP_SUMMARY}"
+          else
+            echo "Playwright deps: cache **miss** on \`${CACHE_KEY}\` — installing once and shipping the run-scoped artifact." >> "${GITHUB_STEP_SUMMARY}"
+          fi
+      # Builds the @mattermost/{client,types} output that lib/src typechecks
+      # against and the workers resolve at run time. Read-only, so this job never
+      # writes the webapp node_modules entry.
       - name: ci/setup-webapp-node-modules
         uses: ./.github/actions/webapp-setup
-      - name: ci/cache-playwright-deps
-        # Caches node_modules + the rolled-up @mattermost/playwright-lib dist
-        # so workers don't re-run rollup on every job.
-        id: cache-playwright
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
         with:
-          path: |
-            e2e-tests/playwright/node_modules
-            e2e-tests/playwright/lib/dist
-            e2e-tests/playwright/lib/node_modules
-          key: e2e-playwright-deps-${{ runner.os }}-${{ hashFiles('e2e-tests/playwright/package-lock.json', 'e2e-tests/playwright/lib/src/**', 'e2e-tests/playwright/lib/package.json', 'e2e-tests/playwright/lib/rollup.config.js', 'e2e-tests/playwright/lib/tsconfig.json') }}
+          read-only: "true"
+      # Cache-miss path: install the dependencies the workers could not restore.
+      # Read-only restore of the registry cache keeps the install short.
+      - name: ci/restore-npm-cache
+        if: steps.deps.outputs.cache-hit != 'true'
+        uses: ./.github/actions/restore-e2e-npm-cache
+      # Skip the browser download here; the next step installs chromium alone.
+      # npm ci symlinks @mattermost/{client,types} to the webapp packages built
+      # above, and its postinstall rolls up lib/dist.
       - name: ci/install-playwright-deps
-        # `npm ci` creates symlinks at node_modules/@mattermost/{client,types}
-        # → webapp/platform/{client,types}; targets must already be built.
-        # The postinstall then builds lib/dist via rollup. Skip browser
-        # download here — chromium is cached separately below.
-        if: steps.cache-playwright.outputs.cache-hit != 'true'
+        if: steps.deps.outputs.cache-hit != 'true'
         working-directory: e2e-tests/playwright
         env:
           PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: "1"
         run: npm ci
-      - name: ci/cache-playwright-browsers
-        # Cache chromium binary (~150MB) keyed on the playwright lockfile so a
-        # version bump invalidates. Restored by workers; no docker image needed.
-        id: cache-pw-browsers
-        uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
-        with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('e2e-tests/playwright/package-lock.json') }}
       - name: ci/install-playwright-chromium
-        if: steps.cache-pw-browsers.outputs.cache-hit != 'true'
+        if: steps.deps.outputs.cache-hit != 'true'
         working-directory: e2e-tests/playwright
         run: npx playwright install chromium
+      - name: ci/pack-playwright-deps
+        if: steps.deps.outputs.cache-hit != 'true'
+        uses: ./.github/actions/pack-playwright-deps
+        with:
+          fips: ${{ inputs.server_edition == 'fips' }}
+      # On the miss path npm ci's postinstall already rolled up lib/dist. On the
+      # hit path node_modules came from the cache, which by design carries no
+      # build output, so roll it up here.
+      - name: ci/build-playwright-lib
+        if: steps.deps.outputs.cache-hit == 'true'
+        working-directory: e2e-tests/playwright
+        run: npm run build
+      # Both build outputs ship by artifact on every run, whichever deps
+      # transport ran.
+      - name: ci/pack-playwright-build
+        uses: ./.github/actions/pack-playwright-build
+        with:
+          fips: ${{ inputs.server_edition == 'fips' }}
 
   # Register the Test System IO run AFTER prep-deps so workers reach
   # dispatch-run within Test System IO's inactivity window.
@@ -250,7 +283,9 @@ jobs:
     name: dispatch-run-${{ matrix.worker_index }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
-    needs: [prepare-run, dispatch-begin]
+    # prep-deps is already an ancestor via dispatch-begin; naming it directly
+    # makes its cache-hit output readable here.
+    needs: [prepare-run, prep-deps, dispatch-begin]
     permissions:
       contents: read
       id-token: write
@@ -294,28 +329,34 @@ jobs:
           persist-credentials: false
           ref: ${{ inputs.commit_sha }}
           fetch-depth: 0
-      - name: ci/setup-webapp-node-modules
-        uses: ./.github/actions/webapp-setup
+      # No webapp-setup here: the build artifact carries the @mattermost/{client,types}
+      # output the file: symlinks resolve to, so workers need neither the webapp
+      # node_modules cache nor an npm ci.
+      - name: ci/setup-node
+        uses: actions/setup-node@6044e13b5dc448c55e2357c09f80417699197238 # v6.2.0
         with:
-          read-only: "true"
+          node-version-file: ".nvmrc"
+      # lib/dist and the platform libs ship by artifact on every run,
+      # independently of which deps transport below runs.
+      - name: ci/reuse-playwright-build
+        uses: ./.github/actions/unpack-playwright-build
+        with:
+          fips: ${{ inputs.server_edition == 'fips' }}
+      # Exactly one of the next two steps runs, per prep-deps' probe. The warmed
+      # cache is the normal path; the artifact only exists when the probe missed.
       - name: ci/restore-playwright-deps
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+        if: needs.prep-deps.outputs.cache-hit == 'true'
+        uses: ./.github/actions/restore-playwright-deps
         with:
-          path: |
-            e2e-tests/playwright/node_modules
-            e2e-tests/playwright/lib/dist
-            e2e-tests/playwright/lib/node_modules
-          key: e2e-playwright-deps-${{ runner.os }}-${{ hashFiles('e2e-tests/playwright/package-lock.json', 'e2e-tests/playwright/lib/src/**', 'e2e-tests/playwright/lib/package.json', 'e2e-tests/playwright/lib/rollup.config.js', 'e2e-tests/playwright/lib/tsconfig.json') }}
-          fail-on-cache-miss: true
-      - name: ci/restore-playwright-browsers
-        uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+          fail-on-cache-miss: "true"
+      - name: ci/reuse-playwright-deps
+        if: needs.prep-deps.outputs.cache-hit != 'true'
+        uses: ./.github/actions/unpack-playwright-deps
         with:
-          path: ~/.cache/ms-playwright
-          key: playwright-browsers-${{ runner.os }}-${{ hashFiles('e2e-tests/playwright/package-lock.json') }}
-          fail-on-cache-miss: true
+          fips: ${{ inputs.server_edition == 'fips' }}
       # Brings up the stack via Testcontainers in `testcontainers` mode (global setup). Also runs the
       # `setup` project so per-spec dispatches can pass --no-deps and skip plugin-load +
-      # server-deployment checks. node_modules, lib/dist, and chromium are all restored from cache.
+      # server-deployment checks. node_modules, lib/dist and chromium come from whichever transport ran.
       - name: ci/prepare-playwright
         working-directory: e2e-tests/playwright
         run: npx playwright test --project=setup


### PR DESCRIPTION
#### Summary

The Playwright counterpart to #38253 and #38261, which did this for Cypress — and it arrives at the same shape those PRs gave Cypress.

Today `prep-deps` writes `node_modules` + the rolled-up `lib/dist` to a shared Actions cache keyed on the Playwright lockfile **and `lib/src`**, and the workers read it back within the same run. Two problems follow from that:

- PR runs write branch-scoped entries no other branch can read. 8 of the 21 live `e2e-playwright-deps-*` entries are off-master.
- `lib/dist` is rolled up from `lib/src`, so `lib/src` has to be in the key. **13.2%** of master commits over the last 90 days touch it, against **1.4%** for the lockfile alone. Editing a test helper threw away `node_modules` and chromium with it.

#### A dependencies cache that holds only dependencies

`e2e-playwright-deps-*` is now keyed on `e2e-tests/playwright/package-lock.json` and nothing else, and carries only what that lockfile determines:

| | payload | key |
|---|---|---|
| `e2e-cypress-deps-*` | `cypress/node_modules`, `~/.cache/Cypress` | cypress lockfile |
| `e2e-playwright-deps-*` | `playwright/node_modules`, `lib/node_modules`, `~/.cache/ms-playwright` | playwright lockfile |

`lib` is an npm workspace of `e2e-tests/playwright`, so its `node_modules` is resolved by the same lockfile. Chromium is pinned by it too, which lets this **absorb the separate `playwright-browsers-*` key** rather than storing chromium in both — that key is retired here.

Everything compiled from our own source moves to a run-scoped artifact, rebuilt every run: `lib/dist`, plus the built `@mattermost/{client,types}` output. Neither is cached, deliberately. Caching them is what dragged `lib/src` and the platform sources into the key in the first place, and `prep-deps` builds both every run regardless, so there is nothing to warm. The rule the split follows: **cache what the lockfile determines; ship what our source determines.** Nothing derived from first-party code is cached, so nothing cached can go stale.

#### Transports

- **Cache (fast path).** A new scheduled workflow is the sole writer of the deps key, warming it from master daily and on any push that changes the lockfile. Workers restore the warmed entry directly. PR and merge runs never write.
- **Artifact (fallback).** On a miss, `prep-deps` installs once and uploads a run-scoped artifact the workers unpack. It costs the shared cache nothing and is retained for a day. Exactly one of the two runs.
- **Build artifact (always).** `lib/dist` and the platform libs, on both paths.

`restore-playwright-deps` centralises the key so the warm workflow, `prep-deps` and the workers cannot drift apart, and its payload must stay identical to `pack`/`unpack-playwright-deps` — the cache entry and the artifact are interchangeable by construction. Artifact names are edition-scoped, since `e2e-tests-ci.yml` invokes this template twice per run.

#### Dropping webapp node_modules from the workers

The workers restored the webapp `node_modules` cache — ~370 MB, once per worker — for one reason: Playwright declares `@mattermost/{client,types}` as `file:` deps, and rollup marks them `external`, so `lib/dist` emits imports that resolve through those symlinks at run time. The compose service mounts the whole repo, so the workers already have the *sources*; what they lack is the `tsc` output. The build artifact carries it, and the workers drop `webapp-setup` for a plain `setup-node`.

This matters beyond the transfer saved. `webapp-setup` runs a full `make node_modules` whenever the exact key misses, so any job calling it downstream of `prep-deps` fans that install across all 40 workers. After this PR no Playwright job downstream of `prep-deps` calls it at all.

The Cypress template still has the old shape — its workers call `webapp-setup`, so its `prep-deps` still writes the webapp cache to absorb that fan-out. Unchanged here; it wants the same treatment separately.

#### Cost

`prep-deps` is no longer a metadata probe on the hit path. It restores the deps cache for real, because it needs `node_modules` present to roll up `lib/dist`, and it runs `webapp-setup` every run to build the platform libs. That is one job, never 40, and it never writes to the cache — but it does add a restore and two builds ahead of the workers on every run.

#### Test Plan

CI on this PR exercises the miss path end to end: the deps key is cold, so `prep-deps` installs once, packs both artifacts, and every worker unpacks them. The `prep-deps` step summary reports which transport ran and the key it computed. The hit path needs the warm workflow to have run on master, so it can only be confirmed after merge.

#### Release Note
```release-note
NONE
```
