### PR TITLE
[MM-70592] Fix read-only settings for section-based plugins without a footer

### DIFF
--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.test.tsx
@@ -212,6 +212,127 @@ describe('custom plugin sections and settings', () => {
         expect(screen.getByText('Section Setting')).toBeInTheDocument();
     });
 
+    it('keeps section settings editable when the enabled plugin has no footer', () => {
+        const state = {
+            ...baseState,
+            entities: {
+                admin: {
+                    plugins: {
+                        testplugin: {
+                            ...plugin,
+                            settings_schema: {
+                                ...plugin.settings_schema,
+                                footer: '',
+                                settings: [],
+                                sections: [{
+                                    key: 'section1',
+                                    title: 'Section 1',
+                                    settings: [{
+                                        key: 'sectionSetting',
+                                        display_name: 'Section Setting',
+                                        type: 'text' as const,
+                                        help_text: 'Section setting help text',
+                                        placeholder: '',
+                                        default: '',
+                                    }],
+                                }],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        renderWithContext(
+            <CustomPluginSettings
+                {...baseProps}
+                patchConfig={jest.fn()}
+            />,
+            state,
+        );
+
+        expect(screen.getByTestId('PluginSettings.Plugins.testplugin.sectionsettinginput')).not.toBeDisabled();
+    });
+
+    it('keeps section settings editable when the enabled plugin has a footer', () => {
+        const state = {
+            ...baseState,
+            entities: {
+                admin: {
+                    plugins: {
+                        testplugin: {
+                            ...plugin,
+                            settings_schema: {
+                                ...plugin.settings_schema,
+                                footer: 'This is the footer',
+                                settings: [],
+                                sections: [{
+                                    key: 'section1',
+                                    title: 'Section 1',
+                                    settings: [{
+                                        key: 'sectionSetting',
+                                        display_name: 'Section Setting',
+                                        type: 'text' as const,
+                                        help_text: 'Section setting help text',
+                                        placeholder: '',
+                                        default: '',
+                                    }],
+                                }],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        renderWithContext(
+            <CustomPluginSettings
+                {...baseProps}
+                patchConfig={jest.fn()}
+            />,
+            state,
+        );
+
+        expect(screen.getByTestId('PluginSettings.Plugins.testplugin.sectionsettinginput')).not.toBeDisabled();
+    });
+
+    it('keeps top-level settings editable for an enabled flat-settings plugin', () => {
+        const state = {
+            ...baseState,
+            entities: {
+                admin: {
+                    plugins: {
+                        testplugin: {
+                            ...plugin,
+                            settings_schema: {
+                                ...plugin.settings_schema,
+                                settings: [{
+                                    key: 'topLevelSetting',
+                                    display_name: 'Top-level Setting',
+                                    type: 'text' as const,
+                                    help_text: 'Top-level setting help text',
+                                    placeholder: '',
+                                    default: '',
+                                }],
+                                sections: [],
+                            },
+                        },
+                    },
+                },
+            },
+        };
+
+        renderWithContext(
+            <CustomPluginSettings
+                {...baseProps}
+                patchConfig={jest.fn()}
+            />,
+            state,
+        );
+
+        expect(screen.getByTestId('PluginSettings.Plugins.testplugin.toplevelsettinginput')).not.toBeDisabled();
+    });
+
     it('renders warnings for top-level custom settings when plugin activation failed', () => {
         const state = {
             ...baseState,

--- a/webapp/channels/src/components/admin_console/custom_plugin_settings/index.tsx
+++ b/webapp/channels/src/components/admin_console/custom_plugin_settings/index.tsx
@@ -161,13 +161,11 @@ function makeGetPluginSchema() {
                     }];
                     settings = [];
                 } else if (sections.length > 0) {
-                    // Keep a lightweight top section only when the schema still has a footer to show; the footer text itself renders generically for the whole sections list.
-                    if (plugin.settings_schema?.footer) {
-                        sections.unshift({
-                            key: pluginEnabledConfigKey + '.Section',
-                            settings: [pluginEnableSetting],
-                        });
-                    }
+                    // The enable setting is hidden but must still be part of the schema so its config value seeds the form state; otherwise stateIsFalse(pluginEnabledConfigKey) reads undefined and disables every setting.
+                    sections.unshift({
+                        key: pluginEnabledConfigKey + '.Section',
+                        settings: [pluginEnableSetting],
+                    });
                 } else {
                     // Otherwise we retain existing behaviour and add the setting in front.
                     settings.unshift(pluginEnableSetting);


### PR DESCRIPTION
#### Summary
Regression from #37588 (MM-70278). In the System Console, an **enabled** plugin whose `settings_schema` uses `sections` and has no top-level `footer` renders every setting read-only.

The enable setting is hidden, so its config value only reaches the form state when the setting is part of the schema. In the sections branch it was added only when the schema had a `footer`, so a section-based plugin without one never seeded `PluginSettings.PluginStates.<id>.Enable` — `stateIsFalse(pluginEnabledConfigKey)` then read `undefined` and disabled every setting even while the plugin was running. Flat-settings plugins were unaffected (their branch always unshifts the enable setting).

The fix always unshifts the hidden enable setting in the sections branch, regardless of footer.

QA steps:
1. Enable a plugin whose settings are defined via `sections` with no top-level `footer`.
2. Open its page under **System Console → Plugins**.
3. The setting fields should be editable (before this fix they were greyed out).

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-70592

#### Screenshots
N/A — verified via unit tests (see below); reproduced against a running server where an enabled section-based plugin (FL3XX) had all fields disabled while a flat-settings plugin (Playbooks) did not.

#### Release Note
```release-note
Fixed a bug where a running plugin's settings could render read-only in the System Console when the plugin defined its settings using sections without a footer.
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to plugin settings schema handling. Automated tests cover flat schemas and section-based schemas with and without footers.

**QA Recommendation:** Manual QA is not required.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->