### PR TITLE
docs: emit redirect stubs at both <from>/index.html and <from>.html

### DIFF
--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -6,6 +6,7 @@
     "docusaurus": "docusaurus",
     "start": "docusaurus start",
     "build": "docusaurus build",
+    "postbuild": "node scripts/duplicate-redirect-stubs.mjs",
     "stage:agents-docs": "node scripts/stage-agents-docs.mjs",
     "build:sidebars": "node scripts/gen-documentation-sidebar.mjs && node scripts/gen-developer-sidebar.mjs",
     "build:openapi:spec": "node scripts/build-openapi.mjs",

--- a/docs/site/scripts/duplicate-redirect-stubs.mjs
+++ b/docs/site/scripts/duplicate-redirect-stubs.mjs
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+// Copy every plugin-client-redirects stub from `build/<from>/index.html` to
+// `build/<from>.html` so the docs CloudFront function's `<uri>.html` fallback
+// branch finds it (see mattermost-iac-docs-prod → 05-cdn →
+// clean-url-rewrite.js).
+
+import {readFileSync, writeFileSync, existsSync, statSync} from 'node:fs';
+import {join, resolve, dirname, sep} from 'node:path';
+import {fileURLToPath} from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const SITE_ROOT = resolve(HERE, '..');
+const BUILD_DIR = join(SITE_ROOT, 'build');
+const REDIRECTS_JSON = join(SITE_ROOT, 'sidebars', 'active-redirects.json');
+
+if (!existsSync(BUILD_DIR)) {
+  console.error(`[duplicate-redirect-stubs] ${BUILD_DIR} not found; run \`docusaurus build\` first.`);
+  process.exit(1);
+}
+
+const {redirects} = JSON.parse(readFileSync(REDIRECTS_JSON, 'utf8'));
+const BUILD_DIR_PREFIX = BUILD_DIR + sep;
+
+let duplicated = 0;
+let skippedExisting = 0;
+let skippedMissingStub = 0;
+let skippedHtmlSuffix = 0;
+let skippedOutsideBuild = 0;
+
+for (const {from} of redirects) {
+  // CFF Phase A already 301s `.html` to the extensionless form.
+  if (from.endsWith('.html')) {
+    skippedHtmlSuffix++;
+    continue;
+  }
+
+  const rel = from.replace(/^\/+/, '');
+  const stubPath = resolve(BUILD_DIR, rel, 'index.html');
+  const flatPath = resolve(BUILD_DIR, `${rel}.html`);
+  if (!stubPath.startsWith(BUILD_DIR_PREFIX) || !flatPath.startsWith(BUILD_DIR_PREFIX)) {
+    skippedOutsideBuild++;
+    continue;
+  }
+
+  if (!existsSync(stubPath) || !statSync(stubPath).isFile()) {
+    skippedMissingStub++;
+    continue;
+  }
+
+  // Never shadow a real content page at the flat key.
+  if (existsSync(flatPath)) {
+    skippedExisting++;
+    continue;
+  }
+
+  writeFileSync(flatPath, readFileSync(stubPath));
+  duplicated++;
+}
+
+console.log(
+  `[duplicate-redirect-stubs] duplicated=${duplicated} ` +
+    `skipped-existing=${skippedExisting} ` +
+    `skipped-missing-stub=${skippedMissingStub} ` +
+    `skipped-html-suffix=${skippedHtmlSuffix} ` +
+    `skipped-outside-build=${skippedOutsideBuild} ` +
+    `total=${redirects.length}`,
+);


### PR DESCRIPTION
#### Summary

Fixes silent 404s for `active-redirects.json` entries whose `from` lives under a first-path-segment that isn't in the docs CloudFront function's frozen legacy-Sphinx prefix set (e.g. `/administration-guide/*`, `/deployment-guide/*`, `/end-user-guide/*`, `/product-overview/*`, `/security-guide/*`, `/integrations-guide/*`, `/use-case-guide/*`, `/agents/*`, `/developers/*`).

The docs CloudFront function ([mattermost-iac-docs-prod → 05-cdn → clean-url-rewrite.js]https://github.com/mattermost-platform/mattermost-iac-docs/blob/main/production/terraform/aws/05-cdn/cloudfront_functions/clean-url-rewrite.js)) has a Phase B split by first path segment: legacy Sphinx prefixes are served as `<uri>/index.html`, everything else falls back to `<uri>.html`. Meanwhile `@docusaurus/plugin-client-redirects` always emits its meta-refresh stub at `<from>/index.html`. When a redirect `from` lives outside the frozen legacy set, CFF asks S3 for `<from>.html` (which doesn't exist) and serves `/404.html`, even though the stub is sitting next door at `<from>/index.html`.

That's why merged redirects like `/administration-guide/configure/calls-deployment-guide` still 404 in production: the stub is deployed, CFF just isn't looking at that key. 63 pre-existing non-legacy-prefix entries on `master` were already broken for the same reason before [#38387](https://github.com/mattermost/mattermost/pull/38387) added 218 more.

This PR adds a `postbuild` step that copies every `build/<from>/index.html` stub to `build/<from>.html`. Purely additive:

- Legacy prefixes keep serving from `<from>/index.html` (unchanged).
- Non-legacy prefixes now find the stub at the flat key CFF's fallback already asks for.
- Real content pages are never overwritten — the script skips any path where `<from>.html` already exists.
- `.html`-suffixed `from` values are skipped (CFF Phase A canonicalizes those to the extensionless form before Phase B routes them).
- `..`-segment traversal in a malformed `from` is rejected before any filesystem call.

No CFF change, no Docusaurus URL scheme change, no infra work required.

**Smoke test** against a local build:

```
[duplicate-redirect-stubs] duplicated=741 skipped-existing=0 skipped-missing-stub=294 skipped-html-suffix=3 skipped-outside-build=0 total=1038
```

Real content page `administration-guide/configure/configuration-settings.html` unchanged. Duplicated file `about/desktop.html` is byte-identical to `about/desktop/index.html` and contains the meta-refresh + `<link rel=canonical>` + JS fallback the plugin emits.

**Post-deploy verification**: after CI merges, `curl -sIL https://docs.mattermost.com/administration-guide/configure/calls-deployment-guide` should chain to `/deployment-guide/calls/calls-deployment-guide` (200), instead of the current 404.

#### Ticket Link

Fixes the deployment-side gap left by [#38387](https://github.com/mattermost/mattermost/pull/38387) and the pre-existing non-legacy-prefix redirect entries on `master`.

```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to the documentation postbuild process. It does not modify shared utilities, infrastructure, APIs, or critical application flows.

**QA Recommendation:** Skip manual QA. Automated coverage and the local smoke test provide sufficient validation.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->