### PR TITLE
Land the React 19 fixes that stand on their own, ahead of the upgrade

### DIFF
--- a/webapp/channels/src/components/__snapshots__/pdf_preview.test.tsx.snap
+++ b/webapp/channels/src/components/__snapshots__/pdf_preview.test.tsx.snap
@@ -33,7 +33,7 @@ exports[`component/PDFPreview should match snapshot, not successful 1`] = `
       />
       <img
         alt="file preview"
-        src=""
+        src="test-file-stub"
       />
     </a>
     <div

--- a/webapp/channels/src/components/add_groups_to_channel_modal/__snapshots__/add_groups_to_channel_modal.test.tsx.snap
+++ b/webapp/channels/src/components/add_groups_to_channel_modal/__snapshots__/add_groups_to_channel_modal.test.tsx.snap
@@ -197,7 +197,7 @@ exports[`components/AddGroupsToChannelModal should match when renderOption is ca
     alt="group picture"
     className="more-modal__image"
     height="32"
-    src=""
+    src="test-file-stub"
     width="32"
   />
   <div
@@ -247,7 +247,7 @@ exports[`components/AddGroupsToChannelModal should match when renderOption is ca
     alt="group picture"
     className="more-modal__image"
     height="32"
-    src=""
+    src="test-file-stub"
     width="32"
   />
   <div
@@ -297,7 +297,7 @@ exports[`components/AddGroupsToChannelModal should match when renderOption is ca
     alt="group picture"
     className="more-modal__image"
     height="32"
-    src=""
+    src="test-file-stub"
     width="32"
   />
   <div

--- a/webapp/channels/src/components/add_groups_to_team_modal/__snapshots__/add_groups_to_team_modal.test.tsx.snap
+++ b/webapp/channels/src/components/add_groups_to_team_modal/__snapshots__/add_groups_to_team_modal.test.tsx.snap
@@ -197,7 +197,7 @@ exports[`components/AddGroupsToTeamModal should match when renderOption is calle
     alt="group picture"
     className="more-modal__image"
     height="32"
-    src=""
+    src="test-file-stub"
     width="32"
   />
   <div
@@ -249,7 +249,7 @@ exports[`components/AddGroupsToTeamModal should match when renderOption is calle
     alt="group picture"
     className="more-modal__image"
     height="32"
-    src=""
+    src="test-file-stub"
     width="32"
   />
   <div

--- a/webapp/channels/src/components/admin_console/access_control/editors/table_editor/table_editor_channel_admin.test.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/editors/table_editor/table_editor_channel_admin.test.tsx
@@ -210,9 +210,11 @@ describe('TableEditor - User Self-Exclusion', () => {
             expect(mockValidateExpression).toHaveBeenCalledWith('user.attributes.department == "Engineering"');
         });
 
-        // Check that the Test Access Rules button is disabled
-        const testButton = screen.getByRole('button', {name: /test access rule/i});
-        expect(testButton).toBeDisabled();
+        // Check that the Test Access Rules button is disabled. The validation call
+        // fires synchronously from the effect, and becoming disabled wraps the button
+        // in WithTooltip, which remounts it — so re-query inside waitFor rather than
+        // holding a reference from before the flip.
+        await waitFor(() => expect(screen.getByRole('button', {name: /test access rule/i})).toBeDisabled());
     });
 
     test('should show tooltip when user would be excluded', async () => {
@@ -233,9 +235,10 @@ describe('TableEditor - User Self-Exclusion', () => {
             expect(mockValidateExpression).toHaveBeenCalledWith('user.attributes.department == "Engineering"');
         });
 
-        // Check that the button is disabled - this is the main behavior we're testing
-        const testButton = screen.getByRole('button', {name: /test access rule/i});
-        expect(testButton).toBeDisabled();
+        // Check that the button is disabled - this is the main behavior we're testing.
+        // Re-query inside waitFor: becoming disabled wraps the button in WithTooltip,
+        // which remounts it, so a reference captured beforehand goes stale.
+        await waitFor(() => expect(screen.getByRole('button', {name: /test access rule/i})).toBeDisabled());
 
         // The tooltip functionality is complex with floating-ui and is already tested in the TestButton unit tests
         // The main functionality we care about is that the button is disabled when the user would be excluded

--- a/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.test.tsx
+++ b/webapp/channels/src/components/admin_console/access_control/policy_details/policy_details.test.tsx
@@ -520,7 +520,9 @@ describe('components/admin_console/access_control/policy_details/PolicyDetails',
         });
 
         // The has-resources subtitle is shown instead of the deletable subtitle.
-        expect(screen.getByText(/Remove all assigned resources/)).toBeInTheDocument();
+        // The Delete policy card renders before fetchPolicy resolves, so the subtitle
+        // has to be awaited rather than read off the first commit.
+        expect(await screen.findByText(/Remove all assigned resources/)).toBeInTheDocument();
 
         // The linked-teams warning lists each team, linking to its System Console page.
         await waitFor(() => {

--- a/webapp/channels/src/components/admin_console/brand_image_setting/brand_image_setting.test.tsx
+++ b/webapp/channels/src/components/admin_console/brand_image_setting/brand_image_setting.test.tsx
@@ -62,6 +62,28 @@ describe('components/admin_console/brand_image_setting', () => {
         expect(baseProps.setSaveNeeded).toHaveBeenCalledTimes(1);
     });
 
+    test('should clear the previous preview while a replacement image is still being read', async () => {
+        renderWithContext(<BrandImageSetting {...baseProps}/>);
+
+        const fileInput = screen.getByTestId('file__upload-input');
+
+        await userEvent.upload(fileInput, new File(['first_image'], 'first_image.png', {type: 'image/png'}));
+
+        expect(await screen.findByAltText('brand image')).toHaveAttribute('src', expect.stringContaining('data:image/png;base64'));
+
+        // Leave the second read pending so the intermediate render is observable.
+        const readAsDataURL = jest.spyOn(FileReader.prototype, 'readAsDataURL').mockImplementation(() => {});
+
+        try {
+            await userEvent.upload(fileInput, new File(['second_image'], 'second_image.png', {type: 'image/png'}));
+
+            expect(readAsDataURL).toHaveBeenCalledTimes(1);
+            await waitFor(() => expect(screen.queryByAltText('brand image')).toBe(null));
+        } finally {
+            readAsDataURL.mockRestore();
+        }
+    });
+
     test('should call setSaveNeeded when the delete button is pressed', async () => {
         renderWithContext(<BrandImageSetting {...baseProps}/>);
 

--- a/webapp/channels/src/components/admin_console/brand_image_setting/brand_image_setting.tsx
+++ b/webapp/channels/src/components/admin_console/brand_image_setting/brand_image_setting.tsx
@@ -12,7 +12,6 @@ import {Client4} from 'mattermost-redux/client';
 import {uploadBrandImage, deleteBrandImage} from 'actions/admin_actions';
 
 import SettingSet from 'components/admin_console/setting_set';
-import useDidUpdate from 'components/common/hooks/useDidUpdate';
 import FormError from 'components/form_error';
 
 import {Constants} from 'utils/constants';
@@ -54,10 +53,10 @@ const BrandImageSetting = ({
     registerSaveAction,
     unRegisterSaveAction,
 }: Props) => {
-    const imageRef = useRef<HTMLImageElement>(null);
     const fileInputRef = useRef<HTMLInputElement>(null);
 
     const [brandImage, setBrandImage] = useState<File | undefined>();
+    const [brandImagePreview, setBrandImagePreview] = useState('');
     const [shouldDeleteBrandImage, setShouldDeleteBrandImage] = useState(false);
     const [brandImageExists, setBrandImageExists] = useState(false);
     const [brandImageTimestamp, setBrandImageTimestamp] = useState(Date.now());
@@ -120,24 +119,20 @@ const BrandImageSetting = ({
         };
     }, [handleSave, registerSaveAction, unRegisterSaveAction]);
 
-    useDidUpdate(() => {
-        if (imageRef.current) {
-            const reader = new FileReader();
-
-            const img = imageRef.current;
-            reader.onload = (e) => {
-                const src =
-                    e.target?.result instanceof ArrayBuffer ? e.target?.result.toString() : e.target?.result;
-
-                if (src) {
-                    img.setAttribute('src', src);
-                }
-            };
-
-            if (brandImage) {
-                reader.readAsDataURL(brandImage);
-            }
+    useEffect(() => {
+        if (!brandImage) {
+            setBrandImagePreview('');
+            return undefined;
         }
+
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            const result = e.target?.result;
+            setBrandImagePreview(result instanceof ArrayBuffer ? result.toString() : (result ?? ''));
+        };
+        reader.readAsDataURL(brandImage);
+
+        return () => reader.abort();
     }, [brandImage]);
 
     const handleSelectClick = useCallback(() => {
@@ -166,15 +161,14 @@ const BrandImageSetting = ({
 
     let img = null;
     if (brandImage) {
-        img = (
+        img = brandImagePreview ? (
             <div className='remove-image__img mb-5'>
                 <img
-                    ref={imageRef}
                     alt='brand image'
-                    src=''
+                    src={brandImagePreview}
                 />
             </div>
-        );
+        ) : null;
     } else if (brandImageExists) {
         let overlay;
         if (!disabled) {

--- a/webapp/channels/src/components/admin_console/brand_image_setting/brand_image_setting.tsx
+++ b/webapp/channels/src/components/admin_console/brand_image_setting/brand_image_setting.tsx
@@ -120,8 +120,9 @@ const BrandImageSetting = ({
     }, [handleSave, registerSaveAction, unRegisterSaveAction]);
 
     useEffect(() => {
+        setBrandImagePreview('');
+
         if (!brandImage) {
-            setBrandImagePreview('');
             return undefined;
         }
 

--- a/webapp/channels/src/components/admin_console/classification_markings/classification_markings.test.tsx
+++ b/webapp/channels/src/components/admin_console/classification_markings/classification_markings.test.tsx
@@ -910,13 +910,8 @@ describe('GlobalClassificationIndicators section', () => {
         const user = userEvent.setup();
 
         // Enable the global banner without selecting a level
-        await act(async () => {
-            await user.click(screen.getByTestId('globalBannerEnabledtrue'));
-        });
-
-        await act(async () => {
-            await user.click(screen.getByText('Save'));
-        });
+        await user.click(screen.getByTestId('globalBannerEnabledtrue'));
+        await user.click(screen.getByText('Save'));
 
         await screen.findByText(/A global classification level must be selected/);
     });
@@ -981,13 +976,8 @@ describe('GlobalClassificationIndicators section', () => {
 
         // Delete the first level (UNCLASSIFIED) which is referenced by the banner.
         const deleteButtons = screen.getAllByRole('button', {name: /Delete level/i});
-        await act(async () => {
-            await user.click(deleteButtons[0]);
-        });
-
-        await act(async () => {
-            await user.click(screen.getByText('Save'));
-        });
+        await user.click(deleteButtons[0]);
+        await user.click(screen.getByText('Save'));
 
         await screen.findByText(/The global classification banner is configured with a level that no longer exists/);
     });

--- a/webapp/channels/src/components/admin_console/openid_convert/__snapshots__/openid_convert.test.tsx.snap
+++ b/webapp/channels/src/components/admin_console/openid_convert/__snapshots__/openid_convert.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`components/OpenIdConvert should match snapshot 1`] = `
       <img
         alt="OpenId Convert Image"
         class="OpenIdConvert_image"
-        src=""
+        src="test-file-stub"
       />
     </div>
     <div

--- a/webapp/channels/src/components/admin_console/team_channel_settings/abstract_list.test.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/abstract_list.test.tsx
@@ -6,7 +6,7 @@ import {FormattedMessage} from 'react-intl';
 
 import type {Channel} from '@mattermost/types/channels';
 
-import {renderWithContext, waitFor} from 'tests/react_testing_utils';
+import {renderWithContext, screen} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';
 
 import AbstractList from './abstract_list';
@@ -63,9 +63,8 @@ describe('admin_console/team_channel_settings/AbstractList', () => {
             />,
         );
 
-        await waitFor(() => {
-            expect(actions.getData).toHaveBeenCalled();
-        });
+        await screen.findByText('test');
+        expect(actions.getData).toHaveBeenCalled();
 
         expect(container).toMatchSnapshot();
     });
@@ -97,9 +96,8 @@ describe('admin_console/team_channel_settings/AbstractList', () => {
             />,
         );
 
-        await waitFor(() => {
-            expect(actions.getData).toHaveBeenCalled();
-        });
+        await screen.findByText('DN');
+        expect(actions.getData).toHaveBeenCalled();
 
         expect(container).toMatchSnapshot();
     });

--- a/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/channel_list.test.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/channel/list/channel_list.test.tsx
@@ -7,7 +7,7 @@ import type {Channel, ChannelWithTeamData} from '@mattermost/types/channels';
 
 import {General} from 'mattermost-redux/constants';
 
-import {renderWithContext, waitFor} from 'tests/react_testing_utils';
+import {renderWithContext, screen} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';
 
 import ChannelList from './channel_list';
@@ -38,9 +38,8 @@ describe('admin_console/team_channel_settings/channel/ChannelList', () => {
             />,
         );
 
-        await waitFor(() => {
-            expect(actions.getData).toHaveBeenCalled();
-        });
+        await screen.findByText('DN');
+        expect(actions.getData).toHaveBeenCalled();
 
         expect(container).toMatchSnapshot();
     });
@@ -69,9 +68,8 @@ describe('admin_console/team_channel_settings/channel/ChannelList', () => {
             />,
         );
 
-        await waitFor(() => {
-            expect(actions.getData).toHaveBeenCalled();
-        });
+        await screen.findByText('DN');
+        expect(actions.getData).toHaveBeenCalled();
 
         expect(container).toMatchSnapshot();
     });
@@ -101,9 +99,8 @@ describe('admin_console/team_channel_settings/channel/ChannelList', () => {
             />,
         );
 
-        await waitFor(() => {
-            expect(actions.getData).toHaveBeenCalled();
-        });
+        await screen.findByText('DN0');
+        expect(actions.getData).toHaveBeenCalled();
 
         expect(container).toMatchSnapshot();
     });
@@ -133,9 +130,8 @@ describe('admin_console/team_channel_settings/channel/ChannelList', () => {
             />,
         );
 
-        await waitFor(() => {
-            expect(actions.getData).toHaveBeenCalled();
-        });
+        await screen.findByText('Archived Public');
+        expect(actions.getData).toHaveBeenCalled();
 
         expect(container).toMatchSnapshot();
     });
@@ -165,9 +161,8 @@ describe('admin_console/team_channel_settings/channel/ChannelList', () => {
             />,
         );
 
-        await waitFor(() => {
-            expect(actions.getData).toHaveBeenCalled();
-        });
+        await screen.findByText('Archived Private');
+        expect(actions.getData).toHaveBeenCalled();
 
         expect(container).toMatchSnapshot();
     });

--- a/webapp/channels/src/components/admin_console/team_channel_settings/group/group_list.test.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/group/group_list.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import type {Group} from '@mattermost/types/groups';
 
-import {renderWithContext, waitFor} from 'tests/react_testing_utils';
+import {renderWithContext, screen} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';
 
 import GroupList from './group_list';
@@ -38,9 +38,8 @@ describe('admin_console/team_channel_settings/group/GroupList', () => {
             />,
         );
 
-        await waitFor(() => {
-            expect(actions.getData).toHaveBeenCalled();
-        });
+        await screen.findByText('DN');
+        expect(actions.getData).toHaveBeenCalled();
 
         expect(container).toMatchSnapshot();
     });
@@ -74,9 +73,8 @@ describe('admin_console/team_channel_settings/group/GroupList', () => {
             />,
         );
 
-        await waitFor(() => {
-            expect(actions.getData).toHaveBeenCalled();
-        });
+        await screen.findByText('DN0');
+        expect(actions.getData).toHaveBeenCalled();
 
         expect(container).toMatchSnapshot();
     });

--- a/webapp/channels/src/components/admin_console/team_channel_settings/team/details/team_details.test.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/team/details/team_details.test.tsx
@@ -1406,6 +1406,9 @@ describe('admin_console/team_channel_settings/team/TeamDetails', () => {
         await userEvent.click(screen.getByText('Save'));
 
         // Saving rule changes surfaces the Apply membership policy confirmation.
+        // onSave counts affected members over several awaits before opening it, so the
+        // modal is not mounted on the commit that follows the Save click.
+        await waitFor(() => expect(screen.getByText('Apply membership policy')).toBeInTheDocument());
         await userEvent.click(document.getElementById('confirmModalButton')!);
 
         await waitFor(() => {

--- a/webapp/channels/src/components/admin_console/team_channel_settings/team/list/team_list.test.tsx
+++ b/webapp/channels/src/components/admin_console/team_channel_settings/team/list/team_list.test.tsx
@@ -32,12 +32,10 @@ describe('admin_console/team_channel_settings/team/TeamList', () => {
         );
 
         // Wait for the component to finish loading
-        await waitFor(() => {
-            expect(actions.getData).toHaveBeenCalled();
-        });
+        const teamDisplayNames = await screen.findAllByTestId('team-display-name');
+        expect(actions.getData).toHaveBeenCalled();
 
         // Verify the team name is displayed
-        const teamDisplayNames = screen.getAllByTestId('team-display-name');
         expect(teamDisplayNames).toHaveLength(1);
         expect(teamDisplayNames[0]).toHaveTextContent('DN');
     });
@@ -65,12 +63,10 @@ describe('admin_console/team_channel_settings/team/TeamList', () => {
         );
 
         // Wait for the component to finish loading
-        await waitFor(() => {
-            expect(actions.getData).toHaveBeenCalled();
-        });
+        const teamDisplayNames = await screen.findAllByTestId('team-display-name');
+        expect(actions.getData).toHaveBeenCalled();
 
         // Verify pagination is working - only first page of teams should be displayed
-        const teamDisplayNames = screen.getAllByTestId('team-display-name');
         expect(teamDisplayNames).toHaveLength(PAGE_SIZE); // Should show exactly 10 teams (first page)
 
         // Verify first few teams from the first page are rendered correctly
@@ -255,12 +251,10 @@ describe('admin_console/team_channel_settings/team/TeamList', () => {
         );
 
         // Wait for teams to load
-        await waitFor(() => {
-            expect(actions.getData).toHaveBeenCalled();
-        });
+        const openManagement = await screen.findByTestId('openManagement');
+        expect(actions.getData).toHaveBeenCalled();
 
         // Verify management type is displayed using testid
-        const openManagement = screen.getByTestId('openManagement');
         const inviteManagement = screen.getByTestId('inviteManagement');
         const policyManagement = screen.getByTestId('policyManagement');
 
@@ -297,12 +291,10 @@ describe('admin_console/team_channel_settings/team/TeamList', () => {
         );
 
         // Wait for teams to load
-        await waitFor(() => {
-            expect(actions.getData).toHaveBeenCalled();
-        });
+        const editLink = await screen.findByRole('link', {name: /edit/i});
+        expect(actions.getData).toHaveBeenCalled();
 
         // Verify edit link is present
-        const editLink = screen.getByRole('link', {name: /edit/i});
         expect(editLink).toBeInTheDocument();
         expect(editLink).toHaveAttribute('href', '/admin_console/user_management/teams/123');
     });

--- a/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/advanced_text_editor.test.tsx
@@ -15,7 +15,7 @@ import type {FileUpload} from 'components/file_upload/file_upload';
 import type Textbox from 'components/textbox/textbox';
 
 import mergeObjects from 'packages/mattermost-redux/test/merge_objects';
-import {renderWithContext, userEvent, screen, act, fireEvent} from 'tests/react_testing_utils';
+import {renderWithContext, userEvent, screen, act, createEvent, fireEvent} from 'tests/react_testing_utils';
 import Constants, {Locations, PostTypes, StoragePrefixes} from 'utils/constants';
 import {TestHelper} from 'utils/test_helper';
 
@@ -369,8 +369,10 @@ describe('components/avanced_text_editor/advanced_text_editor', () => {
                 const textbox = screen.getByPlaceholderText('Write to Other Channel');
                 expect(textbox).toHaveValue(sourceDraft);
 
-                // SuggestionBox listens to onInput, not onChange.
-                fireEvent.input(textbox, {target: {value: destinationMessage}});
+                // SuggestionBox listens to onInput, not onChange. Dispatched directly instead of
+                // with fireEvent because fireEvent opens a nested act(...) scope, which React
+                // rejects while it's already flushing this commit.
+                textbox.dispatchEvent(createEvent.input(textbox, {target: {value: destinationMessage}}));
                 setSendDestinationMessage(true);
             }, [editorChannelId]);
 
@@ -382,7 +384,7 @@ describe('components/avanced_text_editor/advanced_text_editor', () => {
                     return;
                 }
 
-                fireEvent.click(screen.getByTestId('SendMessageButton'));
+                screen.getByTestId('SendMessageButton').click();
             }, [sendDestinationMessage]);
 
             return (
@@ -481,7 +483,10 @@ describe('components/avanced_text_editor/advanced_text_editor', () => {
 
                 const textbox = screen.getByPlaceholderText('Write to Other Channel');
                 expect(textbox).toHaveValue(sourceDraft);
-                fireEvent.input(textbox, {target: {value: destinationMessage}});
+
+                // Dispatched directly instead of with fireEvent because fireEvent opens a nested
+                // act(...) scope, which React rejects while it's already flushing this commit.
+                textbox.dispatchEvent(createEvent.input(textbox, {target: {value: destinationMessage}}));
             }, [editorChannelId]);
 
             return (

--- a/webapp/channels/src/components/advanced_text_editor/use_rewrite.test.tsx
+++ b/webapp/channels/src/components/advanced_text_editor/use_rewrite.test.tsx
@@ -370,8 +370,11 @@ describe('useRewrite', () => {
             const actionHandler = props.onMenuAction(RewriteAction.SHORTEN);
             actionHandler();
 
+            // isProcessing starts false, so waiting on it alone is satisfied by the
+            // initial render — and renderHook publishes result.current from an effect,
+            // so props would still close over the pre-rewrite originalMessage.
             await waitFor(() => {
-                expect(result.current.isProcessing).toBe(false);
+                expect(result.current.rewriteMenuProps.originalMessage).toBe('Test message');
             });
 
             props = result.current.rewriteMenuProps;

--- a/webapp/channels/src/components/announcement_bar/configuration_bar/__snapshots__/configuration_bar.test.tsx.snap
+++ b/webapp/channels/src/components/announcement_bar/configuration_bar/__snapshots__/configuration_bar.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`components/ConfigurationBar should match snapshot, expired 1`] = `
         >
           <img
             class="advisor-icon"
-            src=""
+            src="test-file-stub"
           />
           Enterprise license is expired and some features may be disabled.
           <button
@@ -51,7 +51,7 @@ exports[`components/ConfigurationBar should match snapshot, expired, in grace pe
         >
           <img
             class="advisor-icon"
-            src=""
+            src="test-file-stub"
           />
           Enterprise license is expired and some features may be disabled.
           <button
@@ -83,7 +83,7 @@ exports[`components/ConfigurationBar should match snapshot, expired, regular use
       <span>
         <img
           class="advisor-icon"
-          src=""
+          src="test-file-stub"
         />
         Enterprise license is expired and some features may be disabled. Please contact your System Administrator for details.
       </span>
@@ -108,7 +108,7 @@ exports[`components/ConfigurationBar should match snapshot, expiring, trial lice
         >
           <img
             class="advisor-icon"
-            src=""
+            src="test-file-stub"
           />
           This is the last day of your free trial. Purchase a license now to continue using Mattermost Professional and Enterprise features.
           <button
@@ -143,7 +143,7 @@ exports[`components/ConfigurationBar should match snapshot, expiring, trial lice
         >
           <img
             class="advisor-icon"
-            src=""
+            src="test-file-stub"
           />
           This is the last day of your free trial.
           <button

--- a/webapp/channels/src/components/audio_video_preview/__snapshots__/audio_video_preview.test.tsx.snap
+++ b/webapp/channels/src/components/audio_video_preview/__snapshots__/audio_video_preview.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`AudioVideoPreview should match snapshot, cannot play 1`] = `
       />
       <img
         alt="file preview"
-        src=""
+        src="test-file-stub"
       />
     </a>
     <div

--- a/webapp/channels/src/components/block_renderer/button_element.test.tsx
+++ b/webapp/channels/src/components/block_renderer/button_element.test.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 import type {MmButtonBlock} from '@mattermost/types/mm_blocks';
 
-import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
+import {renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
 
 import {ButtonElement} from './button_element';
 import {MmBlocksInteractionsDisabledContext} from './context';
@@ -120,8 +120,7 @@ describe('ButtonElement', () => {
         expect(screen.getByText('Approve')).toBeInTheDocument();
 
         resolveAction();
-        await screen.findByRole('button', {name: 'Approve'});
-        expect(screen.getByRole('button', {name: 'Approve'})).not.toBeDisabled();
+        await waitFor(() => expect(button).not.toBeDisabled());
         expect(screen.queryByTestId('loadingSpinner')).not.toBeInTheDocument();
     });
 

--- a/webapp/channels/src/components/block_renderer/static_select_element.test.tsx
+++ b/webapp/channels/src/components/block_renderer/static_select_element.test.tsx
@@ -6,7 +6,7 @@ import React from 'react';
 import type {MmStaticSelectBlock} from '@mattermost/types/mm_blocks';
 import type {DeepPartial} from '@mattermost/types/utilities';
 
-import {renderWithContext, screen, userEvent} from 'tests/react_testing_utils';
+import {renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
 
 import type {GlobalState} from 'types/store';
 
@@ -189,8 +189,7 @@ describe('StaticSelectElement', () => {
         expect(screen.getByTestId('autocomplete-select')).toBeDisabled();
 
         resolveAction();
-        await screen.findByTestId('autocomplete-select');
-        expect(screen.getByTestId('autocomplete-select')).not.toBeDisabled();
+        await waitFor(() => expect(screen.getByTestId('autocomplete-select')).not.toBeDisabled());
     });
 
     it('renders for users data_source without static options', () => {

--- a/webapp/channels/src/components/card/card.tsx
+++ b/webapp/channels/src/components/card/card.tsx
@@ -23,8 +23,9 @@ export default class Card extends React.PureComponent<Props> {
         const {expanded, disableExpandAnimation, children} = this.props;
 
         const childrenWithProps = Children.map(children, (child) => {
-            // Checking isValidElement is the safe way and avoids a TS error too.
-            if (isValidElement<CardChildProps>(child)) {
+            // Only Header and Body understand these; forwarding them to any other
+            // child leaks them onto a host element as unknown DOM attributes.
+            if (isValidElement<CardChildProps>(child) && (child.type === CardHeader || child.type === CardBody)) {
                 return cloneElement(child, {expanded, disableExpandAnimation});
             }
             return child;

--- a/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.test.tsx
+++ b/webapp/channels/src/components/channel_invite_modal/channel_invite_modal.test.tsx
@@ -660,6 +660,16 @@ describe('components/channel_invite_modal', () => {
             element?.tagName === 'SPAN' && text.trim() === user,
         ) as HTMLElement;
 
+    // Async variant for the private-ABAC search path. `Client4.searchUsers` resolving
+    // is two renders ahead of the option appearing: the resolution sets
+    // privateAbacSearchHits, and only the effect that mirrors the recomputed options
+    // into groupAndUserOptions actually feeds MultiSelect. Waiting on the call alone
+    // asserts against the pre-search DOM.
+    const findUserSpan = (user: string) =>
+        screen.findByText((text, element) =>
+            element?.tagName === 'SPAN' && text.trim() === user,
+        ) as Promise<HTMLElement>;
+
     test('should not include DM users when ABAC is enabled on a private channel', async () => {
         // Mock Client4 to return user-1 for ABAC channels
         const {Client4} = require('mattermost-redux/client');
@@ -690,7 +700,7 @@ describe('components/channel_invite_modal', () => {
         });
 
         // now only one visible <span> should match "user-1"
-        expect(getUserSpan('user-1')).toBeInTheDocument();
+        expect(await findUserSpan('user-1')).toBeInTheDocument();
 
         // and no <span> with "user-2"
         expect(screen.queryByText('user-2')).toBeNull();
@@ -897,7 +907,7 @@ describe('components/channel_invite_modal', () => {
         });
 
         // Should only show users, not groups when ABAC is enforced
-        expect(getUserSpan('user-1')).toBeInTheDocument();
+        expect(await findUserSpan('user-1')).toBeInTheDocument();
 
         // Groups should not appear in the dropdown
         expect(screen.queryByText('Developers')).toBeNull();
@@ -959,7 +969,7 @@ describe('components/channel_invite_modal', () => {
         });
 
         // Should only show clean ABAC data
-        expect(getUserSpan('user-1')).toBeInTheDocument();
+        expect(await findUserSpan('user-1')).toBeInTheDocument();
         expect(screen.queryByText('user-2')).toBeNull();
     });
 

--- a/webapp/channels/src/components/channel_view/__snapshots__/channel_view.test.tsx.snap
+++ b/webapp/channels/src/components/channel_view/__snapshots__/channel_view.test.tsx.snap
@@ -20,7 +20,7 @@ exports[`components/channel_view Should match snapshot if channel is archived 1`
             alt=""
             class="overlay__files"
             loading="lazy"
-            src=""
+            src="test-file-stub"
           />
           Drop a file to upload it.
         </div>
@@ -74,7 +74,7 @@ exports[`components/channel_view Should match snapshot if channel is deactivated
             alt=""
             class="overlay__files"
             loading="lazy"
-            src=""
+            src="test-file-stub"
           />
           Drop a file to upload it.
         </div>
@@ -127,7 +127,7 @@ exports[`components/channel_view Should match snapshot with base props 1`] = `
             alt=""
             class="overlay__files"
             loading="lazy"
-            src=""
+            src="test-file-stub"
           />
           Drop a file to upload it.
         </div>

--- a/webapp/channels/src/components/create_team/__snapshots__/create_team.test.tsx.snap
+++ b/webapp/channels/src/components/create_team/__snapshots__/create_team.test.tsx.snap
@@ -43,7 +43,7 @@ exports[`component/create_team should match snapshot default 1`] = `
               <img
                 alt="signup logo"
                 class="signup-team-logo"
-                src=""
+                src="test-file-stub"
               />
               <label
                 for="teamNameInput"

--- a/webapp/channels/src/components/emoji_picker/__snapshots__/emoji_picker.test.tsx.snap
+++ b/webapp/channels/src/components/emoji_picker/__snapshots__/emoji_picker.test.tsx.snap
@@ -171,7 +171,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f600"
                 data-testid="grinning"
                 id="emoji-1f600"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -187,7 +187,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f603"
                 data-testid="smiley"
                 id="emoji-1f603"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -203,7 +203,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f604"
                 data-testid="smile"
                 id="emoji-1f604"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -219,7 +219,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f601"
                 data-testid="grin"
                 id="emoji-1f601"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -235,7 +235,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f606"
                 data-testid="laughing,satisfied"
                 id="emoji-1f606"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -251,7 +251,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f605"
                 data-testid="sweat_smile"
                 id="emoji-1f605"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -267,7 +267,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f923"
                 data-testid="rolling_on_the_floor_laughing,rofl"
                 id="emoji-1f923"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -283,7 +283,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f602"
                 data-testid="joy"
                 id="emoji-1f602"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -299,7 +299,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f642"
                 data-testid="slightly_smiling_face"
                 id="emoji-1f642"
-                src=""
+                src="test-file-stub"
               />
             </button>
           </div>
@@ -321,7 +321,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f643"
                 data-testid="upside_down_face"
                 id="emoji-1f643"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -337,7 +337,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f609"
                 data-testid="wink"
                 id="emoji-1f609"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -353,7 +353,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f60a"
                 data-testid="blush"
                 id="emoji-1f60a"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -369,7 +369,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f607"
                 data-testid="innocent"
                 id="emoji-1f607"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -385,7 +385,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f970"
                 data-testid="smiling_face_with_3_hearts"
                 id="emoji-1f970"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -401,7 +401,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f60d"
                 data-testid="heart_eyes"
                 id="emoji-1f60d"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -417,7 +417,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f929"
                 data-testid="star-struck,grinning_face_with_star_eyes"
                 id="emoji-1f929"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -433,7 +433,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f618"
                 data-testid="kissing_heart"
                 id="emoji-1f618"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -449,7 +449,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f617"
                 data-testid="kissing"
                 id="emoji-1f617"
-                src=""
+                src="test-file-stub"
               />
             </button>
           </div>
@@ -471,7 +471,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-263a-fe0f"
                 data-testid="relaxed"
                 id="emoji-263a-fe0f"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -487,7 +487,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f61a"
                 data-testid="kissing_closed_eyes"
                 id="emoji-1f61a"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -503,7 +503,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f619"
                 data-testid="kissing_smiling_eyes"
                 id="emoji-1f619"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -519,7 +519,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f972"
                 data-testid="smiling_face_with_tear"
                 id="emoji-1f972"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -535,7 +535,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f60b"
                 data-testid="yum"
                 id="emoji-1f60b"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -551,7 +551,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f61b"
                 data-testid="stuck_out_tongue"
                 id="emoji-1f61b"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -567,7 +567,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f61c"
                 data-testid="stuck_out_tongue_winking_eye"
                 id="emoji-1f61c"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -583,7 +583,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f92a"
                 data-testid="zany_face,grinning_face_with_one_large_and_one_small_eye"
                 id="emoji-1f92a"
-                src=""
+                src="test-file-stub"
               />
             </button>
             <button
@@ -599,7 +599,7 @@ exports[`components/emoji_picker/EmojiPicker should match snapshot 1`] = `
                 class="emojisprite emoji-category-smileys-emotion emoji-1f61d"
                 data-testid="stuck_out_tongue_closed_eyes"
                 id="emoji-1f61d"
-                src=""
+                src="test-file-stub"
               />
             </button>
           </div>

--- a/webapp/channels/src/components/external_image/external_image.test.tsx
+++ b/webapp/channels/src/components/external_image/external_image.test.tsx
@@ -11,7 +11,8 @@ import ExternalImage from './external_image';
 
 describe('ExternalImage', () => {
     const baseProps = {
-        children: jest.fn((src) => <img src={src}/>),
+        // Real callers treat an empty src as "don't render the image", as does this mock
+        children: jest.fn((src) => (src ? <img src={src}/> : <span/>)),
         enableSVGs: true,
         imageMetadata: {
             format: 'png',
@@ -76,7 +77,7 @@ describe('ExternalImage', () => {
         const {container} = render(<ExternalImage {...props}/>);
 
         expect(props.children).toHaveBeenCalledWith('');
-        expect(container.querySelector('img')).toBeInTheDocument();
+        expect(container.querySelector('img')).not.toBeInTheDocument();
     });
 
     test('should pass src through the image proxy when enabled', () => {

--- a/webapp/channels/src/components/external_image/external_image.test.tsx
+++ b/webapp/channels/src/components/external_image/external_image.test.tsx
@@ -10,8 +10,8 @@ import {render} from 'tests/react_testing_utils';
 import ExternalImage from './external_image';
 
 describe('ExternalImage', () => {
+    // Real callers treat an empty src as "don't render the image", as does this mock
     const baseProps = {
-        // Real callers treat an empty src as "don't render the image", as does this mock
         children: jest.fn((src) => (src ? <img src={src}/> : <span/>)),
         enableSVGs: true,
         imageMetadata: {

--- a/webapp/channels/src/components/file_info_preview/__snapshots__/file_info_preview.test.tsx.snap
+++ b/webapp/channels/src/components/file_info_preview/__snapshots__/file_info_preview.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`components/FileInfoPreview should match snapshot, can download files 1`
       />
       <img
         alt="file preview"
-        src=""
+        src="test-file-stub"
       />
     </a>
     <div
@@ -48,7 +48,7 @@ exports[`components/FileInfoPreview should match snapshot, cannot download files
       />
       <img
         alt="file preview"
-        src=""
+        src="test-file-stub"
       />
     </span>
     <div

--- a/webapp/channels/src/components/file_upload_overlay/__snapshots__/file_upload_overlay.test.tsx.snap
+++ b/webapp/channels/src/components/file_upload_overlay/__snapshots__/file_upload_overlay.test.tsx.snap
@@ -16,7 +16,7 @@ exports[`components/FileUploadOverlay should match snapshot when file upload is 
           alt=""
           class="overlay__files"
           loading="lazy"
-          src=""
+          src="test-file-stub"
         />
         Drop a file to upload it.
       </div>
@@ -41,7 +41,7 @@ exports[`components/FileUploadOverlay should match snapshot when file upload is 
           alt=""
           class="overlay__files"
           loading="lazy"
-          src=""
+          src="test-file-stub"
         />
         Drop a file to upload it.
       </div>
@@ -66,7 +66,7 @@ exports[`components/FileUploadOverlay should match snapshot when file upload is 
           alt=""
           class="overlay__files"
           loading="lazy"
-          src=""
+          src="test-file-stub"
         />
         Drop a file to upload it.
       </div>

--- a/webapp/channels/src/components/integrations/bots/add_bot/__snapshots__/add_bot.test.tsx.snap
+++ b/webapp/channels/src/components/integrations/bots/add_bot/__snapshots__/add_bot.test.tsx.snap
@@ -75,7 +75,7 @@ exports[`components/integrations/bots/AddBot blank 1`] = `
               <img
                 alt="bot image"
                 class="bot-img"
-                src=""
+                src="test-file-stub"
               />
             </div>
             <div

--- a/webapp/channels/src/components/integrations/outgoing_oauth_connections/abstract_outgoing_oauth_connection.test.tsx
+++ b/webapp/channels/src/components/integrations/outgoing_oauth_connections/abstract_outgoing_oauth_connection.test.tsx
@@ -123,15 +123,10 @@ describe('components/integrations/AbstractOutgoingOAuthConnection', () => {
 
         await userEvent.type(container.querySelector('#client_secret') as HTMLInputElement, 'secret');
 
-        await act(async () => {
-            const submitButton = container.querySelector('button.btn-primary') as HTMLButtonElement;
-            submitButton?.click();
-        });
+        await userEvent.click(container.querySelector('button.btn-primary') as HTMLButtonElement);
 
         // Changing the secret marks the form unvalidated, so submitting prompts to save anyway.
-        await act(async () => {
-            (document.querySelector('#confirmModalButton') as HTMLButtonElement)?.click();
-        });
+        await userEvent.click(document.querySelector('#confirmModalButton') as HTMLButtonElement);
 
         expect(submitAction).toHaveBeenCalledWith(expect.objectContaining({client_secret: 'secret'}));
     });

--- a/webapp/channels/src/components/markdown_image/__snapshots__/markdown_image.test.tsx.snap
+++ b/webapp/channels/src/components/markdown_image/__snapshots__/markdown_image.test.tsx.snap
@@ -286,7 +286,7 @@ exports[`components/MarkdownImage should render a link if the source is unsafe 1
     <img
       alt="test image"
       class="markdown-inline-img broken-image"
-      src=""
+      src="test-file-stub"
     />
   </div>
 </div>

--- a/webapp/channels/src/components/new_channel_modal/new_channel_modal.test.tsx
+++ b/webapp/channels/src/components/new_channel_modal/new_channel_modal.test.tsx
@@ -297,12 +297,10 @@ describe('components/new_channel_modal', () => {
         expect(ChannelPurposeTextArea).toBeInTheDocument();
 
         // Simulate user interaction with purpose field including focus/blur for validation - fireEvent used because userEvent doesn't have direct focus/blur methods
-        await act(async () => {
-            fireEvent.focus(ChannelPurposeTextArea);
-            await userEvent.clear(ChannelPurposeTextArea);
-            await userEvent.type(ChannelPurposeTextArea, value);
-            fireEvent.blur(ChannelPurposeTextArea);
-        });
+        fireEvent.focus(ChannelPurposeTextArea);
+        await userEvent.clear(ChannelPurposeTextArea);
+        await userEvent.type(ChannelPurposeTextArea, value);
+        fireEvent.blur(ChannelPurposeTextArea);
 
         // Purpose should have been updated
         expect(ChannelPurposeTextArea).toHaveValue(value);

--- a/webapp/channels/src/components/onboarding_tasklist/__snapshots__/onboarding_tasklist_completed.test.tsx.snap
+++ b/webapp/channels/src/components/onboarding_tasklist/__snapshots__/onboarding_tasklist_completed.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`components/onboarding_tasklist/onboarding_tasklist_completed.tsx should
   >
     <img
       alt="completed tasks image"
-      src=""
+      src="test-file-stub"
     />
     <h2>
       Well done. You’ve completed all of the tasks!

--- a/webapp/channels/src/components/plugin_marketplace/__snapshots__/marketplace_modal.test.tsx.snap
+++ b/webapp/channels/src/components/plugin_marketplace/__snapshots__/marketplace_modal.test.tsx.snap
@@ -382,7 +382,7 @@ exports[`components/marketplace/ hides search and shows web marketplace banner 1
             </div>
           </div>
           <section
-            class="WebMarketplaceBannerRoot-gZFWXe indOpp WebMarketplaceBanner"
+            class="WebMarketplaceBannerRoot-gZFWXe gSAhuj WebMarketplaceBanner"
           >
             <a
               class="ExternalBannerLink-iPYFKS jAjFfs"
@@ -418,15 +418,15 @@ exports[`components/marketplace/ hides search and shows web marketplace banner 1
               >
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
               </div>
             </a>
@@ -534,7 +534,7 @@ exports[`components/marketplace/ should render default 1`] = `
             </div>
           </div>
           <section
-            class="WebMarketplaceBannerRoot-gZFWXe indOpp WebMarketplaceBanner"
+            class="WebMarketplaceBannerRoot-gZFWXe gSAhuj WebMarketplaceBanner"
           >
             <a
               class="ExternalBannerLink-iPYFKS jAjFfs"
@@ -570,15 +570,15 @@ exports[`components/marketplace/ should render default 1`] = `
               >
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
               </div>
             </a>
@@ -728,7 +728,7 @@ exports[`components/marketplace/ should render with error banner 1`] = `
             </div>
           </div>
           <section
-            class="WebMarketplaceBannerRoot-gZFWXe indOpp WebMarketplaceBanner"
+            class="WebMarketplaceBannerRoot-gZFWXe gSAhuj WebMarketplaceBanner"
           >
             <a
               class="ExternalBannerLink-iPYFKS jAjFfs"
@@ -764,15 +764,15 @@ exports[`components/marketplace/ should render with error banner 1`] = `
               >
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
               </div>
             </a>
@@ -906,7 +906,7 @@ exports[`components/marketplace/ should render with no plugins available 1`] = `
             </div>
           </div>
           <section
-            class="WebMarketplaceBannerRoot-gZFWXe indOpp WebMarketplaceBanner"
+            class="WebMarketplaceBannerRoot-gZFWXe gSAhuj WebMarketplaceBanner"
           >
             <a
               class="ExternalBannerLink-iPYFKS jAjFfs"
@@ -942,15 +942,15 @@ exports[`components/marketplace/ should render with no plugins available 1`] = `
               >
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
               </div>
             </a>
@@ -1126,7 +1126,7 @@ exports[`components/marketplace/ should render with plugins available 1`] = `
             </div>
           </div>
           <section
-            class="WebMarketplaceBannerRoot-gZFWXe indOpp WebMarketplaceBanner"
+            class="WebMarketplaceBannerRoot-gZFWXe gSAhuj WebMarketplaceBanner"
           >
             <a
               class="ExternalBannerLink-iPYFKS jAjFfs"
@@ -1162,15 +1162,15 @@ exports[`components/marketplace/ should render with plugins available 1`] = `
               >
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
               </div>
             </a>
@@ -1436,7 +1436,7 @@ exports[`components/marketplace/ should render with plugins installed 1`] = `
             </div>
           </div>
           <section
-            class="WebMarketplaceBannerRoot-gZFWXe indOpp WebMarketplaceBanner"
+            class="WebMarketplaceBannerRoot-gZFWXe gSAhuj WebMarketplaceBanner"
           >
             <a
               class="ExternalBannerLink-iPYFKS jAjFfs"
@@ -1472,15 +1472,15 @@ exports[`components/marketplace/ should render with plugins installed 1`] = `
               >
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
                 <img
                   class="PluginIcon-gwsFHd eGJjnp"
-                  src=""
+                  src="test-file-stub"
                 />
               </div>
             </a>

--- a/webapp/channels/src/components/select_team/__snapshots__/select_team.test.tsx.snap
+++ b/webapp/channels/src/components/select_team/__snapshots__/select_team.test.tsx.snap
@@ -28,7 +28,7 @@ exports[`components/select_team/SelectTeam should match snapshot 1`] = `
         <img
           alt="signup team logo"
           class="signup-team-logo"
-          src=""
+          src="test-file-stub"
         />
         <h1
           id="site_name"
@@ -142,7 +142,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on create team
         <img
           alt="signup team logo"
           class="signup-team-logo"
-          src=""
+          src="test-file-stub"
         />
         <h1
           id="site_name"
@@ -256,7 +256,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on error 1`] =
         <img
           alt="signup team logo"
           class="signup-team-logo"
-          src=""
+          src="test-file-stub"
         />
         <h1
           id="site_name"
@@ -316,7 +316,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on loading 1`]
         <img
           alt="signup team logo"
           class="signup-team-logo"
-          src=""
+          src="test-file-stub"
         />
         <h1
           id="site_name"
@@ -385,7 +385,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on no joinable
         <img
           alt="signup team logo"
           class="signup-team-logo"
-          src=""
+          src="test-file-stub"
         />
         <h1
           id="site_name"
@@ -468,7 +468,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on no joinable
         <img
           alt="signup team logo"
           class="signup-team-logo"
-          src=""
+          src="test-file-stub"
         />
         <h1
           id="site_name"
@@ -528,7 +528,7 @@ exports[`components/select_team/SelectTeam should match snapshot, on no joinable
         <img
           alt="signup team logo"
           class="signup-team-logo"
-          src=""
+          src="test-file-stub"
         />
         <h1
           id="site_name"

--- a/webapp/channels/src/components/team_settings/team_access_tab/team_access_tab.test.tsx
+++ b/webapp/channels/src/components/team_settings/team_access_tab/team_access_tab.test.tsx
@@ -6,7 +6,7 @@ import type {ComponentProps} from 'react';
 
 import {Permissions} from 'mattermost-redux/constants';
 
-import {act, renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
+import {renderWithContext, screen, userEvent, waitFor} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';
 
 import AccessTab from './team_access_tab';
@@ -108,10 +108,8 @@ describe('components/TeamSettings', () => {
         renderWithContext(<AccessTab {...props}/>);
         const allowedDomainsInput = screen.getAllByRole('combobox')[0];
         const newDomain = 'best.com';
-        await act(async () => {
-            await allowedDomainsInput.focus();
-            await userEvent.type(allowedDomainsInput, `${newDomain},`);
-        });
+        allowedDomainsInput.focus();
+        await userEvent.type(allowedDomainsInput, `${newDomain},`);
 
         const newDomainText = screen.getByText(newDomain);
         expect(newDomainText).toBeInTheDocument();

--- a/webapp/channels/src/components/threading/thread_viewer/thread_viewer.test.tsx
+++ b/webapp/channels/src/components/threading/thread_viewer/thread_viewer.test.tsx
@@ -8,7 +8,7 @@ import type {Post} from '@mattermost/types/posts';
 import type {UserThread} from '@mattermost/types/threads';
 
 import {fakeDate} from 'tests/helpers/date';
-import {renderWithContext, waitFor} from 'tests/react_testing_utils';
+import {renderWithContext, screen, waitFor} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';
 
 import type {FakePost} from 'types/store/rhs';
@@ -111,9 +111,8 @@ describe('components/threading/ThreadViewer', () => {
             <ThreadViewer {...baseProps}/>,
         );
 
-        await waitFor(() => {
-            expect(actions.getPostThread).toHaveBeenCalled();
-        });
+        await screen.findByTestId('virtualized-thread-viewer');
+        expect(actions.getPostThread).toHaveBeenCalled();
         expect(container).toMatchSnapshot();
         reset();
     });

--- a/webapp/channels/src/components/user_account_menu/__snapshots__/user_account_name_menuitem.test.tsx.snap
+++ b/webapp/channels/src/components/user_account_menu/__snapshots__/user_account_name_menuitem.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`UserAccountNameMenuItem should not break if no props are passed 1`] = `
         aria-hidden="true"
         class="Avatar Avatar-lg"
         loading="lazy"
+        src="test-file-stub"
       />
     </div>
     <div

--- a/webapp/channels/src/components/user_settings/display/user_settings_theme/custom_theme_chooser/__snapshots__/custom_theme_chooser.test.tsx.snap
+++ b/webapp/channels/src/components/user_settings/display/user_settings_theme/custom_theme_chooser/__snapshots__/custom_theme_chooser.test.tsx.snap
@@ -801,7 +801,7 @@ exports[`components/user_settings/display/CustomThemeChooser should match, init 
             >
               <img
                 alt="code theme image"
-                src=""
+                src="test-file-stub"
               />
             </span>
           </div>

--- a/webapp/channels/src/components/widgets/users/avatar/avatar.test.tsx
+++ b/webapp/channels/src/components/widgets/users/avatar/avatar.test.tsx
@@ -105,12 +105,8 @@ describe('components/widgets/users/Avatar', () => {
 
         fireEvent.error(avatar);
 
-        // Should change from the initial URL (bot icon set, even if empty in test environment)
         expect(avatar.src).not.toBe(initialSrc);
-
-        // In production, this would be the bot default icon
-        // In test environment, it may resolve to empty string or base URL
-        expect(avatar.src === BotDefaultIcon || avatar.src === 'http://localhost:8065/').toBe(true);
+        expect(avatar.src).toBe(new URL(BotDefaultIcon, window.location.href).href);
     });
 
     test('should not change src if already using fallback image', () => {

--- a/webapp/channels/src/components/widgets/users/avatar/avatar.tsx
+++ b/webapp/channels/src/components/widgets/users/avatar/avatar.tsx
@@ -97,7 +97,10 @@ const Avatar = forwardRef<HTMLElement, Props & Attrs>(({
             alt={alt ?? formatMessage({id: 'avatar.alt', defaultMessage: '{username} profile image'}, {
                 username: username || 'user',
             })}
-            src={url}
+
+            // Callers use an empty url to mean "no picture available", but an empty src makes the
+            // browser re-request the current page, so go straight to the fallback image instead
+            src={url || BotDefaultIcon}
             loading='lazy'
             onError={handleOnError}
         />

--- a/webapp/channels/src/tests/image_url_mock.json
+++ b/webapp/channels/src/tests/image_url_mock.json
@@ -1,1 +1,1 @@
-""
+"test-file-stub"

--- a/webapp/channels/src/utils/notifications.test.ts
+++ b/webapp/channels/src/utils/notifications.test.ts
@@ -3,6 +3,8 @@
 
 /* eslint-disable global-require */
 
+import icon50 from 'images/icon50x50.png';
+
 import configureStore from 'tests/test_store';
 
 import type {showNotification} from './notifications';
@@ -94,7 +96,7 @@ describe('Notifications.showNotification', () => {
         expect(call[1]).toEqual({
             body: 'body',
             tag: '',
-            icon: '',
+            icon: icon50,
             requireInteraction: true,
             silent: false,
         });
@@ -120,7 +122,7 @@ describe('Notifications.showNotification', () => {
         expect(call[1]).toEqual({
             body: 'body',
             tag: '',
-            icon: '',
+            icon: icon50,
             requireInteraction: true,
             silent: false,
         });

--- a/webapp/channels/src/utils/notifications.test.ts
+++ b/webapp/channels/src/utils/notifications.test.ts
@@ -4,7 +4,6 @@
 /* eslint-disable global-require */
 
 import icon50 from 'images/icon50x50.png';
-
 import configureStore from 'tests/test_store';
 
 import type {showNotification} from './notifications';

--- a/webapp/patches/react-intl+7.1.14.patch
+++ b/webapp/patches/react-intl+7.1.14.patch
@@ -1,0 +1,86 @@
+diff --git a/node_modules/react-intl/lib/src/utils.js b/node_modules/react-intl/lib/src/utils.js
+index 6a9aae8..b798c02 100644
+--- a/node_modules/react-intl/lib/src/utils.js
++++ b/node_modules/react-intl/lib/src/utils.js
+@@ -12,11 +12,6 @@ export function invariantIntlContext(intl) {
+         '<IntlProvider> needs to exist in the component ancestry.');
+ }
+ export var DEFAULT_INTL_CONFIG = __assign(__assign({}, CORE_DEFAULT_INTL_CONFIG), { textComponent: React.Fragment });
+-var toKeyedReactNode = function (reactNode, key) {
+-    return React.isValidElement(reactNode)
+-        ? React.cloneElement(reactNode, { key: key })
+-        : reactNode;
+-};
+ /**
+  * Builds an array of {@link React.ReactNode}s with index-based keys, similar to
+  * {@link React.Children.toArray}. However, this function tells React that it
+@@ -25,14 +20,19 @@ var toKeyedReactNode = function (reactNode, key) {
+  * React doesn't recommend doing this because it makes reordering inefficient,
+  * but we mostly need this for message chunks, which don't tend to reorder to
+  * begin with.
++ *
+  */
+-export var toKeyedReactNodeArray = function (children) { var _a; 
+-/**
+- * Note: {@link React.Children.map} will add its own index-based prefix to
+- * every key anyway, so the auto-injected one doesn't even have to be unique.
+- * This basically just tells React that it's explicit/intentional.
+- */
+-return (_a = React.Children.map(children, toKeyedReactNode)) !== null && _a !== void 0 ? _a : []; };
++export var toKeyedReactNodeArray = function (children) {
++    var childrenArray = React.Children.toArray(children);
++    return childrenArray.map(function (child, index) {
++        // For React elements, wrap in a keyed Fragment
++        // This creates a new element with a key rather than trying to add one after creation
++        if (React.isValidElement(child)) {
++            return React.createElement(React.Fragment, { key: index }, child);
++        }
++        return child;
++    });
++};
+ /**
+  * Takes a `formatXMLElementFn`, and composes it in function, which passes
+  * argument `parts` through, assigning unique key to each part, to prevent
+diff --git a/node_modules/react-intl/src/utils.js b/node_modules/react-intl/src/utils.js
+index 8ef8083..fd22455 100644
+--- a/node_modules/react-intl/src/utils.js
++++ b/node_modules/react-intl/src/utils.js
+@@ -19,11 +19,6 @@ function invariantIntlContext(intl) {
+         '<IntlProvider> needs to exist in the component ancestry.');
+ }
+ exports.DEFAULT_INTL_CONFIG = tslib_1.__assign(tslib_1.__assign({}, intl_1.DEFAULT_INTL_CONFIG), { textComponent: React.Fragment });
+-var toKeyedReactNode = function (reactNode, key) {
+-    return React.isValidElement(reactNode)
+-        ? React.cloneElement(reactNode, { key: key })
+-        : reactNode;
+-};
+ /**
+  * Builds an array of {@link React.ReactNode}s with index-based keys, similar to
+  * {@link React.Children.toArray}. However, this function tells React that it
+@@ -32,14 +27,19 @@ var toKeyedReactNode = function (reactNode, key) {
+  * React doesn't recommend doing this because it makes reordering inefficient,
+  * but we mostly need this for message chunks, which don't tend to reorder to
+  * begin with.
++ *
+  */
+-var toKeyedReactNodeArray = function (children) { var _a; 
+-/**
+- * Note: {@link React.Children.map} will add its own index-based prefix to
+- * every key anyway, so the auto-injected one doesn't even have to be unique.
+- * This basically just tells React that it's explicit/intentional.
+- */
+-return (_a = React.Children.map(children, toKeyedReactNode)) !== null && _a !== void 0 ? _a : []; };
++var toKeyedReactNodeArray = function (children) {
++    var childrenArray = React.Children.toArray(children);
++    return childrenArray.map(function (child, index) {
++        // For React elements, wrap in a keyed Fragment
++        // This creates a new element with a key rather than trying to add one after creation
++        if (React.isValidElement(child)) {
++            return React.createElement(React.Fragment, { key: index }, child);
++        }
++        return child;
++    });
++};
+ exports.toKeyedReactNodeArray = toKeyedReactNodeArray;
+ /**
+  * Takes a `formatXMLElementFn`, and composes it in function, which passes


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Pulled out of [#38311](https://github.com/mattermost/mattermost/pull/38311). Every change here was needed to get the web app onto React 19, but none of it depends on React 19 — it all compiles and passes on the React 18 we ship today, so it can land first and shrink the upgrade.

**Fixes**

- `Card` cloned its children with `expanded` and `disableExpandAnimation` for any valid element, so a child that was not `CardHeader` or `CardBody` had them forwarded onto a host element as unknown DOM attributes. It now checks the child type. React 19 is what surfaced this, by warning about the unknown attributes, but the leak is present today.
- Two places rendered an `<img>` with an empty `src`, which makes the browser re-request the current page: `Avatar` when given no URL, and `BrandImageSetting`, which mutated the DOM node's `src` directly instead of rendering from state. `Avatar` now falls back to its default icon and `BrandImageSetting` renders the preview from state. React 19 turns this into an error rather than a warning.
- Rendering that preview from state exposed a second bug in `BrandImageSetting`: it only cleared the preview when the selection became empty, so replacing one image with another kept showing the old one while the new `FileReader` was pending — and kept showing it for good if that read never completed. The preview now resets on every change.
- Patched `react-intl` to key rich-text message chunks the way v8 does. Without it, every message with embedded elements produces a missing-key warning.

**Test hardening**

Several tests keyed off something that does not actually imply the render has settled — an action spy having been called, or an element that was already in the DOM before the interaction. They pass today by timing, and stop passing under React 19's scheduling. They now await the rendered output instead. Similarly, a few tests opened an `act()` scope around a `userEvent` call that already wraps its own, and two list tests snapshotted a loading placeholder rather than the loaded list.

The snapshot churn is a consequence of the empty-`src` fix: the shared image mock returns a stub URL instead of an empty string, so `src=""` becomes `src="test-file-stub"` in 79 places. The one class-name change is `WebMarketplaceBanner`, whose styled-component interpolates that URL into `background-image`.

**QA steps**

`npm run check-types`, `npm run check` and `npm run test` all pass on this branch against React 18, with 13519 tests and 1324 snapshots green.

#### Release Note

```release-note
NONE
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a066b7-1bf4-7b96-8f3c-688222230193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a066b7-1bf4-7b96-8f3c-688222230193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** Changes affect shared components, image handling, and `react-intl` across multiple modules. Automated tests cover the updated behavior, but rendering and image-source changes may cause regressions.

**QA Recommendation:** Manual QA is not required. Perform targeted UI checks if time permits.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->