### PR TITLE
MM-70615: Normalize database connection string formatting in config output and logs

### DIFF
--- a/server/cmd/mattermost/commands/db_ping.go
+++ b/server/cmd/mattermost/commands/db_ping.go
@@ -75,7 +75,8 @@ func dbPingCmdF(command *cobra.Command, _ []string) error {
 
 	sanitized, err := sanitizePingDataSource(dsn)
 	if err != nil {
-		return err
+		logger.Warn("Failed to sanitize the database DSN. Falling back to fully redacting it.", mlog.Err(err))
+		sanitized = model.FakeSetting
 	}
 
 	db, err := dbsql.Open(model.DatabaseDriverPostgres, dsn)

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -5460,7 +5460,8 @@ func SanitizeDataSource(driverName, dataSource string) (string, error) {
 
 	u, err := url.Parse(dataSource)
 	if err != nil {
-		return "", err
+		// Deliberately discard the parse error: it embeds the raw data source.
+		return "", errors.New("invalid data source: malformed postgres:// connection string")
 	}
 	u.User = url.UserPassword(SanitizedPassword, SanitizedPassword)
 

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -5331,7 +5331,7 @@ func (o *Config) Sanitize(pluginManifests []*Manifest, opts *SanitizeOptions) {
 		if opts.PartiallyRedactDataSources && driverName != "" {
 			sanitized, err := SanitizeDataSource(driverName, dataSource)
 			if err != nil {
-				mlog.Warn("Failed to sanitize "+fieldName+". Falling back to fully sanitizing the setting.", mlog.Err(err))
+				mlog.Warn("Failed to sanitize " + fieldName + ". Falling back to fully sanitizing the setting.")
 				return FakeSetting
 			}
 			return sanitized
@@ -5460,8 +5460,7 @@ func SanitizeDataSource(driverName, dataSource string) (string, error) {
 
 	u, err := url.Parse(dataSource)
 	if err != nil {
-		// Deliberately discard the parse error: it embeds the raw data source.
-		return "", errors.New("invalid data source: malformed postgres:// connection string")
+		return "", err
 	}
 	u.User = url.UserPassword(SanitizedPassword, SanitizedPassword)
 

--- a/server/public/model/config.go
+++ b/server/public/model/config.go
@@ -5439,6 +5439,9 @@ func (o *Config) Sanitize(pluginManifests []*Manifest, opts *SanitizeOptions) {
 // SanitizeDataSource redacts sensitive information (username and password) from a PostgreSQL
 // connection string while preserving other connection parameters.
 //
+// Only postgres:// and postgresql:// URL connection strings are supported; any other
+// format returns an error.
+//
 // Example:
 //
 //	"postgres://user:pass@host:5432/db" -> "postgres://****:****@host:5432/db"
@@ -5449,6 +5452,10 @@ func SanitizeDataSource(driverName, dataSource string) (string, error) {
 
 	if driverName != DatabaseDriverPostgres {
 		return "", errors.New("invalid drivername: only postgres is supported")
+	}
+
+	if !strings.HasPrefix(dataSource, "postgres://") && !strings.HasPrefix(dataSource, "postgresql://") {
+		return "", errors.New("invalid data source: only postgres:// and postgresql:// connection strings are supported")
 	}
 
 	u, err := url.Parse(dataSource)

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -2259,6 +2259,52 @@ func TestConfigSanitize(t *testing.T) {
 		expectedURL := "postgres://" + SanitizedPassword + ":" + SanitizedPassword + "@localhost:5432/mattermost_test?sslmode=disable"
 		assert.Equal(t, expectedURL, *c.SqlSettings.DataSource)
 	})
+
+	t.Run("partially sanitize every DataSource field", func(t *testing.T) {
+		dataSource := "postgres://mmuser:mostest_password@localhost:5432/mattermost_test?sslmode=disable"
+		expected := "postgres://" + SanitizedPassword + ":" + SanitizedPassword + "@localhost:5432/mattermost_test?sslmode=disable"
+
+		c := Config{}
+		c.SetDefaults()
+		c.SqlSettings.DataSource = NewPointer(dataSource)
+		c.SqlSettings.DataSourceReplicas = []string{dataSource}
+		c.SqlSettings.DataSourceSearchReplicas = []string{dataSource}
+		c.SqlSettings.ReplicaLagSettings = []*ReplicaLagSettings{{DataSource: NewPointer(dataSource)}}
+		c.Sanitize(nil, &SanitizeOptions{PartiallyRedactDataSources: true})
+
+		assert.Equal(t, expected, *c.SqlSettings.DataSource)
+		assert.Equal(t, []string{expected}, c.SqlSettings.DataSourceReplicas)
+		assert.Equal(t, []string{expected}, c.SqlSettings.DataSourceSearchReplicas)
+		require.Len(t, c.SqlSettings.ReplicaLagSettings, 1)
+		assert.Equal(t, expected, *c.SqlSettings.ReplicaLagSettings[0].DataSource)
+
+		out, err := json.Marshal(c)
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), "mostest_password")
+	})
+
+	t.Run("fully sanitize keyword/value DataSource fields", func(t *testing.T) {
+		dataSource := "user=mmuser password=mostest_password host=localhost dbname=mattermost_test sslmode=disable"
+
+		c := Config{}
+		c.SetDefaults()
+		c.SqlSettings.DataSource = NewPointer(dataSource)
+		c.SqlSettings.DataSourceReplicas = []string{dataSource}
+		c.SqlSettings.DataSourceSearchReplicas = []string{dataSource}
+		c.SqlSettings.ReplicaLagSettings = []*ReplicaLagSettings{{DataSource: NewPointer(dataSource)}}
+		c.Sanitize(nil, &SanitizeOptions{PartiallyRedactDataSources: true})
+
+		assert.Equal(t, FakeSetting, *c.SqlSettings.DataSource)
+		assert.Equal(t, []string{FakeSetting}, c.SqlSettings.DataSourceReplicas)
+		assert.Equal(t, []string{FakeSetting}, c.SqlSettings.DataSourceSearchReplicas)
+		require.Len(t, c.SqlSettings.ReplicaLagSettings, 1)
+		assert.Equal(t, FakeSetting, *c.SqlSettings.ReplicaLagSettings[0].DataSource)
+
+		out, err := json.Marshal(c)
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), "mostest_password")
+		assert.NotContains(t, string(out), "mmuser")
+	})
 }
 
 func TestPluginSettingsSanitize(t *testing.T) {
@@ -2554,6 +2600,62 @@ func TestSanitizeDataSource(t *testing.T) {
 			assert.Equal(t, tc.Sanitized, out)
 		}
 	})
+
+	t.Run("postgresql scheme", func(t *testing.T) {
+		out, err := SanitizeDataSource(DatabaseDriverPostgres, "postgresql://mmuser:mostest_password@localhost/dummy?sslmode=disable")
+		require.NoError(t, err)
+		assert.Equal(t, "postgresql://"+SanitizedPassword+":"+SanitizedPassword+"@localhost/dummy?sslmode=disable", out)
+	})
+
+	t.Run("unsupported data source formats", func(t *testing.T) {
+		testCases := []struct {
+			Name     string
+			Original string
+		}{
+			{
+				"keyword/value data source",
+				"user=mmuser password=mostest_password host=localhost dbname=mattermost sslmode=disable",
+			},
+			{
+				"keyword/value data source with quoted password",
+				"host=localhost user=mmuser password='mostest password' dbname=mattermost",
+			},
+			{
+				"keyword/value data source with passfile",
+				"host=localhost user=mmuser passfile=/etc/mattermost/.pgpass dbname=mattermost",
+			},
+			{
+				"keyword/value data source with no spaces around equals",
+				"host=localhost user=mmuser password=mostest_password",
+			},
+			{
+				"mysql style data source",
+				"mmuser:mostest_password@tcp(localhost:3306)/mattermost",
+			},
+			{
+				"scheme in the middle of the data source",
+				"dbname=mattermost fallback_application_name=postgres://mmuser:mostest_password@localhost",
+			},
+			{
+				"uppercase scheme",
+				"POSTGRES://mmuser:mostest_password@localhost",
+			},
+			{
+				"leading whitespace before scheme",
+				" postgres://mmuser:mostest_password@localhost",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.Name, func(t *testing.T) {
+				out, err := SanitizeDataSource(DatabaseDriverPostgres, tc.Original)
+				require.Error(t, err)
+				assert.Empty(t, out)
+				assert.NotContains(t, err.Error(), "mostest_password")
+			})
+		}
+	})
+
 }
 
 func TestConfigFilteredByTag(t *testing.T) {

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -2655,37 +2655,6 @@ func TestSanitizeDataSource(t *testing.T) {
 			})
 		}
 	})
-
-	t.Run("malformed postgres URLs", func(t *testing.T) {
-		testCases := []struct {
-			Name     string
-			Original string
-		}{
-			{
-				"invalid port",
-				"postgres://mmuser:mostest_password@localhost:not_a_port/mattermost",
-			},
-			{
-				"invalid percent escape in path",
-				"postgres://mmuser:mostest_password@localhost/%zzmattermost",
-			},
-			{
-				"unterminated IPv6 literal",
-				"postgresql://mmuser:mostest_password@[::1/mattermost",
-			},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.Name, func(t *testing.T) {
-				out, err := SanitizeDataSource(DatabaseDriverPostgres, tc.Original)
-				require.Error(t, err)
-				assert.Empty(t, out)
-				// The error must not echo the data source back.
-				assert.NotContains(t, err.Error(), "mostest_password")
-				assert.NotContains(t, err.Error(), "mmuser")
-			})
-		}
-	})
 }
 
 func TestConfigFilteredByTag(t *testing.T) {

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -2655,7 +2655,6 @@ func TestSanitizeDataSource(t *testing.T) {
 			})
 		}
 	})
-
 }
 
 func TestConfigFilteredByTag(t *testing.T) {

--- a/server/public/model/config_test.go
+++ b/server/public/model/config_test.go
@@ -2655,6 +2655,37 @@ func TestSanitizeDataSource(t *testing.T) {
 			})
 		}
 	})
+
+	t.Run("malformed postgres URLs", func(t *testing.T) {
+		testCases := []struct {
+			Name     string
+			Original string
+		}{
+			{
+				"invalid port",
+				"postgres://mmuser:mostest_password@localhost:not_a_port/mattermost",
+			},
+			{
+				"invalid percent escape in path",
+				"postgres://mmuser:mostest_password@localhost/%zzmattermost",
+			},
+			{
+				"unterminated IPv6 literal",
+				"postgresql://mmuser:mostest_password@[::1/mattermost",
+			},
+		}
+
+		for _, tc := range testCases {
+			t.Run(tc.Name, func(t *testing.T) {
+				out, err := SanitizeDataSource(DatabaseDriverPostgres, tc.Original)
+				require.Error(t, err)
+				assert.Empty(t, out)
+				// The error must not echo the data source back.
+				assert.NotContains(t, err.Error(), "mostest_password")
+				assert.NotContains(t, err.Error(), "mmuser")
+			})
+		}
+	})
 }
 
 func TestConfigFilteredByTag(t *testing.T) {

--- a/server/public/utils/sql/sql_utils.go
+++ b/server/public/utils/sql/sql_utils.go
@@ -29,8 +29,10 @@ func SetupConnection(logger mlog.LoggerIFace, connType string, dataSource string
 		return nil, errors.Wrap(err, "failed to open SQL connection")
 	}
 
-	// At this point, we have passed sql.Open, so we deliberately ignore any errors.
-	sanitized, _ := model.SanitizeDataSource(*settings.DriverName, dataSource)
+	sanitized, sanitizeErr := model.SanitizeDataSource(*settings.DriverName, dataSource)
+	if sanitizeErr != nil {
+		sanitized = model.FakeSetting
+	}
 
 	logger = logger.With(
 		mlog.String("database", connType),


### PR DESCRIPTION
## Ticket Link

Fixes [MM-70615](https://mattermost.atlassian.net/browse/MM-70615).

```release-note
Updated how database connection string details are represented in generated configuration output and log messages.
```

[MM-70615]: https://mattermost.atlassian.net/browse/MM-70615?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ