### PR TITLE
MM-70511: Add (CreateAt, Id) indices on FileInfo, Channels

### DIFF
--- a/server/channels/db/migrations/migrations.list
+++ b/server/channels/db/migrations/migrations.list
@@ -431,3 +431,7 @@ channels/db/migrations/postgres/000217_resize_message_columns.down.sql
 channels/db/migrations/postgres/000217_resize_message_columns.up.sql
 channels/db/migrations/postgres/000218_create_post_delivery_tracking_channels.down.sql
 channels/db/migrations/postgres/000218_create_post_delivery_tracking_channels.up.sql
+channels/db/migrations/postgres/000219_add_fileinfo_createat_id_index.down.sql
+channels/db/migrations/postgres/000219_add_fileinfo_createat_id_index.up.sql
+channels/db/migrations/postgres/000220_add_channels_createat_id_index.down.sql
+channels/db/migrations/postgres/000220_add_channels_createat_id_index.up.sql

--- a/server/channels/db/migrations/postgres/000219_add_fileinfo_createat_id_index.down.sql
+++ b/server/channels/db/migrations/postgres/000219_add_fileinfo_createat_id_index.down.sql
@@ -1,0 +1,2 @@
+-- morph:nontransactional
+DROP INDEX CONCURRENTLY IF EXISTS idx_fileinfo_create_at_id;

--- a/server/channels/db/migrations/postgres/000219_add_fileinfo_createat_id_index.up.sql
+++ b/server/channels/db/migrations/postgres/000219_add_fileinfo_createat_id_index.up.sql
@@ -1,0 +1,2 @@
+-- morph:nontransactional
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_fileinfo_create_at_id ON Fileinfo (CreateAt, Id);

--- a/server/channels/db/migrations/postgres/000220_add_channels_createat_id_index.down.sql
+++ b/server/channels/db/migrations/postgres/000220_add_channels_createat_id_index.down.sql
@@ -1,0 +1,2 @@
+-- morph:nontransactional
+DROP INDEX CONCURRENTLY IF EXISTS idx_channels_create_at_id;

--- a/server/channels/db/migrations/postgres/000220_add_channels_createat_id_index.up.sql
+++ b/server/channels/db/migrations/postgres/000220_add_channels_createat_id_index.up.sql
@@ -1,0 +1,2 @@
+-- morph:nontransactional
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_channels_create_at_id ON Channels (CreateAt, Id);

--- a/server/channels/store/sqlstore/schema_dump_test.go
+++ b/server/channels/store/sqlstore/schema_dump_test.go
@@ -72,7 +72,7 @@ func TestGetSchemaDefinition(t *testing.T) {
 				if table.Name == "channels" {
 					// Check that indexes are present
 					assert.NotEmpty(t, table.Indexes, "channels table should have indexes")
-					assert.Equal(t, 13, len(table.Indexes), "channels table should have 13 indexes")
+					assert.Equal(t, 14, len(table.Indexes), "channels table should have 14 indexes")
 
 					// Expected index definitions
 					expectedIndexDefs := map[string]string{
@@ -89,6 +89,7 @@ func TestGetSchemaDefinition(t *testing.T) {
 						"idx_channels_team_id_type":            "CREATE INDEX idx_channels_team_id_type ON public.channels USING btree (teamid, type)",
 						"idx_channels_autotranslation_enabled": "CREATE INDEX idx_channels_autotranslation_enabled ON public.channels USING btree (id) WHERE (autotranslation = true)",
 						"idx_channels_discoverable_team":       "CREATE INDEX idx_channels_discoverable_team ON public.channels USING btree (teamid) WHERE ((discoverable = true) AND (type = 'P'::channel_type) AND (deleteat = 0))",
+						"idx_channels_create_at_id":            "CREATE INDEX idx_channels_create_at_id ON public.channels USING btree (createat, id)",
 					}
 
 					// Verify all expected indexes are present with correct definitions


### PR DESCRIPTION
#### Summary
This PR was split from #38206. This one adds new indices to `FileInfo` and `Channels`, both on `(CreateAt, Id)`.

We don't need to cherry-pick this one to any release branch.

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70511

#### Screenshots
--

#### Release Note

```release-note
Added two new indices to improve performance on the bulk-indexing process for Elasticsearch/Opensearch:
- `idx_fileinfo_create_at_id` on `Fileinfo (CreateAt, Id)`
- `idx_channels_create_at_id` on `Channels (CreateAt, Id)`
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The changes modify database migrations and schema validation. The scope is isolated to two new indexes, with reversible migrations and limited blast radius.
**QA Recommendation:** Manual QA is not recommended. Automated migration and schema tests should provide sufficient coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->