### PR TITLE
[MM-7031] Reload SAML SP when certificates are rotated

### DIFF
--- a/server/channels/api4/saml.go
+++ b/server/channels/api4/saml.go
@@ -86,7 +86,7 @@ func addSamlPublicCertificate(c *Context, w http.ResponseWriter, r *http.Request
 	defer c.LogAuditRec(auditRec)
 	model.AddEventParameterToAuditRec(auditRec, "filename", fileData.Filename)
 
-	if err := c.App.AddSamlPublicCertificate(fileData); err != nil {
+	if err := c.App.AddSamlPublicCertificate(c.AppContext, fileData); err != nil {
 		c.Err = err
 		return
 	}
@@ -110,7 +110,7 @@ func addSamlPrivateCertificate(c *Context, w http.ResponseWriter, r *http.Reques
 	defer c.LogAuditRec(auditRec)
 	model.AddEventParameterToAuditRec(auditRec, "filename", fileData.Filename)
 
-	if err := c.App.AddSamlPrivateCertificate(fileData); err != nil {
+	if err := c.App.AddSamlPrivateCertificate(c.AppContext, fileData); err != nil {
 		c.Err = err
 		return
 	}
@@ -146,7 +146,7 @@ func addSamlIdpCertificate(c *Context, w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		if err := c.App.SetSamlIdpCertificateFromMetadata(body); err != nil {
+		if err := c.App.SetSamlIdpCertificateFromMetadata(c.AppContext, body); err != nil {
 			c.Err = err
 			return
 		}
@@ -158,7 +158,7 @@ func addSamlIdpCertificate(c *Context, w http.ResponseWriter, r *http.Request) {
 		}
 		model.AddEventParameterToAuditRec(auditRec, "filename", fileData.Filename)
 
-		if err := c.App.AddSamlIdpCertificate(fileData); err != nil {
+		if err := c.App.AddSamlIdpCertificate(c.AppContext, fileData); err != nil {
 			c.Err = err
 			return
 		}

--- a/server/channels/app/cluster_handlers.go
+++ b/server/channels/app/cluster_handlers.go
@@ -9,6 +9,7 @@ import (
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/plugin"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
+	"github.com/mattermost/mattermost/server/public/shared/request"
 )
 
 func (s *Server) clusterInstallPluginHandler(msg *model.ClusterMessage) {
@@ -54,6 +55,17 @@ func (s *Server) clusterPluginEventHandler(msg *model.ClusterMessage) {
 	})
 }
 
+func (s *Server) clusterReloadSamlHandler(msg *model.ClusterMessage) {
+	saml := s.Channels().Saml
+	if saml == nil {
+		return
+	}
+
+	if err := saml.ConfigureSP(request.EmptyContext(s.Log())); err != nil {
+		s.Log().Error("An error occurred while configuring SAML Service Provider", mlog.Err(err))
+	}
+}
+
 // registerClusterHandlers registers the cluster message handlers that are handled by the server.
 //
 // The cluster event handlers are spread across this function and NewLocalCacheLayer.
@@ -63,6 +75,7 @@ func (s *Server) registerClusterHandlers() {
 	s.platform.RegisterClusterMessageHandler(model.ClusterEventRemovePlugin, s.clusterRemovePluginHandler)
 	s.platform.RegisterClusterMessageHandler(model.ClusterEventPluginEvent, s.clusterPluginEventHandler)
 	s.platform.RegisterClusterMessageHandler(clusterEventInvalidateChannelGuardCache, s.Channels().clusterInvalidateGuardCacheHandler)
+	s.platform.RegisterClusterMessageHandler(model.ClusterEventReloadSaml, s.clusterReloadSamlHandler)
 
 	s.platform.RegisterClusterHandlers()
 }

--- a/server/channels/app/platform/cluster_handlers.go
+++ b/server/channels/app/platform/cluster_handlers.go
@@ -157,6 +157,21 @@ func (ps *PlatformService) InvalidateAllCachesSkipSend() *model.AppError {
 	return nil
 }
 
+// ReloadSamlClusterSend notifies peer nodes to rebuild their in-memory SAML
+// Service Provider. Rotating a certificate reuses the same filename, so the
+// config diff is empty and the config-change path never reaches the peers.
+func (ps *PlatformService) ReloadSamlClusterSend() {
+	if ps.clusterIFace == nil {
+		return
+	}
+
+	ps.clusterIFace.SendClusterMessage(&model.ClusterMessage{
+		Event:            model.ClusterEventReloadSaml,
+		SendType:         model.ClusterSendReliable,
+		WaitForAllToSend: false,
+	})
+}
+
 func (ps *PlatformService) InvalidateAllCaches() *model.AppError {
 	if err := ps.InvalidateAllCachesSkipSend(); err != nil {
 		return err

--- a/server/channels/app/saml.go
+++ b/server/channels/app/saml.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/mlog"
 	"github.com/mattermost/mattermost/server/public/shared/request"
 )
 
@@ -37,6 +38,23 @@ func (a *App) GetSamlMetadata(rctx request.CTX) (string, *model.AppError) {
 	return result, nil
 }
 
+// reloadSaml rebuilds the in-memory SAML Service Provider from the on-disk
+// certificates. Rotating a certificate reuses the same filename, so UpdateConfig
+// sees an identical config and never fires the reload listener; this forces it,
+// locally and across the cluster. Errors are logged, not returned: reconfiguring
+// with a partially-set certificate set is expected (e.g. SP cert before IdP cert).
+func (a *App) reloadSaml(rctx request.CTX) {
+	if a.Saml() == nil {
+		return
+	}
+
+	if err := a.Saml().ConfigureSP(rctx); err != nil {
+		rctx.Logger().Error("An error occurred while configuring SAML Service Provider", mlog.Err(err))
+	}
+
+	a.Srv().platform.ReloadSamlClusterSend()
+}
+
 func (a *App) writeSamlFile(filename string, fileData *multipart.FileHeader) *model.AppError {
 	file, err := fileData.Open()
 	if err != nil {
@@ -57,7 +75,7 @@ func (a *App) writeSamlFile(filename string, fileData *multipart.FileHeader) *mo
 	return nil
 }
 
-func (a *App) AddSamlPublicCertificate(fileData *multipart.FileHeader) *model.AppError {
+func (a *App) AddSamlPublicCertificate(rctx request.CTX, fileData *multipart.FileHeader) *model.AppError {
 	if err := a.writeSamlFile(SamlPublicCertificateName, fileData); err != nil {
 		return err
 	}
@@ -70,11 +88,12 @@ func (a *App) AddSamlPublicCertificate(fileData *multipart.FileHeader) *model.Ap
 	}
 
 	a.UpdateConfig(func(dest *model.Config) { *dest = *cfg })
+	a.reloadSaml(rctx)
 
 	return nil
 }
 
-func (a *App) AddSamlPrivateCertificate(fileData *multipart.FileHeader) *model.AppError {
+func (a *App) AddSamlPrivateCertificate(rctx request.CTX, fileData *multipart.FileHeader) *model.AppError {
 	if err := a.writeSamlFile(SamlPrivateKeyName, fileData); err != nil {
 		return err
 	}
@@ -87,11 +106,12 @@ func (a *App) AddSamlPrivateCertificate(fileData *multipart.FileHeader) *model.A
 	}
 
 	a.UpdateConfig(func(dest *model.Config) { *dest = *cfg })
+	a.reloadSaml(rctx)
 
 	return nil
 }
 
-func (a *App) AddSamlIdpCertificate(fileData *multipart.FileHeader) *model.AppError {
+func (a *App) AddSamlIdpCertificate(rctx request.CTX, fileData *multipart.FileHeader) *model.AppError {
 	if err := a.writeSamlFile(SamlIdpCertificateName, fileData); err != nil {
 		return err
 	}
@@ -104,6 +124,7 @@ func (a *App) AddSamlIdpCertificate(fileData *multipart.FileHeader) *model.AppEr
 	}
 
 	a.UpdateConfig(func(dest *model.Config) { *dest = *cfg })
+	a.reloadSaml(rctx)
 
 	return nil
 }
@@ -254,7 +275,7 @@ func (a *App) BuildSamlMetadataObject(idpMetadata []byte) (*model.SamlMetadataRe
 	return data, nil
 }
 
-func (a *App) SetSamlIdpCertificateFromMetadata(data []byte) *model.AppError {
+func (a *App) SetSamlIdpCertificateFromMetadata(rctx request.CTX, data []byte) *model.AppError {
 	const certPrefix = "-----BEGIN CERTIFICATE-----\n"
 	const certSuffix = "\n-----END CERTIFICATE-----"
 	fixedCertTxt := certPrefix + string(data) + certSuffix
@@ -281,6 +302,7 @@ func (a *App) SetSamlIdpCertificateFromMetadata(data []byte) *model.AppError {
 	}
 
 	a.UpdateConfig(func(dest *model.Config) { *dest = *cfg })
+	a.reloadSaml(rctx)
 
 	return nil
 }

--- a/server/channels/app/saml_test.go
+++ b/server/channels/app/saml_test.go
@@ -1,0 +1,81 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package app
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+	"github.com/mattermost/mattermost/server/v8/channels/testlib"
+	"github.com/mattermost/mattermost/server/v8/einterfaces"
+	"github.com/mattermost/mattermost/server/v8/einterfaces/mocks"
+)
+
+func TestReloadSaml(t *testing.T) {
+	t.Run("no-op when no SAML interface is registered", func(t *testing.T) {
+		RegisterSamlInterface(nil)
+		th := Setup(t)
+
+		require.Nil(t, th.App.Saml())
+		// Team edition has no SAML interface; reloadSaml must not panic.
+		require.NotPanics(t, func() {
+			th.App.reloadSaml(request.TestContext(t))
+		})
+	})
+
+	t.Run("reloads the SP and broadcasts to the cluster", func(t *testing.T) {
+		var configureCalls int
+		saml := &mocks.SamlInterface{}
+		saml.On("ConfigureSP", mock.AnythingOfType("*request.Context")).
+			Run(func(mock.Arguments) { configureCalls++ }).Return(nil)
+		RegisterSamlInterface(func(_ *App) einterfaces.SamlInterface { return saml })
+		defer RegisterSamlInterface(nil)
+
+		cluster := &testlib.FakeClusterInterface{}
+		th := SetupWithClusterMock(t, cluster)
+
+		// Discard the unconditional ConfigureSP call and any messages from startup.
+		configureCalls = 0
+		cluster.ClearMessages()
+
+		th.App.reloadSaml(request.TestContext(t))
+
+		assert.Equal(t, 1, configureCalls)
+		msgs := cluster.SelectMessages(func(m *model.ClusterMessage) bool {
+			return m.Event == model.ClusterEventReloadSaml
+		})
+		require.Len(t, msgs, 1)
+	})
+
+	t.Run("swallows a ConfigureSP error and still broadcasts", func(t *testing.T) {
+		var configureCalls int
+		saml := &mocks.SamlInterface{}
+		saml.On("ConfigureSP", mock.AnythingOfType("*request.Context")).
+			Run(func(mock.Arguments) { configureCalls++ }).Return(errors.New("partial certificate set"))
+		RegisterSamlInterface(func(_ *App) einterfaces.SamlInterface { return saml })
+		defer RegisterSamlInterface(nil)
+
+		cluster := &testlib.FakeClusterInterface{}
+		th := SetupWithClusterMock(t, cluster)
+
+		configureCalls = 0
+		cluster.ClearMessages()
+
+		// A failed local reconfigure (e.g. one certificate uploaded before the
+		// rest) must not abort the reload or the cluster broadcast.
+		th.App.reloadSaml(request.TestContext(t))
+
+		assert.Equal(t, 1, configureCalls)
+		msgs := cluster.SelectMessages(func(m *model.ClusterMessage) bool {
+			return m.Event == model.ClusterEventReloadSaml
+		})
+		require.Len(t, msgs, 1)
+	})
+}

--- a/server/enterprise/metrics/metrics.go
+++ b/server/enterprise/metrics/metrics.go
@@ -559,6 +559,7 @@ func New(ps *platform.PlatformService, driver, dataSource string) *MetricsInterf
 		model.ClusterEventPluginEvent,
 		model.ClusterEventInvalidateCacheForTermsOfService,
 		model.ClusterEventBusyStateChanged,
+		model.ClusterEventReloadSaml,
 	} {
 		m.ClusterEventMap[event] = m.ClusterEventTypeCounters.With(prometheus.Labels{"name": string(event)})
 	}

--- a/server/public/model/cluster_message.go
+++ b/server/public/model/cluster_message.go
@@ -61,6 +61,7 @@ const (
 	ClusterEventInvalidateCacheForUserPropertyValuesEpoch   ClusterEvent = "inv_user_property_values_epoch"
 	ClusterEventAutoTranslationTask                         ClusterEvent = "autotranslation_task"
 	ClusterEventBusyStateChanged                            ClusterEvent = "busy_state_change"
+	ClusterEventReloadSaml                                  ClusterEvent = "reload_saml"
 	// Note: if you are adding a new event, please also add it in the slice of
 	// m.ClusterEventMap in metrics/metrics.go file.
 


### PR DESCRIPTION
#### Summary
Replacing an already-configured SAML certificate (IdP public cert, SP public cert, or SP private key) through the System Console silently failed to take effect until a server restart. The new certificate is written to disk, but the in-memory SAML Service Provider keeps using the stale one.

Root cause: the cert upload handlers write to a fixed on-disk filename (`saml-idp.crt` etc.) and then call `UpdateConfig`. On a *rotation* the filename is unchanged, so the resulting config JSON is byte-identical, `Store.Set` computes `hasChanged == false`, and the config listener that runs `Saml.ConfigureSP` never fires. First-time upload and removal both change a config field, so they worked — only in-place replacement (the IdP rotation flow) was silent. In HA, no config-change message is broadcast either, so no peer picks up the new cert.

Fix:
- Reconfigure the SP directly from the four certificate write paths (`AddSamlPublicCertificate`, `AddSamlPrivateCertificate`, `AddSamlIdpCertificate`, `SetSamlIdpCertificateFromMetadata`), decoupled from the config diff. The request context is threaded from the API so reload errors log with request correlation; reload errors are logged, not returned, so uploading one certificate before the rest is not fatal.
- Add a dedicated `ClusterEventReloadSaml` cluster event so peer nodes rebuild their SP too — the existing config-change message can't carry this because the config is unchanged and every peer re-applies the same diff gate. Peers re-read the new bytes from the shared config store.

The SAML implementation itself lives in the enterprise repository, so the regression test is in mattermost/enterprise#2302; the two should merge together.

QA: Configure SAML with a valid IdP cert and confirm login works. Upload a *different* valid IdP cert via System Console → Authentication → SAML 2.0 (same flow, no removal first). SAML login should immediately succeed with the new cert, with no server restart. On an HA cluster, verify all nodes recover without a rolling restart.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-70315

#### Release Note
```release-note
Fixed an issue where rotating a SAML certificate (IdP public certificate, SP public certificate, or SP private key) through the System Console did not take effect until the server was restarted.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🔴 High

**Regression Risk:** The change affects SAML authentication, public method contracts, and cluster communication. Automated tests cover reload behavior, but certificate upload and HA paths need verification.

**QA Recommendation:** Perform targeted manual QA for certificate rotation and HA certificate reload.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->