### PR TITLE
Select the French language label the code actually renders

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/enterprise/system_console/reporting/site_statistics_spec.js
+++ b/e2e-tests/cypress/tests/integration/channels/enterprise/system_console/reporting/site_statistics_spec.js
@@ -169,7 +169,7 @@ describe('System Console > Site Statistics', () => {
             cy.uiOpenSettingsModal('Display').then(() => {
                 cy.findByText('Language').click();
                 cy.get('#displayLanguage').click();
-                cy.findByText('Français (Beta)').click();
+                cy.findByText('Français (Alpha)').click();
                 cy.uiSave();
             });
 


### PR DESCRIPTION
#### Summary

Fix `site_statistics_spec.js` to actually find `Français (Beta)` instead of the incorrect `Français (Alpha)` hard-coded today.

These tests don't actually run -- missing the `Stage` designation -- but hardening for when we do re-enable.

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to one Cypress selector. It does not affect application logic or shared dependencies.  
**QA Recommendation:** No manual QA is required. Run the affected Cypress test after re-enablement.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->