### PR TITLE
Add a test pinning supportedLocales to the shipped catalogs

### DIFF
--- a/server/public/shared/i18n/i18n_test.go
+++ b/server/public/shared/i18n/i18n_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/mattermost/go-i18n/i18n/bundle"
@@ -234,5 +236,63 @@ func TestGetTranslationFuncForDir(t *testing.T) {
 
 		require.Equal(t, "Décembre", translationFunc("fr")("December"))
 		require.Equal(t, "December", translationFunc("en")("December"))
+	})
+}
+
+// localeFilesIn returns the locale codes of the *.json catalogs in dir.
+func localeFilesIn(t *testing.T, dir string) []string {
+	t.Helper()
+
+	entries, err := os.ReadDir(dir)
+	require.NoError(t, err)
+
+	var locales []string
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		locales = append(locales, strings.TrimSuffix(entry.Name(), ".json"))
+	}
+
+	return locales
+}
+
+// webappLanguageValues returns the locale codes in the webapp's languages map.
+func webappLanguageValues(t *testing.T, path string) []string {
+	t.Helper()
+
+	contents, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	block := regexp.MustCompile(`(?s)export const languages = \{.*?\n\};`).Find(contents)
+	require.NotNil(t, block, "could not locate the languages map in %s", path)
+
+	var locales []string
+	for _, match := range regexp.MustCompile(`value: '([^']+)'`).FindAllSubmatch(block, -1) {
+		locales = append(locales, string(match[1]))
+	}
+
+	return locales
+}
+
+// supportedLocales is hand-maintained in three other places: the catalogs
+// shipped by the server, the catalogs shipped by the webapp, and the webapp's
+// own languages map. Nothing but this test keeps the four in step, and when
+// they drift the symptom is a language that is offered but cannot load, or a
+// catalog that is translated but never reachable.
+func TestSupportedLocalesAreInSync(t *testing.T) {
+	t.Run("server translation files", func(t *testing.T) {
+		assert.ElementsMatch(t, supportedLocales, localeFilesIn(t, "../../../i18n"),
+			"supportedLocales and server/i18n/*.json disagree")
+	})
+
+	t.Run("webapp translation files", func(t *testing.T) {
+		assert.ElementsMatch(t, supportedLocales, localeFilesIn(t, "../../../../webapp/channels/src/i18n"),
+			"supportedLocales and webapp/channels/src/i18n/*.json disagree")
+	})
+
+	t.Run("webapp languages map", func(t *testing.T) {
+		assert.ElementsMatch(t, supportedLocales, webappLanguageValues(t, "../../../../webapp/channels/src/i18n/i18n.ts"),
+			"supportedLocales and the webapp languages map disagree")
 	})
 }


### PR DESCRIPTION
#### Summary

Assert that the `supportedLocales` slice in `server/public/shared/i18n/i18n.go`, the catalog
files in `server/i18n/`, the catalog files in `webapp/channels/src/i18n/`, and
the `languages` map in `webapp/channels/src/i18n/i18n.ts` are always the same set of locales.

In the future, we may converge on a single source of truth, but for now just guarantee that these don't drift.

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes add tests only and do not modify runtime behavior or shared dependencies.  
**QA Recommendation:** Skip manual QA because automated test coverage addresses the affected logic.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->