### PR TITLE
[MM-70582] Auto-link plain phone numbers to clickable tel: links

### DIFF
--- a/server/config/client.go
+++ b/server/config/client.go
@@ -54,6 +54,8 @@ func GenerateClientConfig(c *model.Config, telemetryID string, license *model.Li
 	props["EnableMarketplace"] = strconv.FormatBool(*c.PluginSettings.EnableMarketplace)
 	props["EnableLatex"] = strconv.FormatBool(*c.ServiceSettings.EnableLatex)
 	props["EnableInlineLatex"] = strconv.FormatBool(*c.ServiceSettings.EnableInlineLatex)
+	props["EnablePhoneNumberAutolinkingInternational"] = strconv.FormatBool(*c.ServiceSettings.EnablePhoneNumberAutolinkingInternational)
+	props["EnablePhoneNumberAutolinkingNorthAmerican"] = strconv.FormatBool(*c.ServiceSettings.EnablePhoneNumberAutolinkingNorthAmerican)
 	props["ExtendSessionLengthWithActivity"] = strconv.FormatBool(*c.ServiceSettings.ExtendSessionLengthWithActivity)
 	props["ManagedResourcePaths"] = *c.ServiceSettings.ManagedResourcePaths
 	props["DeleteAccountLink"] = *c.ServiceSettings.DeleteAccountLink

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -525,6 +525,8 @@ type ServiceSettings struct {
 	EnableWebHubChannelIteration                      *bool   `access:"write_restrictable,cloud_restrictable"` // telemetry: none
 	FrameAncestors                                    *string `access:"write_restrictable,cloud_restrictable"` // telemetry: none
 	DeleteAccountLink                                 *string `access:"site_users_and_teams,write_restrictable,cloud_restrictable"`
+	EnablePhoneNumberAutolinkingInternational         *bool   `access:"site_posts"`
+	EnablePhoneNumberAutolinkingNorthAmerican         *bool   `access:"site_posts"`
 }
 
 var MattermostGiphySdkKey string
@@ -1103,6 +1105,14 @@ func (s *ServiceSettings) SetDefaults(isUpdate bool) {
 
 	if s.DeleteAccountLink == nil {
 		s.DeleteAccountLink = new("")
+	}
+
+	if s.EnablePhoneNumberAutolinkingInternational == nil {
+		s.EnablePhoneNumberAutolinkingInternational = new(true)
+	}
+
+	if s.EnablePhoneNumberAutolinkingNorthAmerican == nil {
+		s.EnablePhoneNumberAutolinkingNorthAmerican = new(true)
 	}
 }
 

--- a/webapp/channels/package.json
+++ b/webapp/channels/package.json
@@ -58,6 +58,7 @@
     "html-to-react": "1.6.0",
     "ipaddr.js": "2.1.0",
     "katex": "0.16.21",
+    "libphonenumber-js": "1.11.20",
     "localforage": "1.10.0",
     "localforage-observable": "2.1.1",
     "lodash": "4.18.1",

--- a/webapp/channels/src/components/markdown/index.ts
+++ b/webapp/channels/src/components/markdown/index.ts
@@ -60,6 +60,8 @@ function makeMapStateToProps() {
             minimumHashtagLength: parseInt(config.MinimumHashtagLength || '', 10),
             emojiMap: getEmojiMap(state),
             channelId,
+            enablePhoneNumberAutolinkingInternational: config.EnablePhoneNumberAutolinkingInternational === 'true',
+            enablePhoneNumberAutolinkingNorthAmerican: config.EnablePhoneNumberAutolinkingNorthAmerican === 'true',
         };
     };
 }

--- a/webapp/channels/src/components/markdown/markdown.tsx
+++ b/webapp/channels/src/components/markdown/markdown.tsx
@@ -110,6 +110,8 @@ function Markdown({
     team,
     minimumHashtagLength,
     managedResourcePaths,
+    enablePhoneNumberAutolinkingInternational,
+    enablePhoneNumberAutolinkingNorthAmerican,
 }: Props) {
     if (message === '' || !enableFormatting) {
         return (
@@ -134,6 +136,8 @@ function Markdown({
         managedResourcePaths,
         editedAt,
         postId,
+        enablePhoneNumberAutolinkingInternational,
+        enablePhoneNumberAutolinkingNorthAmerican,
     }, options);
 
     const htmlFormattedText = formatText(message, inputOptions, emojiMap);

--- a/webapp/channels/src/utils/text_formatting.tsx
+++ b/webapp/channels/src/utils/text_formatting.tsx
@@ -3,6 +3,7 @@
 
 import emojiRegex from 'emoji-regex';
 import type {Renderer} from 'marked';
+import {parsePhoneNumber, type CountryCode} from 'libphonenumber-js/min';
 
 import type {SystemEmoji} from '@mattermost/types/emojis';
 import {isRecordOf} from '@mattermost/types/utilities';
@@ -206,6 +207,20 @@ export interface TextFormattingOptionsBase {
      * Whether or not to render text emoticons (:D) as emojis
      */
     renderEmoticonsAsEmoji: boolean;
+
+    /**
+     * Whether to auto-link international phone numbers (starting with +) as tel: links.
+     *
+     * Defaults to `false`.
+     */
+    enablePhoneNumberAutolinkingInternational: boolean;
+
+    /**
+     * Whether to auto-link North American 10-digit phone numbers as tel: links.
+     *
+     * Defaults to `false`.
+     */
+    enablePhoneNumberAutolinkingNorthAmerican: boolean;
 }
 
 export type TextFormattingOptions = Partial<TextFormattingOptionsBase>;
@@ -364,6 +379,16 @@ export function doFormatText(text: string, options: TextFormattingOptions, emoji
         }
 
         output = autolinkEmails(output, tokens);
+
+        if (options.enablePhoneNumberAutolinkingInternational || options.enablePhoneNumberAutolinkingNorthAmerican) {
+            output = autolinkPhoneNumbers(
+                output,
+                tokens,
+                options.enablePhoneNumberAutolinkingInternational ?? false,
+                options.enablePhoneNumberAutolinkingNorthAmerican ?? false,
+            );
+        }
+
         output = autolinkHashtags(output, tokens, options.minimumHashtagLength);
 
         if (!('emoticons' in options) || options.emoticons) {
@@ -436,6 +461,69 @@ function autolinkEmails(text: string, tokens: Tokens) {
     }
 
     return text.replace(emailRegex, replaceEmailWithToken);
+}
+
+// Matches international phone numbers starting with +, followed by digits/separators.
+// The prefix group prevents matching numbers embedded in words.
+// libphonenumber-js validates whether the candidate is a real dialable number.
+// eslint-disable-next-line no-useless-escape
+const internationalPhoneRegex = /(^|[^\p{L}\d])(\+\d[\d\s\-\.\(\)]{5,20})(?=$|[^\d\p{L}])/gu;
+
+// Matches North American phone numbers: optional 1- prefix, area code, exchange, subscriber.
+// Excludes 7-digit numbers (no area code) because the pattern requires three digit groups.
+// The negative look-behind (?<![+\d\p{L}]) excludes matches embedded in words or immediately
+// after digits. The second look-behind (?<!\+\d[\d\s\-.()*#]*) prevents matching the NA
+// portion of an international number (e.g. "555-123-4567" in "+1 555-123-4567").
+// eslint-disable-next-line no-useless-escape
+const northAmericanPhoneRegex = /(?<!\+\d[\d\s\-\.\(\)]*)(?<![+\d\p{L}])((?:1[\s\-\.]?)?\(?\d{3}\)?[\s\-\.]\d{3}[\s\-\.]\d{4})(?=$|[^\d\p{L}])/gu;
+
+function autolinkPhoneNumbers(
+    text: string,
+    tokens: Tokens,
+    enableInternational: boolean,
+    enableNorthAmerican: boolean,
+) {
+    function replacePhoneWithToken(
+        fullMatch: string,
+        prefix: string,
+        candidate: string,
+        defaultRegion?: CountryCode,
+    ) {
+        try {
+            const phoneNumber = parsePhoneNumber(candidate, defaultRegion);
+            if (!phoneNumber?.isPossible()) {
+                return fullMatch;
+            }
+
+            const index = tokens.size;
+            const alias = `$MM_PHONE${index}$`;
+
+            tokens.set(alias, {
+                value: `<a class="theme" href="${phoneNumber.getURI()}" rel="noreferrer">${candidate}</a>`,
+                originalText: candidate,
+            });
+
+            return prefix + alias;
+        } catch {
+            return fullMatch;
+        }
+    }
+
+    let output = text;
+
+    if (enableInternational) {
+        output = output.replace(internationalPhoneRegex, (fullMatch, prefix, candidate) =>
+            replacePhoneWithToken(fullMatch, prefix, candidate),
+        );
+    }
+
+    if (enableNorthAmerican) {
+        output = output.replace(northAmericanPhoneRegex, (fullMatch, candidate) =>
+            replacePhoneWithToken(fullMatch, '', candidate, 'US'),
+        );
+    }
+
+    return output;
 }
 
 export function autolinkAtMentions(text: string, tokens: Tokens): string {

--- a/webapp/package-lock.json
+++ b/webapp/package-lock.json
@@ -106,6 +106,7 @@
         "html-to-react": "1.6.0",
         "ipaddr.js": "2.1.0",
         "katex": "0.16.21",
+        "libphonenumber-js": "1.11.20",
         "localforage": "1.10.0",
         "localforage-observable": "2.1.1",
         "lodash": "4.18.1",
@@ -325,7 +326,6 @@
       "version": "26.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -533,7 +533,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -2243,7 +2242,6 @@
       "integrity": "sha512-DYD23veRYGvBFhcTY1iUvJnDNpuqNd/BzBwCvzOTKUnJjKg5kpUBh3/u9585Agdkgj+QuygG7jLfOPWMa2KVNw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/compat-data": "^7.29.0",
         "@babel/helper-compilation-targets": "^7.28.6",
@@ -2597,7 +2595,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -2621,7 +2618,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -2814,7 +2810,6 @@
       "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.14.0.tgz",
       "integrity": "sha512-O000MLDBDdk/EohJPFUqvnp4qnHeYkVP5B0xEG0D/L7cOKP9kefu2DXn8dj74cQfsEzUqh+sr1RzFqiL1o+PpA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.18.3",
         "@emotion/babel-plugin": "^11.13.5",
@@ -3078,7 +3073,6 @@
       "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
       "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@floating-ui/core": "^1.7.5",
         "@floating-ui/utils": "^0.2.11"
@@ -5143,7 +5137,6 @@
       "integrity": "sha512-LTATglVUPGkPf15zX1wTMlZ0+AU7cGEGF6ekVF1crA8eHUWsGjrYTB+Ht4E3HTrCok8weQG+K01rJndCp/l4XA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/core": "^0.16.13"
@@ -5186,7 +5179,6 @@
       "integrity": "sha512-8Z1k96ZFxlhK2bgrY1JNWNwvaBeI/bciLM0yDOni2+aZwfIIiC7Y6PeWHTAvjHNjphz+XCt01WQmOYWCn0ML6g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -5201,7 +5193,6 @@
       "integrity": "sha512-PvLrfa8vkej3qinlebyhLpksJgCF5aiysDMSVhOZqwH5nQLLtDE9WYbnsofGw4r0VVpyw3H/ANCIzYTyCtP9Cg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -5230,7 +5221,6 @@
       "integrity": "sha512-xW+9BtEvoIkkH/Wde9ql4nAFbYLkVINhpgAE7VcBUsuuB34WUbcBl/taOuUYQrPEFQJ4jfXiAJZ2H/rvKjCVnQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13",
@@ -5280,7 +5270,6 @@
       "integrity": "sha512-WEl2tPVYwzYL8OKme6Go2xqiWgKsgxlMwyHabdAU4tXaRwOCnOI7v4021gCcBb9zn/oWwguHuKHmK30Fw2Z/PA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -5424,7 +5413,6 @@
       "integrity": "sha512-qoqtN8LDknm3fJm9nuPygJv30O3vGhSBD2TxrsCnhtOsxKAqVPJtFVdGd/qVuZ8nqQANQmTlfqTiK9mVWQ7MiQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -5439,7 +5427,6 @@
       "integrity": "sha512-Ev+Jjmj1nHYw897z9C3R9dYsPv7S2/nxdgfFb/h8hOwK0Ovd1k/+yYS46A0uj/JCKK0pQk8wOslYBkPwdnLorw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -5457,7 +5444,6 @@
       "integrity": "sha512-05POQaEJVucjTiSGMoH68ZiELc7QqpIpuQlZ2JBbhCV+WCbPFUBcGSmE7w4Jd0E2GvCho/NoMODLwgcVGQA97A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.7.2",
         "@jimp/utils": "^0.16.13"
@@ -6200,8 +6186,7 @@
       "version": "0.1.61",
       "resolved": "https://registry.npmjs.org/@mattermost/compass-icons/-/compass-icons-0.1.61.tgz",
       "integrity": "sha512-Xq7QHyxq7NPljgqlzwRp6tWGe5sD49tWTzG41q9+sYsI+DdymJmteezupkfO3NxNxYXJiDD+q2kF0Ai2he1Mcg==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@mattermost/components": {
       "resolved": "platform/components",
@@ -7165,7 +7150,6 @@
       "integrity": "sha512-a0CgrW5A5kwuSu5J1RFRoMQaMs9yagvfH2jJMYVw56+/7NRI4KOtu612SG9Y1ERWfY55ZwzyFxtLWvD6LO+Anw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@mischnic/json-sourcemap": "^0.1.1",
         "@parcel/cache": "2.16.4",
@@ -9238,7 +9222,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.26"
@@ -9490,7 +9473,6 @@
       "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.8.0"
       }
@@ -9562,7 +9544,6 @@
       "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
@@ -9657,7 +9638,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.26.1.tgz",
       "integrity": "sha512-TX9PyPqBoix0qDLjtok/bddtdSy54QhzLVha405C07V+WySOpH3s/pWYkywehZQY0SQtcrcY4MNSCeQjCbA28A==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -9741,7 +9721,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-3.26.1.tgz",
       "integrity": "sha512-NY7SYqcrqDVYTSWyaNGdSfCims6pOHoRQ2Rh4DEFb/rb8gLVkqbLZhcHzQCVfinlPqgV3xWF6cYMORwmnlBkXQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -9898,7 +9877,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.26.1.tgz",
       "integrity": "sha512-06nOjnyXpzMO8Ys5k3IbYsDsKib1mv2OtaxBYX1/1uvRyOKwUX5tqDLb/qigic0LIANNL73lkNC8Z8XPeG4Tkg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -9991,7 +9969,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-table/-/extension-table-3.20.0.tgz",
       "integrity": "sha512-vaaMtQ2KnSSr8WVwgWf7NYNzPwrHx/6T0ekA5CxV8qNUEpXIaLXa5+tE7tJHWEdNR2KY3gUJ46D3lfOkxyFrBQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -10071,7 +10048,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.26.1.tgz",
       "integrity": "sha512-PmRaoe6bebTgz/ZQrjmzwZMST1d9js9ZTiKnUXeXl3Fm+V5U/c3TbbKDfqmL63qPQdjtShDMHi9tYuv+c77OFQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -10115,7 +10091,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.26.1.tgz",
       "integrity": "sha512-48cJQRbvr9Ux0+IgM1BR5vOLU5hkC+n+uerdQy2JjrIRKpYE/huU8fQFm6PoRppoKYfilklzb29elsQ+n2TA+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-commands": "^1.6.2",
@@ -10692,7 +10667,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.64.tgz",
       "integrity": "sha512-MlmPvHgjj2p3vZaxbQgFUQFvD8QiZwACfGqEdDSWou5yISWxDQ4/74nCAwsUiX7UFLKZz3BbVSPj+YxeoGGCfg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -10735,7 +10709,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.25.tgz",
       "integrity": "sha512-o/V48vf4MQh7juIKZU2QGDfli6p1+OOi5oXx36Hffpc9adsHeXjVp8rHuPkjd8VT8sOJ2Zp05HR7CdpGTIUFUA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/react": "*"
       }
@@ -10942,7 +10915,6 @@
       "integrity": "sha512-DqVpl8R0vbhVSop4120UHtGrFmHuPeoDwF4hDT0kPJTY8ty0SI38RV3VhCMsWigMUXG+kCXu7vMRqMFNy6eQgA==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "*",
         "@types/react": "*",
@@ -11070,7 +11042,6 @@
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
       "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.61.0",
         "@typescript-eslint/types": "8.61.0",
@@ -11861,7 +11832,6 @@
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -12882,7 +12852,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -13259,8 +13228,7 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.3.2.tgz",
       "integrity": "sha512-CSbhY4cFEJRe6/GQzIk5qXZ4Jeg5pcsP7b5peFSDpffpe1cqjASH/n9UTjBwOp6XpMSTwQ8Za2K5V02ueA7Tmw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/clean-css": {
       "version": "5.3.3",
@@ -13711,6 +13679,7 @@
       "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
       "hasInstallScript": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
@@ -14215,7 +14184,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz",
       "integrity": "sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.11"
       },
@@ -15032,7 +15000,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.4.tgz",
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -15314,7 +15281,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -17037,7 +17003,6 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.6.0.tgz",
       "integrity": "sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
       }
@@ -18438,7 +18403,6 @@
       "integrity": "sha512-Ry+p2+NLk6u8Agh5yVqELfUJvRfV51hhVBRIB5yZPY7mU0DGBmOuFG5GebZbMbm86cdQNK0fhJuDX8/1YorISQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.1.3",
         "@jest/types": "30.0.5",
@@ -20603,6 +20567,12 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/libphonenumber-js": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/libphonenumber-js/-/libphonenumber-js-1.11.20.tgz",
+      "integrity": "sha512-/ipwAMvtSZRdiQBHqW1qxqeYiBMzncOQLVA+62MWYr7N4m7Q2jqpJ0WgT7zlOEOpyLRSqrMXidbJpC0J77AaKA==",
+      "license": "MIT"
+    },
     "node_modules/lie": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
@@ -21030,8 +21000,7 @@
       "version": "4.18.1",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
       "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.18.1",
@@ -21099,7 +21068,6 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -21587,8 +21555,7 @@
       "version": "0.52.2",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.52.2.tgz",
       "integrity": "sha512-GEQWEZmfkOGLdd3XK8ryrfWz3AIP8YymVXiPHEdewrUq7mh0qrKrfHLNCXcbB6sTnMLnOZ3ztSiKcciFUkIJwQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/monaco-editor-webpack-plugin": {
       "version": "7.1.0",
@@ -22884,7 +22851,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -23059,7 +23025,6 @@
       "integrity": "sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -23511,7 +23476,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
       "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -23617,7 +23581,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.2.0.tgz",
       "integrity": "sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
@@ -23697,8 +23660,7 @@
       "version": "18.2.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/react-is-18": {
       "name": "react-is",
@@ -24124,8 +24086,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/redux-batched-actions": {
       "version": "0.5.0",
@@ -24524,7 +24485,6 @@
       "integrity": "sha512-cIFJOD1DESzpjOBl763Kp1AH7UE/0fcdHe6rZXUdQ9c50uvgigvW97u3IcSeBwOkgqL/PXPBktBCh0KEu5L8XQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -24852,7 +24812,6 @@
       "integrity": "sha512-TQd2aoQl/+zsxRMEDSxVdpPIqeq9UFc6pr7PzkugiTx3VYCFPUaa3P4RrBQsqok4PO200Vkz0vXQBNlg7W907g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@parcel/watcher": "^2.4.1",
         "chokidar": "^4.0.0",
@@ -24963,7 +24922,6 @@
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
       "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -25318,8 +25276,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shallow-equals/-/shallow-equals-1.0.0.tgz",
       "integrity": "sha512-xd/FKcdmfmMbyYCca3QTVEJtqUOGuajNzvAX6nt8dXILwjAIEkfHc4hI8/JMGApAmb7VeULO0Q30NTxnbH/15g==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/shallowequal": {
       "version": "1.1.0",
@@ -26170,7 +26127,6 @@
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.7.tgz",
       "integrity": "sha512-JL1b4A79OGqav4TxkrNsuuQfy6ZnrpyQx6hBDQ3Hd3JyuR2IQuVNBpF+FCEWFNZpN5hj+fhkaEVWteVJ18f0tw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -26239,7 +26195,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@csstools/css-parser-algorithms": "^3.0.1",
         "@csstools/css-tokenizer": "^3.0.1",
@@ -26928,7 +26883,6 @@
       "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
       "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@popperjs/core": "^2.9.0"
       }
@@ -27139,8 +27093,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/turndown": {
       "version": "7.2.2",
@@ -27279,7 +27232,6 @@
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.6.3.tgz",
       "integrity": "sha512-hjcS1mhfuyi4WW8IWtjP7brDrG2cuDZukyrYrSauoXGNgx0S7zceP07adYkJycEr56BOUTNPzbInooiN3fn1qw==",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -27710,7 +27662,6 @@
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.106.2.tgz",
       "integrity": "sha512-wGN3qcrBQIFmQ/c0AiOAQBvrZ5lmY8vbbMv4Mxfgzqd/B6+9pXtLo73WuS1dSGXM5QYY3hZnIbvx+K1xxe6FyA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -27759,7 +27710,6 @@
       "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.6.1",
         "@webpack-cli/configtest": "^3.0.1",
@@ -28628,7 +28578,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }
@@ -28810,7 +28759,6 @@
       "version": "26.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -29060,7 +29008,6 @@
       "version": "26.1.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",

--- a/webapp/platform/types/src/config.ts
+++ b/webapp/platform/types/src/config.ts
@@ -82,6 +82,8 @@ export type ClientConfig = {
     EnableJoinLeaveMessageByDefault: string;
     EnableLatex: string;
     EnableInlineLatex: string;
+    EnablePhoneNumberAutolinkingInternational: string;
+    EnablePhoneNumberAutolinkingNorthAmerican: string;
     EnableLdap: string;
     EnableLinkPreviews: string;
     EnableMarketplace: string;


### PR DESCRIPTION
## Summary

- Extends link-recognition in message display to treat plain phone numbers as clickable `tel:` links (display-only; stored text is never modified)
- International format (`+1 555-123-4567`, `+44 20 7946 0958`, etc.) and North American 10-digit format (`555-123-4567`, `(555) 123-4567`, `1-555-123-4567`) are each controlled by their own config flag, both defaulting to `true`
- Uses `libphonenumber-js/min` for validation — `phone.isPossible()` rejects strings with wrong length/structure while accepting correctly-formatted numbers (including fictional 555 numbers)
- A variable-length negative look-behind on the North American regex ensures `+`-prefixed numbers are only matched by the International rule, never by the North American rule

## Config

Two new `ServiceSettings` boolean fields (both default `true`, not surfaced in System Console per product design decision):
- `EnablePhoneNumberAutolinkingInternational`
- `EnablePhoneNumberAutolinkingNorthAmerican`

Both are wired end-to-end: persisted in config, serialized to the client config map, typed in `ClientConfig`, and consumed by `TextFormattingOptions` in `doFormatText`.

## Test plan

- [ ] International numbers (`+1 555-123-4567`, `+44 20 7946 0958`, `+91 98765 43210`) render as `tel:` links in message view
- [ ] North American 10-digit numbers (`555-123-4567`, `(555) 123-4567`, `1-555-123-4567`) render as `tel:` links
- [ ] 7-digit numbers (`555-1212`) are not linked
- [ ] Numbers embedded mid-word (`ORDER555-123-4567X`) are not linked
- [ ] A `+`-prefixed number is not double-linked when both flags are enabled
- [ ] A `+`-prefixed number is not linked by the NA rule when international is disabled
- [ ] Clicking a recognized number opens the `tel:` URI (dialer on mobile, confirmation prompt on Desktop)
- [ ] Stored message text is unchanged

Jira: https://mattermost.atlassian.net/browse/MM-70582

## Release Notes

Added ``ServiceSettings.EnablePhoneNumberAutolinkingInternational`` configuration setting.
Added ``ServiceSettings.EnablePhoneNumberAutolinkingNorthAmerican`` configuration setting.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change affects shared text formatting and spans server and client configuration. Incorrect matching could affect message display, but stored message text remains unchanged.

**QA Recommendation:** Automated tests cover the main matching paths. Manual QA is recommended for representative international and North American numbers.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->