### PR TITLE
Automated cherry pick of #38330

### DIFF
--- a/.github/actions/pack-cypress-deps/action.yml
+++ b/.github/actions/pack-cypress-deps/action.yml
@@ -1,0 +1,46 @@
+name: "Pack Cypress deps artifact"
+description: >
+  The producing half of the artifact transport for the Cypress deps: tars the
+  node_modules and Cypress binary just installed by prep-deps and uploads them
+  as a run-scoped artifact for this run's workers to unpack.
+
+  This is the fallback path, reached only when restore-cypress-deps found the
+  cache key cold. It is not a cache — the artifact is scoped to one run, costs
+  the shared Actions cache nothing, and is retained for a day. It must produce
+  the payload restore-cypress-deps would otherwise have restored, since the
+  workers accept either.
+
+inputs:
+  fips:
+    description: >
+      Whether this is a FIPS-edition run. e2e-tests-ci.yml invokes the cypress
+      template twice per workflow run — once per edition — and artifact names are
+      run-scoped, so the two invocations would otherwise collide. Must match the
+      unpack step.
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    # -C so the archives hold paths relative to their extraction root, letting
+    # unpack extract straight into the workspace and HOME.
+    - name: ci/pack-cypress-deps
+      shell: bash
+      run: |
+        set -euo pipefail
+        tar -czf "${RUNNER_TEMP}/cypress-node-modules.tgz" -C "${GITHUB_WORKSPACE}" e2e-tests/cypress/node_modules
+        tar -czf "${RUNNER_TEMP}/cypress-binary.tgz" -C "${HOME}" .cache/Cypress
+    - name: ci/upload-cypress-deps
+      uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
+      with:
+        name: e2e-cypress-deps${{ inputs.fips == 'true' && '-fips' || '' }}
+        path: |
+          ${{ runner.temp }}/cypress-node-modules.tgz
+          ${{ runner.temp }}/cypress-binary.tgz
+        # Only ever consumed by workers in the same run.
+        retention-days: 1
+        if-no-files-found: error
+        # The tarballs are already gzipped; re-compressing them in the zip
+        # wrapper costs CPU for no gain.
+        compression-level: 0

--- a/.github/actions/restore-cypress-deps/action.yml
+++ b/.github/actions/restore-cypress-deps/action.yml
@@ -1,0 +1,51 @@
+name: "Restore Cypress deps cache"
+description: >
+  The Actions-cache transport for the Cypress deps — node_modules plus the
+  Cypress binary — keyed on the cypress lockfile.
+
+  This is the fast path, taken whenever the key is warm: prep-deps asks whether
+  it exists with lookup-only, and the workers do the real restore. Read-only, as
+  e2e-ci-cache-warm-cypress-deps.yml is the only writer of the key, so PR and
+  merge runs never write to the Actions cache.
+
+  When the key is cold the template falls back to the artifact transport instead
+  — pack-cypress-deps into unpack-cypress-deps — which must land the same
+  payload in the same paths, so the two transports are interchangeable.
+
+inputs:
+  lookup-only:
+    description: "Probe whether the key exists without downloading the entry."
+    required: false
+    default: "false"
+  fail-on-cache-miss:
+    description: "Fail the step when the exact key is absent."
+    required: false
+    default: "false"
+
+outputs:
+  cache-hit:
+    description: "true on an exact-key hit"
+    value: ${{ steps.restore.outputs.cache-hit }}
+  key:
+    description: "The computed cache key"
+    value: ${{ steps.key.outputs.key }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: ci/compute-cypress-deps-key
+      id: key
+      shell: bash
+      run: echo "key=e2e-cypress-deps-${{ runner.os }}-${{ hashFiles('e2e-tests/cypress/package-lock.json') }}" >> "${GITHUB_OUTPUT}"
+    - name: ci/restore-cypress-deps
+      id: restore
+      uses: actions/cache/restore@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5.0.3
+      # No restore-keys: an older node_modules is not a usable substitute for
+      # this lockfile, and a partial hit would silently diverge from `npm ci`.
+      with:
+        path: |
+          e2e-tests/cypress/node_modules
+          ~/.cache/Cypress
+        key: ${{ steps.key.outputs.key }}
+        lookup-only: ${{ inputs.lookup-only }}
+        fail-on-cache-miss: ${{ inputs.fail-on-cache-miss }}

--- a/.github/actions/unpack-cypress-deps/action.yml
+++ b/.github/actions/unpack-cypress-deps/action.yml
@@ -1,0 +1,32 @@
+name: "Unpack Cypress deps artifact"
+description: >
+  The consuming half of the artifact transport for the Cypress deps: downloads
+  this run's artifact from pack-cypress-deps and extracts the node_modules and
+  Cypress binary into place.
+
+  Runs on a worker only when restore-cypress-deps found the cache key cold, and
+  must leave the same paths populated that a cache restore would have, so the
+  steps that follow cannot tell which transport ran.
+
+inputs:
+  fips:
+    description: >
+      Whether this is a FIPS-edition run. Must match the pack step so the correct
+      artifact is downloaded.
+    required: false
+    default: "false"
+
+runs:
+  using: "composite"
+  steps:
+    - name: ci/download-cypress-deps
+      uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3 # v8.0.0
+      with:
+        name: e2e-cypress-deps${{ inputs.fips == 'true' && '-fips' || '' }}
+        path: ${{ runner.temp }}
+    - name: ci/unpack-cypress-deps
+      shell: bash
+      run: |
+        set -euo pipefail
+        tar -xzf "${RUNNER_TEMP}/cypress-node-modules.tgz" -C "${GITHUB_WORKSPACE}"
+        tar -xzf "${RUNNER_TEMP}/cypress-binary.tgz" -C "${HOME}"

--- a/e2e-tests/cypress/tests/fixtures/markdown/markdown_inline_images_1.md
+++ b/e2e-tests/cypress/tests/fixtures/markdown/markdown_inline_images_1.md
@@ -1,3 +1,3 @@
 ### In-line Images
 
-Mattermost/platform build status:  [![Build Status](https://docs.mattermost.com/_images/icon-76x76.png)](https://docs.mattermost.com/_images/icon-76x76.png)
+Mattermost/platform build status:  [![Build Status](https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png)](https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png)

--- a/e2e-tests/cypress/tests/integration/channels/files_and_attachments/image_link_preview_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/files_and_attachments/image_link_preview_spec.js
@@ -100,7 +100,7 @@ describe('Image Link Preview', () => {
         cy.visit(offTopicUrl);
 
         const markdownImageText = 'exampleImage';
-        const markdownImageSrc = 'https://docs.mattermost.com/_images/icon-76x76.png';
+        const markdownImageSrc = 'https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png';
         const markdownImageSrcEncoded = encodeURIComponent(markdownImageSrc); // Since the url preview will be encoded string
         const messageWithMarkdownImage = `![${markdownImageText}](${markdownImageSrc}) an image plus some text that has [a link](https://example.com/)`;
 

--- a/e2e-tests/cypress/tests/integration/channels/markdown/markdown_image_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/markdown/markdown_image_spec.js
@@ -45,11 +45,11 @@ describe('Markdown', () => {
                 and('have.class', 'markdown-inline-img--hover').
                 and('have.class', 'markdown-inline-img--no-border').
                 and('have.attr', 'alt', 'Build Status').
-                and('have.attr', 'src', `${baseUrl}/api/v4/image?url=https%3A%2F%2Fdocs.mattermost.com%2F_images%2Ficon-76x76.png`).
+                and('have.attr', 'src', `${baseUrl}/api/v4/image?url=https%3A%2F%2Fraw.githubusercontent.com%2Fmattermost%2Fmattermost%2Fmaster%2Fe2e-tests%2Fcypress%2Ftests%2Ffixtures%2Fmattermost-icon_128x128.png`).
                 and((inlineImg) => {
-                    expect(inlineImg.height()).to.be.closeTo(76, 76);
+                    expect(inlineImg.height()).to.be.closeTo(128, 2);
                 }).
-                and('have.css', 'width', '76px');
+                and('have.css', 'width', '128px');
         });
     });
 

--- a/e2e-tests/cypress/tests/integration/channels/messaging/inline_markdown_image_link_open_link_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/messaging/inline_markdown_image_link_open_link_spec.js
@@ -21,7 +21,7 @@ describe('Messaging', () => {
 
     it('MM-T188 - Inline markdown image that is a link, opens the link', () => {
         const linkUrl = 'https://www.google.com';
-        const imageUrl = 'https://docs.mattermost.com/_images/icon-76x76.png';
+        const imageUrl = 'https://raw.githubusercontent.com/mattermost/mattermost/master/e2e-tests/cypress/tests/fixtures/mattermost-icon_128x128.png';
         const label = 'Build Status';
         const baseUrl = Cypress.config('baseUrl');
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
Cherry pick of #38330 on release-11.9.

#### Release Note
```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3a92d6ff-cad3-4201-993b-34e47a6b17e6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3a92d6ff-cad3-4201-993b-34e47a6b17e6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

