### PR TITLE
Cherry-pick #38206

### DIFF
--- a/server/channels/store/sqlstore/channel_store.go
+++ b/server/channels/store/sqlstore/channel_store.go
@@ -4101,13 +4101,7 @@ func (s SqlChannelStore) GetChannelsBatchForIndexing(startTime int64, startChann
 	query := s.getQueryBuilder().
 		Select(channelSliceColumns(false)...).
 		From("Channels").
-		Where(sq.Or{
-			sq.Gt{"CreateAt": startTime},
-			sq.And{
-				sq.Eq{"CreateAt": startTime},
-				sq.Gt{"Id": startChannelID},
-			},
-		}).
+		Where("(CreateAt, Id) > (?, ?)", startTime, startChannelID).
 		OrderBy("CreateAt ASC", "Id ASC").
 		Limit(uint64(limit))
 

--- a/server/channels/store/sqlstore/file_info_store.go
+++ b/server/channels/store/sqlstore/file_info_store.go
@@ -699,13 +699,7 @@ func (fs SqlFileInfoStore) GetFilesBatchForIndexing(startTime int64, startFileID
 	query := fs.getQueryBuilder().
 		Select(fs.queryFields...).
 		From("FileInfo").
-		Where(sq.Or{
-			sq.Gt{"FileInfo.CreateAt": startTime},
-			sq.And{
-				sq.Eq{"FileInfo.CreateAt": startTime},
-				sq.Gt{"FileInfo.Id": startFileID},
-			},
-		}).
+		Where("(FileInfo.CreateAt, FileInfo.Id) > (?, ?)", startTime, startFileID).
 		OrderBy("FileInfo.CreateAt ASC, FileInfo.Id ASC").
 		Limit(uint64(limit))
 


### PR DESCRIPTION
#### Summary
Cherry-pick #38206 

#### Ticket Link
https://mattermost.atlassian.net/browse/MM-70511

#### Screenshots
--

#### Release Note
```release-note
Improved performance of the bulk-indexing job for Elasticsearch and Opensearch for very large FileInfo and Channels tables.
```