### PR TITLE
Always render with createRoot and drop the EnableConcurrentReact flag

### DIFF
--- a/e2e-tests/playwright/lib/src/containers/env_baseline.ts
+++ b/e2e-tests/playwright/lib/src/containers/env_baseline.ts
@@ -18,7 +18,6 @@ export const SERVER_ENV_BASELINE: Record<string, string> = {
     MM_SERVICESETTINGS_ENABLETESTING: 'true',
     // Feature flags this test suite needs on, off by default in the server
     MM_FEATUREFLAGS_ATTRIBUTEVALUEMASKING: 'true',
-    MM_FEATUREFLAGS_ENABLECONCURRENTREACT: 'true',
     MM_FEATUREFLAGS_PERMISSIONPOLICIES: 'true',
     MM_FEATUREFLAGS_PROPERTYFIELDRANK: 'true',
     MM_FEATUREFLAGS_RECURRINGSCHEDULEDPOSTS: 'true',

--- a/e2e-tests/playwright/lib/src/server/default_config.ts
+++ b/e2e-tests/playwright/lib/src/server/default_config.ts
@@ -816,7 +816,6 @@ const defaultServerConfig: AdminConfig = {
         MmBlocksEnabled: true,
         ClusterGracefulDrain: true,
         ChannelBookmarks: true,
-        EnableConcurrentReact: true,
         EnableMFIPluginSignaturePublicKey: true,
         RecurringScheduledPosts: false,
     },

--- a/e2e-tests/playwright/specs/functional/channels/drafts/draft_channel_switch.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/drafts/draft_channel_switch.spec.ts
@@ -62,53 +62,47 @@ test.describe('draft channel switch', () => {
 
     /**
      * @objective Verify Ctrl/Cmd+K restores the destination draft and routes
-     * messages to the selected channel with concurrent React enabled.
+     * messages to the selected channel.
      */
-    test(
-        'quick switcher keeps drafts and messages scoped to their channels with concurrent React',
-        {tag: '@messaging'},
-        async ({pw}) => {
-            await pw.ensureFeatureFlag('EnableConcurrentReact', true);
+    test('quick switcher keeps drafts and messages scoped to their channels', {tag: '@messaging'}, async ({pw}) => {
+        const {team, user} = await pw.initSetup();
+        const {channelsPage, page} = await pw.testBrowser.login(user);
 
-            const {team, user} = await pw.initSetup();
-            const {channelsPage, page} = await pw.testBrowser.login(user);
+        await channelsPage.goto(team.name, 'off-topic');
+        await channelsPage.toBeVisible();
 
-            await channelsPage.goto(team.name, 'off-topic');
-            await channelsPage.toBeVisible();
+        const originDraft = `quick-switch-origin-${pw.random.id()}`;
+        const destinationMessage = `quick-switch-destination-${pw.random.id()}`;
 
-            const originDraft = `quick-switch-origin-${pw.random.id()}`;
-            const destinationMessage = `quick-switch-destination-${pw.random.id()}`;
+        // # Leave a draft in Off-Topic
+        await channelsPage.centerView.postCreate.writeMessage(originDraft);
 
-            // # Leave a draft in Off-Topic
-            await channelsPage.centerView.postCreate.writeMessage(originDraft);
+        // # Switch to Town Square using Ctrl/Cmd+K
+        await page.keyboard.press('ControlOrMeta+K');
+        await expect(channelsPage.findChannelsModal.input).toBeVisible();
+        await channelsPage.findChannelsModal.input.fill('town');
+        await channelsPage.findChannelsModal.selectChannel('town-square');
+        await channelsPage.centerView.header.toHaveTitle('Town Square');
 
-            // # Switch to Town Square using Ctrl/Cmd+K
-            await page.keyboard.press('ControlOrMeta+K');
-            await expect(channelsPage.findChannelsModal.input).toBeVisible();
-            await channelsPage.findChannelsModal.input.fill('town');
-            await channelsPage.findChannelsModal.selectChannel('town-square');
-            await channelsPage.centerView.header.toHaveTitle('Town Square');
+        // * Town Square did not inherit the Off-Topic draft
+        expect(await channelsPage.centerView.postCreate.getInputValue()).toBe('');
 
-            // * Town Square did not inherit the Off-Topic draft
-            expect(await channelsPage.centerView.postCreate.getInputValue()).toBe('');
+        // # Send a destination-owned message
+        await channelsPage.centerView.postCreate.writeMessage(destinationMessage);
+        await channelsPage.centerView.postCreate.sendMessage();
+        await channelsPage.centerView.waitUntilLastPostContains(destinationMessage);
 
-            // # Send a destination-owned message
-            await channelsPage.centerView.postCreate.writeMessage(destinationMessage);
-            await channelsPage.centerView.postCreate.sendMessage();
-            await channelsPage.centerView.waitUntilLastPostContains(destinationMessage);
+        // # Return to Off-Topic using Ctrl/Cmd+K
+        await page.keyboard.press('ControlOrMeta+K');
+        await expect(channelsPage.findChannelsModal.input).toBeVisible();
+        await channelsPage.findChannelsModal.input.fill('off');
+        await channelsPage.findChannelsModal.selectChannel('off-topic');
+        await channelsPage.centerView.header.toHaveTitle('Off-Topic');
 
-            // # Return to Off-Topic using Ctrl/Cmd+K
-            await page.keyboard.press('ControlOrMeta+K');
-            await expect(channelsPage.findChannelsModal.input).toBeVisible();
-            await channelsPage.findChannelsModal.input.fill('off');
-            await channelsPage.findChannelsModal.selectChannel('off-topic');
-            await channelsPage.centerView.header.toHaveTitle('Off-Topic');
-
-            // * The origin draft was restored and the destination message was not misrouted
-            expect(await channelsPage.centerView.postCreate.getInputValue()).toBe(originDraft);
-            await expect(channelsPage.centerView.container).not.toContainText(destinationMessage);
-        },
-    );
+        // * The origin draft was restored and the destination message was not misrouted
+        expect(await channelsPage.centerView.postCreate.getInputValue()).toBe(originDraft);
+        await expect(channelsPage.centerView.container).not.toContainText(destinationMessage);
+    });
 
     /**
      * @objective Verify sending /msg to an existing DM clears the origin

--- a/server/channels/utils/subpath.go
+++ b/server/channels/utils/subpath.go
@@ -12,7 +12,6 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 
 	"github.com/pkg/errors"
@@ -33,16 +32,6 @@ func getSubpathScript(subpath string) string {
 	return fmt.Sprintf("window.publicPath='%s'", newPath)
 }
 
-// getConcurrentReactScript renders the inline script that defines window.enableConcurrentReact to change how React
-// initializes the web app.
-func getConcurrentReactScript(enableConcurrentReact bool) string {
-	if !enableConcurrentReact {
-		return ""
-	}
-
-	return "window.enableConcurrentReact=true"
-}
-
 // GetScriptHash computes the script-src addition required for an inline script injected into the root.html.
 func GetScriptHash(script string) string {
 	// No hash is required when there's no script
@@ -57,18 +46,15 @@ func GetScriptHash(script string) string {
 
 // GetStaticScriptHashes computes the combined script-src additions required for the inline scripts injected
 // into root.html to bypass CSP protections.
-func GetStaticScriptHashes(subpath string, enableConcurrentReact bool) string {
-	return GetScriptHash(getSubpathScript(subpath)) + GetScriptHash(getConcurrentReactScript(enableConcurrentReact))
+func GetStaticScriptHashes(subpath string) string {
+	return GetScriptHash(getSubpathScript(subpath))
 }
 
-// UpdateAssetsSubpathInDir rewrites static assets in the given directory based on configuration options.
-// The following changes are made:
-//   - HTML and CSS files are rewritten to assume the application is hosted at the given subpath instead of at the root.
-//   - HTML is rewritten to add the enableConcurrentReact setting, needed while loading the web app. If omitted, the
-//     existing value is preserved.
+// UpdateAssetsSubpathInDir rewrites static assets in the given directory so that HTML and CSS files assume the
+// application is hosted at the given subpath instead of at the root.
 //
 // No changes are written unless necessary.
-func UpdateAssetsSubpathInDir(subpath, directory string, enableConcurrentReactPtr *bool) error {
+func UpdateAssetsSubpathInDir(subpath, directory string) error {
 	if subpath == "" {
 		subpath = "/"
 	}
@@ -104,21 +90,8 @@ func UpdateAssetsSubpathInDir(subpath, directory string, enableConcurrentReactPt
 	pathToReplace := path.Join(oldSubpath, "static") + "/"
 	newPath := path.Join(subpath, "static") + "/"
 
-	// Keep the previous value of enableConcurrentReact if it isn't provided
-	enableConcurrentReact := false
-	if enableConcurrentReactPtr == nil {
-		reConcurrentReactScript := regexp.MustCompile("window.enableConcurrentReact=(true|false)")
-		if matches := reConcurrentReactScript.FindSubmatch(oldRootHTML); matches != nil {
-			if value, convErr := strconv.ParseBool(string(matches[1])); convErr == nil {
-				enableConcurrentReact = value
-			}
-		}
-	} else {
-		enableConcurrentReact = *enableConcurrentReactPtr
-	}
-
 	// Update the root.html file
-	if err := updateRootFile(string(oldRootHTML), rootHTMLPath, alreadyRewritten, pathToReplace, newPath, subpath, enableConcurrentReact); err != nil {
+	if err := updateRootFile(string(oldRootHTML), rootHTMLPath, alreadyRewritten, pathToReplace, newPath, subpath); err != nil {
 		return fmt.Errorf("failed to update root.html: %w", err)
 	}
 
@@ -130,7 +103,7 @@ func UpdateAssetsSubpathInDir(subpath, directory string, enableConcurrentReactPt
 	return nil
 }
 
-func updateRootFile(oldRootHTML string, rootHTMLPath string, alreadyRewritten bool, pathToReplace, newPath, subpath string, enableConcurrentReact bool) error {
+func updateRootFile(oldRootHTML string, rootHTMLPath string, alreadyRewritten bool, pathToReplace, newPath, subpath string) error {
 	newRootHTML := oldRootHTML
 
 	reCSP := regexp.MustCompile(`<meta http-equiv="Content-Security-Policy" content="script-src 'self'([^"]*)">`)
@@ -140,7 +113,7 @@ func updateRootFile(oldRootHTML string, rootHTMLPath string, alreadyRewritten bo
 
 	newRootHTML = reCSP.ReplaceAllLiteralString(newRootHTML, fmt.Sprintf(
 		`<meta http-equiv="Content-Security-Policy" content="script-src 'self'%s">`,
-		GetStaticScriptHashes(subpath, enableConcurrentReact),
+		GetStaticScriptHashes(subpath),
 	))
 
 	// Rewrite the root.html references to `/static/*` to include the given subpath.
@@ -157,10 +130,6 @@ func updateRootFile(oldRootHTML string, rootHTMLPath string, alreadyRewritten bo
 		subpathScript := getSubpathScript(subpath)
 		newRootHTML = publicPathInWindowsScriptRegex.ReplaceAllLiteralString(newRootHTML, fmt.Sprintf("<script id=\"publicPathInWindowScript\">%s</script>", subpathScript))
 	}
-
-	// Inject (or clear) the script defining `window.enableConcurrentReact` to match the feature flag.
-	concurrentReactScriptRegex := regexp.MustCompile(`(?s)<script id="enableConcurrentReactScript">(.*?)</script>`)
-	newRootHTML = concurrentReactScriptRegex.ReplaceAllLiteralString(newRootHTML, fmt.Sprintf("<script id=\"enableConcurrentReactScript\">%s</script>", getConcurrentReactScript(enableConcurrentReact)))
 
 	if newRootHTML == oldRootHTML {
 		mlog.Debug("No need to rewrite unmodified root.html", mlog.String("from_subpath", pathToReplace), mlog.String("to_subpath", newPath))
@@ -207,8 +176,8 @@ func updateManifestAndCSSFiles(staticDir, pathToReplace, newPath, subpath string
 
 // UpdateAssetsSubpath rewrites assets in the /client directory to assume the application is hosted
 // at the given subpath instead of at the root. No changes are written unless necessary.
-func UpdateAssetsSubpath(subpath string, enableConcurrentReact *bool) error {
-	return UpdateAssetsSubpathInDir(subpath, model.ClientDir, enableConcurrentReact)
+func UpdateAssetsSubpath(subpath string) error {
+	return UpdateAssetsSubpathInDir(subpath, model.ClientDir)
 }
 
 // UpdateAssetsSubpathFromConfig uses UpdateAssetsSubpath and any path defined in the SiteURL.
@@ -231,12 +200,7 @@ func UpdateAssetsSubpathFromConfig(config *model.Config) error {
 		return err
 	}
 
-	enableConcurrentReact := false
-	if config != nil && config.FeatureFlags != nil {
-		enableConcurrentReact = config.FeatureFlags.EnableConcurrentReact
-	}
-
-	return UpdateAssetsSubpath(subpath, &enableConcurrentReact)
+	return UpdateAssetsSubpath(subpath)
 }
 
 func GetSubpathFromConfig(config *model.Config) (string, error) {

--- a/server/channels/utils/subpath_test.go
+++ b/server/channels/utils/subpath_test.go
@@ -53,7 +53,7 @@ func TestUpdateAssetsSubpath(t *testing.T) {
 		tempDir := t.TempDir()
 		t.Chdir(tempDir)
 
-		err := utils.UpdateAssetsSubpath("/", nil)
+		err := utils.UpdateAssetsSubpath("/")
 		require.Error(t, err)
 	})
 
@@ -159,7 +159,7 @@ func TestUpdateAssetsSubpath(t *testing.T) {
 				require.NoError(t, os.WriteFile(filepath.Join(tempDir, model.ClientDir, "root.html"), []byte(testCase.RootHTML), 0700))
 				require.NoError(t, os.WriteFile(filepath.Join(tempDir, model.ClientDir, "main.css"), []byte(testCase.MainCSS), 0700))
 				require.NoError(t, os.WriteFile(filepath.Join(tempDir, model.ClientDir, "manifest.json"), []byte(testCase.ManifestJSON), 0700))
-				err := utils.UpdateAssetsSubpath(testCase.Subpath, nil)
+				err := utils.UpdateAssetsSubpath(testCase.Subpath)
 				if testCase.ExpectedError != nil {
 					require.Equal(t, testCase.ExpectedError, err)
 				} else {
@@ -183,57 +183,6 @@ func TestUpdateAssetsSubpath(t *testing.T) {
 				require.Equal(t, testCase.ExpectedManifestJSON, string(contents))
 			})
 		}
-	})
-}
-
-func TestUpdateAssetsSubpathConcurrentReact(t *testing.T) {
-	// concurrentReactHash is the CSP script-src addition for the "window.enableConcurrentReact=true" inline script.
-	const concurrentReactHash = " 'sha256-VKORZJUo6WeDwDHwpxEgzZDt8C1kBbDOmUq72sfrx8M='"
-
-	// rootHTML renders a minimal root.html with the given CSP addition and concurrent React script body.
-	rootHTML := func(cspExtra, concurrentReactBody string) string {
-		return `<!DOCTYPE html> <html lang=en> <head> ` +
-			`<meta http-equiv="Content-Security-Policy" content="script-src 'self'` + cspExtra + `"> ` +
-			`<script id="publicPathInWindowScript"></script> ` +
-			`<script id="enableConcurrentReactScript">` + concurrentReactBody + `</script> ` +
-			`<link href="/static/main.js" rel="stylesheet"></head> <body></body> </html>`
-	}
-
-	writeAndUpdate := func(t *testing.T, initial string, enableConcurrentReact *bool) string {
-		t.Helper()
-
-		tempDir := t.TempDir()
-		t.Chdir(tempDir)
-		require.NoError(t, os.Mkdir(model.ClientDir, 0700))
-		require.NoError(t, os.WriteFile(filepath.Join(tempDir, model.ClientDir, "root.html"), []byte(initial), 0700))
-
-		require.NoError(t, utils.UpdateAssetsSubpath("/", enableConcurrentReact))
-
-		contents, err := os.ReadFile(filepath.Join(tempDir, model.ClientDir, "root.html"))
-		require.NoError(t, err)
-		return string(contents)
-	}
-
-	t.Run("enabled injects the script and CSP hash", func(t *testing.T) {
-		got := writeAndUpdate(t, rootHTML("", ""), model.NewPointer(true))
-		require.Equal(t, rootHTML(concurrentReactHash, "window.enableConcurrentReact=true"), got)
-	})
-
-	t.Run("disabled clears the script and CSP hash", func(t *testing.T) {
-		got := writeAndUpdate(t, rootHTML(concurrentReactHash, "window.enableConcurrentReact=true"), model.NewPointer(false))
-		require.Equal(t, rootHTML("", ""), got)
-	})
-
-	t.Run("nil preserves an enabled script", func(t *testing.T) {
-		initial := rootHTML(concurrentReactHash, "window.enableConcurrentReact=true")
-		got := writeAndUpdate(t, initial, nil)
-		require.Equal(t, initial, got)
-	})
-
-	t.Run("nil preserves a disabled script", func(t *testing.T) {
-		initial := rootHTML("", "")
-		got := writeAndUpdate(t, initial, nil)
-		require.Equal(t, initial, got)
 	})
 }
 

--- a/server/channels/web/handlers.go
+++ b/server/channels/web/handlers.go
@@ -62,11 +62,6 @@ func (w *Web) NewStaticHandler(h func(*Context, http.ResponseWriter, *http.Reque
 	cfg := w.srv.Config()
 	subpath, _ := utils.GetSubpathFromConfig(cfg)
 
-	enableConcurrentReact := false
-	if cfg.FeatureFlags != nil {
-		enableConcurrentReact = cfg.FeatureFlags.EnableConcurrentReact
-	}
-
 	return &Handler{
 		Srv:            w.srv,
 		HandleFunc:     h,
@@ -76,7 +71,7 @@ func (w *Web) NewStaticHandler(h func(*Context, http.ResponseWriter, *http.Reque
 		RequireMfa:     false,
 		IsStatic:       true,
 
-		cspShaDirective: utils.GetStaticScriptHashes(subpath, enableConcurrentReact),
+		cspShaDirective: utils.GetStaticScriptHashes(subpath),
 	}
 }
 

--- a/server/channels/web/handlers_test.go
+++ b/server/channels/web/handlers_test.go
@@ -338,42 +338,6 @@ func TestHandlerServeCSPHeader(t *testing.T) {
 		assert.Equal(t, []string{"frame-ancestors 'self' " + *th.App.Config().ServiceSettings.FrameAncestors + "; script-src 'self'"}, response.Header()["Content-Security-Policy"])
 	})
 
-	t.Run("static, with EnableConcurrentReact enabled", func(t *testing.T) {
-		th := SetupWithStoreMock(t)
-
-		// Feature flags are read-only in the config store, so mutate the live config directly.
-		th.App.Config().FeatureFlags.EnableConcurrentReact = true
-
-		web := New(th.Server)
-
-		// NewStaticHandler computes the CSP SHA directive from the current config, so the
-		// concurrent React inline script's hash must be present in the script-src directive.
-		handler := web.NewStaticHandler(handlerForCSPHeader)
-
-		request := httptest.NewRequest("POST", "/", nil)
-		response := httptest.NewRecorder()
-		handler.ServeHTTP(response, request)
-		assert.Equal(t, 200, response.Code)
-		assert.Equal(t, []string{"frame-ancestors 'self' " + *th.App.Config().ServiceSettings.FrameAncestors + "; script-src 'self' 'sha256-VKORZJUo6WeDwDHwpxEgzZDt8C1kBbDOmUq72sfrx8M='"}, response.Header()["Content-Security-Policy"])
-	})
-
-	t.Run("static, with EnableConcurrentReact disabled", func(t *testing.T) {
-		th := SetupWithStoreMock(t)
-
-		// Feature flags are read-only in the config store, so mutate the live config directly.
-		th.App.Config().FeatureFlags.EnableConcurrentReact = false
-
-		web := New(th.Server)
-
-		handler := web.NewStaticHandler(handlerForCSPHeader)
-
-		request := httptest.NewRequest("POST", "/", nil)
-		response := httptest.NewRecorder()
-		handler.ServeHTTP(response, request)
-		assert.Equal(t, 200, response.Code)
-		assert.Equal(t, []string{"frame-ancestors 'self' " + *th.App.Config().ServiceSettings.FrameAncestors + "; script-src 'self'"}, response.Header()["Content-Security-Policy"])
-	})
-
 	t.Run("static, with subpath and frame ancestors", func(t *testing.T) {
 		th := SetupWithStoreMock(t)
 

--- a/server/cmd/mmctl/commands/config.go
+++ b/server/cmd/mmctl/commands/config.go
@@ -554,7 +554,7 @@ func configSubpathCmdF(cmd *cobra.Command, _ []string) error {
 	assetsDir, _ := cmd.Flags().GetString("assets-dir")
 	path, _ := cmd.Flags().GetString("path")
 
-	if err := utils.UpdateAssetsSubpathInDir(path, assetsDir, nil); err != nil {
+	if err := utils.UpdateAssetsSubpathInDir(path, assetsDir); err != nil {
 		return errors.Wrap(err, "failed to update assets subpath")
 	}
 

--- a/server/public/model/feature_flags.go
+++ b/server/public/model/feature_flags.go
@@ -155,9 +155,6 @@ type FeatureFlags struct {
 	// being unreachable.
 	ClusterGracefulDrain bool
 
-	// Enable React concurrent rendering
-	EnableConcurrentReact bool
-
 	// Enable verifying plugin signatures against the MFI public key, in addition to the
 	// existing hard-coded Mattermost public key and any admin-configured public keys.
 	EnableMFIPluginSignaturePublicKey bool
@@ -228,8 +225,6 @@ func (f *FeatureFlags) SetDefaults() {
 	f.ChannelAttributes = false
 
 	f.MmBlocksEnabled = true
-
-	f.EnableConcurrentReact = true
 
 	f.EnableMFIPluginSignaturePublicKey = true
 

--- a/webapp/channels/src/components/root/actions/index.ts
+++ b/webapp/channels/src/components/root/actions/index.ts
@@ -3,7 +3,6 @@
 
 import type {History} from 'history';
 
-import {LogLevel} from '@mattermost/types/client4';
 import type {ServerError} from '@mattermost/types/errors';
 import type {UserProfile} from '@mattermost/types/users';
 
@@ -26,7 +25,7 @@ import {reloadPage} from 'utils/browser_utils';
 import {StoragePrefixes} from 'utils/constants';
 import {doesCookieContainsMMUserId} from 'utils/utils';
 
-import type {ActionFuncAsync, ThunkActionFunc} from 'types/store';
+import type {ThunkActionFunc} from 'types/store';
 import type {Translations} from 'types/store/i18n';
 
 export type TranslationPluginFunction = (locale: string) => Translations;
@@ -155,21 +154,5 @@ export function handleLoginLogoutSignal(e: StorageEvent): ThunkActionFunc<void> 
             }
             window.addEventListener('focus', reloadOnFocus);
         }
-    };
-}
-
-export function logIfConcurrentReactEnabled(): ActionFuncAsync<boolean> {
-    return async () => {
-        const concurrentReactEnabled = window.enableConcurrentReact;
-
-        if (concurrentReactEnabled) {
-            Client4.logClientError(
-                "This user's session is using experimental concurrent React which may cause visual bugs. It is enabled " +
-                    'for all users due to a feature flag.',
-                LogLevel.Debug,
-            );
-        }
-
-        return {data: concurrentReactEnabled};
     };
 }

--- a/webapp/channels/src/components/root/index.ts
+++ b/webapp/channels/src/components/root/index.ts
@@ -32,7 +32,6 @@ import {
     loadConfigAndMe,
     handleLoginLogoutSignal,
     redirectToOnboardingOrDefaultTeam,
-    logIfConcurrentReactEnabled,
 } from './actions';
 import Root from './root';
 
@@ -78,7 +77,6 @@ function mapDispatchToProps(dispatch: Dispatch) {
         actions: bindActionCreators({
             loadConfigAndMe,
             loadRecentlyUsedCustomEmojis,
-            logIfConcurrentReactEnabled,
             migrateRecentEmojis,
             initializeProducts,
             handleLoginLogoutSignal,

--- a/webapp/channels/src/components/root/root.test.tsx
+++ b/webapp/channels/src/components/root/root.test.tsx
@@ -72,7 +72,6 @@ describe('components/Root', () => {
                 });
             }),
             loadRecentlyUsedCustomEmojis: jest.fn(),
-            logIfConcurrentReactEnabled: jest.fn(),
             migrateRecentEmojis: jest.fn(),
             initializeProducts: jest.fn(),
             ...bindActionCreators({

--- a/webapp/channels/src/components/root/root.tsx
+++ b/webapp/channels/src/components/root/root.tsx
@@ -231,8 +231,6 @@ export default class Root extends React.PureComponent<Props, State> {
     initiateMeRequests = async () => {
         const {isLoaded, isMeRequested} = await this.props.actions.loadConfigAndMe();
 
-        this.props.actions.logIfConcurrentReactEnabled();
-
         if (isLoaded) {
             const isUserAtRootRoute = this.props.location.pathname === '/';
 

--- a/webapp/channels/src/entry.tsx
+++ b/webapp/channels/src/entry.tsx
@@ -2,7 +2,6 @@
 // See LICENSE.txt for license information.
 
 import React from 'react';
-import ReactDOM from 'react-dom';
 import ReactDOMClient from 'react-dom/client';
 
 import {logError, LogErrorBarMode} from 'mattermost-redux/actions/errors';
@@ -24,7 +23,6 @@ import '@mattermost/components/dist/index.esm.css';
 declare global {
     interface Window {
         publicPath?: string;
-        enableConcurrentReact?: boolean;
     }
 }
 
@@ -59,18 +57,7 @@ function preRenderSetup(onPreRenderSetupReady: () => void) {
 function renderReactRootComponent() {
     const container = document.getElementById('root')!;
 
-    if (window.enableConcurrentReact) {
-        // eslint-disable-next-line no-console
-        console.log('Enabling concurrent React 18 due to server-wide feature flag');
-
-        // Enable this experimentally since it may cause other issues
-        ReactDOMClient.createRoot(container).render(<App/>);
-    } else {
-        // We're using React 18, but we're using the deprecated way of starting React because ReactDOM.createRoot enables
-        // new features such as automatic batching which breaks some components. This will need to be changed in the future
-        // because this method of starting the app will be removed in React 19.
-        ReactDOM.render(<App/>, container);
-    }
+    ReactDOMClient.createRoot(container).render(<App/>);
 }
 
 /**

--- a/webapp/channels/src/root.html
+++ b/webapp/channels/src/root.html
@@ -22,9 +22,6 @@
     <!-- Initialize subpath empty script for subpath support which will be replaced by server/channels/utils/subpath.go -->
     <script id="publicPathInWindowScript"></script>
 
-    <!-- Initialize empty script for the EnableConcurrentReact feature flag which will be replaced by server/channels/utils/subpath.go -->
-    <script id="enableConcurrentReactScript"></script>
-
     <!--
         This "empty" link element is used as a dynamic inject placeholder for the syntax highlighting css styles:
         1. The highlight.js lib finds this element by its 'code_theme' class.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary

Pulled out of [#38311](https://github.com/mattermost/mattermost/pull/38311), where it was bundled with the React 19 upgrade. It does not need React 19: `createRoot` has been available since React 18, and the flag has defaulted to `true` since it was enabled server-wide, so concurrent React is already what every user gets.

Calling `createRoot` unconditionally makes that the only path and removes the `ReactDOM.render` call that React 19 deletes. That leaves the flag with nothing to switch, so it comes out of:

- the web app — the `window.enableConcurrentReact` branch in `entry.tsx`, and the `logIfConcurrentReactEnabled` action that logged a client error when the flag was on.
- the server — `getConcurrentReactScript`, the `enableConcurrentReactScript` injection into `root.html`, and the flag's contribution to the static CSP script-src hash. `UpdateAssetsSubpathInDir` loses its `enableConcurrentReact` parameter, along with the logic that parsed the previous value back out of the existing `root.html` when the caller passed `nil`.
- the e2e config and the `FeatureFlags` model.

Landing this before the upgrade means concurrent-only rendering gets its own bisect point, rather than being entangled with the React 19 bump if something regresses.

The trade-off worth naming: after this there is no kill switch for concurrent rendering. The flag is already on for everyone, and React 19 removes the alternative regardless, so the switch is only nominally still there.

**QA steps**

`npm run check-types`, `npm run check` and `npm run test` pass on this branch against React 18, with 13504 tests and 1324 snapshots green. `go build` and the `channels/utils` subpath and CSP-hash tests pass, and `server/public` builds.

#### Release Note

```release-note
Removed the EnableConcurrentReact feature flag. The web app now always renders with concurrent React, which was already the default.
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a066b7-1bf4-7b96-8f3c-688222230193?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a066b7-1bf4-7b96-8f3c-688222230193&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change affects the shared web rendering path and server asset utilities. The main risk is a regression in application startup or CSP handling, but authentication, persistence, and data integrity are not affected.

**QA Recommendation:** Manual QA is not required. Automated test coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->