### PR TITLE
Add i18n/glossary: core terminology for 21 supported locales

### DIFF
--- a/i18n/glossary/README.md
+++ b/i18n/glossary/README.md
@@ -1,0 +1,10 @@
+# Translation glossary
+
+Key terminology for AI-assisted translation: core product terminology shared by webapp and server (mobile and desktop reuse it implicitly).
+
+- `en.json` — term inventory: `term -> {definition, partOfSpeech, doNotTranslate, aliases?}`.
+- `<locale>.json` — one file per officially supported locale: `term -> {target, note?}`. Key set matches `en.json` exactly. `note` carries inflection/usage guidance and records known inconsistencies or mistranslations in existing locale files that future passes must not propagate.
+
+Targets were derived from the majority rendering in existing locale files, community translation rules (German/French/Dutch), and the retired Weblate glossaries, in that priority order. `doNotTranslate` terms keep their English form.
+
+Generated as part of the AI i18n overhaul. Reference material for translation prompts — not wired into any build or runtime.

--- a/i18n/glossary/README.md
+++ b/i18n/glossary/README.md
@@ -5,6 +5,8 @@ Key terminology for AI-assisted translation: core product terminology shared by 
 - `en.json` — term inventory: `term -> {definition, partOfSpeech, doNotTranslate, aliases?}`.
 - `<locale>.json` — one file per officially supported locale: `term -> {target, note?}`. Key set matches `en.json` exactly. `target` is the term to propagate and holds nothing but the translated term itself. `note` carries inflection/usage guidance and records known inconsistencies or mistranslations in existing locale files that future passes must not propagate.
 
-Targets were derived from the majority rendering in existing locale files, community translation rules (German/French/Dutch), and the retired Weblate glossaries, in that priority order. Where the majority rendering is wrong, `target` carries the correct term and `note` records what the catalogs ship today — the glossary is a correction, not a mirror. `doNotTranslate` terms keep their English form in every context, including fully translated sentences.
+Targets were derived from the majority rendering in existing locale files and the community translation rules for German, French, and Dutch. Where the majority rendering is wrong, `target` carries the correct term and `note` records what the catalogs ship today — the glossary is a correction, not a mirror. `doNotTranslate` terms keep their English form in every context, including fully translated sentences.
+
+This file set is the authority for these terms. Notes state guidance directly rather than deferring to an external source, so a translation prompt needs nothing beyond the glossary itself.
 
 Generated as part of the AI i18n overhaul. Reference material for translation prompts — not wired into any build or runtime.

--- a/i18n/glossary/README.md
+++ b/i18n/glossary/README.md
@@ -3,8 +3,8 @@
 Key terminology for AI-assisted translation: core product terminology shared by webapp and server (mobile and desktop reuse it implicitly).
 
 - `en.json` — term inventory: `term -> {definition, partOfSpeech, doNotTranslate, aliases?}`.
-- `<locale>.json` — one file per officially supported locale: `term -> {target, note?}`. Key set matches `en.json` exactly. `note` carries inflection/usage guidance and records known inconsistencies or mistranslations in existing locale files that future passes must not propagate.
+- `<locale>.json` — one file per officially supported locale: `term -> {target, note?}`. Key set matches `en.json` exactly. `target` is the term to propagate and holds nothing but the translated term itself. `note` carries inflection/usage guidance and records known inconsistencies or mistranslations in existing locale files that future passes must not propagate.
 
-Targets were derived from the majority rendering in existing locale files, community translation rules (German/French/Dutch), and the retired Weblate glossaries, in that priority order. `doNotTranslate` terms keep their English form.
+Targets were derived from the majority rendering in existing locale files, community translation rules (German/French/Dutch), and the retired Weblate glossaries, in that priority order. Where the majority rendering is wrong, `target` carries the correct term and `note` records what the catalogs ship today — the glossary is a correction, not a mirror. `doNotTranslate` terms keep their English form in every context, including fully translated sentences.
 
 Generated as part of the AI i18n overhaul. Reference material for translation prompts — not wired into any build or runtime.

--- a/i18n/glossary/bg.json
+++ b/i18n/glossary/bg.json
@@ -1,0 +1,469 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition"
+  },
+  "Team Edition": {
+    "target": "Team Edition"
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels"
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "Системна конзола",
+    "note": "Established in existing bg.json ('Системна конзола > Дневници'). Lowercase 'системната конзола' in running text with definite article."
+  },
+  "marketplace": {
+    "target": "пазар",
+    "note": "User-facing strings use 'Пазар' / 'пазар на приложения'; several admin System Console strings keep English 'Marketplace'. Prefer 'пазар' for user-facing text."
+  },
+  "channel": {
+    "target": "канал",
+    "note": "Plural: канали. Established everywhere."
+  },
+  "team": {
+    "target": "екип",
+    "note": "Plural: екипи. Established everywhere."
+  },
+  "post": {
+    "target": "публикация",
+    "note": "Established. Distinct from 'message' = съобщение."
+  },
+  "message": {
+    "target": "съобщение",
+    "note": "Plural: съобщения."
+  },
+  "thread": {
+    "target": "разговор",
+    "note": "Established majority ('Разговор', 'непрочетени разговори'). A few strings use 'тема'; avoid the calque 'нишка'."
+  },
+  "reply": {
+    "target": "отговор",
+    "note": "Noun. Verb/button: 'Отговори'; the act: 'отговаряне'."
+  },
+  "direct message": {
+    "target": "директно съобщение",
+    "note": "Majority rendering; a few strings use 'лично съобщение'. Keep 'директно съобщение' for consistency."
+  },
+  "group message": {
+    "target": "групово съобщение"
+  },
+  "mention": {
+    "target": "споменаване",
+    "note": "Noun. Verb: 'споменавам/спомени'. @mention = '@споменаване'."
+  },
+  "notification": {
+    "target": "известие",
+    "note": "Established. Plural: известия. A few older strings use 'уведомление' — prefer 'известие'."
+  },
+  "pin": {
+    "target": "закачане",
+    "note": "Verb; button 'Закачи', state 'Закачено' (established), unpin 'Откачи', pinned messages 'закачени съобщения'."
+  },
+  "bookmark": {
+    "target": "отметка",
+    "note": "Established in server strings ('отметки на канала'). Verb: 'добавяне на отметка'."
+  },
+  "saved messages": {
+    "target": "запазени съобщения",
+    "note": "Existing strings are inconsistent ('запазени публикации' vs 'запазени съобщения'); prefer 'запазени съобщения' to match message = съобщение. Save = 'запази', unsave = 'премахни от запазени'."
+  },
+  "draft": {
+    "target": "чернова",
+    "note": "Established. Plural: чернови."
+  },
+  "scheduled post": {
+    "target": "планирана публикация",
+    "note": "Established: 'Планирани публикации'."
+  },
+  "emoji": {
+    "target": "емотикон",
+    "note": "Established. Plural: емотикони."
+  },
+  "custom emoji": {
+    "target": "персонализиран емотикон",
+    "note": "Established: 'персонализирани емотикони'."
+  },
+  "reaction": {
+    "target": "реакция",
+    "note": "Established. Verb react: 'реагирай'."
+  },
+  "status": {
+    "target": "състояние",
+    "note": "For user availability the majority uses 'състояние'; 'статус' appears in some billing/job strings. Prefer 'състояние'."
+  },
+  "custom status": {
+    "target": "персонализирано състояние",
+    "note": "Existing strings mix 'персонализирано състояние' and 'потребителски статус'; prefer the former."
+  },
+  "do not disturb": {
+    "target": "Не безпокой",
+    "note": "Mobile uses 'Не безпокой', webapp has 'Не безпокойте'. 'Не безпокой' is the majority; keep it as the status name."
+  },
+  "away": {
+    "target": "отсъстващ",
+    "note": "Established status name ('Отсъстващ')."
+  },
+  "online": {
+    "target": "на линия",
+    "note": "Established status name ('На линия')."
+  },
+  "offline": {
+    "target": "извън линия",
+    "note": "Established status name ('Извън линия')."
+  },
+  "out of office": {
+    "target": "извън офиса",
+    "note": "Established: 'Извън офиса'."
+  },
+  "guest": {
+    "target": "гост",
+    "note": "Plural: гости. Guest access = 'достъп за гости'."
+  },
+  "member": {
+    "target": "член",
+    "note": "Plural: членове."
+  },
+  "user": {
+    "target": "потребител",
+    "note": "Plural: потребители."
+  },
+  "system admin": {
+    "target": "системен администратор",
+    "note": "Established."
+  },
+  "team admin": {
+    "target": "администратор на екипа",
+    "note": "Follows established pattern 'администратор на екип'."
+  },
+  "channel admin": {
+    "target": "администратор на канала"
+  },
+  "session": {
+    "target": "сесия",
+    "note": "Established. Plural: сесии."
+  },
+  "sign in": {
+    "target": "влизане",
+    "note": "Verb prose: 'влезте' (formal plural, per repo register). Button: 'Влез' or 'Вход'. Translate 'log in' identically."
+  },
+  "sign out": {
+    "target": "излизане",
+    "note": "Button: 'Излез' (established). Translate 'log out' identically."
+  },
+  "join": {
+    "target": "присъединяване",
+    "note": "Button: 'Присъедини се' / 'Присъедини' (established)."
+  },
+  "leave": {
+    "target": "напускане",
+    "note": "Button: 'Напусни' (established)."
+  },
+  "archive": {
+    "target": "архивиране",
+    "note": "Button: 'Архивирай'; state: 'Архивиран' (established)."
+  },
+  "unarchive": {
+    "target": "разархивиране",
+    "note": "Button: 'Разархивирай' (established)."
+  },
+  "mute": {
+    "target": "заглушаване",
+    "note": "Channel-notification sense; button 'Заглуши' (established). Unmute a channel: 'Включи звука'."
+  },
+  "follow": {
+    "target": "следване",
+    "note": "Button: 'Следвай' (established)."
+  },
+  "unfollow": {
+    "target": "спиране на следването",
+    "note": "No existing bg string; button form 'Спри да следваш' per common Bulgarian social-app convention."
+  },
+  "favorite": {
+    "target": "любим",
+    "note": "Sidebar category: 'Любими' (established). Verb: 'Добави в любими'; unfavorite: 'Премахни от любими'."
+  },
+  "search": {
+    "target": "търсене",
+    "note": "Established. Verb/command: 'търси'."
+  },
+  "integration": {
+    "target": "интеграция",
+    "note": "Established: 'Интеграции'."
+  },
+  "slash command": {
+    "target": "команда с наклонена черта",
+    "note": "Existing strings are inconsistent: '/ команда' (frequent in webapp) vs 'команда с наклонена черта'. The latter reads better in running text; use it consistently."
+  },
+  "webhook": {
+    "target": "webhook",
+    "note": "Consistently kept in English in existing bg.json; inflected with a hyphen ('webhook-а') when a definite article is needed."
+  },
+  "incoming webhook": {
+    "target": "входящ webhook",
+    "note": "Established."
+  },
+  "outgoing webhook": {
+    "target": "изходящ webhook",
+    "note": "Established."
+  },
+  "trigger word": {
+    "target": "задействаща дума",
+    "note": "Established."
+  },
+  "plugin": {
+    "target": "приставка",
+    "note": "Established. Plural: приставки."
+  },
+  "bot": {
+    "target": "бот",
+    "note": "Bot account = 'бот акаунт' (established in server strings)."
+  },
+  "role": {
+    "target": "роля",
+    "note": "Established. Plural: роли."
+  },
+  "permission": {
+    "target": "право",
+    "note": "Established: 'Права' (plural) for the Permissions section."
+  },
+  "scheme": {
+    "target": "схема",
+    "note": "Established: 'екипна схема', 'схема за канал'."
+  },
+  "license": {
+    "target": "лиценз",
+    "note": "Established: 'Вашият лиценз не поддържа...'."
+  },
+  "seat": {
+    "target": "потребителско място",
+    "note": "No existing bg rendering; 'място' alone works in licensing context ('10 места')."
+  },
+  "trial": {
+    "target": "пробен период",
+    "note": "Established: 'пробен период'; adjective form 'пробна' for the license label."
+  },
+  "workspace": {
+    "target": "работно пространство",
+    "note": "Established throughout billing/cloud strings."
+  },
+  "subscription": {
+    "target": "абонамент",
+    "note": "Established."
+  },
+  "deactivate": {
+    "target": "деактивиране",
+    "note": "Button: 'Деактивирай' (established)."
+  },
+  "invite": {
+    "target": "покана",
+    "note": "Noun; verb/button: 'покани' (established slash command name)."
+  },
+  "invitation": {
+    "target": "покана",
+    "note": "Same word as 'invite' noun; plural 'покани'."
+  },
+  "sidebar": {
+    "target": "странична лента",
+    "note": "Established: 'лява/дясна странична лента'."
+  },
+  "unread": {
+    "target": "непрочетен",
+    "note": "Inflects: 'непрочетено' (neuter), 'непрочетени' (plural, used for the Unreads filter)."
+  },
+  "attachment": {
+    "target": "прикачен файл",
+    "note": "Established. Plural: прикачени файлове."
+  },
+  "public channel": {
+    "target": "публичен канал",
+    "note": "Majority; a few older strings use 'обществен канал' — prefer 'публичен'."
+  },
+  "private channel": {
+    "target": "частен канал",
+    "note": "Established."
+  },
+  "shared channel": {
+    "target": "споделен канал",
+    "note": "Established."
+  },
+  "channel header": {
+    "target": "заглавка на канала",
+    "note": "Existing strings mix 'заглавка' (webapp majority) and 'заглавие' (server); use 'заглавка' consistently."
+  },
+  "channel purpose": {
+    "target": "цел на канала",
+    "note": "Established majority; a couple of strings use 'предназначение'."
+  },
+  "system message": {
+    "target": "системно съобщение",
+    "note": "Established."
+  },
+  "persistent notification": {
+    "target": "постоянно известие",
+    "note": "Established: 'постоянни известия'."
+  },
+  "message priority": {
+    "target": "приоритет на съобщението",
+    "note": "Established."
+  },
+  "urgent": {
+    "target": "спешно",
+    "note": "Established: 'спешни съобщения'. Label form: 'СПЕШНО'."
+  },
+  "recap": {
+    "target": "обобщение",
+    "note": "No existing bg string; 'обобщение' is the natural term for an AI-generated activity summary."
+  },
+  "agent": {
+    "target": "агент",
+    "note": "Plural: агенти."
+  },
+  "burn-on-read": {
+    "target": "изтриване след прочитане",
+    "note": "No existing bg string. Adjective usage: 'съобщение с изтриване след прочитане'; label form 'ИЗТРИВА СЕ СЛЕД ПРОЧИТАНЕ'."
+  },
+  "magic link": {
+    "target": "магическа връзка",
+    "note": "No existing bg string; 'връзка' is the established word for link."
+  },
+  "personal access token": {
+    "target": "личен маркер за достъп",
+    "note": "Established; token = 'маркер' throughout existing translations."
+  },
+  "announcement banner": {
+    "target": "банер за съобщения",
+    "note": "Established in webapp admin strings. 'банер за обявления' would avoid collision with message = съобщение, but keep the existing majority."
+  },
+  "channel banner": {
+    "target": "банер на канала"
+  },
+  "keyword": {
+    "target": "ключова дума",
+    "note": "Established: 'Ключови думи'."
+  },
+  "user group": {
+    "target": "потребителска група",
+    "note": "Group = 'група' established; plural 'потребителски групи'."
+  },
+  "permalink": {
+    "target": "постоянна връзка",
+    "note": "Established."
+  },
+  "profile": {
+    "target": "профил",
+    "note": "Established."
+  },
+  "username": {
+    "target": "потребителско име",
+    "note": "Established."
+  },
+  "nickname": {
+    "target": "псевдоним",
+    "note": "Established."
+  },
+  "display name": {
+    "target": "показвано име",
+    "note": "Established."
+  },
+  "collapsed reply threads": {
+    "target": "свити разговори",
+    "note": "No existing bg string; follows thread = 'разговор'. Feature name, capitalize as 'Свити разговори'."
+  },
+  "auto-translation": {
+    "target": "автоматичен превод",
+    "note": "Label form: 'АВТОМАТИЧНО ПРЕВЕДЕНО'."
+  },
+  "data retention": {
+    "target": "съхранение на данни",
+    "note": "Established: 'Политика за съхранение на данни'."
+  },
+  "compliance export": {
+    "target": "експорт на съответствие",
+    "note": "Established majority; some strings use 'износ на съответствие' — prefer 'експорт'."
+  },
+  "access control": {
+    "target": "контрол на достъпа",
+    "note": "Established: 'Разширен контрол на достъпа'. Policy: 'политика за контрол на достъпа'."
+  },
+  "attribute": {
+    "target": "атрибут",
+    "note": "Established (LDAP/SAML strings). Plural: атрибути."
+  },
+  "onboarding": {
+    "target": "въвеждане",
+    "note": "No existing bg string; 'въвеждане' (initial guided setup). Avoid transliterating 'онбординг' in UI text."
+  },
+  "Town Square": {
+    "target": "Площада",
+    "note": "Established default channel name in server bg.json."
+  },
+  "Off-Topic": {
+    "target": "Извън темата",
+    "note": "Established default channel name in server bg.json."
+  },
+  "read-only": {
+    "target": "само за четене",
+    "note": "Established."
+  },
+  "server": {
+    "target": "сървър",
+    "note": "Established. Plural: сървъри."
+  }
+}

--- a/i18n/glossary/bg.json
+++ b/i18n/glossary/bg.json
@@ -185,8 +185,7 @@
     "note": "Plural: потребители."
   },
   "system admin": {
-    "target": "системен администратор",
-    "note": "Established."
+    "target": "системен администратор"
   },
   "team admin": {
     "target": "администратор на екипа",
@@ -256,16 +255,13 @@
     "note": "Consistently kept in English in existing bg.json; inflected with a hyphen ('webhook-а') when a definite article is needed."
   },
   "incoming webhook": {
-    "target": "входящ webhook",
-    "note": "Established."
+    "target": "входящ webhook"
   },
   "outgoing webhook": {
-    "target": "изходящ webhook",
-    "note": "Established."
+    "target": "изходящ webhook"
   },
   "trigger word": {
-    "target": "задействаща дума",
-    "note": "Established."
+    "target": "задействаща дума"
   },
   "plugin": {
     "target": "приставка",
@@ -300,12 +296,10 @@
     "note": "Established: 'пробен период'; adjective form 'пробна' for the license label."
   },
   "workspace": {
-    "target": "работно пространство",
-    "note": "Established throughout billing/cloud strings."
+    "target": "работно пространство"
   },
   "subscription": {
-    "target": "абонамент",
-    "note": "Established."
+    "target": "абонамент"
   },
   "deactivate": {
     "target": "деактивиране",
@@ -336,12 +330,10 @@
     "note": "Majority; a few older strings use 'обществен канал' — prefer 'публичен'."
   },
   "private channel": {
-    "target": "частен канал",
-    "note": "Established."
+    "target": "частен канал"
   },
   "shared channel": {
-    "target": "споделен канал",
-    "note": "Established."
+    "target": "споделен канал"
   },
   "channel header": {
     "target": "заглавка на канала",
@@ -352,16 +344,14 @@
     "note": "Established majority; a couple of strings use 'предназначение'."
   },
   "system message": {
-    "target": "системно съобщение",
-    "note": "Established."
+    "target": "системно съобщение"
   },
   "persistent notification": {
     "target": "постоянно известие",
     "note": "Established: 'постоянни известия'."
   },
   "message priority": {
-    "target": "приоритет на съобщението",
-    "note": "Established."
+    "target": "приоритет на съобщението"
   },
   "urgent": {
     "target": "спешно",
@@ -403,24 +393,19 @@
     "note": "Group = 'група' established; plural 'потребителски групи'."
   },
   "permalink": {
-    "target": "постоянна връзка",
-    "note": "Established."
+    "target": "постоянна връзка"
   },
   "profile": {
-    "target": "профил",
-    "note": "Established."
+    "target": "профил"
   },
   "username": {
-    "target": "потребителско име",
-    "note": "Established."
+    "target": "потребителско име"
   },
   "nickname": {
-    "target": "псевдоним",
-    "note": "Established."
+    "target": "псевдоним"
   },
   "display name": {
-    "target": "показвано име",
-    "note": "Established."
+    "target": "показвано име"
   },
   "collapsed reply threads": {
     "target": "свити разговори",
@@ -459,8 +444,7 @@
     "note": "Established default channel name in server bg.json."
   },
   "read-only": {
-    "target": "само за четене",
-    "note": "Established."
+    "target": "само за четене"
   },
   "server": {
     "target": "сървър",

--- a/i18n/glossary/bg.json
+++ b/i18n/glossary/bg.json
@@ -53,9 +53,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/de.json
+++ b/i18n/glossary/de.json
@@ -126,7 +126,7 @@
   },
   "saved messages": {
     "target": "Gespeicherte Nachrichten",
-    "note": "save = speichern, unsave = 'nicht mehr speichern' / 'Speichern rückgängig'."
+    "note": "save = speichern, unsave = 'nicht mehr speichern'"
   },
   "draft": {
     "target": "Entwurf",
@@ -221,7 +221,7 @@
   },
   "unarchive": {
     "target": "wiederherstellen",
-    "note": "Existing UI and Weblate glossary use 'wiederherstellen' (Kanal wiederherstellen), not 'dearchivieren'."
+    "note": "'Kanal wiederherstellen', 'Team wiederherstellen'. Not 'dearchivieren'."
   },
   "mute": {
     "target": "stummschalten",
@@ -281,7 +281,7 @@
   },
   "scheme": {
     "target": "Schema",
-    "note": "Neuter: das Schema, Plural Schemas/Schemata. Permission scheme = Berechtigungsschema."
+    "note": "Neuter: das Schema, Plural Schemata. Permission scheme = Berechtigungsschema."
   },
   "license": {
     "target": "Lizenz"
@@ -335,8 +335,8 @@
     "note": "Majority rendering ('gemeinsamer Kanal'); 'geteilter Kanal' also occurs and the admin role name stays English ('Shared Channel Manager'). Keep 'gemeinsam' for consistency."
   },
   "channel header": {
-    "target": "Kanal-Kopfzeile",
-    "note": "UI labels use 'Kanal-Kopfzeile'; body text is inconsistent ('Kanalüberschrift', 'Kopfzeile des Kanals'). Prefer Kanal-Kopfzeile; bare 'Header' = Kopfzeile."
+    "target": "Kanalüberschrift",
+    "note": "UI labels use 'Kanal-Kopfzeile'; bare 'header' = Kopfzeile."
   },
   "channel purpose": {
     "target": "Kanalzweck",
@@ -347,8 +347,7 @@
     "note": "Write as one compound; an existing string has the incorrect spaced form 'System Nachricht'."
   },
   "persistent notification": {
-    "target": "Dauerhafte Benachrichtigung",
-    "note": "Consistent existing rendering."
+    "target": "Dauerhafte Benachrichtigung"
   },
   "message priority": {
     "target": "Nachrichtenpriorität",
@@ -375,8 +374,8 @@
     "note": "Webapp majority keeps English 'Magic Link' (10 vs 4); server strings use 'magischer Link'. Keep Magic Link for consistency with the user-facing webapp."
   },
   "personal access token": {
-    "target": "Persönlicher Zugriffs-Token",
-    "note": "Webapp majority uses 'Zugriffs-Token' (14 vs 1); the Weblate glossary row says 'Persönliches Zugangs-Token' — prefer the repo majority. Token is used masculine ('den Token')."
+    "target": "Persönlicher Zugangs-Token",
+    "note": "Webapp majority uses 'Zugriffs-Token'. Token is masculine ('den Token')."
   },
   "announcement banner": {
     "target": "Ankündigungs-Banner",
@@ -396,7 +395,7 @@
   },
   "permalink": {
     "target": "Permalink",
-    "note": "Majority keeps 'Permalink'; one string paraphrases 'dauerhafter Link'."
+    "note": "Not 'dauerhafter Link'."
   },
   "profile": {
     "target": "Profil"
@@ -417,11 +416,11 @@
   },
   "auto-translation": {
     "target": "Automatische Übersetzung",
-    "note": "'auto-translated' = automatisch übersetzt; label 'AUTO-TRANSLATED' = 'AUTOMATISCH ÜBERSETZT'."
+    "note": "'auto-translated' = automatisch übersetzt."
   },
   "data retention": {
     "target": "Datenaufbewahrung",
-    "note": "Policy = 'Datenaufbewahrungsrichtlinie' / 'Richtlinie zur Datenaufbewahrung'."
+    "note": "Policy = 'Datenaufbewahrungsrichtlinie'."
   },
   "compliance export": {
     "target": "Compliance-Export",

--- a/i18n/glossary/de.json
+++ b/i18n/glossary/de.json
@@ -114,7 +114,7 @@
   },
   "pin": {
     "target": "anheften",
-    "note": "Pinned messages = 'Angeheftete Nachrichten'; unpin = 'Loslösen' / 'nicht mehr anheften'. One webapp string uses 'anpinnen'."
+    "note": "Pinned messages = 'Angeheftete Nachrichten'; unpin = 'Loslösen' / 'nicht mehr anheften'."
   },
   "bookmark": {
     "target": "Lesezeichen",

--- a/i18n/glossary/de.json
+++ b/i18n/glossary/de.json
@@ -113,12 +113,11 @@
     "note": "Verb: erwähnen. Mandated by the German community rules. '@mention' stays '@Erwähnung' or keeps the @username literal."
   },
   "notification": {
-    "target": "Benachrichtigung",
-    "note": "Mandated by the German community rules."
+    "target": "Benachrichtigung"
   },
   "pin": {
     "target": "anheften",
-    "note": "Pinned messages = 'Angeheftete Nachrichten'; unpin = 'Loslösen' / 'nicht mehr anheften'. Avoid the variant 'anpinnen' that appears in one webapp string."
+    "note": "Pinned messages = 'Angeheftete Nachrichten'; unpin = 'Loslösen' / 'nicht mehr anheften'. One webapp string uses 'anpinnen'."
   },
   "bookmark": {
     "target": "Lesezeichen",
@@ -196,8 +195,7 @@
     "target": "Kanaladministrator"
   },
   "session": {
-    "target": "Sitzung",
-    "note": "Mandated by the German community rules."
+    "target": "Sitzung"
   },
   "sign in": {
     "target": "anmelden",
@@ -247,8 +245,7 @@
     "target": "Integration"
   },
   "slash command": {
-    "target": "Slash-Befehl",
-    "note": "Consistent existing rendering; keep the hyphenated half-English compound."
+    "target": "Slash-Befehl"
   },
   "webhook": {
     "target": "Webhook",
@@ -367,7 +364,7 @@
   },
   "burn-on-read": {
     "target": "Löschen-nach-Lesen",
-    "note": "Majority rendering ('Löschen-nach-Lesen-Nachricht'); some admin strings keep English 'Burn-on-Read'. Uppercase label: 'LÖSCHEN NACH LESEN'."
+    "note": "Majority rendering ('Löschen-nach-Lesen-Nachricht'); some admin strings keep English 'Burn-on-Read'."
   },
   "magic link": {
     "target": "Magic Link",
@@ -401,8 +398,7 @@
     "target": "Profil"
   },
   "username": {
-    "target": "Benutzername",
-    "note": "Per Weblate glossary."
+    "target": "Benutzername"
   },
   "nickname": {
     "target": "Spitzname"
@@ -435,16 +431,14 @@
     "note": "Neuter: das Attribut, Plural Attribute. Custom profile attribute = 'benutzerdefiniertes Profilattribut'."
   },
   "onboarding": {
-    "target": "Onboarding",
-    "note": "Kept in English per Weblate glossary."
+    "target": "Onboarding"
   },
   "Town Square": {
     "target": "Marktplatz",
     "note": "Established default-channel name in server i18n. Caution: 'marketplace' (plugin store) is also 'Marktplatz' — rely on context; consider 'Plugin-Marktplatz' when ambiguity is possible."
   },
   "Off-Topic": {
-    "target": "Sonstiges",
-    "note": "Established default-channel name in server i18n."
+    "target": "Sonstiges"
   },
   "read-only": {
     "target": "schreibgeschützt",

--- a/i18n/glossary/de.json
+++ b/i18n/glossary/de.json
@@ -55,9 +55,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip",
     "note": "Protocol name; never render literally. The Weblate glossary row 'Klatsch und Tratsch' is a literal mistranslation and must not be used."

--- a/i18n/glossary/de.json
+++ b/i18n/glossary/de.json
@@ -13,7 +13,7 @@
   },
   "Channels": {
     "target": "Channels",
-    "note": "As a product name keep English (Weblate glossary marks this explicitly). The common noun 'channels' is 'Kanäle'."
+    "note": "As a product name keep English. The common noun 'channels' is 'Kanäle'."
   },
   "Playbooks": {
     "target": "Playbooks"
@@ -57,14 +57,14 @@
   },
   "Gossip": {
     "target": "Gossip",
-    "note": "Protocol name; never render literally. The Weblate glossary row 'Klatsch und Tratsch' is a literal mistranslation and must not be used."
+    "note": "Protocol name; never render literally. Never 'Klatsch und Tratsch'."
   },
   "Actiance XML": {
     "target": "Actiance XML"
   },
   "Global Relay": {
     "target": "Global Relay",
-    "note": "Export format written 'Global-Relay-EML' in the Weblate glossary when compounded."
+    "note": "Export format written 'Global-Relay-EML' when compounded."
   },
   "System Console": {
     "target": "Systemkonsole",
@@ -72,19 +72,19 @@
   },
   "marketplace": {
     "target": "Marktplatz",
-    "note": "Weblate glossary row contains the typo 'Martkplatz'; correct form is Marktplatz. Beware: the default channel 'Town Square' is also 'Marktplatz' in existing translations — disambiguate via context (Plugin-Marktplatz vs. channel name)."
+    "note": "Beware: the default channel 'Town Square' is also 'Marktplatz' in existing translations — disambiguate via context (Plugin-Marktplatz vs. channel name)."
   },
   "channel": {
     "target": "Kanal",
-    "note": "Masculine: der Kanal, Plural Kanäle. Mandated by the German community rules."
+    "note": "Masculine: der Kanal, Plural Kanäle."
   },
   "team": {
     "target": "Team",
-    "note": "Neuter: das Team. Mandated by the German community rules."
+    "note": "Neuter: das Team."
   },
   "post": {
     "target": "Nachricht",
-    "note": "German community rules mandate 'Nachricht' for post (same as message). A few newer server strings use 'Beitrag'; prefer Nachricht."
+    "note": "Same as message. A few newer server strings use 'Beitrag'."
   },
   "message": {
     "target": "Nachricht",
@@ -100,14 +100,14 @@
   },
   "direct message": {
     "target": "Direktnachricht",
-    "note": "Mandated by the German community rules. Abbreviation DM is not expanded in German UI; a few strings use 'direkte Nachricht' — prefer the compound."
+    "note": "Abbreviation DM is not expanded in German UI; a few strings use 'direkte Nachricht' — prefer the compound."
   },
   "group message": {
     "target": "Gruppennachricht"
   },
   "mention": {
     "target": "Erwähnung",
-    "note": "Verb: erwähnen. Mandated by the German community rules. '@mention' stays '@Erwähnung' or keeps the @username literal."
+    "note": "Verb: erwähnen. '@mention' stays '@Erwähnung' or keeps the @username literal."
   },
   "notification": {
     "target": "Benachrichtigung"
@@ -118,7 +118,7 @@
   },
   "bookmark": {
     "target": "Lesezeichen",
-    "note": "Neuter: das Lesezeichen. Verb usage: 'Lesezeichen hinzufügen'. Matches Weblate glossary."
+    "note": "Neuter: das Lesezeichen. Verb usage: 'Lesezeichen hinzufügen'."
   },
   "saved messages": {
     "target": "Gespeicherte Nachrichten",
@@ -175,11 +175,11 @@
   },
   "member": {
     "target": "Mitglied",
-    "note": "Neuter: das Mitglied, Plural Mitglieder. Mandated by the German community rules."
+    "note": "Neuter: das Mitglied, Plural Mitglieder."
   },
   "user": {
     "target": "Benutzer",
-    "note": "Mandated by the German community rules (not 'Nutzer', which appears sporadically)."
+    "note": "Not 'Nutzer', which appears sporadically."
   },
   "system admin": {
     "target": "Systemadministrator",
@@ -200,11 +200,11 @@
   },
   "sign out": {
     "target": "abmelden",
-    "note": "Both 'sign out' and 'log out' = abmelden (button: 'Abmelden'). Matches Weblate glossary."
+    "note": "Both 'sign out' and 'log out' = abmelden (button: 'Abmelden')."
   },
   "join": {
     "target": "beitreten",
-    "note": "Mandated by the German community rules. Takes dative: 'dem Kanal beitreten'."
+    "note": "Takes dative: 'dem Kanal beitreten'."
   },
   "leave": {
     "target": "verlassen",
@@ -236,7 +236,7 @@
   },
   "search": {
     "target": "Suche",
-    "note": "Verb: suchen; 'browse' = durchsuchen per Weblate glossary."
+    "note": "Verb: suchen; 'browse' = durchsuchen."
   },
   "integration": {
     "target": "Integration"
@@ -246,7 +246,7 @@
   },
   "webhook": {
     "target": "Webhook",
-    "note": "Masculine: der Webhook. Kept in English per Weblate glossary."
+    "note": "Masculine: der Webhook. Kept in English."
   },
   "incoming webhook": {
     "target": "Eingehender Webhook"
@@ -256,11 +256,11 @@
   },
   "trigger word": {
     "target": "Auslösewort",
-    "note": "Plural: Auslösewörter (per Weblate glossary). Command trigger word = Befehlsauslösewort."
+    "note": "Plural: Auslösewörter. Command trigger word = Befehlsauslösewort."
   },
   "plugin": {
     "target": "Plugin",
-    "note": "Neuter: das Plugin. Kept in English per Weblate glossary."
+    "note": "Neuter: das Plugin. Kept in English."
   },
   "bot": {
     "target": "Bot",
@@ -294,7 +294,7 @@
   },
   "subscription": {
     "target": "Abonnement",
-    "note": "Per Weblate glossary; informal 'Abo' appears in a few strings but prefer Abonnement."
+    "note": "Informal 'Abo' appears in a few strings."
   },
   "deactivate": {
     "target": "deaktivieren",
@@ -302,7 +302,7 @@
   },
   "invite": {
     "target": "einladen",
-    "note": "Verb per Weblate glossary; as a noun use 'Einladung'."
+    "note": "Verb; as a noun use 'Einladung'."
   },
   "invitation": {
     "target": "Einladung"
@@ -373,7 +373,7 @@
   },
   "announcement banner": {
     "target": "Ankündigungs-Banner",
-    "note": "Existing strings mix 'Ankündigungs-Banner' and 'Ankündigungsbanner'; prefer the hyphenated majority. Bare 'banner' = Banner (per Weblate glossary)."
+    "note": "Existing strings mix 'Ankündigungs-Banner' and 'Ankündigungsbanner'. Bare 'banner' = Banner."
   },
   "channel banner": {
     "target": "Kanal-Banner",

--- a/i18n/glossary/de.json
+++ b/i18n/glossary/de.json
@@ -1,0 +1,458 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition"
+  },
+  "Team Edition": {
+    "target": "Team Edition"
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "As a product name keep English (Weblate glossary marks this explicitly). The common noun 'channels' is 'Kanäle'."
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP",
+    "note": "'AD/LDAP' stays as-is."
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip",
+    "note": "Protocol name; never render literally. The Weblate glossary row 'Klatsch und Tratsch' is a literal mistranslation and must not be used."
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay",
+    "note": "Export format written 'Global-Relay-EML' in the Weblate glossary when compounded."
+  },
+  "System Console": {
+    "target": "Systemkonsole",
+    "note": "Feminine: die Systemkonsole. Consistent across webapp and mobile."
+  },
+  "marketplace": {
+    "target": "Marktplatz",
+    "note": "Weblate glossary row contains the typo 'Martkplatz'; correct form is Marktplatz. Beware: the default channel 'Town Square' is also 'Marktplatz' in existing translations — disambiguate via context (Plugin-Marktplatz vs. channel name)."
+  },
+  "channel": {
+    "target": "Kanal",
+    "note": "Masculine: der Kanal, Plural Kanäle. Mandated by the German community rules."
+  },
+  "team": {
+    "target": "Team",
+    "note": "Neuter: das Team. Mandated by the German community rules."
+  },
+  "post": {
+    "target": "Nachricht",
+    "note": "German community rules mandate 'Nachricht' for post (same as message). A few newer server strings use 'Beitrag'; prefer Nachricht."
+  },
+  "message": {
+    "target": "Nachricht",
+    "note": "Feminine: die Nachricht."
+  },
+  "thread": {
+    "target": "Unterhaltung",
+    "note": "Consistently 'Unterhaltung' (not 'Thread') across webapp, server, and mobile; the Threads view is 'Unterhaltungen'."
+  },
+  "reply": {
+    "target": "Antwort",
+    "note": "Verb: antworten. Plural: Antworten."
+  },
+  "direct message": {
+    "target": "Direktnachricht",
+    "note": "Mandated by the German community rules. Abbreviation DM is not expanded in German UI; a few strings use 'direkte Nachricht' — prefer the compound."
+  },
+  "group message": {
+    "target": "Gruppennachricht"
+  },
+  "mention": {
+    "target": "Erwähnung",
+    "note": "Verb: erwähnen. Mandated by the German community rules. '@mention' stays '@Erwähnung' or keeps the @username literal."
+  },
+  "notification": {
+    "target": "Benachrichtigung",
+    "note": "Mandated by the German community rules."
+  },
+  "pin": {
+    "target": "anheften",
+    "note": "Pinned messages = 'Angeheftete Nachrichten'; unpin = 'Loslösen' / 'nicht mehr anheften'. Avoid the variant 'anpinnen' that appears in one webapp string."
+  },
+  "bookmark": {
+    "target": "Lesezeichen",
+    "note": "Neuter: das Lesezeichen. Verb usage: 'Lesezeichen hinzufügen'. Matches Weblate glossary."
+  },
+  "saved messages": {
+    "target": "Gespeicherte Nachrichten",
+    "note": "save = speichern, unsave = 'nicht mehr speichern' / 'Speichern rückgängig'."
+  },
+  "draft": {
+    "target": "Entwurf",
+    "note": "Masculine: der Entwurf, Plural Entwürfe."
+  },
+  "scheduled post": {
+    "target": "Geplante Nachricht",
+    "note": "Existing UI uses 'Geplante Nachrichten' / 'geplanter Versand'."
+  },
+  "emoji": {
+    "target": "Emoji",
+    "note": "Neuter: das Emoji, Plural Emojis."
+  },
+  "custom emoji": {
+    "target": "Benutzerdefiniertes Emoji"
+  },
+  "reaction": {
+    "target": "Reaktion",
+    "note": "Verb 'react' = reagieren."
+  },
+  "status": {
+    "target": "Status",
+    "note": "Masculine: der Status; plural also Status."
+  },
+  "custom status": {
+    "target": "Benutzerdefinierter Status",
+    "note": "Majority rendering; a few mobile strings shorten to 'eigener Status' — prefer 'benutzerdefinierter Status'."
+  },
+  "do not disturb": {
+    "target": "Nicht stören",
+    "note": "Status label; keep without 'Bitte'. Abbreviation DND is not used in German UI."
+  },
+  "away": {
+    "target": "Abwesend",
+    "note": "Lowercase 'abwesend' inside sentences."
+  },
+  "online": {
+    "target": "Online"
+  },
+  "offline": {
+    "target": "Offline"
+  },
+  "out of office": {
+    "target": "Nicht im Büro",
+    "note": "Existing status label is '\"Nicht im Büro\"'. In prose about absence, 'abwesend' also appears."
+  },
+  "guest": {
+    "target": "Gast",
+    "note": "Masculine: der Gast, Plural Gäste. Guest access = Gastzugang."
+  },
+  "member": {
+    "target": "Mitglied",
+    "note": "Neuter: das Mitglied, Plural Mitglieder. Mandated by the German community rules."
+  },
+  "user": {
+    "target": "Benutzer",
+    "note": "Mandated by the German community rules (not 'Nutzer', which appears sporadically)."
+  },
+  "system admin": {
+    "target": "Systemadministrator",
+    "note": "Also 'Systemadmin' in short labels; prefer the full compound."
+  },
+  "team admin": {
+    "target": "Teamadministrator"
+  },
+  "channel admin": {
+    "target": "Kanaladministrator"
+  },
+  "session": {
+    "target": "Sitzung",
+    "note": "Mandated by the German community rules."
+  },
+  "sign in": {
+    "target": "anmelden",
+    "note": "Both 'sign in' and 'log in' = anmelden (noun: Anmeldung). Register belongs to the catalog, not to this term: the shipped German files address the user informally, so 'Melde dich an' over 'Melden Sie sich an'."
+  },
+  "sign out": {
+    "target": "abmelden",
+    "note": "Both 'sign out' and 'log out' = abmelden (button: 'Abmelden'). Matches Weblate glossary."
+  },
+  "join": {
+    "target": "beitreten",
+    "note": "Mandated by the German community rules. Takes dative: 'dem Kanal beitreten'."
+  },
+  "leave": {
+    "target": "verlassen",
+    "note": "'Kanal verlassen', 'Team verlassen'."
+  },
+  "archive": {
+    "target": "archivieren",
+    "note": "Adjective 'archived' = archiviert."
+  },
+  "unarchive": {
+    "target": "wiederherstellen",
+    "note": "Existing UI and Weblate glossary use 'wiederherstellen' (Kanal wiederherstellen), not 'dearchivieren'."
+  },
+  "mute": {
+    "target": "stummschalten",
+    "note": "'Kanal stummschalten'; unmute a channel = 'Stummschaltung aufheben'. Same verb is used for microphone mute in Calls."
+  },
+  "follow": {
+    "target": "folgen",
+    "note": "Takes dative: 'einer Unterhaltung folgen'."
+  },
+  "unfollow": {
+    "target": "nicht mehr folgen",
+    "note": "'Nicht mehr folgen' is the established button label."
+  },
+  "favorite": {
+    "target": "Favorit",
+    "note": "Masculine: der Favorit, Plural Favoriten (sidebar category 'Favoriten'). Verb: 'zu Favoriten hinzufügen'; unfavorite: 'aus Favoriten entfernen'."
+  },
+  "search": {
+    "target": "Suche",
+    "note": "Verb: suchen; 'browse' = durchsuchen per Weblate glossary."
+  },
+  "integration": {
+    "target": "Integration"
+  },
+  "slash command": {
+    "target": "Slash-Befehl",
+    "note": "Consistent existing rendering; keep the hyphenated half-English compound."
+  },
+  "webhook": {
+    "target": "Webhook",
+    "note": "Masculine: der Webhook. Kept in English per Weblate glossary."
+  },
+  "incoming webhook": {
+    "target": "Eingehender Webhook"
+  },
+  "outgoing webhook": {
+    "target": "Ausgehender Webhook"
+  },
+  "trigger word": {
+    "target": "Auslösewort",
+    "note": "Plural: Auslösewörter (per Weblate glossary). Command trigger word = Befehlsauslösewort."
+  },
+  "plugin": {
+    "target": "Plugin",
+    "note": "Neuter: das Plugin. Kept in English per Weblate glossary."
+  },
+  "bot": {
+    "target": "Bot",
+    "note": "Masculine: der Bot. Bot account = Bot-Konto."
+  },
+  "role": {
+    "target": "Rolle"
+  },
+  "permission": {
+    "target": "Berechtigung",
+    "note": "Consistent existing rendering (not 'Erlaubnis'/'Recht')."
+  },
+  "scheme": {
+    "target": "Schema",
+    "note": "Neuter: das Schema, Plural Schemas/Schemata. Permission scheme = Berechtigungsschema."
+  },
+  "license": {
+    "target": "Lizenz"
+  },
+  "seat": {
+    "target": "Sitz",
+    "note": "Majority rendering in licensing strings (Plural Sitze); 'Lizenzplatz' also appears once and is arguably clearer, but keep 'Sitz' for consistency."
+  },
+  "trial": {
+    "target": "Testversion",
+    "note": "Majority rendering; 'Testphase'/'Testzeitraum' appear when a period is meant. Free trial = 'kostenlose Testversion'."
+  },
+  "workspace": {
+    "target": "Arbeitsbereich",
+    "note": "Strong majority (56 vs 2 occurrences of untranslated 'Workspace')."
+  },
+  "subscription": {
+    "target": "Abonnement",
+    "note": "Per Weblate glossary; informal 'Abo' appears in a few strings but prefer Abonnement."
+  },
+  "deactivate": {
+    "target": "deaktivieren",
+    "note": "Deactivated account = deaktiviertes Konto."
+  },
+  "invite": {
+    "target": "einladen",
+    "note": "Verb per Weblate glossary; as a noun use 'Einladung'."
+  },
+  "invitation": {
+    "target": "Einladung"
+  },
+  "sidebar": {
+    "target": "Seitenleiste"
+  },
+  "unread": {
+    "target": "ungelesen",
+    "note": "'Unreads' view = 'Ungelesene Nachrichten' / 'Ungelesenes'."
+  },
+  "attachment": {
+    "target": "Anhang",
+    "note": "Masculine: der Anhang, Plural Anhänge."
+  },
+  "public channel": {
+    "target": "Öffentlicher Kanal"
+  },
+  "private channel": {
+    "target": "Privater Kanal"
+  },
+  "shared channel": {
+    "target": "Gemeinsamer Kanal",
+    "note": "Majority rendering ('gemeinsamer Kanal'); 'geteilter Kanal' also occurs and the admin role name stays English ('Shared Channel Manager'). Keep 'gemeinsam' for consistency."
+  },
+  "channel header": {
+    "target": "Kanal-Kopfzeile",
+    "note": "UI labels use 'Kanal-Kopfzeile'; body text is inconsistent ('Kanalüberschrift', 'Kopfzeile des Kanals'). Prefer Kanal-Kopfzeile; bare 'Header' = Kopfzeile."
+  },
+  "channel purpose": {
+    "target": "Kanalzweck",
+    "note": "Bare 'purpose' = Zweck."
+  },
+  "system message": {
+    "target": "Systemnachricht",
+    "note": "Write as one compound; an existing string has the incorrect spaced form 'System Nachricht'."
+  },
+  "persistent notification": {
+    "target": "Dauerhafte Benachrichtigung",
+    "note": "Consistent existing rendering."
+  },
+  "message priority": {
+    "target": "Nachrichtenpriorität",
+    "note": "Existing strings vary between 'Nachrichtenpriorität' and 'Nachrichten-Priorität'; prefer the solid compound."
+  },
+  "urgent": {
+    "target": "Dringend",
+    "note": "Priority label; lowercase 'dringend' in sentences. 'Important' = Wichtig."
+  },
+  "recap": {
+    "target": "Rückblick",
+    "note": "Webapp UI uses 'Rückblick'; server error strings use 'Zusammenfassung' (inconsistent). Prefer Rückblick to avoid clashing with summary = Zusammenfassung."
+  },
+  "agent": {
+    "target": "Agent",
+    "note": "Masculine: der Agent, Plural Agenten. 'AI agent' is rendered inconsistently as 'KI-Agent' and 'AI-Agent'; prefer 'KI-Agent'."
+  },
+  "burn-on-read": {
+    "target": "Löschen-nach-Lesen",
+    "note": "Majority rendering ('Löschen-nach-Lesen-Nachricht'); some admin strings keep English 'Burn-on-Read'. Uppercase label: 'LÖSCHEN NACH LESEN'."
+  },
+  "magic link": {
+    "target": "Magic Link",
+    "note": "Webapp majority keeps English 'Magic Link' (10 vs 4); server strings use 'magischer Link'. Keep Magic Link for consistency with the user-facing webapp."
+  },
+  "personal access token": {
+    "target": "Persönlicher Zugriffs-Token",
+    "note": "Webapp majority uses 'Zugriffs-Token' (14 vs 1); the Weblate glossary row says 'Persönliches Zugangs-Token' — prefer the repo majority. Token is used masculine ('den Token')."
+  },
+  "announcement banner": {
+    "target": "Ankündigungs-Banner",
+    "note": "Existing strings mix 'Ankündigungs-Banner' and 'Ankündigungsbanner'; prefer the hyphenated majority. Bare 'banner' = Banner (per Weblate glossary)."
+  },
+  "channel banner": {
+    "target": "Kanal-Banner",
+    "note": "Existing strings mix 'Kanal-Banner' and 'Kanalbanner'."
+  },
+  "keyword": {
+    "target": "Schlüsselwort",
+    "note": "Notification settings use 'Schlüsselwörter'; compliance UI uses 'Stichworte' (inconsistent). For mention keywords use Schlüsselwort."
+  },
+  "user group": {
+    "target": "Benutzergruppe",
+    "note": "Bare 'group' = Gruppe."
+  },
+  "permalink": {
+    "target": "Permalink",
+    "note": "Majority keeps 'Permalink'; one string paraphrases 'dauerhafter Link'."
+  },
+  "profile": {
+    "target": "Profil"
+  },
+  "username": {
+    "target": "Benutzername",
+    "note": "Per Weblate glossary."
+  },
+  "nickname": {
+    "target": "Spitzname"
+  },
+  "display name": {
+    "target": "Anzeigename"
+  },
+  "collapsed reply threads": {
+    "target": "Unterhaltungen",
+    "note": "Existing UI renders the feature name simply as 'Unterhaltungen' (mobile display settings). If a literal rendering is required, use 'Eingeklappte Unterhaltungen' — but prefer the established short form."
+  },
+  "auto-translation": {
+    "target": "Automatische Übersetzung",
+    "note": "'auto-translated' = automatisch übersetzt; label 'AUTO-TRANSLATED' = 'AUTOMATISCH ÜBERSETZT'."
+  },
+  "data retention": {
+    "target": "Datenaufbewahrung",
+    "note": "Policy = 'Datenaufbewahrungsrichtlinie' / 'Richtlinie zur Datenaufbewahrung'."
+  },
+  "compliance export": {
+    "target": "Compliance-Export",
+    "note": "Keep 'Compliance' English; consistent existing rendering."
+  },
+  "access control": {
+    "target": "Zugriffskontrolle",
+    "note": "Attribute-based access control = 'attributbasierte Zugriffskontrolle'; policy = Richtlinie."
+  },
+  "attribute": {
+    "target": "Attribut",
+    "note": "Neuter: das Attribut, Plural Attribute. Custom profile attribute = 'benutzerdefiniertes Profilattribut'."
+  },
+  "onboarding": {
+    "target": "Onboarding",
+    "note": "Kept in English per Weblate glossary."
+  },
+  "Town Square": {
+    "target": "Marktplatz",
+    "note": "Established default-channel name in server i18n. Caution: 'marketplace' (plugin store) is also 'Marktplatz' — rely on context; consider 'Plugin-Marktplatz' when ambiguity is possible."
+  },
+  "Off-Topic": {
+    "target": "Sonstiges",
+    "note": "Established default-channel name in server i18n."
+  },
+  "read-only": {
+    "target": "schreibgeschützt",
+    "note": "Channel context uses 'Dieser Kanal ist schreibgeschützt'; admin strings also use 'Nur Lesen'/'Nur-Lese-…'. Prefer schreibgeschützt for channels."
+  },
+  "server": {
+    "target": "Server",
+    "note": "Masculine: der Server; plural Server."
+  }
+}

--- a/i18n/glossary/en-AU.json
+++ b/i18n/glossary/en-AU.json
@@ -1,0 +1,373 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition"
+  },
+  "Team Edition": {
+    "target": "Team Edition"
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels"
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "System Console"
+  },
+  "marketplace": {
+    "target": "marketplace"
+  },
+  "channel": {
+    "target": "channel"
+  },
+  "team": {
+    "target": "team"
+  },
+  "post": {
+    "target": "post"
+  },
+  "message": {
+    "target": "message"
+  },
+  "thread": {
+    "target": "thread"
+  },
+  "reply": {
+    "target": "reply"
+  },
+  "direct message": {
+    "target": "direct message"
+  },
+  "group message": {
+    "target": "group message"
+  },
+  "mention": {
+    "target": "mention"
+  },
+  "notification": {
+    "target": "notification"
+  },
+  "pin": {
+    "target": "pin"
+  },
+  "bookmark": {
+    "target": "bookmark"
+  },
+  "saved messages": {
+    "target": "saved messages"
+  },
+  "draft": {
+    "target": "draft"
+  },
+  "scheduled post": {
+    "target": "scheduled post"
+  },
+  "emoji": {
+    "target": "emoji"
+  },
+  "custom emoji": {
+    "target": "custom emoji"
+  },
+  "reaction": {
+    "target": "reaction"
+  },
+  "status": {
+    "target": "status"
+  },
+  "custom status": {
+    "target": "custom status"
+  },
+  "do not disturb": {
+    "target": "do not disturb"
+  },
+  "away": {
+    "target": "away"
+  },
+  "online": {
+    "target": "online"
+  },
+  "offline": {
+    "target": "offline"
+  },
+  "out of office": {
+    "target": "out of office"
+  },
+  "guest": {
+    "target": "guest"
+  },
+  "member": {
+    "target": "member"
+  },
+  "user": {
+    "target": "user"
+  },
+  "system admin": {
+    "target": "system admin"
+  },
+  "team admin": {
+    "target": "team admin"
+  },
+  "channel admin": {
+    "target": "channel admin"
+  },
+  "session": {
+    "target": "session"
+  },
+  "sign in": {
+    "target": "sign in"
+  },
+  "sign out": {
+    "target": "sign out"
+  },
+  "join": {
+    "target": "join"
+  },
+  "leave": {
+    "target": "leave"
+  },
+  "archive": {
+    "target": "archive"
+  },
+  "unarchive": {
+    "target": "unarchive"
+  },
+  "mute": {
+    "target": "mute"
+  },
+  "follow": {
+    "target": "follow"
+  },
+  "unfollow": {
+    "target": "unfollow"
+  },
+  "favorite": {
+    "target": "favourite",
+    "note": "AU spelling; Favourites category, Unfavourite."
+  },
+  "search": {
+    "target": "search"
+  },
+  "integration": {
+    "target": "integration"
+  },
+  "slash command": {
+    "target": "slash command"
+  },
+  "webhook": {
+    "target": "webhook"
+  },
+  "incoming webhook": {
+    "target": "incoming webhook"
+  },
+  "outgoing webhook": {
+    "target": "outgoing webhook"
+  },
+  "trigger word": {
+    "target": "trigger word"
+  },
+  "plugin": {
+    "target": "plugin"
+  },
+  "bot": {
+    "target": "bot"
+  },
+  "role": {
+    "target": "role"
+  },
+  "permission": {
+    "target": "permission"
+  },
+  "scheme": {
+    "target": "scheme"
+  },
+  "license": {
+    "target": "licence",
+    "note": "Noun is 'licence'; verb/participle stays 'licensed' (matches existing en-AU)."
+  },
+  "seat": {
+    "target": "seat"
+  },
+  "trial": {
+    "target": "trial"
+  },
+  "workspace": {
+    "target": "workspace"
+  },
+  "subscription": {
+    "target": "subscription"
+  },
+  "deactivate": {
+    "target": "deactivate"
+  },
+  "invite": {
+    "target": "invite"
+  },
+  "invitation": {
+    "target": "invitation"
+  },
+  "sidebar": {
+    "target": "sidebar"
+  },
+  "unread": {
+    "target": "unread"
+  },
+  "attachment": {
+    "target": "attachment"
+  },
+  "public channel": {
+    "target": "public channel"
+  },
+  "private channel": {
+    "target": "private channel"
+  },
+  "shared channel": {
+    "target": "shared channel"
+  },
+  "channel header": {
+    "target": "channel header"
+  },
+  "channel purpose": {
+    "target": "channel purpose"
+  },
+  "system message": {
+    "target": "system message"
+  },
+  "persistent notification": {
+    "target": "persistent notification"
+  },
+  "message priority": {
+    "target": "message priority"
+  },
+  "urgent": {
+    "target": "urgent"
+  },
+  "recap": {
+    "target": "recap"
+  },
+  "agent": {
+    "target": "agent"
+  },
+  "burn-on-read": {
+    "target": "burn-on-read"
+  },
+  "magic link": {
+    "target": "magic link"
+  },
+  "personal access token": {
+    "target": "personal access token"
+  },
+  "announcement banner": {
+    "target": "announcement banner"
+  },
+  "channel banner": {
+    "target": "channel banner"
+  },
+  "keyword": {
+    "target": "keyword"
+  },
+  "user group": {
+    "target": "user group"
+  },
+  "permalink": {
+    "target": "permalink"
+  },
+  "profile": {
+    "target": "profile"
+  },
+  "username": {
+    "target": "username"
+  },
+  "nickname": {
+    "target": "nickname"
+  },
+  "display name": {
+    "target": "display name"
+  },
+  "collapsed reply threads": {
+    "target": "collapsed reply threads"
+  },
+  "auto-translation": {
+    "target": "auto-translation"
+  },
+  "data retention": {
+    "target": "data retention"
+  },
+  "compliance export": {
+    "target": "compliance export"
+  },
+  "access control": {
+    "target": "access control"
+  },
+  "attribute": {
+    "target": "attribute"
+  },
+  "onboarding": {
+    "target": "onboarding"
+  },
+  "Town Square": {
+    "target": "Town Square"
+  },
+  "Off-Topic": {
+    "target": "Off-Topic"
+  },
+  "read-only": {
+    "target": "read-only"
+  },
+  "server": {
+    "target": "server"
+  }
+}

--- a/i18n/glossary/en-AU.json
+++ b/i18n/glossary/en-AU.json
@@ -53,9 +53,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/en.json
+++ b/i18n/glossary/en.json
@@ -1,0 +1,1021 @@
+{
+  "Mattermost": {
+    "definition": "Brand name of the product and the company; never translate or transliterate.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "Enterprise Edition": {
+    "definition": "Name of the commercial, licensed edition of the Mattermost server.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true,
+    "aliases": [
+      "EE"
+    ]
+  },
+  "Team Edition": {
+    "definition": "Name of the free, open-source edition of the Mattermost server.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "Mattermost Cloud": {
+    "definition": "Name of the hosted SaaS offering of Mattermost.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "Channels": {
+    "definition": "Product name of the Mattermost messaging product; as a product name it stays in English, unlike the common noun 'channel'.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "Playbooks": {
+    "definition": "Product name of the Mattermost workflow product; as a product name it stays in English.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "Boards": {
+    "definition": "Product name of the Mattermost project/kanban board product; as a product name it stays in English.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "Calls": {
+    "definition": "Product name of the Mattermost voice/video calling feature; as a product name it stays in English.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "Markdown": {
+    "definition": "Name of the text formatting syntax used in Mattermost messages.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "OAuth": {
+    "definition": "Authorization protocol used for app integrations and single sign-on; technical identity.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true,
+    "aliases": [
+      "OAuth 2.0"
+    ]
+  },
+  "SAML": {
+    "definition": "Single sign-on protocol (Security Assertion Markup Language); technical identity.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "LDAP": {
+    "definition": "Directory protocol used for AD/LDAP login and user sync; technical identity.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true,
+    "aliases": [
+      "AD/LDAP"
+    ]
+  },
+  "SSO": {
+    "definition": "Abbreviation for single sign-on; keep the abbreviation as-is.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "MFA": {
+    "definition": "Abbreviation for multi-factor authentication; keep the abbreviation as-is.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "OpenID Connect": {
+    "definition": "Identity protocol used as a single sign-on option; technical identity.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "Entra ID": {
+    "definition": "Microsoft's identity platform (formerly Azure AD), offered as a login option.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "GitLab": {
+    "definition": "Third-party product offered as a single sign-on option; brand name.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "Elasticsearch": {
+    "definition": "Third-party search engine that can back Mattermost's search; brand name.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "Bleve": {
+    "definition": "Name of the embedded search engine option in the System Console; brand name.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "Gossip": {
+    "definition": "Name of the cluster communication protocol shown in high-availability settings; never translate literally as 'chatter'.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "Actiance XML": {
+    "definition": "Name of a compliance export format; product identity.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true
+  },
+  "Global Relay": {
+    "definition": "Third-party compliance archiving service and export format; brand name.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": true,
+    "aliases": [
+      "Global Relay EML"
+    ]
+  },
+  "System Console": {
+    "definition": "The administrator interface where system admins configure the Mattermost server; translate consistently as a named UI area.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "system console"
+    ]
+  },
+  "marketplace": {
+    "definition": "The in-product store where admins browse and install plugins and apps.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Marketplace"
+    ]
+  },
+  "channel": {
+    "definition": "A conversation space where messages are exchanged; the basic organizing unit of communication in Mattermost.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Channel",
+      "channels"
+    ]
+  },
+  "team": {
+    "definition": "A named collection of channels and users; a workspace can contain multiple teams.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Team",
+      "teams"
+    ]
+  },
+  "post": {
+    "definition": "A single message published to a channel or thread; used interchangeably with 'message' in the UI.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "posts"
+    ]
+  },
+  "message": {
+    "definition": "Text (and attachments) a user sends in a channel, thread, or direct message.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Message",
+      "messages"
+    ]
+  },
+  "thread": {
+    "definition": "A set of replies attached to a root message, viewed and followed as one conversation.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Thread",
+      "threads",
+      "Threads"
+    ]
+  },
+  "reply": {
+    "definition": "A message posted in a thread in response to a root message; also the act of doing so.",
+    "partOfSpeech": "noun/verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "replies",
+      "Reply"
+    ]
+  },
+  "direct message": {
+    "definition": "A private one-to-one conversation between two users.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Direct Message",
+      "direct messages",
+      "DM"
+    ]
+  },
+  "group message": {
+    "definition": "A private conversation among three to eight users, without a named channel.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Group Message",
+      "group messages",
+      "GM"
+    ]
+  },
+  "mention": {
+    "definition": "Referencing a user or group with @username so they are notified; also the notification itself.",
+    "partOfSpeech": "noun/verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Mention",
+      "mentions",
+      "@mention"
+    ]
+  },
+  "notification": {
+    "definition": "An alert (desktop, email, or mobile) informing a user of activity such as mentions or replies.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Notifications"
+    ]
+  },
+  "pin": {
+    "definition": "To attach a message to a channel's pinned list so all members can find it easily.",
+    "partOfSpeech": "verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Pinned",
+      "unpin",
+      "pinned messages"
+    ]
+  },
+  "bookmark": {
+    "definition": "A saved link or file attached to the top of a channel for quick access; also the act of adding one.",
+    "partOfSpeech": "noun/verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Bookmarks",
+      "bookmarks"
+    ]
+  },
+  "saved messages": {
+    "definition": "A user's personal list of messages they saved for later follow-up; visible only to that user.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Saved Messages",
+      "save",
+      "unsave"
+    ]
+  },
+  "draft": {
+    "definition": "An unsent message that is kept until the user sends, schedules, or deletes it.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Drafts",
+      "drafts"
+    ]
+  },
+  "scheduled post": {
+    "definition": "A message set to be sent automatically at a future date and time.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Scheduled Post",
+      "scheduled message",
+      "scheduled posts"
+    ]
+  },
+  "emoji": {
+    "definition": "A small pictograph inserted into messages or used as a reaction.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Emoji",
+      "emojis"
+    ]
+  },
+  "custom emoji": {
+    "definition": "A user-uploaded emoji available across the workspace in addition to the standard set.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Custom Emoji"
+    ]
+  },
+  "reaction": {
+    "definition": "An emoji attached to an existing message to respond without posting a reply.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "reactions",
+      "react"
+    ]
+  },
+  "status": {
+    "definition": "A user's availability indicator: online, away, do not disturb, or offline.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Status"
+    ]
+  },
+  "custom status": {
+    "definition": "A user-defined emoji and text (e.g. 'In a meeting') shown next to their name, separate from availability.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Custom Status"
+    ]
+  },
+  "do not disturb": {
+    "definition": "Availability status that silences all notifications until turned off or a timer expires.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Do Not Disturb",
+      "Do not disturb",
+      "DND"
+    ]
+  },
+  "away": {
+    "definition": "Availability status shown when a user is inactive or sets themselves as away.",
+    "partOfSpeech": "adjective",
+    "doNotTranslate": false,
+    "aliases": [
+      "Away"
+    ]
+  },
+  "online": {
+    "definition": "Availability status shown when a user is active in Mattermost.",
+    "partOfSpeech": "adjective",
+    "doNotTranslate": false,
+    "aliases": [
+      "Online"
+    ]
+  },
+  "offline": {
+    "definition": "Availability status shown when a user is not connected to Mattermost.",
+    "partOfSpeech": "adjective",
+    "doNotTranslate": false,
+    "aliases": [
+      "Offline"
+    ]
+  },
+  "out of office": {
+    "definition": "Availability status set automatically or manually when a user is away from work; can trigger automatic replies.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Out of Office",
+      "Out Of Office"
+    ]
+  },
+  "guest": {
+    "definition": "An account type with restricted access, limited to specific channels and teams they are invited to.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Guest",
+      "guests"
+    ]
+  },
+  "member": {
+    "definition": "A regular (non-guest, non-admin) user belonging to a team or channel.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Member",
+      "members"
+    ]
+  },
+  "user": {
+    "definition": "Any account on the Mattermost server, including members, guests, admins, and bots.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "User",
+      "users"
+    ]
+  },
+  "system admin": {
+    "definition": "The highest administrative role, with full access to the System Console and server settings.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "System Admin",
+      "system administrator",
+      "System Administrator"
+    ]
+  },
+  "team admin": {
+    "definition": "A role with administrative permissions scoped to a single team.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Team Admin"
+    ]
+  },
+  "channel admin": {
+    "definition": "A role with administrative permissions scoped to a single channel.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Channel Admin"
+    ]
+  },
+  "session": {
+    "definition": "An authenticated login on a device; sessions expire and can be revoked by admins.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "sessions",
+      "Session"
+    ]
+  },
+  "sign in": {
+    "definition": "To authenticate and start a session; the UI uses 'log in' and 'sign in' interchangeably — translate both the same way.",
+    "partOfSpeech": "verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Sign in",
+      "log in",
+      "Log In",
+      "login"
+    ]
+  },
+  "sign out": {
+    "definition": "To end the current session; the UI uses 'log out' and 'sign out' interchangeably — translate both the same way.",
+    "partOfSpeech": "verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "log out",
+      "Log Out",
+      "logout"
+    ]
+  },
+  "join": {
+    "definition": "To become a member of a channel or team.",
+    "partOfSpeech": "verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Join",
+      "joined"
+    ]
+  },
+  "leave": {
+    "definition": "To remove oneself from a channel or team.",
+    "partOfSpeech": "verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Leave",
+      "left"
+    ]
+  },
+  "archive": {
+    "definition": "To close a channel so it becomes read-only and hidden from the sidebar, without deleting its history.",
+    "partOfSpeech": "verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Archive",
+      "archived",
+      "Archived"
+    ]
+  },
+  "unarchive": {
+    "definition": "To restore an archived channel to active use.",
+    "partOfSpeech": "verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Unarchive"
+    ]
+  },
+  "mute": {
+    "definition": "To silence notifications from a channel while remaining a member; distinct from muting a microphone in Calls.",
+    "partOfSpeech": "verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Mute",
+      "muted",
+      "unmute"
+    ]
+  },
+  "follow": {
+    "definition": "To subscribe to a thread (or message) so its replies appear in the Threads view and trigger notifications.",
+    "partOfSpeech": "verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Follow",
+      "following",
+      "followed"
+    ]
+  },
+  "unfollow": {
+    "definition": "To stop following a thread and its reply notifications.",
+    "partOfSpeech": "verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Unfollow"
+    ]
+  },
+  "favorite": {
+    "definition": "To mark a channel so it appears in the Favorites sidebar category; also the marked item itself.",
+    "partOfSpeech": "noun/verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Favorite",
+      "Favorites",
+      "unfavorite"
+    ]
+  },
+  "search": {
+    "definition": "The feature for finding messages and files across channels using terms and modifiers.",
+    "partOfSpeech": "noun/verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Search"
+    ]
+  },
+  "integration": {
+    "definition": "A connection between Mattermost and an external tool, such as webhooks, slash commands, or OAuth apps.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Integrations",
+      "integrations"
+    ]
+  },
+  "slash command": {
+    "definition": "A command typed in the message box starting with '/', which triggers a built-in or custom action.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Slash Command",
+      "slash commands"
+    ]
+  },
+  "webhook": {
+    "definition": "An HTTP-based integration for posting or receiving messages; the word may be translated or kept depending on locale convention, but must be consistent.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Webhook",
+      "webhooks"
+    ]
+  },
+  "incoming webhook": {
+    "definition": "An integration that lets external services post messages into a Mattermost channel.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Incoming Webhook",
+      "incoming webhooks"
+    ]
+  },
+  "outgoing webhook": {
+    "definition": "An integration that sends channel messages matching trigger words to an external service.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Outgoing Webhook",
+      "outgoing webhooks"
+    ]
+  },
+  "trigger word": {
+    "definition": "A word that, when it starts or appears in a message, activates an outgoing webhook.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "trigger words",
+      "Trigger Words"
+    ]
+  },
+  "plugin": {
+    "definition": "An installable extension that adds features to the Mattermost server and apps.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Plugin",
+      "plugins",
+      "Plugins"
+    ]
+  },
+  "bot": {
+    "definition": "A non-human account used by integrations and plugins to post and interact.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Bot",
+      "bots",
+      "bot account"
+    ]
+  },
+  "role": {
+    "definition": "A named set of permissions assigned to users, such as member, team admin, or system admin.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "roles",
+      "Role"
+    ]
+  },
+  "permission": {
+    "definition": "An individual capability (e.g. create channels) that roles grant or deny.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Permissions",
+      "permissions"
+    ]
+  },
+  "scheme": {
+    "definition": "A named set of role-to-permission mappings applied to teams or channels (permission scheme).",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Scheme",
+      "schemes"
+    ]
+  },
+  "license": {
+    "definition": "The file or key that activates paid Mattermost features on a server.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "License"
+    ]
+  },
+  "seat": {
+    "definition": "One licensed user slot counted against a paid subscription.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "seats"
+    ]
+  },
+  "trial": {
+    "definition": "A time-limited free period of Enterprise features before purchasing a license.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Trial",
+      "free trial"
+    ]
+  },
+  "workspace": {
+    "definition": "A complete Mattermost instance (server plus its teams and data), especially in Cloud contexts.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Workspace",
+      "workspaces"
+    ]
+  },
+  "subscription": {
+    "definition": "A recurring paid plan for Mattermost Cloud or licensed features.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Subscription"
+    ]
+  },
+  "deactivate": {
+    "definition": "To disable a user account so it can no longer sign in, without deleting its data.",
+    "partOfSpeech": "verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Deactivate",
+      "deactivated",
+      "Deactivated"
+    ]
+  },
+  "invite": {
+    "definition": "To ask a person to join a team or channel, typically by email or link; also the request itself.",
+    "partOfSpeech": "noun/verb",
+    "doNotTranslate": false,
+    "aliases": [
+      "Invite",
+      "invited"
+    ]
+  },
+  "invitation": {
+    "definition": "The email or link sent when inviting someone to a team or channel.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "invitations"
+    ]
+  },
+  "sidebar": {
+    "definition": "The left-hand panel listing channels, direct messages, and categories.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Sidebar"
+    ]
+  },
+  "unread": {
+    "definition": "Describes messages or channels with content the user has not viewed yet.",
+    "partOfSpeech": "adjective",
+    "doNotTranslate": false,
+    "aliases": [
+      "Unread",
+      "Unreads",
+      "unreads"
+    ]
+  },
+  "attachment": {
+    "definition": "A file or media item included with a message.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Attachment",
+      "attachments"
+    ]
+  },
+  "public channel": {
+    "definition": "A channel any team member can find and join.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Public Channel",
+      "public channels"
+    ]
+  },
+  "private channel": {
+    "definition": "A channel visible only to invited members.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Private Channel",
+      "private channels"
+    ]
+  },
+  "shared channel": {
+    "definition": "A channel shared across connected Mattermost workspaces so users on different servers can participate.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Shared Channel",
+      "shared channels"
+    ]
+  },
+  "channel header": {
+    "definition": "The editable text shown at the top of a channel, next to the channel name.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Header",
+      "header"
+    ]
+  },
+  "channel purpose": {
+    "definition": "A short description of what a channel is for, shown in channel info and search.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Purpose",
+      "purpose"
+    ]
+  },
+  "system message": {
+    "definition": "An automatic message posted by Mattermost itself, e.g. when someone joins or renames a channel.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "system messages"
+    ]
+  },
+  "persistent notification": {
+    "definition": "A repeated notification for an urgent message that keeps alerting recipients until acknowledged.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "persistent notifications",
+      "Persistent notifications"
+    ]
+  },
+  "message priority": {
+    "definition": "A label (Standard, Important, Urgent) a sender can attach to a message to indicate importance.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Message Priority"
+    ]
+  },
+  "urgent": {
+    "definition": "The highest message priority level; shown as a red label on the message.",
+    "partOfSpeech": "adjective",
+    "doNotTranslate": false,
+    "aliases": [
+      "Urgent",
+      "URGENT"
+    ]
+  },
+  "recap": {
+    "definition": "An AI-generated summary of activity in one or more channels over a time period.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Recap",
+      "recaps"
+    ]
+  },
+  "agent": {
+    "definition": "An AI assistant in Mattermost that users can ask questions or delegate tasks to.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Agent",
+      "Agents",
+      "agents"
+    ]
+  },
+  "burn-on-read": {
+    "definition": "A message type that is permanently deleted a set time after the recipient reads it.",
+    "partOfSpeech": "adjective",
+    "doNotTranslate": false,
+    "aliases": [
+      "Burn-on-read",
+      "Burn-on-Read",
+      "BURN ON READ"
+    ]
+  },
+  "magic link": {
+    "definition": "A sign-in link sent by email that authenticates the user without a password.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Magic Link",
+      "magic links"
+    ]
+  },
+  "personal access token": {
+    "definition": "A user-generated credential for authenticating API requests without a password.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Personal Access Token",
+      "personal access tokens"
+    ]
+  },
+  "announcement banner": {
+    "definition": "A system-wide banner configured by admins, shown across the top of the app for all users.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Announcement Banner"
+    ]
+  },
+  "channel banner": {
+    "definition": "A colored banner with custom text shown at the top of a specific channel.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Channel Banner",
+      "Channel banner"
+    ]
+  },
+  "keyword": {
+    "definition": "A word or phrase a user configures to trigger mention notifications when posted.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "keywords",
+      "Keywords"
+    ]
+  },
+  "user group": {
+    "definition": "A named collection of users that can be @-mentioned together and used for membership management.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "User Group",
+      "user groups",
+      "group"
+    ]
+  },
+  "permalink": {
+    "definition": "A permanent link to a specific message that can be copied and shared.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Permalink"
+    ]
+  },
+  "profile": {
+    "definition": "A user's account information: name, username, nickname, picture, and custom attributes.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Profile"
+    ]
+  },
+  "username": {
+    "definition": "The unique handle used for @-mentions and sign-in; distinct from the display name.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Username",
+      "user name"
+    ]
+  },
+  "nickname": {
+    "definition": "An optional informal name a user can set, shown according to display settings.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Nickname"
+    ]
+  },
+  "display name": {
+    "definition": "The human-readable name shown for a user, channel, team, or server in the UI.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Display Name"
+    ]
+  },
+  "collapsed reply threads": {
+    "definition": "The threading mode where replies are grouped under the root message and tracked in a Threads view.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Collapsed Reply Threads",
+      "Collapsed Reply Thread"
+    ]
+  },
+  "auto-translation": {
+    "definition": "A feature that automatically translates channel messages into the viewer's language.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Auto-translation",
+      "auto-translated",
+      "AUTO-TRANSLATED"
+    ]
+  },
+  "data retention": {
+    "definition": "Admin policies that automatically delete messages and files after a set period.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Data Retention",
+      "data retention policy"
+    ]
+  },
+  "compliance export": {
+    "definition": "An admin feature that exports message history in formats required for legal compliance.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Compliance Export"
+    ]
+  },
+  "access control": {
+    "definition": "Attribute-based rules that restrict who can access certain channels or resources.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Access Control",
+      "access control policy"
+    ]
+  },
+  "attribute": {
+    "definition": "A custom profile field or property (e.g. department) used on user profiles and in access control rules.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Attribute",
+      "attributes",
+      "custom profile attribute"
+    ]
+  },
+  "onboarding": {
+    "definition": "The guided first-run experience that helps new users and admins set up Mattermost.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Onboarding"
+    ]
+  },
+  "Town Square": {
+    "definition": "The default channel every team member belongs to; translate as a channel name, consistently.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false
+  },
+  "Off-Topic": {
+    "definition": "A default channel for informal conversation created with each team; translate consistently.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false
+  },
+  "read-only": {
+    "definition": "Describes a channel where only authorized users can post; others can only read.",
+    "partOfSpeech": "adjective",
+    "doNotTranslate": false,
+    "aliases": [
+      "Read only",
+      "read only"
+    ]
+  },
+  "server": {
+    "definition": "The Mattermost backend instance that hosts teams, channels, and users.",
+    "partOfSpeech": "noun",
+    "doNotTranslate": false,
+    "aliases": [
+      "Server",
+      "servers"
+    ]
+  }
+}

--- a/i18n/glossary/en.json
+++ b/i18n/glossary/en.json
@@ -98,11 +98,6 @@
     "partOfSpeech": "noun",
     "doNotTranslate": true
   },
-  "Bleve": {
-    "definition": "Name of the embedded search engine option in the System Console; brand name.",
-    "partOfSpeech": "noun",
-    "doNotTranslate": true
-  },
   "Gossip": {
     "definition": "Name of the cluster communication protocol shown in high-availability settings; never translate literally as 'chatter'.",
     "partOfSpeech": "noun",

--- a/i18n/glossary/es.json
+++ b/i18n/glossary/es.json
@@ -1,0 +1,424 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition"
+  },
+  "Team Edition": {
+    "target": "Team Edition"
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels"
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "Consola del Sistema",
+    "note": "Repo mixes 'Consola del Sistema' and 'Consola de sistema'; standardize on 'Consola del Sistema' as a named UI area."
+  },
+  "marketplace": {
+    "target": "Marketplace",
+    "note": "Kept in English throughout existing es.json (e.g. 'URL del Marketplace'); treat as a proper name, masculine ('el Marketplace')."
+  },
+  "channel": {
+    "target": "canal",
+    "note": "Masculine; plural 'canales'."
+  },
+  "team": {
+    "target": "equipo"
+  },
+  "post": {
+    "target": "mensaje",
+    "note": "Existing translations render both 'post' and 'message' as 'mensaje'; 'publicación' appears occasionally but 'mensaje' is the majority."
+  },
+  "message": {
+    "target": "mensaje"
+  },
+  "thread": {
+    "target": "hilo",
+    "note": "Majority rendering; a few legacy strings use 'conversación' (e.g. 'Seguir conversación') — prefer 'hilo'."
+  },
+  "reply": {
+    "target": "respuesta",
+    "note": "Verb: 'responder'."
+  },
+  "direct message": {
+    "target": "mensaje directo",
+    "note": "Abbreviation DM is not used in Spanish UI; spell out."
+  },
+  "group message": {
+    "target": "mensaje de grupo",
+    "note": "Majority rendering; 'mensaje grupal' also appears — prefer 'mensaje de grupo'."
+  },
+  "mention": {
+    "target": "mención",
+    "note": "Verb: 'mencionar'."
+  },
+  "notification": {
+    "target": "notificación"
+  },
+  "pin": {
+    "target": "destacar",
+    "note": "Majority rendering ('Mensajes Destacados'); one string uses 'anclados'. Unpin: 'dejar de destacar'. Pinned: 'destacado'."
+  },
+  "bookmark": {
+    "target": "marcador",
+    "note": "No established repo rendering; 'marcador' matches browser convention. Verb: 'añadir a marcadores'."
+  },
+  "saved messages": {
+    "target": "mensajes guardados",
+    "note": "Save: 'guardar'; unsave: 'eliminar de guardados'."
+  },
+  "draft": {
+    "target": "borrador"
+  },
+  "scheduled post": {
+    "target": "mensaje programado",
+    "note": "No repo signal; 'programado' follows es convention for scheduled sends (e.g. Gmail 'programar envío')."
+  },
+  "emoji": {
+    "target": "emoji",
+    "note": "Repo is split: legacy strings use 'emoticono' (slight majority) while newer ones use 'emoji'. 'Emoji' is the modern es convention (WhatsApp, Slack, Discord) and RAE-accepted; invariable-ish plural 'emojis'."
+  },
+  "custom emoji": {
+    "target": "emoji personalizado"
+  },
+  "reaction": {
+    "target": "reacción",
+    "note": "Verb 'reaccionar'; existing UI renders 'Add Reaction' simply as 'Reaccionar'."
+  },
+  "status": {
+    "target": "estado"
+  },
+  "custom status": {
+    "target": "estado personalizado"
+  },
+  "do not disturb": {
+    "target": "No molestar"
+  },
+  "away": {
+    "target": "Ausente"
+  },
+  "online": {
+    "target": "En línea"
+  },
+  "offline": {
+    "target": "Desconectado"
+  },
+  "out of office": {
+    "target": "Fuera de la oficina",
+    "note": "Repo mixes 'Fuera de Oficina' and 'Fuera de la Oficina'; prefer 'Fuera de la oficina'."
+  },
+  "guest": {
+    "target": "huésped",
+    "note": "Majority rendering (~85 vs ~22 for 'invitado'). 'Invitado' also appears and collides with 'invite/invitar'; keep 'huésped' for the account type."
+  },
+  "member": {
+    "target": "miembro"
+  },
+  "user": {
+    "target": "usuario"
+  },
+  "system admin": {
+    "target": "administrador del sistema",
+    "note": "Short form 'Admin del Sistema' used where space is tight."
+  },
+  "team admin": {
+    "target": "administrador del equipo"
+  },
+  "channel admin": {
+    "target": "administrador del canal"
+  },
+  "session": {
+    "target": "sesión"
+  },
+  "sign in": {
+    "target": "iniciar sesión",
+    "note": "Used for both 'sign in' and 'log in' consistently in the repo."
+  },
+  "sign out": {
+    "target": "cerrar sesión",
+    "note": "Repo mixes 'Salir' (menu items) and 'Cerrar sesión'; prefer 'cerrar sesión' for both 'sign out' and 'log out'."
+  },
+  "join": {
+    "target": "unirse",
+    "note": "'Unirse al canal/equipo'."
+  },
+  "leave": {
+    "target": "abandonar",
+    "note": "Existing convention: 'Abandonar Canal', 'Abandonar Equipo'."
+  },
+  "archive": {
+    "target": "archivar",
+    "note": "Archived: 'archivado'."
+  },
+  "unarchive": {
+    "target": "desarchivar"
+  },
+  "mute": {
+    "target": "silenciar",
+    "note": "For channel notifications; same verb is used in Calls for microphones."
+  },
+  "follow": {
+    "target": "seguir"
+  },
+  "unfollow": {
+    "target": "dejar de seguir"
+  },
+  "favorite": {
+    "target": "favorito",
+    "note": "Verb: 'marcar como favorito'; sidebar category 'Favoritos'."
+  },
+  "search": {
+    "target": "búsqueda",
+    "note": "Verb/button: 'buscar'."
+  },
+  "integration": {
+    "target": "integración"
+  },
+  "slash command": {
+    "target": "comando de barra"
+  },
+  "webhook": {
+    "target": "webhook",
+    "note": "Kept in English throughout existing es.json; masculine ('el webhook')."
+  },
+  "incoming webhook": {
+    "target": "webhook de entrada"
+  },
+  "outgoing webhook": {
+    "target": "webhook de salida"
+  },
+  "trigger word": {
+    "target": "palabra de activación",
+    "note": "Legacy strings paraphrase as 'palabra que dispara la acción/el comando'; 'palabra de activación' is the concise glossary form consistent with that intent."
+  },
+  "plugin": {
+    "target": "plugin",
+    "note": "Kept in English throughout existing es.json; masculine ('el plugin', 'los plugins'). 'Complemento' would be the alternative but is not used."
+  },
+  "bot": {
+    "target": "bot",
+    "note": "Bot account: 'cuenta bot'."
+  },
+  "role": {
+    "target": "rol",
+    "note": "Plural 'roles'."
+  },
+  "permission": {
+    "target": "permiso"
+  },
+  "scheme": {
+    "target": "esquema"
+  },
+  "license": {
+    "target": "licencia"
+  },
+  "seat": {
+    "target": "puesto",
+    "note": "Repo is inconsistent ('sedes' [incorrect], 'puestos pagados', 'licencias para usuarios'); 'puesto' is the standard SaaS term."
+  },
+  "trial": {
+    "target": "prueba",
+    "note": "'Período de prueba' when spelled out; free trial: 'prueba gratuita'."
+  },
+  "workspace": {
+    "target": "espacio de trabajo"
+  },
+  "subscription": {
+    "target": "suscripción"
+  },
+  "deactivate": {
+    "target": "desactivar",
+    "note": "Deactivated: 'desactivado'."
+  },
+  "invite": {
+    "target": "invitar",
+    "note": "Noun: 'invitación'."
+  },
+  "invitation": {
+    "target": "invitación"
+  },
+  "sidebar": {
+    "target": "barra lateral"
+  },
+  "unread": {
+    "target": "no leído",
+    "note": "Majority rendering; 'sin leer' also appears. Plural 'no leídos'."
+  },
+  "attachment": {
+    "target": "adjunto",
+    "note": "Also 'archivo adjunto' when spelled out."
+  },
+  "public channel": {
+    "target": "canal público"
+  },
+  "private channel": {
+    "target": "canal privado"
+  },
+  "shared channel": {
+    "target": "canal compartido"
+  },
+  "channel header": {
+    "target": "encabezado del canal",
+    "note": "Majority rendering; one legacy string uses 'cabecera'."
+  },
+  "channel purpose": {
+    "target": "propósito del canal"
+  },
+  "system message": {
+    "target": "mensaje del sistema"
+  },
+  "persistent notification": {
+    "target": "notificación persistente"
+  },
+  "message priority": {
+    "target": "prioridad del mensaje"
+  },
+  "urgent": {
+    "target": "urgente",
+    "note": "Label form: 'URGENTE'."
+  },
+  "recap": {
+    "target": "resumen",
+    "note": "No repo signal; 'resumen' aligns with the AI summary concept. Disambiguate from Calls 'meeting summary' ('resumen de la reunión') via context if both appear."
+  },
+  "agent": {
+    "target": "agente"
+  },
+  "burn-on-read": {
+    "target": "autodestrucción al leer",
+    "note": "No repo signal; follows messaging-app convention (Telegram 'autodestrucción'). As a message label: 'AUTODESTRUCCIÓN AL LEER'."
+  },
+  "magic link": {
+    "target": "enlace mágico"
+  },
+  "personal access token": {
+    "target": "token de acceso personal"
+  },
+  "announcement banner": {
+    "target": "banner de anuncio",
+    "note": "Existing strings use 'banner de anuncio'; one legacy string uses 'Notificaciones para todo el sistema' — prefer 'banner de anuncio'."
+  },
+  "channel banner": {
+    "target": "banner del canal"
+  },
+  "keyword": {
+    "target": "palabra clave",
+    "note": "Plural 'palabras clave' (clave stays singular)."
+  },
+  "user group": {
+    "target": "grupo de usuarios"
+  },
+  "permalink": {
+    "target": "enlace permanente"
+  },
+  "profile": {
+    "target": "perfil"
+  },
+  "username": {
+    "target": "nombre de usuario"
+  },
+  "nickname": {
+    "target": "sobrenombre",
+    "note": "Consistent repo rendering; 'apodo' is the common alternative but is not used."
+  },
+  "display name": {
+    "target": "nombre a mostrar",
+    "note": "Majority rendering; 'nombre de visualización' appears occasionally."
+  },
+  "collapsed reply threads": {
+    "target": "hilos de respuesta contraídos",
+    "note": "No established repo rendering for the feature name; 'contraído' matches the UI sense of collapsed."
+  },
+  "auto-translation": {
+    "target": "traducción automática",
+    "note": "Auto-translated label: 'TRADUCIDO AUTOMÁTICAMENTE'."
+  },
+  "data retention": {
+    "target": "retención de datos",
+    "note": "Majority rendering; 'conservación de datos' appears once. Policy: 'política de retención de datos'."
+  },
+  "compliance export": {
+    "target": "exportación de cumplimiento",
+    "note": "Majority rendering; some legacy strings use 'Exportación de Conformidad'."
+  },
+  "access control": {
+    "target": "control de acceso"
+  },
+  "attribute": {
+    "target": "atributo"
+  },
+  "onboarding": {
+    "target": "incorporación",
+    "note": "Existing rendering ('Habilitar la incorporación')."
+  },
+  "Town Square": {
+    "target": "General",
+    "note": "Existing server translation renders the default channel name as 'General' (not a literal translation); keep for consistency with created channels."
+  },
+  "Off-Topic": {
+    "target": "Fuera de Tópico",
+    "note": "Existing server translation; 'Fuera de tema' would be more natural but keep the established name."
+  },
+  "read-only": {
+    "target": "solo lectura",
+    "note": "Prefer un-accented 'solo' per current RAE; repo mixes 'solo' and 'sólo'."
+  },
+  "server": {
+    "target": "servidor"
+  }
+}

--- a/i18n/glossary/es.json
+++ b/i18n/glossary/es.json
@@ -240,8 +240,8 @@
     "target": "webhook de salida"
   },
   "trigger word": {
-    "target": "palabra de activación",
-    "note": "Legacy strings paraphrase as 'palabra que dispara la acción/el comando'."
+    "target": "palabra disparadora",
+    "note": "Plural 'palabras disparadoras'. Server strings paraphrase as 'palabra que dispara / que desencadena la acción'."
   },
   "plugin": {
     "target": "plugin",
@@ -265,7 +265,7 @@
   },
   "seat": {
     "target": "puesto",
-    "note": "Repo is inconsistent ('sedes' [incorrect], 'puestos pagados', 'licencias para usuarios'); 'puesto' is the standard SaaS term."
+    "note": "Repo is inconsistent ('sedes' and 'asientos' [both incorrect], 'puestos pagados', 'Licencias para Usuarios'); 'puesto' is the standard SaaS term."
   },
   "trial": {
     "target": "prueba",

--- a/i18n/glossary/es.json
+++ b/i18n/glossary/es.json
@@ -53,9 +53,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/es.json
+++ b/i18n/glossary/es.json
@@ -128,7 +128,7 @@
   },
   "emoji": {
     "target": "emoji",
-    "note": "Repo is split: legacy strings use 'emoticono' (slight majority) while newer ones use 'emoji'. 'Emoji' is the modern es convention (WhatsApp, Slack, Discord) and RAE-accepted; invariable-ish plural 'emojis'."
+    "note": "Repo is split: legacy strings use 'emoticono' (slight majority) while newer ones use 'emoji'. Plural 'emojis'."
   },
   "custom emoji": {
     "target": "emoji personalizado"
@@ -241,7 +241,7 @@
   },
   "trigger word": {
     "target": "palabra de activación",
-    "note": "Legacy strings paraphrase as 'palabra que dispara la acción/el comando'; 'palabra de activación' is the concise glossary form consistent with that intent."
+    "note": "Legacy strings paraphrase as 'palabra que dispara la acción/el comando'."
   },
   "plugin": {
     "target": "plugin",
@@ -410,7 +410,7 @@
   },
   "read-only": {
     "target": "solo lectura",
-    "note": "Prefer un-accented 'solo' per current RAE; repo mixes 'solo' and 'sólo'."
+    "note": "Un-accented 'solo'; repo mixes 'solo' and 'sólo'."
   },
   "server": {
     "target": "servidor"

--- a/i18n/glossary/es.json
+++ b/i18n/glossary/es.json
@@ -405,8 +405,8 @@
     "note": "Existing server translation renders the default channel name as 'General' (not a literal translation); keep for consistency with created channels."
   },
   "Off-Topic": {
-    "target": "Fuera de tema",
-    "note": "Existing server translation is 'Fuera de Tópico', which is unidiomatic; Spanish sentence casing applies."
+    "target": "Fuera de Tópico",
+    "note": "Established default-channel name in server es.json; keep for consistency with existing channels. 'Fuera de tema' is more idiomatic but would rename the channel."
   },
   "read-only": {
     "target": "solo lectura",

--- a/i18n/glossary/es.json
+++ b/i18n/glossary/es.json
@@ -97,11 +97,11 @@
   },
   "direct message": {
     "target": "mensaje directo",
-    "note": "Abbreviation DM is not used in Spanish UI; spell out."
+    "note": "Spell out in UI. 'MD' is the usual Spanish abbreviation in prose, not 'DM'."
   },
   "group message": {
-    "target": "mensaje de grupo",
-    "note": "Majority rendering; 'mensaje grupal' also appears — prefer 'mensaje de grupo'."
+    "target": "mensaje grupal",
+    "note": "Existing majority is 'mensaje de grupo'; 'mensaje grupal' is more idiomatic."
   },
   "mention": {
     "target": "mención",
@@ -111,8 +111,8 @@
     "target": "notificación"
   },
   "pin": {
-    "target": "destacar",
-    "note": "Majority rendering ('Mensajes Destacados'); one string uses 'anclados'. Unpin: 'dejar de destacar'. Pinned: 'destacado'."
+    "target": "fijar",
+    "note": "Existing strings use 'destacar' ('Mensajes Destacados') and one uses 'anclados'. Unpin: 'desfijar'; pinned: 'fijado' ('mensajes fijados'). Matches Telegram and WhatsApp."
   },
   "bookmark": {
     "target": "marcador",
@@ -411,8 +411,8 @@
     "note": "Existing server translation renders the default channel name as 'General' (not a literal translation); keep for consistency with created channels."
   },
   "Off-Topic": {
-    "target": "Fuera de Tópico",
-    "note": "Existing server translation; 'Fuera de tema' would be more natural but keep the established name."
+    "target": "Fuera de tema",
+    "note": "Existing server translation is 'Fuera de Tópico', which is unidiomatic; Spanish sentence casing applies."
   },
   "read-only": {
     "target": "solo lectura",

--- a/i18n/glossary/es.json
+++ b/i18n/glossary/es.json
@@ -255,8 +255,7 @@
     "note": "Bot account: 'cuenta bot'."
   },
   "role": {
-    "target": "rol",
-    "note": "Plural 'roles'."
+    "target": "rol"
   },
   "permission": {
     "target": "permiso"
@@ -329,8 +328,7 @@
     "target": "prioridad del mensaje"
   },
   "urgent": {
-    "target": "urgente",
-    "note": "Label form: 'URGENTE'."
+    "target": "urgente"
   },
   "recap": {
     "target": "resumen",
@@ -341,7 +339,7 @@
   },
   "burn-on-read": {
     "target": "autodestrucción al leer",
-    "note": "No repo signal; follows messaging-app convention (Telegram 'autodestrucción'). As a message label: 'AUTODESTRUCCIÓN AL LEER'."
+    "note": "No repo signal; follows messaging-app convention (Telegram 'autodestrucción')."
   },
   "magic link": {
     "target": "enlace mágico"
@@ -357,8 +355,7 @@
     "target": "banner del canal"
   },
   "keyword": {
-    "target": "palabra clave",
-    "note": "Plural 'palabras clave' (clave stays singular)."
+    "target": "palabra clave"
   },
   "user group": {
     "target": "grupo de usuarios"
@@ -386,7 +383,7 @@
   },
   "auto-translation": {
     "target": "traducción automática",
-    "note": "Auto-translated label: 'TRADUCIDO AUTOMÁTICAMENTE'."
+    "note": "'auto-translated' = 'traducido automáticamente'."
   },
   "data retention": {
     "target": "retención de datos",

--- a/i18n/glossary/es.json
+++ b/i18n/glossary/es.json
@@ -163,8 +163,8 @@
     "note": "Repo mixes 'Fuera de Oficina' and 'Fuera de la Oficina'; prefer 'Fuera de la oficina'."
   },
   "guest": {
-    "target": "huésped",
-    "note": "Majority rendering (~85 vs ~22 for 'invitado'). 'Invitado' also appears and collides with 'invite/invitar'; keep 'huésped' for the account type."
+    "target": "invitado",
+    "note": "Catalog majority is 'huésped' (112 vs 39), which reads as a hotel guest. Overlaps with invite = 'invitar'; context disambiguates the account type from the action."
   },
   "member": {
     "target": "miembro"

--- a/i18n/glossary/fa.json
+++ b/i18n/glossary/fa.json
@@ -1,0 +1,444 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition"
+  },
+  "Team Edition": {
+    "target": "Team Edition"
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels"
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "کنسول سیستم"
+  },
+  "marketplace": {
+    "target": "بازار",
+    "note": "Existing fa uses بازار for lowercase marketplace; the proper name Marketplace is sometimes left in English in admin strings."
+  },
+  "channel": {
+    "target": "کانال"
+  },
+  "team": {
+    "target": "تیم"
+  },
+  "post": {
+    "target": "پست",
+    "note": "Existing fa mixes پست (majority) and نوشته; prefer پست. In most UI strings 'post' and 'message' are interchangeable — پیام is fine where it reads more naturally."
+  },
+  "message": {
+    "target": "پیام"
+  },
+  "thread": {
+    "target": "موضوع",
+    "note": "Existing fa is very inconsistent (موضوع، گفت‌وگو، رشته، نخ، تاپیک). The Threads view is موضوعات in both webapp and mobile, so standardize on موضوع. Plural: موضوعات."
+  },
+  "reply": {
+    "target": "پاسخ",
+    "note": "Verb: پاسخ دادن."
+  },
+  "direct message": {
+    "target": "پیام مستقیم",
+    "note": "Majority rendering in webapp/server. Mobile sometimes uses گفت‌وگوی شخصی — standardize on پیام مستقیم."
+  },
+  "group message": {
+    "target": "پیام گروهی"
+  },
+  "mention": {
+    "target": "اشاره",
+    "note": "Verb: اشاره کردن. Established across webapp and mobile; do not use the transliteration منشن."
+  },
+  "notification": {
+    "target": "اعلان",
+    "note": "Plural: اعلان‌ها. Majority rendering; some older webapp strings use اطلاعیه — prefer اعلان."
+  },
+  "pin": {
+    "target": "پین کردن",
+    "note": "Majority rendering (پین شده، پین کردن به کانال). سنجاق کردن (Telegram convention) also appears; standardize on پین."
+  },
+  "bookmark": {
+    "target": "نشانک",
+    "note": "Verb: نشانک‌گذاری کردن. Matches the one existing server string and standard Persian (Firefox) usage."
+  },
+  "saved messages": {
+    "target": "پیام‌های ذخیره‌شده",
+    "note": "save (verb) = ذخیره کردن، unsave = حذف از ذخیره‌شده‌ها. Avoid the mistranslation صرفه جویی seen in some webapp strings."
+  },
+  "draft": {
+    "target": "پیش‌نویس",
+    "note": "Plural: پیش‌نویس‌ها (with ZWNJ)."
+  },
+  "scheduled post": {
+    "target": "پیام زمان‌بندی‌شده",
+    "note": "No existing fa signal; follows standard Persian UI convention (زمان‌بندی for scheduling)."
+  },
+  "emoji": {
+    "target": "ایموجی",
+    "note": "Webapp (user-facing) uses ایموجی; server strings use شکلک. Standardize on ایموجی."
+  },
+  "custom emoji": {
+    "target": "ایموجی سفارشی"
+  },
+  "reaction": {
+    "target": "واکنش",
+    "note": "Verb (react): واکنش نشان دادن."
+  },
+  "status": {
+    "target": "وضعیت"
+  },
+  "custom status": {
+    "target": "وضعیت سفارشی"
+  },
+  "do not disturb": {
+    "target": "مزاحم نشوید"
+  },
+  "away": {
+    "target": "دور",
+    "note": "Majority rendering; mobile once uses غایب — prefer دور."
+  },
+  "online": {
+    "target": "آنلاین",
+    "note": "Majority rendering; mobile sometimes uses برخط — prefer آنلاین."
+  },
+  "offline": {
+    "target": "آفلاین",
+    "note": "Majority rendering; mobile sometimes uses برون‌خط — prefer آفلاین."
+  },
+  "out of office": {
+    "target": "خارج از دفتر"
+  },
+  "guest": {
+    "target": "مهمان",
+    "note": "Plural: مهمانان. Spelling مهمان (not میهمان) is the strong majority."
+  },
+  "member": {
+    "target": "عضو",
+    "note": "Plural: اعضا."
+  },
+  "user": {
+    "target": "کاربر",
+    "note": "Plural: کاربران."
+  },
+  "system admin": {
+    "target": "مدیر سیستم",
+    "note": "مدیر is the strong majority for admin (مدیران سیستم); some webapp role labels use ادمین سیستم — prefer مدیر سیستم."
+  },
+  "team admin": {
+    "target": "مدیر تیم"
+  },
+  "channel admin": {
+    "target": "مدیر کانال"
+  },
+  "session": {
+    "target": "جلسه",
+    "note": "Existing fa consistently uses جلسه/جلسات for login sessions; نشست would be more precise Persian but keep جلسه for consistency."
+  },
+  "sign in": {
+    "target": "ورود",
+    "note": "Full verb: وارد شدن. Translate 'log in' identically."
+  },
+  "sign out": {
+    "target": "خروج",
+    "note": "Full verb: خارج شدن. خروج از حساب also used for Log out — plain خروج is fine as a button label."
+  },
+  "join": {
+    "target": "پیوستن",
+    "note": "e.g. پیوستن به کانال. Avoid the misspelling محلق شوید present in some existing strings (should be ملحق)."
+  },
+  "leave": {
+    "target": "ترک کردن",
+    "note": "e.g. ترک کانال، ترک تیم."
+  },
+  "archive": {
+    "target": "بایگانی کردن",
+    "note": "Adjective: بایگانی‌شده. Majority rendering; آرشیو also appears — prefer بایگانی."
+  },
+  "unarchive": {
+    "target": "خارج کردن از بایگانی",
+    "note": "Existing fa mixes لغو بایگانی and از بایگانی خارج کردن; the latter is clearer Persian."
+  },
+  "mute": {
+    "target": "بی‌صدا کردن",
+    "note": "For channels this silences notifications; existing webapp uses نادیده گرفتن کانال but بی‌صدا کردن is the majority and matches Calls usage. Unmute: باصدا کردن."
+  },
+  "follow": {
+    "target": "دنبال کردن"
+  },
+  "unfollow": {
+    "target": "لغو دنبال کردن",
+    "note": "Majority rendering (لغو دنبال کردن پیام/موضوع)."
+  },
+  "favorite": {
+    "target": "برگزیده",
+    "note": "Verb: برگزیده کردن; Favorites category: برگزیده‌ها."
+  },
+  "search": {
+    "target": "جستجو",
+    "note": "Verb: جستجو کردن. Use the closed spelling جستجو (majority), not جست‌وجو."
+  },
+  "integration": {
+    "target": "ادغام",
+    "note": "Plural: ادغام‌ها. Existing majority; یکپارچه‌سازی is arguably a better Persian rendering of 'integration' but keep ادغام for consistency."
+  },
+  "slash command": {
+    "target": "دستور اسلش",
+    "note": "Plural: دستورات اسلش."
+  },
+  "webhook": {
+    "target": "وب‌هوک",
+    "note": "Established transliteration; existing files write it with a space (وب هوک) — prefer ZWNJ (وب‌هوک). Plural: وب‌هوک‌ها."
+  },
+  "incoming webhook": {
+    "target": "وب‌هوک ورودی"
+  },
+  "outgoing webhook": {
+    "target": "وب‌هوک خروجی"
+  },
+  "trigger word": {
+    "target": "کلمه محرک",
+    "note": "Plural: کلمات محرک (existing rendering)."
+  },
+  "plugin": {
+    "target": "افزونه",
+    "note": "Majority rendering; پلاگین also appears — prefer افزونه."
+  },
+  "bot": {
+    "target": "ربات",
+    "note": "ربات and بات both appear in roughly equal numbers; standardize on ربات (Telegram convention). Bot account: حساب ربات."
+  },
+  "role": {
+    "target": "نقش"
+  },
+  "permission": {
+    "target": "مجوز",
+    "note": "Plural: مجوزها. Note: existing fa also uses مجوز for 'license'; where both occur together, use اجازه/دسترسی for permission to disambiguate."
+  },
+  "scheme": {
+    "target": "طرح",
+    "note": "Permission scheme: طرح مجوز."
+  },
+  "license": {
+    "target": "مجوز",
+    "note": "Existing fa consistently uses مجوز for license, colliding with permission = مجوز. Use لایسنس only if a string needs both concepts distinguished."
+  },
+  "seat": {
+    "target": "صندلی",
+    "note": "No existing fa usage. صندلی = licensed user slot; in running text «به ازای هر کاربر» may read more naturally."
+  },
+  "trial": {
+    "target": "دوره آزمایشی",
+    "note": "Free trial: دوره آزمایشی رایگان."
+  },
+  "workspace": {
+    "target": "فضای کاری",
+    "note": "Majority rendering; محیط‌کار also appears — prefer فضای کاری."
+  },
+  "subscription": {
+    "target": "اشتراک"
+  },
+  "deactivate": {
+    "target": "غیرفعال کردن",
+    "note": "Deactivated: غیرفعال‌شده."
+  },
+  "invite": {
+    "target": "دعوت کردن",
+    "note": "Noun: دعوت."
+  },
+  "invitation": {
+    "target": "دعوت‌نامه",
+    "note": "Write with ZWNJ; existing files often use دعوت نامه with a space."
+  },
+  "sidebar": {
+    "target": "نوار کناری"
+  },
+  "unread": {
+    "target": "خوانده‌نشده",
+    "note": "Unreads (view): خوانده‌نشده‌ها."
+  },
+  "attachment": {
+    "target": "پیوست",
+    "note": "Strong majority; ضمیمه also appears rarely."
+  },
+  "public channel": {
+    "target": "کانال عمومی"
+  },
+  "private channel": {
+    "target": "کانال خصوصی"
+  },
+  "shared channel": {
+    "target": "کانال مشترک",
+    "note": "Plural: کانال‌های مشترک."
+  },
+  "channel header": {
+    "target": "هدر کانال",
+    "note": "Majority uses the transliteration هدر; mobile uses سربرگ and some webapp strings use سرصفحه — standardize on هدر."
+  },
+  "channel purpose": {
+    "target": "هدف کانال"
+  },
+  "system message": {
+    "target": "پیام سیستم",
+    "note": "Plural: پیام‌های سیستم."
+  },
+  "persistent notification": {
+    "target": "اعلان مداوم",
+    "note": "No existing fa; coined consistently with اعلان for notification."
+  },
+  "message priority": {
+    "target": "اولویت پیام"
+  },
+  "urgent": {
+    "target": "فوری",
+    "note": "Webapp uses فوری, mobile uses ضروری — standardize on فوری."
+  },
+  "recap": {
+    "target": "جمع‌بندی",
+    "note": "No existing fa; جمع‌بندی conveys an activity summary better than plain خلاصه (used for 'summary')."
+  },
+  "agent": {
+    "target": "عامل",
+    "note": "No existing fa. عامل is the standard Persian AI term; in marketing contexts the English 'Agent' may also be left as-is."
+  },
+  "burn-on-read": {
+    "target": "حذف پس از خواندن",
+    "note": "No existing fa. As an adjective/label: پیام حذف‌شونده پس از خواندن; all-caps label BURN ON READ → حذف پس از خواندن."
+  },
+  "magic link": {
+    "target": "پیوند جادویی",
+    "note": "پیوند is the majority rendering for 'link'; لینک جادویی is a common colloquial alternative."
+  },
+  "personal access token": {
+    "target": "توکن دسترسی شخصی",
+    "note": "توکن is the majority rendering; نشانه and رمز also appear — prefer توکن."
+  },
+  "announcement banner": {
+    "target": "بنر اعلامیه",
+    "note": "Existing fa mixes بنر اعلامیه and بنر اطلاعیه; prefer اعلامیه for announcement (اعلان is reserved for notification)."
+  },
+  "channel banner": {
+    "target": "بنر کانال"
+  },
+  "keyword": {
+    "target": "کلیدواژه",
+    "note": "Plural: کلیدواژه‌ها. Write closed with ZWNJ, not کلید واژه."
+  },
+  "user group": {
+    "target": "گروه کاربری",
+    "note": "Plain group: گروه."
+  },
+  "permalink": {
+    "target": "پیوند ثابت"
+  },
+  "profile": {
+    "target": "نمایه",
+    "note": "Majority rendering; مشخصات and پروفایل also appear — prefer نمایه."
+  },
+  "username": {
+    "target": "نام کاربری"
+  },
+  "nickname": {
+    "target": "نام مستعار",
+    "note": "Existing fa is inconsistent (کنیه، لقب); کنیه is archaic — نام مستعار is the standard Persian UI term."
+  },
+  "display name": {
+    "target": "نام نمایشی"
+  },
+  "collapsed reply threads": {
+    "target": "موضوعات پاسخ جمع‌شده",
+    "note": "Mobile's existing rendering (پاسخ گفت‌وگوهای جمع‌شده) is garbled; this follows thread = موضوع."
+  },
+  "auto-translation": {
+    "target": "ترجمه خودکار",
+    "note": "AUTO-TRANSLATED label: ترجمه‌شده به‌صورت خودکار."
+  },
+  "data retention": {
+    "target": "حفظ داده‌ها",
+    "note": "Existing fa mixes حفظ داده‌ها and نگهداری داده‌ها; حفظ has a slight majority. Policy: سیاست حفظ داده‌ها."
+  },
+  "compliance export": {
+    "target": "خروجی انطباق",
+    "note": "Existing fa uses صادرات انطباق, but صادرات implies trade exports; خروجی is the standard Persian for file/data export."
+  },
+  "access control": {
+    "target": "کنترل دسترسی",
+    "note": "One existing webapp string mistranslates this as مدیریت کانال — do not follow it."
+  },
+  "attribute": {
+    "target": "ویژگی",
+    "note": "Custom profile attribute: ویژگی سفارشی نمایه."
+  },
+  "onboarding": {
+    "target": "آشناسازی اولیه",
+    "note": "Existing fa leaves Onboarding in English; آشناسازی اولیه is a natural Persian rendering for the guided first-run experience."
+  },
+  "Town Square": {
+    "target": "میدان شهر",
+    "note": "The existing server rendering دانشگاه (university) is a mistranslation; use میدان شهر consistently as the default channel name."
+  },
+  "Off-Topic": {
+    "target": "بحث آزاد",
+    "note": "Existing server rendering; keep it."
+  },
+  "read-only": {
+    "target": "فقط خواندنی"
+  },
+  "server": {
+    "target": "سرور"
+  }
+}

--- a/i18n/glossary/fa.json
+++ b/i18n/glossary/fa.json
@@ -53,9 +53,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/fa.json
+++ b/i18n/glossary/fa.json
@@ -432,8 +432,7 @@
     "note": "The existing server rendering دانشگاه (university) is a mistranslation; use میدان شهر consistently as the default channel name."
   },
   "Off-Topic": {
-    "target": "بحث آزاد",
-    "note": "Existing server rendering; keep it."
+    "target": "بحث آزاد"
   },
   "read-only": {
     "target": "فقط خواندنی"

--- a/i18n/glossary/fr.json
+++ b/i18n/glossary/fr.json
@@ -1,0 +1,453 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition"
+  },
+  "Team Edition": {
+    "target": "Team Edition"
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "Product name, keep in English; the common noun 'channel' is 'canal'."
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO",
+    "note": "When spelled out, use 'authentification unique (SSO)' per community rules; keep the abbreviation itself."
+  },
+  "MFA": {
+    "target": "MFA",
+    "note": "Spelled out as 'authentification multi-facteurs (MFA)' where needed."
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip",
+    "note": "Weblate glossary allows the clarification 'Bavardage (gossip protocol)'; never translate alone as 'bavardage'."
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "console système",
+    "note": "Feminine. Lowercase in running text per French rules; capitalize only as a menu item ('Console système')."
+  },
+  "marketplace": {
+    "target": "marché",
+    "note": "Masculine. Existing webapp translations consistently use 'marché' (e.g. 'Activer le marché'); the community glossary suggests 'place de marché', which is clearer but not the current majority."
+  },
+  "channel": {
+    "target": "canal",
+    "note": "Masculine; plural 'canaux'. Never 'chaîne' or 'salon'."
+  },
+  "team": {
+    "target": "équipe",
+    "note": "Feminine."
+  },
+  "post": {
+    "target": "message",
+    "note": "General rule from community glossary: translate 'post' as 'message'. Use 'publication' only for the root message of a thread or integration-posted content."
+  },
+  "message": {
+    "target": "message",
+    "note": "Masculine. A user 'envoie' (sends) a message; the system 'publie' (posts) system messages."
+  },
+  "thread": {
+    "target": "fil de discussion",
+    "note": "Masculine. 'fil' alone is acceptable when space is tight or on repeat mentions."
+  },
+  "reply": {
+    "target": "réponse",
+    "note": "Noun: 'réponse' (f.); verb: 'répondre'."
+  },
+  "direct message": {
+    "target": "message personnel",
+    "note": "Webapp/server consistently use 'message personnel'; mobile inconsistently uses 'message direct'. Community rules mandate 'message personnel' and forbid 'message direct'/'DM'."
+  },
+  "group message": {
+    "target": "message de groupe",
+    "note": "Webapp also uses 'conversation de groupe' in places; 'message de groupe' is the community-rules rendering and mobile majority."
+  },
+  "mention": {
+    "target": "mention",
+    "note": "Noun: 'mention' (f.); verb: 'mentionner'."
+  },
+  "notification": {
+    "target": "notification",
+    "note": "Feminine. Order: 'notification par e-mail', 'notifications push' — put 'notification' first per community rules."
+  },
+  "pin": {
+    "target": "épingler",
+    "note": "'messages épinglés' for pinned messages; unpin: 'désépingler'."
+  },
+  "bookmark": {
+    "target": "marque-page",
+    "note": "Masculine; plural 'marque-pages'. Verb: 'ajouter un marque-page'."
+  },
+  "saved messages": {
+    "target": "messages marqués",
+    "note": "Webapp majority is 'messages marqués' (legacy of 'flagged'); mobile uses 'messages enregistrés', which matches the save='enregistrer' rule and may be the better long-term choice. Verb save: 'enregistrer'."
+  },
+  "draft": {
+    "target": "brouillon",
+    "note": "Masculine."
+  },
+  "scheduled post": {
+    "target": "message planifié",
+    "note": "Majority rendering; 'programmé' also appears (esp. verb 'programmer le brouillon'). Pick one per surface but stay consistent."
+  },
+  "emoji": {
+    "target": "émoticône",
+    "note": "Feminine. Community rules prefer 'émoticône' over 'emoji'."
+  },
+  "custom emoji": {
+    "target": "émoticône personnalisée",
+    "note": "Feminine agreement."
+  },
+  "reaction": {
+    "target": "réaction",
+    "note": "Feminine. Verb react: 'réagir'."
+  },
+  "status": {
+    "target": "statut",
+    "note": "'statut' for user availability; existing translations use 'état' for system/job status."
+  },
+  "custom status": {
+    "target": "statut personnalisé"
+  },
+  "do not disturb": {
+    "target": "Ne pas déranger"
+  },
+  "away": {
+    "target": "absent",
+    "note": "Agreement: 'absent(e)' when referring to a specific user; mobile uses 'Absent(e)' in places."
+  },
+  "online": {
+    "target": "en ligne"
+  },
+  "offline": {
+    "target": "hors ligne"
+  },
+  "out of office": {
+    "target": "absent du bureau",
+    "note": "As a status label: « Absent du bureau »."
+  },
+  "guest": {
+    "target": "utilisateur invité",
+    "note": "Community rules mandate 'utilisateur invité' (not 'invité' alone) to avoid awkward phrases like 'inviter des invités'."
+  },
+  "member": {
+    "target": "membre",
+    "note": "Masculine."
+  },
+  "user": {
+    "target": "utilisateur",
+    "note": "Masculine; 'le masculin l'emporte' per community rules — no inclusive middot forms."
+  },
+  "system admin": {
+    "target": "administrateur système",
+    "note": "Plural: 'administrateurs système' (invariable 'système') per community rules."
+  },
+  "team admin": {
+    "target": "administrateur d'équipe"
+  },
+  "channel admin": {
+    "target": "administrateur de canal"
+  },
+  "session": {
+    "target": "session",
+    "note": "Feminine."
+  },
+  "sign in": {
+    "target": "se connecter",
+    "note": "Noun/label: 'Connexion'. Translate 'log in' identically."
+  },
+  "sign out": {
+    "target": "se déconnecter",
+    "note": "Noun/label: 'Déconnexion'. Translate 'log out' identically."
+  },
+  "join": {
+    "target": "rejoindre",
+    "note": "For channels/teams/calls. 'joindre' is reserved for attaching files per community rules."
+  },
+  "leave": {
+    "target": "quitter"
+  },
+  "archive": {
+    "target": "archiver",
+    "note": "Adjective: 'archivé'."
+  },
+  "unarchive": {
+    "target": "désarchiver"
+  },
+  "mute": {
+    "target": "mettre en sourdine",
+    "note": "Channel notifications context. Muted: 'en sourdine'; unmute: 'réactiver' or 'enlever la sourdine'."
+  },
+  "follow": {
+    "target": "suivre"
+  },
+  "unfollow": {
+    "target": "ne plus suivre"
+  },
+  "favorite": {
+    "target": "favori",
+    "note": "Noun: 'favori' (m.); category: 'Favoris'. Verb: 'mettre en favori' / 'ajouter aux favoris'."
+  },
+  "search": {
+    "target": "recherche",
+    "note": "Noun: 'recherche' (f.); verb/button: 'rechercher'."
+  },
+  "integration": {
+    "target": "intégration",
+    "note": "Feminine."
+  },
+  "slash command": {
+    "target": "commande slash",
+    "note": "Community-rules rendering; do not translate 'slash'."
+  },
+  "webhook": {
+    "target": "webhook",
+    "note": "Kept in English (masculine) — consistent across 60+ existing strings."
+  },
+  "incoming webhook": {
+    "target": "webhook entrant"
+  },
+  "outgoing webhook": {
+    "target": "webhook sortant"
+  },
+  "trigger word": {
+    "target": "mot-clé déclencheur",
+    "note": "Community-rules rendering; 'mot déclencheur' also appears in server strings."
+  },
+  "plugin": {
+    "target": "plugin",
+    "note": "Kept in English (masculine) per Weblate glossary and existing translations."
+  },
+  "bot": {
+    "target": "bot",
+    "note": "Kept in English per community rules."
+  },
+  "role": {
+    "target": "rôle",
+    "note": "Masculine."
+  },
+  "permission": {
+    "target": "permission",
+    "note": "Feminine. Community rules mandate 'permission' (not 'droit' or 'autorisation') for role capabilities."
+  },
+  "scheme": {
+    "target": "schéma de permissions",
+    "note": "Permission-scheme sense per community rules. For URI/URL scheme use 'protocole URL' instead."
+  },
+  "license": {
+    "target": "licence",
+    "note": "Feminine."
+  },
+  "seat": {
+    "target": "siège",
+    "note": "Masculine; existing billing strings use 'sièges'."
+  },
+  "trial": {
+    "target": "essai",
+    "note": "Masculine; free trial: 'essai gratuit'."
+  },
+  "workspace": {
+    "target": "espace de travail",
+    "note": "Masculine."
+  },
+  "subscription": {
+    "target": "abonnement",
+    "note": "Masculine."
+  },
+  "deactivate": {
+    "target": "désactiver",
+    "note": "Deactivated: 'désactivé'."
+  },
+  "invite": {
+    "target": "inviter",
+    "note": "Verb: 'inviter'; noun: 'invitation' (f.)."
+  },
+  "invitation": {
+    "target": "invitation",
+    "note": "'invitation par e-mail' (never 'adresse électronique' — use 'e-mail')."
+  },
+  "sidebar": {
+    "target": "barre latérale",
+    "note": "Feminine."
+  },
+  "unread": {
+    "target": "non lu",
+    "note": "No hyphen per community rules; plural 'non lus'."
+  },
+  "attachment": {
+    "target": "pièce jointe",
+    "note": "Feminine. Verb attach (files): 'joindre'."
+  },
+  "public channel": {
+    "target": "canal public"
+  },
+  "private channel": {
+    "target": "canal privé"
+  },
+  "shared channel": {
+    "target": "canal partagé"
+  },
+  "channel header": {
+    "target": "en-tête du canal",
+    "note": "Masculine. Webapp uses 'en-tête'; older server/mobile strings use 'entête' — prefer 'en-tête'."
+  },
+  "channel purpose": {
+    "target": "description du canal",
+    "note": "Community rules translate 'purpose' as 'description' in this context, not 'objet' or 'but'."
+  },
+  "system message": {
+    "target": "message système"
+  },
+  "persistent notification": {
+    "target": "notification persistante"
+  },
+  "message priority": {
+    "target": "priorité du message"
+  },
+  "urgent": {
+    "target": "urgent",
+    "note": "Label: 'Urgent'; feminine agreement 'priorité urgente' when qualifying 'priorité'."
+  },
+  "recap": {
+    "target": "récapitulatif",
+    "note": "No existing French translation yet (new AI feature); 'récapitulatif' (m.) is the natural rendering, 'résumé' being reserved for 'summary'."
+  },
+  "agent": {
+    "target": "agent",
+    "note": "Masculine; same word in French for AI agents."
+  },
+  "burn-on-read": {
+    "target": "à autodestruction après lecture",
+    "note": "No existing French translation yet. For short badges (BURN ON READ) 'AUTODESTRUCTION' may be needed for space."
+  },
+  "magic link": {
+    "target": "lien magique",
+    "note": "No existing translation yet; 'lien magique' is the established rendering in French SaaS (Slack, Notion)."
+  },
+  "personal access token": {
+    "target": "jeton d'accès personnel",
+    "note": "'token' is always 'jeton' per community rules."
+  },
+  "announcement banner": {
+    "target": "bannière d'annonce"
+  },
+  "channel banner": {
+    "target": "bannière de canal"
+  },
+  "keyword": {
+    "target": "mot-clé",
+    "note": "Masculine; plural 'mots-clés'."
+  },
+  "user group": {
+    "target": "groupe d'utilisateurs"
+  },
+  "permalink": {
+    "target": "lien permanent",
+    "note": "Masculine."
+  },
+  "profile": {
+    "target": "profil",
+    "note": "Masculine."
+  },
+  "username": {
+    "target": "nom d'utilisateur"
+  },
+  "nickname": {
+    "target": "pseudo",
+    "note": "Existing user-settings label; 'surnom' appears in some admin strings — prefer 'pseudo' for the profile field."
+  },
+  "display name": {
+    "target": "nom d'affichage",
+    "note": "'nom affiché' also appears; prefer 'nom d'affichage' (desktop and admin majority)."
+  },
+  "collapsed reply threads": {
+    "target": "fils de discussion repliables",
+    "note": "Weblate glossary rendering; singular 'fil de discussion repliable'. Mobile has older inconsistent renderings."
+  },
+  "auto-translation": {
+    "target": "traduction automatique",
+    "note": "AUTO-TRANSLATED label: 'TRADUIT AUTOMATIQUEMENT'."
+  },
+  "data retention": {
+    "target": "rétention des données",
+    "note": "Admin console uses 'rétention des données'; 'conservation de données' also appears — prefer 'rétention'."
+  },
+  "compliance export": {
+    "target": "export de conformité",
+    "note": "Existing strings vary ('vérification de conformité de l'exportation' is a mistranslation); 'export de conformité' matches the feature."
+  },
+  "access control": {
+    "target": "contrôle d'accès",
+    "note": "Policy: 'politique de contrôle d'accès'."
+  },
+  "attribute": {
+    "target": "attribut",
+    "note": "Masculine."
+  },
+  "onboarding": {
+    "target": "intégration",
+    "note": "'processus d'intégration' in existing admin strings; avoid 'inscription' which appears once and means registration."
+  },
+  "Town Square": {
+    "target": "Centre-ville",
+    "note": "Established default-channel name in server fr.json; keep consistently."
+  },
+  "Off-Topic": {
+    "target": "Hors-sujet",
+    "note": "Established default-channel name in server fr.json."
+  },
+  "read-only": {
+    "target": "en lecture seule"
+  },
+  "server": {
+    "target": "serveur",
+    "note": "Masculine."
+  }
+}

--- a/i18n/glossary/fr.json
+++ b/i18n/glossary/fr.json
@@ -42,7 +42,7 @@
   },
   "MFA": {
     "target": "MFA",
-    "note": "Spelled out as 'authentification multi-facteurs (MFA)' where needed."
+    "note": "Spelled out as 'authentification multifacteur (MFA)' where needed."
   },
   "OpenID Connect": {
     "target": "OpenID Connect"

--- a/i18n/glossary/fr.json
+++ b/i18n/glossary/fr.json
@@ -56,9 +56,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip",
     "note": "Weblate glossary allows the clarification 'Bavardage (gossip protocol)'; never translate alone as 'bavardage'."

--- a/i18n/glossary/fr.json
+++ b/i18n/glossary/fr.json
@@ -74,8 +74,8 @@
     "note": "Feminine. Lowercase in running text per French rules; capitalize only as a menu item ('Console système')."
   },
   "marketplace": {
-    "target": "marché",
-    "note": "Masculine. Existing webapp translations consistently use 'marché' (e.g. 'Activer le marché'); the community glossary suggests 'place de marché', which is clearer but not the current majority."
+    "target": "place de marché",
+    "note": "Masculine 'marché' alone means a physical market. Webapp strings use bare 'marché'; server strings already use 'place de marché'."
   },
   "channel": {
     "target": "canal",

--- a/i18n/glossary/fr.json
+++ b/i18n/glossary/fr.json
@@ -266,8 +266,7 @@
     "note": "Kept in English (masculine) per Weblate glossary and existing translations."
   },
   "bot": {
-    "target": "bot",
-    "note": "Kept in English per community rules."
+    "target": "bot"
   },
   "role": {
     "target": "rôle",

--- a/i18n/glossary/fr.json
+++ b/i18n/glossary/fr.json
@@ -38,7 +38,7 @@
   },
   "SSO": {
     "target": "SSO",
-    "note": "When spelled out, use 'authentification unique (SSO)' per community rules; keep the abbreviation itself."
+    "note": "When spelled out, use 'authentification unique (SSO)'; keep the abbreviation itself."
   },
   "MFA": {
     "target": "MFA",
@@ -58,7 +58,7 @@
   },
   "Gossip": {
     "target": "Gossip",
-    "note": "Weblate glossary allows the clarification 'Bavardage (gossip protocol)'; never translate alone as 'bavardage'."
+    "note": "The clarification 'Bavardage (gossip protocol)' is acceptable; never translate alone as 'bavardage'."
   },
   "Actiance XML": {
     "target": "Actiance XML"
@@ -68,7 +68,7 @@
   },
   "System Console": {
     "target": "console système",
-    "note": "Feminine. Lowercase in running text per French rules; capitalize only as a menu item ('Console système')."
+    "note": "Feminine. Lowercase in running text; capitalize only as a menu item ('Console système')."
   },
   "marketplace": {
     "target": "place de marché",
@@ -84,7 +84,7 @@
   },
   "post": {
     "target": "message",
-    "note": "General rule from community glossary: translate 'post' as 'message'. Use 'publication' only for the root message of a thread or integration-posted content."
+    "note": "Use 'publication' only for the root message of a thread or integration-posted content."
   },
   "message": {
     "target": "message",
@@ -100,7 +100,7 @@
   },
   "direct message": {
     "target": "message personnel",
-    "note": "Webapp/server consistently use 'message personnel'; mobile inconsistently uses 'message direct'. Community rules mandate 'message personnel' and forbid 'message direct'/'DM'."
+    "note": "Webapp/server consistently use 'message personnel'; mobile inconsistently uses 'message direct'. Never 'message direct' or 'DM'."
   },
   "group message": {
     "target": "message de groupe",
@@ -112,7 +112,7 @@
   },
   "notification": {
     "target": "notification",
-    "note": "Feminine. Order: 'notification par e-mail', 'notifications push' — put 'notification' first per community rules."
+    "note": "Feminine. Order: 'notification par e-mail', 'notifications push' — put 'notification' first."
   },
   "pin": {
     "target": "épingler",
@@ -136,7 +136,7 @@
   },
   "emoji": {
     "target": "émoticône",
-    "note": "Feminine. Community rules prefer 'émoticône' over 'emoji'."
+    "note": "Feminine. Not 'emoji'."
   },
   "custom emoji": {
     "target": "émoticône personnalisée",
@@ -172,7 +172,7 @@
   },
   "guest": {
     "target": "utilisateur invité",
-    "note": "Community rules mandate 'utilisateur invité' (not 'invité' alone) to avoid awkward phrases like 'inviter des invités'."
+    "note": "Not 'invité' alone, which produces awkward phrases like 'inviter des invités'."
   },
   "member": {
     "target": "membre",
@@ -180,11 +180,11 @@
   },
   "user": {
     "target": "utilisateur",
-    "note": "Masculine; 'le masculin l'emporte' per community rules — no inclusive middot forms."
+    "note": "Masculine; no inclusive middot forms."
   },
   "system admin": {
     "target": "administrateur système",
-    "note": "Plural: 'administrateurs système' (invariable 'système') per community rules."
+    "note": "Plural: 'administrateurs système' (invariable 'système')."
   },
   "team admin": {
     "target": "administrateur d'équipe"
@@ -206,7 +206,7 @@
   },
   "join": {
     "target": "rejoindre",
-    "note": "For channels/teams/calls. 'joindre' is reserved for attaching files per community rules."
+    "note": "For channels/teams/calls. 'joindre' is reserved for attaching files."
   },
   "leave": {
     "target": "quitter"
@@ -260,7 +260,7 @@
   },
   "plugin": {
     "target": "plugin",
-    "note": "Kept in English (masculine) per Weblate glossary and existing translations."
+    "note": "Kept in English (masculine)."
   },
   "bot": {
     "target": "bot"
@@ -271,11 +271,11 @@
   },
   "permission": {
     "target": "permission",
-    "note": "Feminine. Community rules mandate 'permission' (not 'droit' or 'autorisation') for role capabilities."
+    "note": "Feminine. Not 'droit' or 'autorisation' for role capabilities."
   },
   "scheme": {
     "target": "schéma de permissions",
-    "note": "Permission-scheme sense per community rules. For URI/URL scheme use 'protocole URL' instead."
+    "note": "Permission-scheme sense. For URI/URL scheme use 'protocole URL' instead."
   },
   "license": {
     "target": "licence",
@@ -315,7 +315,7 @@
   },
   "unread": {
     "target": "non lu",
-    "note": "No hyphen per community rules; plural 'non lus'."
+    "note": "No hyphen; plural 'non lus'."
   },
   "attachment": {
     "target": "pièce jointe",
@@ -336,7 +336,7 @@
   },
   "channel purpose": {
     "target": "description du canal",
-    "note": "Community rules translate 'purpose' as 'description' in this context, not 'objet' or 'but'."
+    "note": "'purpose' is 'description' in this context, not 'objet' or 'but'."
   },
   "system message": {
     "target": "message système"
@@ -369,7 +369,7 @@
   },
   "personal access token": {
     "target": "jeton d'accès personnel",
-    "note": "'token' is always 'jeton' per community rules."
+    "note": "'token' is always 'jeton'."
   },
   "announcement banner": {
     "target": "bannière d'annonce"
@@ -405,7 +405,7 @@
   },
   "collapsed reply threads": {
     "target": "fils de discussion repliables",
-    "note": "Weblate glossary rendering; singular 'fil de discussion repliable'. Mobile has older inconsistent renderings."
+    "note": "Singular 'fil de discussion repliable'. Mobile has older inconsistent renderings."
   },
   "auto-translation": {
     "target": "traduction automatique",

--- a/i18n/glossary/hu.json
+++ b/i18n/glossary/hu.json
@@ -1,0 +1,445 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition",
+    "note": "Repo sometimes shows 'Enterprise Kiadás'; keep the English product name."
+  },
+  "Team Edition": {
+    "target": "Team Edition",
+    "note": "Repo shows 'Team kiadás'; keep the English product name, 'kiadás' (edition) may follow as a common noun."
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels"
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "Rendszerkonzol",
+    "note": "Consistently one word in the repo (Rendszerkonzol); lowercase 'rendszerkonzol' mid-sentence."
+  },
+  "marketplace": {
+    "target": "piactér",
+    "note": "Established in webapp ('Piactér engedélyezése'); capitalize as Piactér when used as a named UI area."
+  },
+  "channel": {
+    "target": "csatorna",
+    "note": "Majority rendering. Some legacy mobile/webapp strings use 'beszélgetés' (conversation) — do not follow; use 'csatorna' consistently."
+  },
+  "team": {
+    "target": "csapat"
+  },
+  "post": {
+    "target": "bejegyzés",
+    "note": "Established; distinct from 'üzenet' (message) even though English uses them interchangeably."
+  },
+  "message": {
+    "target": "üzenet"
+  },
+  "thread": {
+    "target": "üzenetszál",
+    "note": "Established compound; plural 'üzenetszálak'."
+  },
+  "reply": {
+    "target": "válasz",
+    "note": "Noun 'válasz'; verb 'válaszol' (e.g. 'Válasz erre az üzenetszálra')."
+  },
+  "direct message": {
+    "target": "közvetlen üzenet",
+    "note": "Established; do not use 'privát üzenet'."
+  },
+  "group message": {
+    "target": "csoportos üzenet"
+  },
+  "mention": {
+    "target": "említés",
+    "note": "Noun 'említés'; verb 'megemlít'."
+  },
+  "notification": {
+    "target": "értesítés"
+  },
+  "pin": {
+    "target": "kitűz",
+    "note": "Verb 'kitűz', noun/adjective 'kitűzött' (e.g. 'Kitűzött üzenetek'); unpin = 'kitűzés eltávolítása' or 'levesz'."
+  },
+  "bookmark": {
+    "target": "könyvjelző",
+    "note": "Established in mobile; verb: 'könyvjelző hozzáadása'."
+  },
+  "saved messages": {
+    "target": "mentett üzenetek",
+    "note": "Mobile/Playbooks use 'mentett üzenetek'; webapp sometimes 'mentett bejegyzések' — prefer 'mentett üzenetek'. save = 'mentés', unsave = 'eltávolítás a mentettek közül'."
+  },
+  "draft": {
+    "target": "piszkozat",
+    "note": "Mobile uses 'piszkozat'; server has legacy 'tervezet' — prefer 'piszkozat'."
+  },
+  "scheduled post": {
+    "target": "időzített bejegyzés",
+    "note": "Established in mobile ('Időzített bejegyzés törlése'); scheduled message = 'időzített üzenet'."
+  },
+  "emoji": {
+    "target": "emoji",
+    "note": "Kept as 'emoji' in Hungarian; plural 'emojik'."
+  },
+  "custom emoji": {
+    "target": "egyéni emoji"
+  },
+  "reaction": {
+    "target": "reakció",
+    "note": "Verb react = 'reagál'."
+  },
+  "status": {
+    "target": "állapot"
+  },
+  "custom status": {
+    "target": "egyéni állapot"
+  },
+  "do not disturb": {
+    "target": "Ne zavarj",
+    "note": "Established status name; keep as a quoted status label ('Ne zavarj')."
+  },
+  "away": {
+    "target": "Nincs a gépnél",
+    "note": "Established status name; 'távol' appears occasionally but 'Nincs a gépnél' is the majority rendering."
+  },
+  "online": {
+    "target": "Elérhető",
+    "note": "Established status name."
+  },
+  "offline": {
+    "target": "Nem elérhető",
+    "note": "Established status name; lowercase 'nem elérhető' mid-sentence."
+  },
+  "out of office": {
+    "target": "Irodán kívül",
+    "note": "Established status name."
+  },
+  "guest": {
+    "target": "vendég"
+  },
+  "member": {
+    "target": "tag"
+  },
+  "user": {
+    "target": "felhasználó"
+  },
+  "system admin": {
+    "target": "rendszergazda",
+    "note": "Established; 'rendszer adminisztrátor' appears in legacy server strings — prefer 'rendszergazda'."
+  },
+  "team admin": {
+    "target": "csapat admin",
+    "note": "Webapp majority is 'Csapat admin'; mobile has 'csapatadminisztrátor'. Follow the majority."
+  },
+  "channel admin": {
+    "target": "csatorna admin"
+  },
+  "session": {
+    "target": "munkamenet"
+  },
+  "sign in": {
+    "target": "bejelentkezés",
+    "note": "Verb: 'bejelentkezik'; imperative in UI: 'Jelentkezzen be' (formal Ön register is used throughout). Translate 'log in' identically."
+  },
+  "sign out": {
+    "target": "kijelentkezés",
+    "note": "Verb: 'kijelentkezik'; translate 'log out' identically."
+  },
+  "join": {
+    "target": "csatlakozás",
+    "note": "Verb: 'csatlakozik' + -hoz/-hez (e.g. 'Csatlakozás a csatornához')."
+  },
+  "leave": {
+    "target": "kilépés",
+    "note": "Verb: 'kilép' + -ból/-ből (e.g. 'Kilépés a csatornából')."
+  },
+  "archive": {
+    "target": "archiválás",
+    "note": "Verb: 'archivál'; adjective: 'archivált'."
+  },
+  "unarchive": {
+    "target": "visszaállítás",
+    "note": "Webapp uses 'visszaállítás'; mobile has 'visszaaktiválás' — prefer 'visszaállítás'."
+  },
+  "mute": {
+    "target": "némítás",
+    "note": "Verb: 'némít' / 'elnémít'; unmute = 'némítás feloldása'. Channel-notification sense; same word family as Calls mute."
+  },
+  "follow": {
+    "target": "követés",
+    "note": "Verb: 'követ' (e.g. 'Üzenetszál követése')."
+  },
+  "unfollow": {
+    "target": "követés kikapcsolása",
+    "note": "Webapp: 'követés kikapcsolása'; mobile: 'követés visszavonása' — prefer the webapp form."
+  },
+  "favorite": {
+    "target": "kedvenc",
+    "note": "Noun 'kedvenc', category 'Kedvencek'; verb 'kedvencnek jelöl', unfavorite = 'eltávolítás a kedvencekből'."
+  },
+  "search": {
+    "target": "keresés",
+    "note": "Verb: 'keres'."
+  },
+  "integration": {
+    "target": "integráció",
+    "note": "Repo shows minor inconsistency ('integrálás' once); use 'integráció'."
+  },
+  "slash command": {
+    "target": "perjel parancs",
+    "note": "Majority in webapp; 'perjeles parancs' also appears (Playbooks). Prefer 'perjel parancs'."
+  },
+  "webhook": {
+    "target": "webhook",
+    "note": "Kept in English in webapp/server (majority). Playbooks legacy uses 'webhorog' — do not follow; use 'webhook'."
+  },
+  "incoming webhook": {
+    "target": "bejövő webhook"
+  },
+  "outgoing webhook": {
+    "target": "kimenő webhook"
+  },
+  "trigger word": {
+    "target": "kulcsszó",
+    "note": "Established repo rendering, although it collides with 'keyword' (also 'kulcsszó'). If disambiguation is needed, 'aktiváló szó' may be used, but repo convention is 'kulcsszó'."
+  },
+  "plugin": {
+    "target": "bővítmény",
+    "note": "Majority; 'plugin' and 'kiegészítő' appear sporadically — use 'bővítmény'."
+  },
+  "bot": {
+    "target": "bot",
+    "note": "Kept as 'bot'; bot account = 'bot fiók'."
+  },
+  "role": {
+    "target": "szerepkör"
+  },
+  "permission": {
+    "target": "jogosultság"
+  },
+  "scheme": {
+    "target": "séma",
+    "note": "Permission scheme = 'jogosultság séma'."
+  },
+  "license": {
+    "target": "licenc",
+    "note": "Spelling 'licenc' (not 'licensz'/'license'); minor misspellings exist in repo."
+  },
+  "seat": {
+    "target": "felhasználói hely",
+    "note": "No existing repo rendering; 'felhasználói hely' is the common Hungarian SaaS term for a licensed seat."
+  },
+  "trial": {
+    "target": "próbaidőszak",
+    "note": "Established; free trial = 'ingyenes próbaidőszak'."
+  },
+  "workspace": {
+    "target": "munkaterület"
+  },
+  "subscription": {
+    "target": "előfizetés"
+  },
+  "deactivate": {
+    "target": "deaktivál",
+    "note": "Majority 'deaktivál' (Fiók deaktiválása); 'letilt' also appears for accounts — reserve 'letilt' for disable."
+  },
+  "invite": {
+    "target": "meghívás",
+    "note": "Verb: 'meghív'; noun act: 'meghívás'."
+  },
+  "invitation": {
+    "target": "meghívó",
+    "note": "The email/link artifact is 'meghívó' (invitation), distinct from the act 'meghívás'."
+  },
+  "sidebar": {
+    "target": "oldalsáv"
+  },
+  "unread": {
+    "target": "olvasatlan"
+  },
+  "attachment": {
+    "target": "melléklet",
+    "note": "Majority; 'csatolmány' also appears — prefer 'melléklet'."
+  },
+  "public channel": {
+    "target": "nyilvános csatorna"
+  },
+  "private channel": {
+    "target": "privát csatorna",
+    "note": "Majority; 'magán csatorna' appears sporadically — use 'privát csatorna'."
+  },
+  "shared channel": {
+    "target": "megosztott csatorna"
+  },
+  "channel header": {
+    "target": "csatorna fejléce",
+    "note": "Short UI label: 'Fejléc'."
+  },
+  "channel purpose": {
+    "target": "csatorna célja",
+    "note": "Short UI label: 'Cél'."
+  },
+  "system message": {
+    "target": "rendszerüzenet"
+  },
+  "persistent notification": {
+    "target": "tartós értesítés",
+    "note": "Server majority; 'állandó értesítés' appears once — prefer 'tartós értesítés'."
+  },
+  "message priority": {
+    "target": "üzenet prioritása",
+    "note": "No established repo rendering; label form 'Üzenet prioritása'. Priority levels: Standard = 'Normál', Important = 'Fontos', Urgent = 'Sürgős'."
+  },
+  "urgent": {
+    "target": "sürgős",
+    "note": "Established ('Sürgős'); as a red label: 'SÜRGŐS'."
+  },
+  "recap": {
+    "target": "összefoglaló",
+    "note": "No repo signal; 'összefoglaló' (summary) is the natural Hungarian term for an AI recap."
+  },
+  "agent": {
+    "target": "ügynök",
+    "note": "Established in mobile ('Ügynök kiválasztása', 'MI ügynök')."
+  },
+  "burn-on-read": {
+    "target": "olvasás után megsemmisülő",
+    "note": "Mobile label uses 'MEGSEMMISÍTÉS OLVASÁS UTÁN' for the BURN ON READ badge; adjectival form 'olvasás után megsemmisülő üzenet'."
+  },
+  "magic link": {
+    "target": "varázslink",
+    "note": "No repo signal; 'varázslink' is the common Hungarian rendering for passwordless sign-in links."
+  },
+  "personal access token": {
+    "target": "személyes hozzáférési token",
+    "note": "Established in server strings."
+  },
+  "announcement banner": {
+    "target": "közlemény banner",
+    "note": "Webapp majority ('közlemény banneren'); 'bejelentés banner' appears once. 'Banner' is kept in Hungarian."
+  },
+  "channel banner": {
+    "target": "csatorna banner"
+  },
+  "keyword": {
+    "target": "kulcsszó",
+    "note": "Same word as the repo rendering of 'trigger word'; context disambiguates."
+  },
+  "user group": {
+    "target": "felhasználói csoport",
+    "note": "Plain 'group' = 'csoport'."
+  },
+  "permalink": {
+    "target": "állandó hivatkozás",
+    "note": "No consistent repo rendering (one instance loosely translated as 'link'); 'állandó hivatkozás' is the standard Hungarian term."
+  },
+  "profile": {
+    "target": "profil"
+  },
+  "username": {
+    "target": "felhasználónév"
+  },
+  "nickname": {
+    "target": "becenév"
+  },
+  "display name": {
+    "target": "megjelenítési név"
+  },
+  "collapsed reply threads": {
+    "target": "összecsukott válaszszálak",
+    "note": "Established in mobile."
+  },
+  "auto-translation": {
+    "target": "automatikus fordítás",
+    "note": "Adjective 'automatikusan fordított'; badge form 'AUTOMATIKUSAN FORDÍTVA'."
+  },
+  "data retention": {
+    "target": "adatmegőrzés",
+    "note": "Policy = 'adatmegőrzési szabályzat'; written as one compound ('adatmegőrzés'), though the repo occasionally splits it."
+  },
+  "compliance export": {
+    "target": "megfelelőségi export",
+    "note": "Repo has occasional misspelling 'megfelelősségi' — correct form is 'megfelelőségi'."
+  },
+  "access control": {
+    "target": "hozzáférés-vezérlés",
+    "note": "Webapp once rendered 'Advanced Access Control' as 'Csatorna moderáció' (legacy, do not follow). Use the standard 'hozzáférés-vezérlés'; policy = 'hozzáférés-vezérlési szabályzat'."
+  },
+  "attribute": {
+    "target": "attribútum"
+  },
+  "onboarding": {
+    "target": "bevezetés",
+    "note": "Repo is inconsistent ('üdvözlő varázsló', 'rendszerbeállítás'); 'bevezetés' is a safe general term, 'üdvözlő varázsló' acceptable for the setup wizard specifically."
+  },
+  "Town Square": {
+    "target": "Főtér",
+    "note": "Established default-channel name in server i18n."
+  },
+  "Off-Topic": {
+    "target": "Egyebek",
+    "note": "Established default-channel name in server i18n."
+  },
+  "read-only": {
+    "target": "csak olvasható",
+    "note": "Majority; 'írásvédett' also appears — prefer 'csak olvasható'."
+  },
+  "server": {
+    "target": "szerver",
+    "note": "Majority in webapp/server; 'kiszolgáló' also widely used (especially mobile). Prefer 'szerver' for core product; keep consistency within a given surface."
+  }
+}

--- a/i18n/glossary/hu.json
+++ b/i18n/glossary/hu.json
@@ -55,9 +55,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/hu.json
+++ b/i18n/glossary/hu.json
@@ -149,24 +149,21 @@
     "target": "egyéni állapot"
   },
   "do not disturb": {
-    "target": "Ne zavarj",
-    "note": "Established status name; keep as a quoted status label ('Ne zavarj')."
+    "target": "Ne zavarj"
   },
   "away": {
     "target": "Nincs a gépnél",
     "note": "Established status name; 'távol' appears occasionally but 'Nincs a gépnél' is the majority rendering."
   },
   "online": {
-    "target": "Elérhető",
-    "note": "Established status name."
+    "target": "Elérhető"
   },
   "offline": {
     "target": "Nem elérhető",
     "note": "Established status name; lowercase 'nem elérhető' mid-sentence."
   },
   "out of office": {
-    "target": "Irodán kívül",
-    "note": "Established status name."
+    "target": "Irodán kívül"
   },
   "guest": {
     "target": "vendég"
@@ -345,8 +342,7 @@
     "note": "No established repo rendering; label form 'Üzenet prioritása'. Priority levels: Standard = 'Normál', Important = 'Fontos', Urgent = 'Sürgős'."
   },
   "urgent": {
-    "target": "sürgős",
-    "note": "Established ('Sürgős'); as a red label: 'SÜRGŐS'."
+    "target": "sürgős"
   },
   "recap": {
     "target": "összefoglaló",
@@ -365,8 +361,7 @@
     "note": "No repo signal; 'varázslink' is the common Hungarian rendering for passwordless sign-in links."
   },
   "personal access token": {
-    "target": "személyes hozzáférési token",
-    "note": "Established in server strings."
+    "target": "személyes hozzáférési token"
   },
   "announcement banner": {
     "target": "közlemény banner",
@@ -400,8 +395,7 @@
     "target": "megjelenítési név"
   },
   "collapsed reply threads": {
-    "target": "összecsukott válaszszálak",
-    "note": "Established in mobile."
+    "target": "összecsukott válaszszálak"
   },
   "auto-translation": {
     "target": "automatikus fordítás",
@@ -427,12 +421,10 @@
     "note": "Repo is inconsistent ('üdvözlő varázsló', 'rendszerbeállítás'); 'bevezetés' is a safe general term, 'üdvözlő varázsló' acceptable for the setup wizard specifically."
   },
   "Town Square": {
-    "target": "Főtér",
-    "note": "Established default-channel name in server i18n."
+    "target": "Főtér"
   },
   "Off-Topic": {
-    "target": "Egyebek",
-    "note": "Established default-channel name in server i18n."
+    "target": "Egyebek"
   },
   "read-only": {
     "target": "csak olvasható",

--- a/i18n/glossary/it.json
+++ b/i18n/glossary/it.json
@@ -1,0 +1,460 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition",
+    "note": "Legacy webapp string 'Edizione squadra' exists for Team Edition, but edition names are product names; keep in English."
+  },
+  "Team Edition": {
+    "target": "Team Edition",
+    "note": "Legacy strings render this as 'Edizione squadra'/'Edizione Team'; as a product name it should stay in English."
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "Product name; do not confuse with the common noun 'canali'."
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls",
+    "note": "Product name; the common noun 'call' is 'chiamata'."
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "Console di Sistema",
+    "note": "Established rendering in webapp it.json; keep capitalized as a named UI area."
+  },
+  "marketplace": {
+    "target": "Marketplace",
+    "note": "Kept in English in existing translations ('Attiva marketplace', 'URL marketplace'); masculine: 'il Marketplace'."
+  },
+  "channel": {
+    "target": "canale",
+    "note": "Masculine; plural 'canali'."
+  },
+  "team": {
+    "target": "squadra",
+    "note": "Majority rendering in webapp/server (285 occurrences vs 35 for kept 'team'); mobile occasionally keeps 'team' — prefer 'squadra' for consistency. Feminine; plural 'squadre'."
+  },
+  "post": {
+    "target": "pubblicazione",
+    "note": "Established webapp/server rendering (~148 occurrences); mobile often renders 'post' as 'messaggio' since the UI treats them interchangeably. Feminine. Verb 'to post' = 'pubblicare'."
+  },
+  "message": {
+    "target": "messaggio",
+    "note": "Masculine; plural 'messaggi'."
+  },
+  "thread": {
+    "target": "thread",
+    "note": "Kept in English (majority across webapp/mobile/calls); masculine, invariable: 'il thread', 'i thread'. Some older strings use 'discussione' or 'conversazione' — avoid mixing."
+  },
+  "reply": {
+    "target": "risposta",
+    "note": "Noun 'risposta' (feminine); verb 'rispondere', button 'Rispondi'."
+  },
+  "direct message": {
+    "target": "messaggio diretto",
+    "note": "Majority rendering; a few legacy strings use 'Messaggio Privato' — avoid. Sidebar heading 'Messaggi diretti'."
+  },
+  "group message": {
+    "target": "messaggio di gruppo"
+  },
+  "mention": {
+    "target": "citazione",
+    "note": "Majority in webapp/server (42+ occurrences, zero 'menzione' there); newer mobile strings use 'menzione', which is the more standard modern Italian UI term (Slack/Teams) — flagged for possible future unification. Verb: 'citare'."
+  },
+  "notification": {
+    "target": "notifica",
+    "note": "Feminine; plural 'notifiche'."
+  },
+  "pin": {
+    "target": "bloccare",
+    "note": "Existing majority: 'Blocca al canale', 'Pubblicazioni bloccate', 'Sblocca dal canale' (unpin). Newer mobile strings use 'appuntare' ('Messaggi appuntati'), arguably clearer, but 'bloccare' is the established rendering."
+  },
+  "bookmark": {
+    "target": "segnalibro",
+    "note": "No existing signal (channel bookmarks untranslated in it.json); standard Italian UI term. Masculine; verb: 'aggiungere un segnalibro'."
+  },
+  "saved messages": {
+    "target": "messaggi salvati",
+    "note": "Majority rendering; legacy webapp strings use 'contrassegnato' ('Pubblicazioni contrassegnate') — avoid. Verb save = 'salvare', unsave = 'rimuovi dai salvati'."
+  },
+  "draft": {
+    "target": "bozza",
+    "note": "Untranslated in current it.json files; standard Italian term. Feminine; plural 'bozze'."
+  },
+  "scheduled post": {
+    "target": "messaggio programmato",
+    "note": "Untranslated in current it.json; 'programmato' matches standard Italian UI convention (e.g. Slack/Gmail 'invio programmato')."
+  },
+  "emoji": {
+    "target": "emoji",
+    "note": "Invariable. Existing strings treat it as feminine ('un'emoji personalizzata') — use feminine consistently."
+  },
+  "custom emoji": {
+    "target": "emoji personalizzata",
+    "note": "Feminine per existing usage; plural 'emoji personalizzate'."
+  },
+  "reaction": {
+    "target": "reazione",
+    "note": "Verb react = 'reagire' ('reagire alla pubblicazione' in existing strings)."
+  },
+  "status": {
+    "target": "stato"
+  },
+  "custom status": {
+    "target": "stato personalizzato"
+  },
+  "do not disturb": {
+    "target": "Non disturbare",
+    "note": "Consistent existing rendering across webapp and mobile."
+  },
+  "away": {
+    "target": "Assente",
+    "note": "Majority rendering; scattered mobile variants ('Via', 'In trasferta', 'non al computer') should be avoided."
+  },
+  "online": {
+    "target": "In linea",
+    "note": "Webapp uses 'In Linea'; mobile sometimes keeps 'Online'. 'In linea' pairs with 'Non in linea' for offline."
+  },
+  "offline": {
+    "target": "Non in linea",
+    "note": "Webapp rendering, pairs with 'In linea'; mobile sometimes keeps 'Offline'."
+  },
+  "out of office": {
+    "target": "Fuori sede",
+    "note": "Webapp majority; mobile uses 'Fuori ufficio' — prefer 'Fuori sede'."
+  },
+  "guest": {
+    "target": "ospite",
+    "note": "Majority rendering; one legacy string uses 'Visitatori'. Beware collision with Calls 'host' mistranslated as 'ospite' in some Calls strings."
+  },
+  "member": {
+    "target": "membro",
+    "note": "Masculine; plural 'membri'."
+  },
+  "user": {
+    "target": "utente",
+    "note": "Masculine/feminine; plural 'utenti'."
+  },
+  "system admin": {
+    "target": "amministratore di sistema",
+    "note": "Existing: 'Amministratore di Sistema' (capitalized as a role name in admin UI)."
+  },
+  "team admin": {
+    "target": "amministratore di squadra",
+    "note": "Consistent with team = 'squadra'."
+  },
+  "channel admin": {
+    "target": "amministratore del canale"
+  },
+  "session": {
+    "target": "sessione",
+    "note": "Feminine; 'Sessioni attive' = Active Sessions."
+  },
+  "sign in": {
+    "target": "accedere",
+    "note": "Button/imperative: 'Accedi'. Use for both 'sign in' and 'log in' per existing usage ('Accedi ad un altro Server')."
+  },
+  "sign out": {
+    "target": "uscire",
+    "note": "Existing consistent rendering: 'Esci' for both Log Out and Sign Out. Alternative 'disconnettersi' appears rarely."
+  },
+  "join": {
+    "target": "unirsi (a)",
+    "note": "Existing: 'Unirsi', 'Ti sei unito alla squadra'; button form 'Unisciti'. Calls uses 'partecipare' for joining a call — keep that distinction."
+  },
+  "leave": {
+    "target": "abbandonare",
+    "note": "Existing majority: 'Abbandona canale', 'Abbandona la squadra'."
+  },
+  "archive": {
+    "target": "archiviare",
+    "note": "'Archivia Canale', 'Archiviato' in existing strings."
+  },
+  "unarchive": {
+    "target": "disarchiviare",
+    "note": "Existing: 'Disarchivia'."
+  },
+  "mute": {
+    "target": "silenziare",
+    "note": "For channels: 'Silenzia canale', 'canale silenziato'. Avoid mobile variants 'Muto'/'disattivato'. Unmute = 'riattiva le notifiche' or 'rimuovi silenziamento' (existing mobile)."
+  },
+  "follow": {
+    "target": "seguire",
+    "note": "'Segui il thread', 'Stai seguendo' in existing strings."
+  },
+  "unfollow": {
+    "target": "smettere di seguire",
+    "note": "Button: 'Non seguire più'. Existing mobile renderings are inconsistent ('Thread da non seguire', 'Messaggio di esclusione') — avoid."
+  },
+  "favorite": {
+    "target": "preferito",
+    "note": "Noun/adjective 'preferito'; verb: 'aggiungere ai preferiti', unfavorite: 'rimuovi dai preferiti' (existing)."
+  },
+  "search": {
+    "target": "ricerca",
+    "note": "Noun 'ricerca' (feminine); verb 'cercare', button 'Cerca'."
+  },
+  "integration": {
+    "target": "integrazione"
+  },
+  "slash command": {
+    "target": "comando slash",
+    "note": "Existing: 'Comandi Slash', 'comandi slash integrati'."
+  },
+  "webhook": {
+    "target": "webhook",
+    "note": "Kept in English per existing usage; masculine, invariable: 'il webhook', 'i webhook' (avoid legacy plural 'webhooks' in Italian text)."
+  },
+  "incoming webhook": {
+    "target": "webhook in ingresso"
+  },
+  "outgoing webhook": {
+    "target": "webhook in uscita"
+  },
+  "trigger word": {
+    "target": "parola di attivazione",
+    "note": "Existing strings are inconsistent ('parole di innesco', 'parola chiave', 'parola di esecuzione'); 'parola di attivazione' avoids collision with keyword = 'parola chiave'."
+  },
+  "plugin": {
+    "target": "plugin",
+    "note": "Kept in English; masculine, invariable: 'il plugin', 'i plugin' (avoid legacy 'plugins' plural in Italian text)."
+  },
+  "bot": {
+    "target": "bot",
+    "note": "Kept in English; masculine, invariable. 'Account bot' = bot account (existing)."
+  },
+  "role": {
+    "target": "ruolo",
+    "note": "Masculine; plural 'ruoli'."
+  },
+  "permission": {
+    "target": "permesso",
+    "note": "Existing consistent: 'Permessi', 'Schemi di Permesso'. The alternative 'autorizzazione' is not used in this product."
+  },
+  "scheme": {
+    "target": "schema",
+    "note": "Masculine: 'lo schema', 'gli schemi'; 'Schema di Sistema' = System Scheme (existing)."
+  },
+  "license": {
+    "target": "licenza"
+  },
+  "seat": {
+    "target": "postazione",
+    "note": "No existing signal; standard Italian licensing term for per-user seats. Feminine; plural 'postazioni'."
+  },
+  "trial": {
+    "target": "periodo di prova",
+    "note": "Majority rendering ('prova gratuita' for free trial); a couple of legacy strings keep 'trial' — avoid."
+  },
+  "workspace": {
+    "target": "spazio di lavoro",
+    "note": "Majority rendering; one legacy string uses 'area di lavoro' — avoid."
+  },
+  "subscription": {
+    "target": "abbonamento",
+    "note": "Standard Italian SaaS term; the single existing string uses 'sottoscrizione', which is less idiomatic for recurring plans."
+  },
+  "deactivate": {
+    "target": "disattivare",
+    "note": "Existing: 'Disattiva', 'disattivato'."
+  },
+  "invite": {
+    "target": "invitare",
+    "note": "Verb 'invitare' ('Invita ospiti'); noun (an invite) = 'invito'."
+  },
+  "invitation": {
+    "target": "invito",
+    "note": "Masculine; plural 'inviti'."
+  },
+  "sidebar": {
+    "target": "barra laterale"
+  },
+  "unread": {
+    "target": "non letto",
+    "note": "'Segna come non letto'; plural noun usage (unreads) = 'non letti' ('Filtra non letti')."
+  },
+  "attachment": {
+    "target": "allegato"
+  },
+  "public channel": {
+    "target": "canale pubblico"
+  },
+  "private channel": {
+    "target": "canale privato"
+  },
+  "shared channel": {
+    "target": "canale condiviso"
+  },
+  "channel header": {
+    "target": "intestazione del canale",
+    "note": "Existing consistent: 'intestazione'."
+  },
+  "channel purpose": {
+    "target": "scopo del canale",
+    "note": "Existing consistent: 'scopo' ('Modifica Scopo')."
+  },
+  "system message": {
+    "target": "messaggio di sistema"
+  },
+  "persistent notification": {
+    "target": "notifica persistente"
+  },
+  "message priority": {
+    "target": "priorità del messaggio",
+    "note": "Existing mobile rendering."
+  },
+  "urgent": {
+    "target": "urgente",
+    "note": "Label form: 'URGENTE' (existing mobile)."
+  },
+  "recap": {
+    "target": "riepilogo",
+    "note": "New AI feature, untranslated in it.json; 'riepilogo' aligns with Calls meeting summary = 'riepilogo della riunione'."
+  },
+  "agent": {
+    "target": "agente",
+    "note": "Masculine; plural 'agenti'. The Agents product/feature name may stay 'Agents' when used as a proper name."
+  },
+  "burn-on-read": {
+    "target": "con distruzione alla lettura",
+    "note": "New feature, no existing signal. Adjective use: 'messaggio con distruzione alla lettura'; label: 'DISTRUZIONE ALLA LETTURA'."
+  },
+  "magic link": {
+    "target": "link magico",
+    "note": "Slack's Italian rendering; 'magic link' kept in English is also common in Italian products — use one form consistently."
+  },
+  "personal access token": {
+    "target": "token di accesso personale",
+    "note": "Existing consistent rendering; 'token' is kept in English (masculine, invariable)."
+  },
+  "announcement banner": {
+    "target": "banner di annunci",
+    "note": "'banner' kept in English (masculine, invariable) per existing usage ('Testo Banner', 'Colore Banner')."
+  },
+  "channel banner": {
+    "target": "banner del canale"
+  },
+  "keyword": {
+    "target": "parola chiave",
+    "note": "Existing consistent: 'Parole chiave che attivano le menzioni'."
+  },
+  "user group": {
+    "target": "gruppo di utenti",
+    "note": "Plain 'gruppo' when context is clear (existing: 'Citazione gruppo')."
+  },
+  "permalink": {
+    "target": "link permanente",
+    "note": "No existing signal; standard Italian rendering."
+  },
+  "profile": {
+    "target": "profilo",
+    "note": "One legacy string maps Profile to 'Impostazioni Account' — avoid; use 'profilo'."
+  },
+  "username": {
+    "target": "nome utente",
+    "note": "Existing consistent rendering."
+  },
+  "nickname": {
+    "target": "soprannome",
+    "note": "Existing consistent rendering."
+  },
+  "display name": {
+    "target": "nome visualizzato",
+    "note": "Majority across desktop/mobile/webapp-notifications; a couple of legacy webapp strings use 'Nome visibile' — prefer 'nome visualizzato'."
+  },
+  "collapsed reply threads": {
+    "target": "thread di risposta compressi",
+    "note": "Existing mobile rendering; a duplicate string uses 'collassati' — prefer 'compressi'."
+  },
+  "auto-translation": {
+    "target": "traduzione automatica",
+    "note": "Label form for auto-translated messages: 'TRADOTTO AUTOMATICAMENTE'."
+  },
+  "data retention": {
+    "target": "ritenzione dei dati",
+    "note": "Existing consistent rendering in webapp/server ('Politica Ritenzione dei Dati'); 'conservazione dei dati' is the standard Italian/GDPR term and arguably better — kept 'ritenzione' for consistency."
+  },
+  "compliance export": {
+    "target": "esportazione di conformità",
+    "note": "Legacy strings use 'Esportazione Conforme (Beta)', which misreads the English ('compliant export'); 'esportazione di conformità' is more accurate."
+  },
+  "access control": {
+    "target": "controllo degli accessi",
+    "note": "No reliable existing signal (one legacy string relabels it 'Moderazione canale'); standard Italian security term. Policy: 'politica di controllo degli accessi'."
+  },
+  "attribute": {
+    "target": "attributo",
+    "note": "Masculine; plural 'attributi'. Existing: 'Attributo Nome Gruppo Visualizzato'."
+  },
+  "onboarding": {
+    "target": "onboarding",
+    "note": "Commonly kept in English in Italian software; masculine: 'l'onboarding'."
+  },
+  "Town Square": {
+    "target": "Piazza",
+    "note": "Existing server rendering of the default channel name."
+  },
+  "Off-Topic": {
+    "target": "Senza-Argomento",
+    "note": "Existing server rendering of the default channel name (hyphenated to remain a valid channel name)."
+  },
+  "read-only": {
+    "target": "in sola lettura",
+    "note": "Existing: 'Questo canale è in sola lettura' (webapp); mobile uses 'di sola lettura' — either preposition works, prefer 'in sola lettura'."
+  },
+  "server": {
+    "target": "server",
+    "note": "Kept in English; masculine, invariable: 'il server', 'i server' (avoid legacy plural 'servers' in Italian text)."
+  }
+}

--- a/i18n/glossary/it.json
+++ b/i18n/glossary/it.json
@@ -155,8 +155,7 @@
     "target": "stato personalizzato"
   },
   "do not disturb": {
-    "target": "Non disturbare",
-    "note": "Consistent existing rendering across webapp and mobile."
+    "target": "Non disturbare"
   },
   "away": {
     "target": "Assente",
@@ -351,12 +350,10 @@
     "target": "notifica persistente"
   },
   "message priority": {
-    "target": "priorità del messaggio",
-    "note": "Existing mobile rendering."
+    "target": "priorità del messaggio"
   },
   "urgent": {
-    "target": "urgente",
-    "note": "Label form: 'URGENTE' (existing mobile)."
+    "target": "urgente"
   },
   "recap": {
     "target": "riepilogo",
@@ -402,12 +399,10 @@
     "note": "One legacy string maps Profile to 'Impostazioni Account' — avoid; use 'profilo'."
   },
   "username": {
-    "target": "nome utente",
-    "note": "Existing consistent rendering."
+    "target": "nome utente"
   },
   "nickname": {
-    "target": "soprannome",
-    "note": "Existing consistent rendering."
+    "target": "soprannome"
   },
   "display name": {
     "target": "nome visualizzato",
@@ -442,12 +437,10 @@
     "note": "Commonly kept in English in Italian software; masculine: 'l'onboarding'."
   },
   "Town Square": {
-    "target": "Piazza",
-    "note": "Existing server rendering of the default channel name."
+    "target": "Piazza"
   },
   "Off-Topic": {
-    "target": "Senza-Argomento",
-    "note": "Existing server rendering of the default channel name (hyphenated to remain a valid channel name)."
+    "target": "Senza-Argomento"
   },
   "read-only": {
     "target": "in sola lettura",

--- a/i18n/glossary/it.json
+++ b/i18n/glossary/it.json
@@ -57,9 +57,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/ja.json
+++ b/i18n/glossary/ja.json
@@ -1,0 +1,406 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition"
+  },
+  "Team Edition": {
+    "target": "Team Edition"
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels"
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "システムコンソール"
+  },
+  "marketplace": {
+    "target": "マーケットプレース",
+    "note": "Existing translations consistently use マーケットプレース (not マーケットプレイス); keep this spelling."
+  },
+  "channel": {
+    "target": "チャンネル"
+  },
+  "team": {
+    "target": "チーム"
+  },
+  "post": {
+    "target": "投稿",
+    "note": "Verb: 投稿する."
+  },
+  "message": {
+    "target": "メッセージ"
+  },
+  "thread": {
+    "target": "スレッド"
+  },
+  "reply": {
+    "target": "返信",
+    "note": "Verb (button): 返信する."
+  },
+  "direct message": {
+    "target": "ダイレクトメッセージ",
+    "note": "Do not abbreviate to DM in translated text unless the English source uses 'DM'."
+  },
+  "group message": {
+    "target": "グループメッセージ"
+  },
+  "mention": {
+    "target": "メンション",
+    "note": "Verb: メンションする."
+  },
+  "notification": {
+    "target": "通知"
+  },
+  "pin": {
+    "target": "ピン留めする",
+    "note": "Noun/past participle: ピン留め / ピン留めされた. Unpin: ピン留めをやめる (existing 'Unpin from Channel' → チャンネルへのピン留めをやめる)."
+  },
+  "bookmark": {
+    "target": "ブックマーク",
+    "note": "Verb: ブックマークする (add: ブックマークを追加)."
+  },
+  "saved messages": {
+    "target": "保存されたメッセージ",
+    "note": "Existing usage is inconsistent: 保存されたメッセージ and 保存済みのメッセージ both occur. Prefer 保存されたメッセージ for the feature name; 保存済み for the short 'Saved' badge."
+  },
+  "draft": {
+    "target": "下書き"
+  },
+  "scheduled post": {
+    "target": "スケジュール済みの投稿"
+  },
+  "emoji": {
+    "target": "絵文字"
+  },
+  "custom emoji": {
+    "target": "カスタム絵文字"
+  },
+  "reaction": {
+    "target": "リアクション",
+    "note": "Verb 'react': リアクションする."
+  },
+  "status": {
+    "target": "ステータス",
+    "note": "In-context sentences use ステータス; a few standalone labels use 状態. Prefer ステータス for availability."
+  },
+  "custom status": {
+    "target": "カスタムステータス"
+  },
+  "do not disturb": {
+    "target": "取り込み中"
+  },
+  "away": {
+    "target": "離席中"
+  },
+  "online": {
+    "target": "オンライン"
+  },
+  "offline": {
+    "target": "オフライン"
+  },
+  "out of office": {
+    "target": "外出中"
+  },
+  "guest": {
+    "target": "ゲスト"
+  },
+  "member": {
+    "target": "メンバー"
+  },
+  "user": {
+    "target": "ユーザー"
+  },
+  "system admin": {
+    "target": "システム管理者"
+  },
+  "team admin": {
+    "target": "チーム管理者"
+  },
+  "channel admin": {
+    "target": "チャンネル管理者"
+  },
+  "session": {
+    "target": "セッション"
+  },
+  "sign in": {
+    "target": "ログインする",
+    "note": "Login screen consistently uses ログイン; some admin-console strings use サインイン. Prefer ログイン for both 'log in' and 'sign in' per majority."
+  },
+  "sign out": {
+    "target": "ログアウトする"
+  },
+  "join": {
+    "target": "参加する"
+  },
+  "leave": {
+    "target": "脱退する",
+    "note": "Existing: チームを脱退する, チャンネルから脱退する. One string uses 離脱する for groups; prefer 脱退する."
+  },
+  "archive": {
+    "target": "アーカイブする",
+    "note": "Adjective 'archived': アーカイブ済み / アーカイブされた."
+  },
+  "unarchive": {
+    "target": "アーカイブから復元する"
+  },
+  "mute": {
+    "target": "ミュートする",
+    "note": "Channel-notification muting; unmute: ミュートを解除する."
+  },
+  "follow": {
+    "target": "フォローする",
+    "note": "Following (state): フォロー中."
+  },
+  "unfollow": {
+    "target": "フォローをやめる",
+    "note": "Menu items use フォローをやめる; past-tense confirmation uses フォローを解除しました. Either is acceptable, prefer フォローをやめる for actions."
+  },
+  "favorite": {
+    "target": "お気に入り",
+    "note": "Verb: お気に入りに追加する; remove: お気に入りから削除する."
+  },
+  "search": {
+    "target": "検索",
+    "note": "Verb: 検索する."
+  },
+  "integration": {
+    "target": "統合機能"
+  },
+  "slash command": {
+    "target": "スラッシュコマンド"
+  },
+  "webhook": {
+    "target": "ウェブフック",
+    "note": "Katakana ウェブフック is established in existing translations; do not keep as English 'Webhook'."
+  },
+  "incoming webhook": {
+    "target": "内向きのウェブフック"
+  },
+  "outgoing webhook": {
+    "target": "外向きのウェブフック"
+  },
+  "trigger word": {
+    "target": "トリガーワード"
+  },
+  "plugin": {
+    "target": "プラグイン"
+  },
+  "bot": {
+    "target": "Bot",
+    "note": "Existing translations keep 'Bot' in Latin script (Botアカウント, Botアイコン, BOT tag); do not use ボット."
+  },
+  "role": {
+    "target": "ロール"
+  },
+  "permission": {
+    "target": "権限"
+  },
+  "scheme": {
+    "target": "スキーム"
+  },
+  "license": {
+    "target": "ライセンス"
+  },
+  "seat": {
+    "target": "シート"
+  },
+  "trial": {
+    "target": "トライアル"
+  },
+  "workspace": {
+    "target": "ワークスペース"
+  },
+  "subscription": {
+    "target": "サブスクリプション"
+  },
+  "deactivate": {
+    "target": "無効化する",
+    "note": "Deactivated: 無効化済み. Existing also uses 無効にする; prefer 無効化する for accounts."
+  },
+  "invite": {
+    "target": "招待する",
+    "note": "Noun: 招待."
+  },
+  "invitation": {
+    "target": "招待"
+  },
+  "sidebar": {
+    "target": "サイドバー"
+  },
+  "unread": {
+    "target": "未読"
+  },
+  "attachment": {
+    "target": "添付ファイル",
+    "note": "Short label sometimes just 添付."
+  },
+  "public channel": {
+    "target": "公開チャンネル"
+  },
+  "private channel": {
+    "target": "非公開チャンネル",
+    "note": "Existing convention is 非公開チャンネル, not プライベートチャンネル."
+  },
+  "shared channel": {
+    "target": "共有チャンネル"
+  },
+  "channel header": {
+    "target": "チャンネルヘッダー"
+  },
+  "channel purpose": {
+    "target": "チャンネルの目的"
+  },
+  "system message": {
+    "target": "システムメッセージ"
+  },
+  "persistent notification": {
+    "target": "永続的な通知"
+  },
+  "message priority": {
+    "target": "メッセージの優先度",
+    "note": "Existing usage varies between メッセージの優先度 and メッセージ優先度; prefer メッセージの優先度."
+  },
+  "urgent": {
+    "target": "緊急"
+  },
+  "recap": {
+    "target": "リキャップ",
+    "note": "No existing translation (new feature). リキャップ follows established Japanese Microsoft Teams terminology for AI recaps; alternative 要約 would collide with 'summary'."
+  },
+  "agent": {
+    "target": "エージェント",
+    "note": "No existing translation (new feature); エージェント is the standard Japanese term for AI agents."
+  },
+  "burn-on-read": {
+    "target": "閲覧後消去",
+    "note": "No existing translation (new feature). Label form: 閲覧後消去メッセージ. Alternative phrasing 閲覧後に自動削除される may suit descriptions."
+  },
+  "magic link": {
+    "target": "マジックリンク"
+  },
+  "personal access token": {
+    "target": "パーソナルアクセストークン"
+  },
+  "announcement banner": {
+    "target": "アナウンスバナー",
+    "note": "Majority rendering; one legacy string uses 通知バナー — prefer アナウンスバナー."
+  },
+  "channel banner": {
+    "target": "チャンネルバナー"
+  },
+  "keyword": {
+    "target": "キーワード"
+  },
+  "user group": {
+    "target": "ユーザーグループ"
+  },
+  "permalink": {
+    "target": "パーマリンク"
+  },
+  "profile": {
+    "target": "プロフィール"
+  },
+  "username": {
+    "target": "ユーザー名"
+  },
+  "nickname": {
+    "target": "ニックネーム"
+  },
+  "display name": {
+    "target": "表示名"
+  },
+  "collapsed reply threads": {
+    "target": "スレッド形式の議論",
+    "note": "Existing admin-console title for this feature ('Threaded Discussions'). Use it for the feature name rather than a literal 折りたたみ返信スレッド."
+  },
+  "auto-translation": {
+    "target": "自動翻訳",
+    "note": "Auto-translated (label): 自動翻訳済み."
+  },
+  "data retention": {
+    "target": "データ保持",
+    "note": "Policy: データ保持ポリシー."
+  },
+  "compliance export": {
+    "target": "コンプライアンスエクスポート"
+  },
+  "access control": {
+    "target": "アクセス制御",
+    "note": "Majority rendering; アクセスコントロール appears once (アクセスコントロールポリシー) — prefer アクセス制御."
+  },
+  "attribute": {
+    "target": "属性"
+  },
+  "onboarding": {
+    "target": "オンボーディング"
+  },
+  "Town Square": {
+    "target": "タウンスクウェア",
+    "note": "Server default-channel name uses タウンスクウェア; a couple of webapp admin descriptions use タウンスクエア. Follow the server rendering (what users see as the channel name)."
+  },
+  "Off-Topic": {
+    "target": "オフトピック",
+    "note": "One webapp string contains the typo オフトピッック; correct form is オフトピック."
+  },
+  "read-only": {
+    "target": "読み取り専用"
+  },
+  "server": {
+    "target": "サーバー"
+  }
+}

--- a/i18n/glossary/ja.json
+++ b/i18n/glossary/ja.json
@@ -53,9 +53,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/ko.json
+++ b/i18n/glossary/ko.json
@@ -1,0 +1,430 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition",
+    "note": "Prose occasionally uses 엔터프라이즈 에디션; keep the English name for the edition itself."
+  },
+  "Team Edition": {
+    "target": "Team Edition"
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "Product name; the common noun 'channel' is 채널."
+  },
+  "Playbooks": {
+    "target": "Playbooks",
+    "note": "Product name; the common noun 'playbook' is 플레이북."
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls",
+    "note": "Product name; the common noun 'call' is 통화."
+  },
+  "Markdown": {
+    "target": "Markdown",
+    "note": "마크다운 is acceptable in prose, but existing UI keeps the English form."
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP",
+    "note": "AD/LDAP stays as AD/LDAP."
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA",
+    "note": "When spelled out, 'multi-factor authentication' is 다단계 인증 in existing strings."
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "시스템 콘솔",
+    "note": "Majority rendering (32 vs 6); a few legacy strings use 관리자 도구 — do not reuse it."
+  },
+  "marketplace": {
+    "target": "마켓플레이스"
+  },
+  "channel": {
+    "target": "채널"
+  },
+  "team": {
+    "target": "팀"
+  },
+  "post": {
+    "target": "게시물",
+    "note": "Repo usage is mixed (메시지/글/게시물/게시글). Use 게시물 to keep the noun distinct from message = 메시지; 글 appears in some admin labels."
+  },
+  "message": {
+    "target": "메시지"
+  },
+  "thread": {
+    "target": "스레드",
+    "note": "Majority rendering (40 vs 22); older strings use 글타래 — prefer 스레드 for consistency."
+  },
+  "reply": {
+    "target": "답글",
+    "note": "Noun and verb stem (답글, 답글 달기). 댓글/회신 appear in a few legacy strings; prefer 답글."
+  },
+  "direct message": {
+    "target": "쪽지",
+    "note": "Majority rendering (30 vs 18); some headings/legacy strings use 개인 메시지. DM abbreviation can stay DM."
+  },
+  "group message": {
+    "target": "그룹 메시지"
+  },
+  "mention": {
+    "target": "멘션",
+    "note": "Verb: 멘션하다. 언급 appears in some admin strings; prefer 멘션."
+  },
+  "notification": {
+    "target": "알림"
+  },
+  "pin": {
+    "target": "고정",
+    "note": "Verb: 고정하다; pinned messages = 고정된 메시지; unpin = 고정 해제. One legacy string uses 공지하기 — avoid."
+  },
+  "bookmark": {
+    "target": "북마크",
+    "note": "Verb: 북마크에 추가하다 / 북마크하다."
+  },
+  "saved messages": {
+    "target": "저장된 메시지",
+    "note": "Repo is inconsistent (중요 메시지, 보관된 메시지 in legacy strings); save = 저장, unsave = 저장 해제."
+  },
+  "draft": {
+    "target": "초안",
+    "note": "Repo splits between 초안 (10) and 임시 글 (8); use 초안 consistently."
+  },
+  "scheduled post": {
+    "target": "예약된 메시지",
+    "note": "Also rendered 예약된 게시물 in admin strings; prefer 예약된 메시지."
+  },
+  "emoji": {
+    "target": "이모지",
+    "note": "이모티콘 is nearly as frequent in the repo, but 이모지 is the accurate Korean term for emoji; use it consistently."
+  },
+  "custom emoji": {
+    "target": "커스텀 이모지"
+  },
+  "reaction": {
+    "target": "반응",
+    "note": "Verb: 반응 추가하다. 리액션 appears in a few strings; prefer 반응."
+  },
+  "status": {
+    "target": "상태"
+  },
+  "custom status": {
+    "target": "사용자 지정 상태"
+  },
+  "do not disturb": {
+    "target": "방해 금지"
+  },
+  "away": {
+    "target": "자리 비움",
+    "note": "Existing labels vary between 자리비움 and 자리 비움; standard spacing is 자리 비움."
+  },
+  "online": {
+    "target": "온라인"
+  },
+  "offline": {
+    "target": "오프라인"
+  },
+  "out of office": {
+    "target": "부재 중"
+  },
+  "guest": {
+    "target": "게스트"
+  },
+  "member": {
+    "target": "구성원",
+    "note": "Majority rendering (103 vs 32 멤버, 48 회원); use 구성원."
+  },
+  "user": {
+    "target": "사용자"
+  },
+  "system admin": {
+    "target": "시스템 관리자"
+  },
+  "team admin": {
+    "target": "팀 관리자"
+  },
+  "channel admin": {
+    "target": "채널 관리자"
+  },
+  "session": {
+    "target": "세션"
+  },
+  "sign in": {
+    "target": "로그인",
+    "note": "Verb: 로그인하다. Both 'sign in' and 'log in' map to 로그인."
+  },
+  "sign out": {
+    "target": "로그아웃",
+    "note": "Verb: 로그아웃하다. Both 'sign out' and 'log out' map to 로그아웃."
+  },
+  "join": {
+    "target": "참여",
+    "note": "Verb: 참여하다 for channels; teams often use 가입(하다) in existing strings — either is fine per object, but keep channels = 참여."
+  },
+  "leave": {
+    "target": "나가기",
+    "note": "Verb: 나가다. Repo mixes 떠나기/탈퇴/나가기; prefer 나가기 (탈퇴 acceptable for teams)."
+  },
+  "archive": {
+    "target": "보관",
+    "note": "Verb: 보관하다; archived = 보관됨. A few strings use 아카이브 — prefer 보관."
+  },
+  "unarchive": {
+    "target": "보관 해제",
+    "note": "Verb: 보관을 해제하다."
+  },
+  "mute": {
+    "target": "음소거",
+    "note": "Channel-mute strings often render 'Mute Channel' as 채널 알림 끄기; plain Mute label is 음소거. Keep Calls microphone mute also 음소거."
+  },
+  "follow": {
+    "target": "팔로우",
+    "note": "Verb: 팔로우하다. Legacy strings use 구독/지켜보기; prefer 팔로우 (matches follower = 팔로워)."
+  },
+  "unfollow": {
+    "target": "팔로우 해제",
+    "note": "Legacy strings use 구독 해제; prefer 팔로우 해제."
+  },
+  "favorite": {
+    "target": "즐겨찾기",
+    "note": "Verb: 즐겨찾기에 추가하다; unfavorite = 즐겨찾기에서 제거."
+  },
+  "search": {
+    "target": "검색",
+    "note": "Verb: 검색하다."
+  },
+  "integration": {
+    "target": "통합"
+  },
+  "slash command": {
+    "target": "슬래시 명령어"
+  },
+  "webhook": {
+    "target": "웹훅",
+    "note": "Repo is inconsistent (many strings keep English 'Webhook'); standardize on 웹훅."
+  },
+  "incoming webhook": {
+    "target": "들어오는 웹훅",
+    "note": "Repo mostly leaves this in English; 들어오는 웹훅 mirrors the existing 나가는 웹훅. 수신 웹훅 is an acceptable alternative if used consistently with 발신 웹훅."
+  },
+  "outgoing webhook": {
+    "target": "나가는 웹훅",
+    "note": "Existing rendering; pair with 들어오는 웹훅."
+  },
+  "trigger word": {
+    "target": "트리거 단어"
+  },
+  "plugin": {
+    "target": "플러그인"
+  },
+  "bot": {
+    "target": "봇"
+  },
+  "role": {
+    "target": "역할"
+  },
+  "permission": {
+    "target": "권한"
+  },
+  "scheme": {
+    "target": "스키마",
+    "note": "Majority rendering; avoid 스킴/계획 seen in a few strings."
+  },
+  "license": {
+    "target": "라이선스"
+  },
+  "seat": {
+    "target": "좌석"
+  },
+  "trial": {
+    "target": "평가판",
+    "note": "Majority rendering (45 vs 7 체험판); free trial = 무료 평가판."
+  },
+  "workspace": {
+    "target": "워크스페이스",
+    "note": "Majority rendering (33 vs 22 작업 공간); prefer 워크스페이스."
+  },
+  "subscription": {
+    "target": "구독"
+  },
+  "deactivate": {
+    "target": "비활성화",
+    "note": "Verb: 비활성화하다; deactivated = 비활성화됨."
+  },
+  "invite": {
+    "target": "초대",
+    "note": "Verb: 초대하다."
+  },
+  "invitation": {
+    "target": "초대",
+    "note": "For the email/link itself, 초대장 or 초대 링크 may be used where the sentence needs a concrete object."
+  },
+  "sidebar": {
+    "target": "사이드바"
+  },
+  "unread": {
+    "target": "읽지 않음",
+    "note": "Attributive: 읽지 않은 (e.g. 읽지 않은 메시지)."
+  },
+  "attachment": {
+    "target": "첨부 파일"
+  },
+  "public channel": {
+    "target": "공개 채널"
+  },
+  "private channel": {
+    "target": "비공개 채널",
+    "note": "Never 개인 채널 (seen once in a legacy string)."
+  },
+  "shared channel": {
+    "target": "공유 채널"
+  },
+  "channel header": {
+    "target": "채널 헤더"
+  },
+  "channel purpose": {
+    "target": "채널 목적",
+    "note": "Some legacy strings use 설명; prefer 목적."
+  },
+  "system message": {
+    "target": "시스템 메시지"
+  },
+  "persistent notification": {
+    "target": "영구 알림",
+    "note": "Majority rendering; 지속 알림 appears in a few strings — prefer 영구 알림."
+  },
+  "message priority": {
+    "target": "메시지 우선순위"
+  },
+  "urgent": {
+    "target": "긴급"
+  },
+  "recap": {
+    "target": "리캡",
+    "note": "No existing translation; 리캡 keeps it distinct from summary = 요약. If a descriptive form is needed, 요약 정리 works in prose."
+  },
+  "agent": {
+    "target": "에이전트",
+    "note": "One legacy string mistranslates Agents as 상담원 (customer-service agent) — avoid."
+  },
+  "burn-on-read": {
+    "target": "읽은 후 삭제",
+    "note": "No existing translation; label form (BURN ON READ) can be 읽은 후 삭제됨."
+  },
+  "magic link": {
+    "target": "매직 링크"
+  },
+  "personal access token": {
+    "target": "개인 액세스 토큰"
+  },
+  "announcement banner": {
+    "target": "공지 배너",
+    "note": "Repo also has 알림 배너/시스템 전체 알림; standardize on 공지 배너."
+  },
+  "channel banner": {
+    "target": "채널 배너"
+  },
+  "keyword": {
+    "target": "키워드"
+  },
+  "user group": {
+    "target": "사용자 그룹"
+  },
+  "permalink": {
+    "target": "영구 링크"
+  },
+  "profile": {
+    "target": "프로필",
+    "note": "Legacy menu items use 계정 설정 for Profile; the current convention is 프로필."
+  },
+  "username": {
+    "target": "사용자 이름"
+  },
+  "nickname": {
+    "target": "별명"
+  },
+  "display name": {
+    "target": "표시 이름",
+    "note": "표시명 appears in some short labels; prefer 표시 이름."
+  },
+  "collapsed reply threads": {
+    "target": "접힌 답글 스레드",
+    "note": "No existing translation; keep 스레드 (not 글타래) to match the thread glossary entry."
+  },
+  "auto-translation": {
+    "target": "자동 번역",
+    "note": "AUTO-TRANSLATED label: 자동 번역됨."
+  },
+  "data retention": {
+    "target": "데이터 보존",
+    "note": "Policy: 데이터 보존 정책."
+  },
+  "compliance export": {
+    "target": "컴플라이언스 내보내기",
+    "note": "규정 준수 내보내기 also appears; prefer 컴플라이언스 내보내기 (majority)."
+  },
+  "access control": {
+    "target": "액세스 제어",
+    "note": "Policy: 액세스 제어 정책; attribute-based access control = 속성 기반 액세스 제어."
+  },
+  "attribute": {
+    "target": "속성"
+  },
+  "onboarding": {
+    "target": "온보딩"
+  },
+  "Town Square": {
+    "target": "타운 스퀘어",
+    "note": "Grounded in the only existing rendering; write with a space (타운 스퀘어), not 타운스퀘어."
+  },
+  "Off-Topic": {
+    "target": "오프토픽",
+    "note": "Grounded in the only existing rendering."
+  },
+  "read-only": {
+    "target": "읽기 전용"
+  },
+  "server": {
+    "target": "서버"
+  }
+}

--- a/i18n/glossary/ko.json
+++ b/i18n/glossary/ko.json
@@ -60,9 +60,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/ko.json
+++ b/i18n/glossary/ko.json
@@ -415,8 +415,8 @@
     "note": "Grounded in the only existing rendering; write with a space (타운 스퀘어), not 타운스퀘어."
   },
   "Off-Topic": {
-    "target": "오프토픽",
-    "note": "Grounded in the only existing rendering."
+    "target": "잡담",
+    "note": "Established default-channel name in server ko.json. '오프토픽' appears only in admin prose describing the channel."
   },
   "read-only": {
     "target": "읽기 전용"

--- a/i18n/glossary/ko.json
+++ b/i18n/glossary/ko.json
@@ -29,7 +29,7 @@
   },
   "Markdown": {
     "target": "Markdown",
-    "note": "마크다운 is acceptable in prose, but existing UI keeps the English form."
+    "note": "Existing UI keeps the English form; 마크다운 appears in prose but the format name stays Markdown."
   },
   "OAuth": {
     "target": "OAuth"

--- a/i18n/glossary/nl.json
+++ b/i18n/glossary/nl.json
@@ -1,0 +1,456 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition",
+    "note": "Product name; existing strings occasionally show 'Enterprise editie' but keep the English edition name."
+  },
+  "Team Edition": {
+    "target": "Team Edition"
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "Product name, stays English; the common noun 'channel' is 'kanaal'."
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP",
+    "note": "Also AD/LDAP; never translate, per dutch-rules.md (product/protocol name)."
+  },
+  "SSO": {
+    "target": "SSO",
+    "note": "Per dutch-rules.md render spelled-out form as 'Single Sign-On (SSO)'; 'vereenvoudigde authenticatie' is not allowed."
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip",
+    "note": "Protocol name; the Weblate glossary row 'Praatjes' is a mistranslation — keep English."
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "systeemconsole",
+    "note": "Majority rendering (28 vs 18 for 'Systeem console'); capitalize 'Systeemconsole' when used as a menu/UI-area name per dutch-rules.md capitalization rule."
+  },
+  "marketplace": {
+    "target": "marktplaats",
+    "note": "Per dutch-rules.md and Weblate glossary; 'Plugin Marketplace' = 'Plugin marktplaats'."
+  },
+  "channel": {
+    "target": "kanaal",
+    "note": "Plural: kanalen."
+  },
+  "team": {
+    "target": "team",
+    "note": "Plural: teams."
+  },
+  "post": {
+    "target": "bericht",
+    "note": "Per dutch-rules.md 'post' is an anglicism; use 'bericht'. Use 'publiceren' only for system/integration posts, 'versturen' for user messages."
+  },
+  "message": {
+    "target": "bericht",
+    "note": "Plural: berichten."
+  },
+  "thread": {
+    "target": "draadje",
+    "note": "Consistently 'draadje' (89 of 92 occurrences); plural 'draadjes'. Do not use 'discussie' or keep English."
+  },
+  "reply": {
+    "target": "antwoord",
+    "note": "Noun 'antwoord'; verb 'antwoorden'. Per dutch-rules.md you 'verzendt' (send) a reply."
+  },
+  "direct message": {
+    "target": "privé-bericht",
+    "note": "Existing usage is split between 'privé-bericht' (majority, matches dutch-rules.md) and 'direct bericht'/'rechtstreeks bericht'; keep 'privé-bericht' and the derived 'privé-berichtkanaal'."
+  },
+  "group message": {
+    "target": "groepsbericht",
+    "note": "Plural: groepsberichten."
+  },
+  "mention": {
+    "target": "vermelding",
+    "note": "Noun 'vermelding' (plural 'vermeldingen'); verb 'vermelden'. Per dutch-rules.md."
+  },
+  "notification": {
+    "target": "melding",
+    "note": "Per dutch-rules.md; put 'melding' last in compounds: e-mailmelding, pushmelding, bureaubladmelding. Avoid 'notificatie' (legacy inconsistency)."
+  },
+  "pin": {
+    "target": "vastmaken",
+    "note": "Majority 'vastgemaakt(e)' (14 vs 5 for 'vastgezet'); 'pinned messages' = 'vastgemaakte berichten', 'unpin' = 'losmaken'."
+  },
+  "bookmark": {
+    "target": "bladwijzer",
+    "note": "Noun; verb phrase 'een bladwijzer toevoegen'. 'Channel bookmark' = 'kanaalbladwijzer'."
+  },
+  "saved messages": {
+    "target": "bewaarde berichten",
+    "note": "Verb 'save' in this feature = 'bewaren' (exception to the general 'Opslaan' preference, matches existing UI)."
+  },
+  "draft": {
+    "target": "concept",
+    "note": "Majority rendering (19 vs 2 for 'ontwerp'); plural 'concepten'."
+  },
+  "scheduled post": {
+    "target": "gepland bericht",
+    "note": "Tab label 'Scheduled' = 'Gepland'; plural 'geplande berichten'."
+  },
+  "emoji": {
+    "target": "emoticon",
+    "note": "Per dutch-rules.md and majority usage (63 vs 33); 'emoji' also occurs — prefer 'emoticon' for consistency. Plural 'emoticons'."
+  },
+  "custom emoji": {
+    "target": "aangepaste emoticon"
+  },
+  "reaction": {
+    "target": "reactie",
+    "note": "Plural 'reacties'; verb 'reageren'. Distinct from a reply ('antwoord') per dutch-rules.md."
+  },
+  "status": {
+    "target": "status"
+  },
+  "custom status": {
+    "target": "aangepaste status"
+  },
+  "do not disturb": {
+    "target": "niet storen",
+    "note": "Capitalized 'Niet storen' as a menu item; keep 'DND' abbreviation only in technical contexts."
+  },
+  "away": {
+    "target": "afwezig"
+  },
+  "online": {
+    "target": "online"
+  },
+  "offline": {
+    "target": "offline"
+  },
+  "out of office": {
+    "target": "out of office",
+    "note": "Existing UI keeps the English phrase ('Out of office' in webapp/mobile status menus); keep for consistency. 'Afwezig van kantoor' would be the translated alternative."
+  },
+  "guest": {
+    "target": "gast",
+    "note": "Majority in-product rendering; dutch-rules.md prefers 'gastgebruiker', which also appears in admin screens — both are in use, prefer 'gast' in short UI labels and 'gastgebruiker' when disambiguation from a visitor is needed."
+  },
+  "member": {
+    "target": "lid",
+    "note": "Plural 'leden'; 'channel member' = 'kanaallid', 'team member' = 'teamlid'."
+  },
+  "user": {
+    "target": "gebruiker",
+    "note": "Plural 'gebruikers'."
+  },
+  "system admin": {
+    "target": "systeembeheerder",
+    "note": "Per dutch-rules.md; plural 'systeembeheerders'."
+  },
+  "team admin": {
+    "target": "teambeheerder"
+  },
+  "channel admin": {
+    "target": "kanaalbeheerder"
+  },
+  "session": {
+    "target": "sessie",
+    "note": "Plural 'sessies'."
+  },
+  "sign in": {
+    "target": "aanmelden",
+    "note": "Use for both 'sign in' and 'log in' (majority; 'inloggen' occurs occasionally). Imperative button: 'Aanmelden'."
+  },
+  "sign out": {
+    "target": "afmelden",
+    "note": "Use for both 'sign out' and 'log out', per Weblate glossary ('Log Out' = 'Afmelden')."
+  },
+  "join": {
+    "target": "lid worden",
+    "note": "For channels/teams: 'lid worden (van)'. For calls use 'deelnemen (aan)'."
+  },
+  "leave": {
+    "target": "verlaten"
+  },
+  "archive": {
+    "target": "archiveren",
+    "note": "Past participle 'gearchiveerd'."
+  },
+  "unarchive": {
+    "target": "dearchiveren",
+    "note": "Existing UI buttons use 'Dearchiveren'; the system message uses 'haalde het kanaal terug uit het archief' — both acceptable, prefer 'dearchiveren' in labels."
+  },
+  "mute": {
+    "target": "dempen",
+    "note": "For channel notifications; 'unmute' = 'niet langer dempen' (webapp) / 'dempen uitschakelen' (calls)."
+  },
+  "follow": {
+    "target": "volgen",
+    "note": "'Following' state label = 'Volgend'."
+  },
+  "unfollow": {
+    "target": "niet langer volgen"
+  },
+  "favorite": {
+    "target": "favoriet",
+    "note": "Noun/adjective 'favoriet' (plural 'Favorieten' for the sidebar category); verb 'markeren als favoriet', 'unfavorite' = 'verwijderen uit favorieten'."
+  },
+  "search": {
+    "target": "zoeken",
+    "note": "Verb/label 'zoeken'; noun (a search) 'zoekopdracht'."
+  },
+  "integration": {
+    "target": "integratie",
+    "note": "Plural 'integraties'."
+  },
+  "slash command": {
+    "target": "slash-opdracht",
+    "note": "Majority rendering (15 vs 9); dutch-rules.md prefers 'slash-commando'. Existing usage is inconsistent (slashopdracht, slash-opdracht, slash-commando) — standardize on 'slash-opdracht'."
+  },
+  "webhook": {
+    "target": "webhook",
+    "note": "Kept in English per Weblate glossary; plural 'webhooks'."
+  },
+  "incoming webhook": {
+    "target": "inkomende webhook"
+  },
+  "outgoing webhook": {
+    "target": "uitgaande webhook"
+  },
+  "trigger word": {
+    "target": "triggerwoord",
+    "note": "Per dutch-rules.md; existing usage is inconsistent ('activeer-woord', 'trigger woord') — standardize on 'triggerwoord'."
+  },
+  "plugin": {
+    "target": "plugin",
+    "note": "Kept in English (majority usage); plural 'plugins'."
+  },
+  "bot": {
+    "target": "bot",
+    "note": "Per dutch-rules.md keep 'bot'/'BOT'; 'bot account' = 'botaccount'."
+  },
+  "role": {
+    "target": "rol",
+    "note": "Plural 'rollen'."
+  },
+  "permission": {
+    "target": "recht",
+    "note": "Plural 'rechten', per dutch-rules.md ('Rechten heeft de voorkeur'); avoid 'machtigingen'/'permissies'/'toestemmingen' which appear inconsistently in older strings."
+  },
+  "scheme": {
+    "target": "schema",
+    "note": "Permission scheme = '(toestemmings)schema'; existing strings mostly use plain 'schema'. For URL scheme use 'URL-protocol' per dutch-rules.md."
+  },
+  "license": {
+    "target": "licentie"
+  },
+  "seat": {
+    "target": "gebruiker",
+    "note": "Billing strings translate 'seats' as 'gebruikers' (e.g. '{num} seats' = '{num} gebruikers'); use 'gebruikerslicentie' only if disambiguation is required."
+  },
+  "trial": {
+    "target": "proefperiode",
+    "note": "'Free trial' = 'gratis proefperiode'. Avoid 'probeerversie'/'proefversie' which appear sporadically."
+  },
+  "workspace": {
+    "target": "werkruimte",
+    "note": "Majority rendering (78 vs 8 English); plural 'werkruimten'."
+  },
+  "subscription": {
+    "target": "abonnement"
+  },
+  "deactivate": {
+    "target": "deactiveren",
+    "note": "Past participle 'gedeactiveerd'."
+  },
+  "invite": {
+    "target": "uitnodigen",
+    "note": "Verb 'uitnodigen'; noun 'uitnodiging'."
+  },
+  "invitation": {
+    "target": "uitnodiging",
+    "note": "Plural 'uitnodigingen'; e-mail invitations = 'e-mailuitnodigingen' (note 'e-mail' spelling per dutch-rules.md)."
+  },
+  "sidebar": {
+    "target": "zijbalk"
+  },
+  "unread": {
+    "target": "ongelezen"
+  },
+  "attachment": {
+    "target": "bijlage",
+    "note": "Plural 'bijlagen'; verb 'attach' for files = 'toevoegen'/'bijvoegen' per dutch-rules.md, 'koppelen' otherwise."
+  },
+  "public channel": {
+    "target": "publiek kanaal",
+    "note": "Usage is split between 'publiek kanaal' (majority, 12) and 'openbaar kanaal' (9); standardize on 'publiek kanaal'."
+  },
+  "private channel": {
+    "target": "privé-kanaal",
+    "note": "Majority spelling (37 vs 15 for 'privékanaal'); keep the hyphenated form for consistency."
+  },
+  "shared channel": {
+    "target": "gedeeld kanaal",
+    "note": "Plural 'gedeelde kanalen'."
+  },
+  "channel header": {
+    "target": "kanaalkoptekst",
+    "note": "Existing usage is inconsistent (kanaalkoptekst, hoofding, koptekst, kop); server strings mostly use 'kanaalkoptekst' — standardize on that; avoid the Flemish 'hoofding'."
+  },
+  "channel purpose": {
+    "target": "kanaaldoel",
+    "note": "Existing strings consistently use 'doel'/'kanaaldoel'; dutch-rules.md suggests 'beschrijving' in this context but repo usage wins."
+  },
+  "system message": {
+    "target": "systeembericht"
+  },
+  "persistent notification": {
+    "target": "blijvende melding",
+    "note": "Plural 'blijvende meldingen'."
+  },
+  "message priority": {
+    "target": "berichtprioriteit",
+    "note": "Also rendered 'prioriteit van het bericht' in picker headers; use 'berichtprioriteit' as compound term."
+  },
+  "urgent": {
+    "target": "dringend",
+    "note": "Label 'DRINGEND' in caps context; 'urgente meldingen' also occurs but prefer 'dringend' (majority)."
+  },
+  "recap": {
+    "target": "samenvatting",
+    "note": "Existing recap feature strings use 'samenvatting'; disambiguate as 'AI-samenvatting' only if plain 'samenvatting' is ambiguous in context."
+  },
+  "agent": {
+    "target": "agent",
+    "note": "AI feature; 'AI agent' = 'AI-agent', plural 'AI-agenten'. Keep product name 'Agents' in English where used as a product."
+  },
+  "burn-on-read": {
+    "target": "verbrand-na-lezen",
+    "note": "Webapp UI uses 'verbrand-na-lezen berichten'; some server strings keep English 'burn-on-read' — prefer the Dutch form in user-facing text."
+  },
+  "magic link": {
+    "target": "magische link",
+    "note": "Majority rendering; 'Magic Link' kept in English in a few strings — prefer 'magische link'."
+  },
+  "personal access token": {
+    "target": "persoonlijk toegangstoken",
+    "note": "'Token' stays untranslated per dutch-rules.md; avoid Weblate glossary's 'toegangsbewijs' (not used in product strings)."
+  },
+  "announcement banner": {
+    "target": "aankondigingsbanner"
+  },
+  "channel banner": {
+    "target": "kanaalbanner"
+  },
+  "keyword": {
+    "target": "trefwoord",
+    "note": "Plural 'trefwoorden'."
+  },
+  "user group": {
+    "target": "gebruikersgroep",
+    "note": "Plural 'gebruikersgroepen'; plain 'group' = 'groep'."
+  },
+  "permalink": {
+    "target": "permalink",
+    "note": "Kept in English (existing usage)."
+  },
+  "profile": {
+    "target": "profiel",
+    "note": "'Profile picture' = 'profielafbeelding' or 'profielfoto'."
+  },
+  "username": {
+    "target": "gebruikersnaam"
+  },
+  "nickname": {
+    "target": "roepnaam",
+    "note": "Existing UI uses 'roepnaam'; keep 'Nickname' in AD/LDAP-attribute admin contexts where the technical attribute name is meant."
+  },
+  "display name": {
+    "target": "weergavenaam"
+  },
+  "collapsed reply threads": {
+    "target": "ingeklapte draadjes",
+    "note": "Majority mobile rendering; 'ingeklapte antwoorddraadjes' also occurs — prefer the shorter form."
+  },
+  "auto-translation": {
+    "target": "automatische vertaling",
+    "note": "Consistent existing rendering; 'AUTO-TRANSLATED' label = 'AUTOMATISCH VERTAALD'."
+  },
+  "data retention": {
+    "target": "gegevensbewaring",
+    "note": "'Data retention policy' = 'gegevensbewaarbeleid' (majority); avoid 'dataretentie' which appears sporadically."
+  },
+  "compliance export": {
+    "target": "nalevingsexport",
+    "note": "Majority webapp rendering; 'compliance export' also kept English in some strings. Dutch-rules.md renders 'Beta' contexts as 'Experimenteel'."
+  },
+  "access control": {
+    "target": "toegangscontrole",
+    "note": "'Attribute-based access control (ABAC)' = 'attribuutgebaseerde toegangscontrole (ABAC)'."
+  },
+  "attribute": {
+    "target": "attribuut",
+    "note": "Plural 'attributen'; 'kenmerk' also occurs in ABAC strings — prefer 'attribuut' for the profile/access-control field."
+  },
+  "onboarding": {
+    "target": "verwelkoming",
+    "note": "Per Weblate glossary; existing strings are inconsistent (verwelkoming, onboarding, introductie) — standardize on 'verwelkoming'."
+  },
+  "Town Square": {
+    "target": "Dorpsplein",
+    "note": "Established default-channel name in server i18n."
+  },
+  "Off-Topic": {
+    "target": "Off-Topic",
+    "note": "Existing server translation keeps the English channel name."
+  },
+  "read-only": {
+    "target": "alleen-lezen",
+    "note": "Predicative use: 'alleen lezen' ('Kanaal is alleen lezen')."
+  },
+  "server": {
+    "target": "server",
+    "note": "Plural 'servers'."
+  }
+}

--- a/i18n/glossary/nl.json
+++ b/i18n/glossary/nl.json
@@ -57,9 +57,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip",
     "note": "Protocol name; the Weblate glossary row 'Praatjes' is a mistranslation — keep English."

--- a/i18n/glossary/nl.json
+++ b/i18n/glossary/nl.json
@@ -36,11 +36,11 @@
   },
   "LDAP": {
     "target": "LDAP",
-    "note": "Also AD/LDAP; never translate, per dutch-rules.md (product/protocol name)."
+    "note": "Also AD/LDAP; never translate (product/protocol name)."
   },
   "SSO": {
     "target": "SSO",
-    "note": "Per dutch-rules.md render spelled-out form as 'Single Sign-On (SSO)'; 'vereenvoudigde authenticatie' is not allowed."
+    "note": "Render the spelled-out form as 'Single Sign-On (SSO)'; never 'vereenvoudigde authenticatie'."
   },
   "MFA": {
     "target": "MFA"
@@ -59,7 +59,7 @@
   },
   "Gossip": {
     "target": "Gossip",
-    "note": "Protocol name; the Weblate glossary row 'Praatjes' is a mistranslation — keep English."
+    "note": "Protocol name; never 'Praatjes'."
   },
   "Actiance XML": {
     "target": "Actiance XML"
@@ -69,11 +69,11 @@
   },
   "System Console": {
     "target": "systeemconsole",
-    "note": "Majority rendering (28 vs 18 for 'Systeem console'); capitalize 'Systeemconsole' when used as a menu/UI-area name per dutch-rules.md capitalization rule."
+    "note": "Existing strings split 28 vs 18 with 'Systeem console'. Capitalize 'Systeemconsole' when used as a menu or UI-area name."
   },
   "marketplace": {
     "target": "marktplaats",
-    "note": "Per dutch-rules.md and Weblate glossary; 'Plugin Marketplace' = 'Plugin marktplaats'."
+    "note": "'Plugin Marketplace' = 'Plugin marktplaats'."
   },
   "channel": {
     "target": "kanaal",
@@ -85,7 +85,7 @@
   },
   "post": {
     "target": "bericht",
-    "note": "Per dutch-rules.md 'post' is an anglicism; use 'bericht'. Use 'publiceren' only for system/integration posts, 'versturen' for user messages."
+    "note": "'post' is an anglicism. Use 'publiceren' only for system/integration posts, 'versturen' for user messages."
   },
   "message": {
     "target": "bericht",
@@ -97,11 +97,11 @@
   },
   "reply": {
     "target": "antwoord",
-    "note": "Noun 'antwoord'; verb 'antwoorden'. Per dutch-rules.md you 'verzendt' (send) a reply."
+    "note": "Noun 'antwoord'; verb 'antwoorden'. You 'verzendt' (send) a reply."
   },
   "direct message": {
     "target": "privé-bericht",
-    "note": "Existing usage is split between 'privé-bericht' (majority, matches dutch-rules.md) and 'direct bericht'/'rechtstreeks bericht'; keep 'privé-bericht' and the derived 'privé-berichtkanaal'."
+    "note": "Existing usage is split between 'privé-bericht' (majority) and 'direct bericht'/'rechtstreeks bericht'. Derived form: 'privé-berichtkanaal'."
   },
   "group message": {
     "target": "groepsbericht",
@@ -109,11 +109,11 @@
   },
   "mention": {
     "target": "vermelding",
-    "note": "Noun 'vermelding' (plural 'vermeldingen'); verb 'vermelden'. Per dutch-rules.md."
+    "note": "Noun 'vermelding' (plural 'vermeldingen'); verb 'vermelden'."
   },
   "notification": {
     "target": "melding",
-    "note": "Per dutch-rules.md; put 'melding' last in compounds: e-mailmelding, pushmelding, bureaubladmelding. Avoid 'notificatie' (legacy inconsistency)."
+    "note": "Put 'melding' last in compounds: e-mailmelding, pushmelding, bureaubladmelding. Avoid 'notificatie' (legacy inconsistency)."
   },
   "pin": {
     "target": "vastmaken",
@@ -137,14 +137,14 @@
   },
   "emoji": {
     "target": "emoticon",
-    "note": "Per dutch-rules.md and majority usage (63 vs 33); 'emoji' also occurs — prefer 'emoticon' for consistency. Plural 'emoticons'."
+    "note": "Majority usage (63 vs 33); 'emoji' also occurs. Plural 'emoticons'."
   },
   "custom emoji": {
     "target": "aangepaste emoticon"
   },
   "reaction": {
     "target": "reactie",
-    "note": "Plural 'reacties'; verb 'reageren'. Distinct from a reply ('antwoord') per dutch-rules.md."
+    "note": "Plural 'reacties'; verb 'reageren'. Distinct from a reply ('antwoord')."
   },
   "status": {
     "target": "status"
@@ -171,7 +171,7 @@
   },
   "guest": {
     "target": "gast",
-    "note": "Majority in-product rendering; dutch-rules.md prefers 'gastgebruiker', which also appears in admin screens — both are in use, prefer 'gast' in short UI labels and 'gastgebruiker' when disambiguation from a visitor is needed."
+    "note": "Both 'gast' and 'gastgebruiker' are in use; 'gastgebruiker' appears in admin screens. Use 'gast' in short UI labels and 'gastgebruiker' when disambiguation from a visitor is needed."
   },
   "member": {
     "target": "lid",
@@ -183,7 +183,7 @@
   },
   "system admin": {
     "target": "systeembeheerder",
-    "note": "Per dutch-rules.md; plural 'systeembeheerders'."
+    "note": "Plural 'systeembeheerders'."
   },
   "team admin": {
     "target": "teambeheerder"
@@ -201,7 +201,7 @@
   },
   "sign out": {
     "target": "afmelden",
-    "note": "Use for both 'sign out' and 'log out', per Weblate glossary ('Log Out' = 'Afmelden')."
+    "note": "Use for both 'sign out' and 'log out' ('Log Out' = 'Afmelden')."
   },
   "join": {
     "target": "lid worden",
@@ -243,11 +243,11 @@
   },
   "slash command": {
     "target": "slash-opdracht",
-    "note": "Majority rendering (15 vs 9); dutch-rules.md prefers 'slash-commando'. Existing usage is inconsistent (slashopdracht, slash-opdracht, slash-commando) — standardize on 'slash-opdracht'."
+    "note": "Existing usage is inconsistent: slashopdracht, slash-opdracht (majority, 15 vs 9), slash-commando."
   },
   "webhook": {
     "target": "webhook",
-    "note": "Kept in English per Weblate glossary; plural 'webhooks'."
+    "note": "Kept in English; plural 'webhooks'."
   },
   "incoming webhook": {
     "target": "inkomende webhook"
@@ -257,7 +257,7 @@
   },
   "trigger word": {
     "target": "triggerwoord",
-    "note": "Per dutch-rules.md; existing usage is inconsistent ('activeer-woord', 'trigger woord') — standardize on 'triggerwoord'."
+    "note": "Existing usage is inconsistent: 'activeer-woord', 'trigger woord'."
   },
   "plugin": {
     "target": "plugin",
@@ -265,7 +265,7 @@
   },
   "bot": {
     "target": "bot",
-    "note": "Per dutch-rules.md keep 'bot'/'BOT'; 'bot account' = 'botaccount'."
+    "note": "Keep 'bot'/'BOT'; 'bot account' = 'botaccount'."
   },
   "role": {
     "target": "rol",
@@ -273,11 +273,11 @@
   },
   "permission": {
     "target": "recht",
-    "note": "Plural 'rechten', per dutch-rules.md ('Rechten heeft de voorkeur'); avoid 'machtigingen'/'permissies'/'toestemmingen' which appear inconsistently in older strings."
+    "note": "Plural 'rechten'. Avoid 'machtigingen'/'permissies'/'toestemmingen', which appear inconsistently in older strings."
   },
   "scheme": {
     "target": "schema",
-    "note": "Permission scheme = '(toestemmings)schema'; existing strings mostly use plain 'schema'. For URL scheme use 'URL-protocol' per dutch-rules.md."
+    "note": "Permission scheme = '(toestemmings)schema'; existing strings mostly use plain 'schema'. For URL scheme use 'URL-protocol'."
   },
   "license": {
     "target": "licentie"
@@ -307,7 +307,7 @@
   },
   "invitation": {
     "target": "uitnodiging",
-    "note": "Plural 'uitnodigingen'; e-mail invitations = 'e-mailuitnodigingen' (note 'e-mail' spelling per dutch-rules.md)."
+    "note": "Plural 'uitnodigingen'; e-mail invitations = 'e-mailuitnodigingen' (note the 'e-mail' spelling)."
   },
   "sidebar": {
     "target": "zijbalk"
@@ -317,7 +317,7 @@
   },
   "attachment": {
     "target": "bijlage",
-    "note": "Plural 'bijlagen'; verb 'attach' for files = 'toevoegen'/'bijvoegen' per dutch-rules.md, 'koppelen' otherwise."
+    "note": "Plural 'bijlagen'; verb 'attach' for files = 'toevoegen'/'bijvoegen', 'koppelen' otherwise."
   },
   "public channel": {
     "target": "publiek kanaal",
@@ -337,7 +337,7 @@
   },
   "channel purpose": {
     "target": "kanaaldoel",
-    "note": "Existing strings consistently use 'doel'/'kanaaldoel'; dutch-rules.md suggests 'beschrijving' in this context but repo usage wins."
+    "note": "Existing strings consistently use 'doel'/'kanaaldoel'; 'beschrijving' is an alternative in this context."
   },
   "system message": {
     "target": "systeembericht"
@@ -372,7 +372,7 @@
   },
   "personal access token": {
     "target": "persoonlijk toegangstoken",
-    "note": "'Token' stays untranslated per dutch-rules.md; avoid Weblate glossary's 'toegangsbewijs' (not used in product strings)."
+    "note": "'Token' stays untranslated; avoid 'toegangsbewijs', which is not used in product strings."
   },
   "announcement banner": {
     "target": "aankondigingsbanner"
@@ -419,7 +419,7 @@
   },
   "compliance export": {
     "target": "nalevingsexport",
-    "note": "Majority webapp rendering; 'compliance export' also kept English in some strings. Dutch-rules.md renders 'Beta' contexts as 'Experimenteel'."
+    "note": "'compliance export' is also kept in English in some strings. 'Beta' contexts render as 'Experimenteel'."
   },
   "access control": {
     "target": "toegangscontrole",

--- a/i18n/glossary/nl.json
+++ b/i18n/glossary/nl.json
@@ -355,7 +355,7 @@
   },
   "urgent": {
     "target": "dringend",
-    "note": "Label 'DRINGEND' in caps context; 'urgente meldingen' also occurs but prefer 'dringend' (majority)."
+    "note": "'urgente meldingen' also occurs in some strings."
   },
   "recap": {
     "target": "samenvatting",
@@ -392,8 +392,7 @@
     "note": "Plural 'gebruikersgroepen'; plain 'group' = 'groep'."
   },
   "permalink": {
-    "target": "permalink",
-    "note": "Kept in English (existing usage)."
+    "target": "permalink"
   },
   "profile": {
     "target": "profiel",
@@ -434,12 +433,10 @@
     "note": "Plural 'attributen'; 'kenmerk' also occurs in ABAC strings — prefer 'attribuut' for the profile/access-control field."
   },
   "onboarding": {
-    "target": "verwelkoming",
-    "note": "Per Weblate glossary; existing strings are inconsistent (verwelkoming, onboarding, introductie) — standardize on 'verwelkoming'."
+    "target": "verwelkoming"
   },
   "Town Square": {
-    "target": "Dorpsplein",
-    "note": "Established default-channel name in server i18n."
+    "target": "Dorpsplein"
   },
   "Off-Topic": {
     "target": "Off-Topic",

--- a/i18n/glossary/pl.json
+++ b/i18n/glossary/pl.json
@@ -1,0 +1,468 @@
+{
+  "Mattermost": {
+    "target": "Mattermost",
+    "note": "Brand name; never translate or decline. Keep uninflected in all cases (do Mattermost, w Mattermost)."
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition",
+    "note": "Product edition name; keep in English. Existing pl.json once mistranslates it as 'Edytuj Zespół' (Team Edition) — do not follow that."
+  },
+  "Team Edition": {
+    "target": "Team Edition",
+    "note": "Product edition name; keep in English."
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "Product name; keep in English. The common noun 'channel' is translated as 'kanał'."
+  },
+  "Playbooks": {
+    "target": "Playbooks",
+    "note": "Product name; keep in English."
+  },
+  "Boards": {
+    "target": "Boards",
+    "note": "Product name; keep in English."
+  },
+  "Calls": {
+    "target": "Calls",
+    "note": "Product name; keep in English. The common noun 'call' is translated as 'połączenie'."
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP",
+    "note": "Keep 'AD/LDAP' compound as-is too."
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA",
+    "note": "Spelled-out form is 'uwierzytelnianie wieloskładnikowe' in existing translations."
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip",
+    "note": "Protocol name; never translate literally (not 'plotka')."
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "Konsola systemowa",
+    "note": "Established rendering across webapp/server/mobile. Locative: 'w Konsoli systemowej'. Existing usage varies in capitalization ('konsola systemowa' mid-sentence is fine)."
+  },
+  "marketplace": {
+    "target": "sklep z wtyczkami",
+    "note": "Existing usage is inconsistent: 'sklep z wtyczkami' (webapp admin), plain 'Sklep' (server /marketplace command), and untranslated 'Marketplace'. Prefer 'sklep z wtyczkami'; when referring to the proper name in admin settings, 'Marketplace' may be kept."
+  },
+  "channel": {
+    "target": "kanał",
+    "note": "Masculine. Plural 'kanały'; locative 'w kanale/na kanale' (both occur; 'w kanale' is slightly more common and preferred)."
+  },
+  "team": {
+    "target": "zespół",
+    "note": "Masculine. Plural 'zespoły'; genitive 'zespołu'."
+  },
+  "post": {
+    "target": "post",
+    "note": "Majority rendering is the loanword 'post' (masculine; plural 'posty'). 'wpis' appears sporadically — avoid it for consistency."
+  },
+  "message": {
+    "target": "wiadomość",
+    "note": "Feminine. Plural 'wiadomości'."
+  },
+  "thread": {
+    "target": "wątek",
+    "note": "Masculine. Plural 'wątki'; locative 'w wątku'."
+  },
+  "reply": {
+    "target": "odpowiedź",
+    "note": "Noun: 'odpowiedź' (feminine, plural 'odpowiedzi'). Verb: 'odpowiedzieć' / imperative button 'Odpowiedz'."
+  },
+  "direct message": {
+    "target": "wiadomość bezpośrednia",
+    "note": "Established rendering; plural 'wiadomości bezpośrednie'. Do not translate the DM abbreviation."
+  },
+  "group message": {
+    "target": "wiadomość grupowa",
+    "note": "Plural 'wiadomości grupowe'."
+  },
+  "mention": {
+    "target": "wzmianka",
+    "note": "Noun: 'wzmianka' (feminine). Verb: 'wspomnieć (o kimś)'. '@mention' → 'wzmianka @'."
+  },
+  "notification": {
+    "target": "powiadomienie",
+    "note": "Neuter. Plural 'powiadomienia'."
+  },
+  "pin": {
+    "target": "przypiąć",
+    "note": "Imperative button 'Przypnij'. 'Pinned messages' → 'Przypięte wiadomości'; 'unpin' → 'odepnij'. One legacy webapp string uses 'pinezki' — avoid."
+  },
+  "bookmark": {
+    "target": "zakładka",
+    "note": "Noun: 'zakładka' (feminine). Verb: 'dodaj zakładkę'. Channel bookmark → 'zakładka kanału'."
+  },
+  "saved messages": {
+    "target": "zapisane wiadomości",
+    "note": "'save' → 'zapisz'; 'unsave' → 'usuń z zapisanych'."
+  },
+  "draft": {
+    "target": "wersja robocza",
+    "note": "Existing usage is split between 'wersja robocza' and 'szkic'; 'wersja robocza' is the majority in user-facing strings and matches Polish UI convention. Plural 'wersje robocze'."
+  },
+  "scheduled post": {
+    "target": "zaplanowany post",
+    "note": "'scheduled message' → 'zaplanowana wiadomość'. Section label 'Scheduled' → 'Zaplanowane'."
+  },
+  "emoji": {
+    "target": "emoji",
+    "note": "Indeclinable neuter loanword; same form in singular and plural ('to emoji', 'te emoji')."
+  },
+  "custom emoji": {
+    "target": "niestandardowe emoji"
+  },
+  "reaction": {
+    "target": "reakcja",
+    "note": "Verb 'react' → 'zareagować'; 'Add reaction' → 'Dodaj reakcję'."
+  },
+  "status": {
+    "target": "status",
+    "note": "Masculine. Use 'status' (not 'stan') for user availability."
+  },
+  "custom status": {
+    "target": "status niestandardowy",
+    "note": "Word order varies in existing strings ('niestandardowy status' also common); both acceptable, prefer 'status niestandardowy' for labels."
+  },
+  "do not disturb": {
+    "target": "Nie przeszkadzać",
+    "note": "Established status name. Keep 'tryb „Nie przeszkadzać”' when used as a noun phrase. Do not translate the DND abbreviation."
+  },
+  "away": {
+    "target": "Zaraz wracam",
+    "note": "Established status name (lit. 'be right back'), consistent across webapp and mobile. Avoid 'nieobecny', which appears in a few legacy server strings."
+  },
+  "online": {
+    "target": "Online",
+    "note": "Majority keeps the loanword 'online' (indeclinable). Mobile occasionally uses 'Dostępny' — prefer 'Online' for the status name."
+  },
+  "offline": {
+    "target": "Offline",
+    "note": "Majority keeps 'offline' (indeclinable). 'Niedostępny' appears in some server command strings."
+  },
+  "out of office": {
+    "target": "Poza biurem",
+    "note": "Established status name."
+  },
+  "guest": {
+    "target": "gość",
+    "note": "Masculine. Plural 'goście'; genitive plural 'gości'. 'Guest access' → 'dostęp dla gości'."
+  },
+  "member": {
+    "target": "członek",
+    "note": "Masculine personal. Plural 'członkowie'; genitive 'członka'. 'channel member' → 'członek kanału'."
+  },
+  "user": {
+    "target": "użytkownik",
+    "note": "Plural 'użytkownicy'."
+  },
+  "system admin": {
+    "target": "administrator systemu",
+    "note": "Plural 'administratorzy systemu'. Use consistently for 'System Administrator' too."
+  },
+  "team admin": {
+    "target": "administrator zespołu"
+  },
+  "channel admin": {
+    "target": "administrator kanału"
+  },
+  "session": {
+    "target": "sesja",
+    "note": "Feminine. Plural 'sesje'. 'Session expired' → 'Sesja wygasła'."
+  },
+  "sign in": {
+    "target": "zalogować się",
+    "note": "Button 'Zaloguj się'. Translate 'log in' and 'sign in' identically."
+  },
+  "sign out": {
+    "target": "wylogować się",
+    "note": "Button 'Wyloguj się'. Translate 'log out' and 'sign out' identically."
+  },
+  "join": {
+    "target": "dołączyć",
+    "note": "Button 'Dołącz'. 'joined the channel' → 'dołączył(a) do kanału'."
+  },
+  "leave": {
+    "target": "opuścić",
+    "note": "Button 'Opuść'. 'left the channel' → 'opuścił(a) kanał'."
+  },
+  "archive": {
+    "target": "zarchiwizować",
+    "note": "Button 'Zarchiwizuj'; 'archived' → 'zarchiwizowany'."
+  },
+  "unarchive": {
+    "target": "cofnąć archiwizację",
+    "note": "Existing renderings are inconsistent ('Odarchiwizuj', 'Zdearchiwizuj', 'Cofnij archiwizację'); none has a clear majority. Prefer the standard 'cofnij archiwizację' (button 'Cofnij archiwizację') and avoid the non-standard coinages."
+  },
+  "mute": {
+    "target": "wyciszyć",
+    "note": "Button 'Wycisz'; 'muted' → 'wyciszony'; 'unmute' → 'wyłącz wyciszenie'. Same verb is used for Calls microphone muting."
+  },
+  "follow": {
+    "target": "obserwować",
+    "note": "Button 'Obserwuj'. Majority rendering; 'śledzić' appears in some thread-related strings — prefer 'obserwować' for consistency with webapp and Playbooks."
+  },
+  "unfollow": {
+    "target": "przestać obserwować",
+    "note": "Button 'Przestań obserwować' (mobile/playbooks) or 'Nie obserwuj' (webapp menu items)."
+  },
+  "favorite": {
+    "target": "ulubiony",
+    "note": "Adjective/noun 'ulubiony'; sidebar category 'Ulubione'; verb → 'dodaj do ulubionych', 'unfavorite' → 'usuń z ulubionych'."
+  },
+  "search": {
+    "target": "wyszukiwanie",
+    "note": "Noun 'wyszukiwanie'; verb/button 'Szukaj' or 'wyszukaj'."
+  },
+  "integration": {
+    "target": "integracja",
+    "note": "Feminine. Plural 'integracje'."
+  },
+  "slash command": {
+    "target": "polecenie po ukośniku",
+    "note": "Majority rendering (mobile, playbooks, newer webapp). Older strings use 'komenda po ukośniku' — prefer 'polecenie'."
+  },
+  "webhook": {
+    "target": "webhook",
+    "note": "Kept in English by convention; declined as masculine ('webhooka', 'webhooki', 'webhookami')."
+  },
+  "incoming webhook": {
+    "target": "webhook przychodzący",
+    "note": "Word order varies in existing strings ('przychodzący webhook' also common); prefer noun-first 'webhook przychodzący' for term consistency with 'webhook wychodzący'."
+  },
+  "outgoing webhook": {
+    "target": "webhook wychodzący"
+  },
+  "trigger word": {
+    "target": "słowo wyzwalające",
+    "note": "Existing usage mixes 'słowo wyzwalające' and 'słowo wyzwalacza'; prefer 'słowo wyzwalające'."
+  },
+  "plugin": {
+    "target": "wtyczka",
+    "note": "Feminine. Plural 'wtyczki'. Avoid the loanword 'plugin' seen in a few legacy strings."
+  },
+  "bot": {
+    "target": "bot",
+    "note": "Masculine. Plural 'boty'; 'bot account' → 'konto bota'."
+  },
+  "role": {
+    "target": "rola",
+    "note": "Feminine. Plural 'role'."
+  },
+  "permission": {
+    "target": "uprawnienie",
+    "note": "Neuter. Plural 'uprawnienia'. Majority rendering; avoid 'pozwolenie' seen sporadically."
+  },
+  "scheme": {
+    "target": "schemat",
+    "note": "'permission scheme' → 'schemat uprawnień'."
+  },
+  "license": {
+    "target": "licencja"
+  },
+  "seat": {
+    "target": "miejsce",
+    "note": "Licensed seat → 'miejsce' (plural 'miejsca', genitive plural 'miejsc'). 'stanowisko' appears once — avoid."
+  },
+  "trial": {
+    "target": "okres próbny",
+    "note": "For the time period use 'okres próbny'; for a trial license use 'licencja próbna'. Avoid 'wersja testowa' seen in some strings."
+  },
+  "workspace": {
+    "target": "obszar roboczy",
+    "note": "Majority rendering; 'przestrzeń robocza' also occurs — prefer 'obszar roboczy'. Locative 'w obszarze roboczym'."
+  },
+  "subscription": {
+    "target": "subskrypcja",
+    "note": "Majority rendering; 'abonament' appears once in billing — prefer 'subskrypcja'."
+  },
+  "deactivate": {
+    "target": "dezaktywować",
+    "note": "Button 'Dezaktywuj'; 'deactivated' → 'dezaktywowany'."
+  },
+  "invite": {
+    "target": "zaprosić",
+    "note": "Verb 'zaprosić' (button 'Zaproś'); noun uses 'zaproszenie'."
+  },
+  "invitation": {
+    "target": "zaproszenie",
+    "note": "Neuter. Plural 'zaproszenia'."
+  },
+  "sidebar": {
+    "target": "pasek boczny",
+    "note": "Locative 'w pasku bocznym' / 'na pasku bocznym'."
+  },
+  "unread": {
+    "target": "nieprzeczytane",
+    "note": "Adjective; agrees in gender/number ('nieprzeczytana wiadomość', 'nieprzeczytane kanały'). Category label 'Unreads' → 'Nieprzeczytane'."
+  },
+  "attachment": {
+    "target": "załącznik",
+    "note": "Masculine. Plural 'załączniki'."
+  },
+  "public channel": {
+    "target": "kanał publiczny"
+  },
+  "private channel": {
+    "target": "kanał prywatny"
+  },
+  "shared channel": {
+    "target": "kanał udostępniony",
+    "note": "Majority rendering; 'kanał współdzielony' appears in some server strings — prefer 'udostępniony'."
+  },
+  "channel header": {
+    "target": "nagłówek kanału"
+  },
+  "channel purpose": {
+    "target": "cel kanału",
+    "note": "Standalone label 'Purpose' → 'Cel'."
+  },
+  "system message": {
+    "target": "wiadomość systemowa"
+  },
+  "persistent notification": {
+    "target": "trwałe powiadomienie",
+    "note": "Majority rendering; 'powiadomienie stałe' also occurs — prefer 'trwałe powiadomienie'."
+  },
+  "message priority": {
+    "target": "priorytet wiadomości",
+    "note": "Priority levels: Standard → 'Standardowy', Important → 'Ważne', Urgent → 'Pilne'."
+  },
+  "urgent": {
+    "target": "pilne",
+    "note": "Label 'PILNE' when uppercased. Agrees with 'wiadomość': 'pilna wiadomość', 'pilna wzmianka'."
+  },
+  "recap": {
+    "target": "podsumowanie",
+    "note": "Established rendering in webapp/server AI strings. Plural 'podsumowania'."
+  },
+  "agent": {
+    "target": "agent",
+    "note": "AI assistant. Masculine personal: plural 'agenci' (nominative), 'agentów' (genitive/accusative). 'AI agents' → 'agenci AI'."
+  },
+  "burn-on-read": {
+    "target": "burn-on-read",
+    "note": "Existing translations mostly keep the English term ('wiadomość burn-on-read', 'post burn-on-read'); occasional literal renderings ('do zniszczenia przy odczycie') are inconsistent. Keep English and treat as indeclinable attribute."
+  },
+  "magic link": {
+    "target": "magiczny link",
+    "note": "Majority rendering; a few strings keep English 'magic link' — prefer 'magiczny link'. Genitive 'magicznego linku'."
+  },
+  "personal access token": {
+    "target": "osobisty token dostępu",
+    "note": "Plural 'osobiste tokeny dostępu'."
+  },
+  "announcement banner": {
+    "target": "baner ogłoszeń",
+    "note": "Existing renderings vary ('baner ogłoszenia', 'baner ogłoszeniowy'); prefer 'baner ogłoszeń'."
+  },
+  "channel banner": {
+    "target": "baner kanału"
+  },
+  "keyword": {
+    "target": "słowo kluczowe",
+    "note": "Plural 'słowa kluczowe'."
+  },
+  "user group": {
+    "target": "grupa użytkowników",
+    "note": "Plain 'group' in this sense is also 'grupa'."
+  },
+  "permalink": {
+    "target": "permalink",
+    "note": "Kept as loanword in existing translations; declined as masculine ('permalinku'). A more descriptive alternative would be 'link bezpośredni', but stay with 'permalink' for consistency."
+  },
+  "profile": {
+    "target": "profil",
+    "note": "'Profile picture' → 'zdjęcie profilowe'."
+  },
+  "username": {
+    "target": "nazwa użytkownika"
+  },
+  "nickname": {
+    "target": "pseudonim"
+  },
+  "display name": {
+    "target": "nazwa wyświetlana"
+  },
+  "collapsed reply threads": {
+    "target": "zawijanie odpowiedzi w wątkach",
+    "note": "Only existing rendering (mobile settings) is 'Zawijanie Odpowiedzi w Wątkach'. A more literal alternative is 'zwinięte wątki odpowiedzi', but keep the established form for consistency."
+  },
+  "auto-translation": {
+    "target": "autotłumaczenie",
+    "note": "'auto-translated' → 'przetłumaczone automatycznie'; label 'AUTO-TRANSLATED' → 'AUTOTŁUMACZENIE'."
+  },
+  "data retention": {
+    "target": "przechowywanie danych",
+    "note": "Majority rendering in webapp; 'retencja danych' appears in server enterprise strings. Prefer 'przechowywanie danych'; policy → 'zasady przechowywania danych'."
+  },
+  "compliance export": {
+    "target": "eksport zgodności"
+  },
+  "access control": {
+    "target": "kontrola dostępu",
+    "note": "'attribute-based access control' → 'kontrola dostępu oparta na atrybutach'; policy → 'polityka kontroli dostępu'."
+  },
+  "attribute": {
+    "target": "atrybut",
+    "note": "Masculine. Plural 'atrybuty'. 'custom profile attribute' → 'niestandardowy atrybut profilu' / 'atrybut użytkownika'."
+  },
+  "onboarding": {
+    "target": "onboarding",
+    "note": "Existing translations mostly keep the loanword 'onboarding'; 'proces wprowadzania' appears descriptively. Keep 'onboarding' (masculine, declinable: 'onboardingu')."
+  },
+  "Town Square": {
+    "target": "Rynek",
+    "note": "Established default-channel name in server translations; translate consistently as a channel name."
+  },
+  "Off-Topic": {
+    "target": "Pogawędki",
+    "note": "Established default-channel name in server translations."
+  },
+  "read-only": {
+    "target": "tylko do odczytu",
+    "note": "Avoid hyphenated 'tylko-do-odczytu' seen in a few legacy strings; standard Polish is unhyphenated."
+  },
+  "server": {
+    "target": "serwer",
+    "note": "Masculine. Locative 'na serwerze'; genitive 'serwera'."
+  }
+}

--- a/i18n/glossary/pl.json
+++ b/i18n/glossary/pl.json
@@ -8,8 +8,7 @@
     "note": "Product edition name; keep in English. Existing pl.json once mistranslates it as 'Edytuj Zespół' (Team Edition) — do not follow that."
   },
   "Team Edition": {
-    "target": "Team Edition",
-    "note": "Product edition name; keep in English."
+    "target": "Team Edition"
   },
   "Mattermost Cloud": {
     "target": "Mattermost Cloud"
@@ -19,12 +18,10 @@
     "note": "Product name; keep in English. The common noun 'channel' is translated as 'kanał'."
   },
   "Playbooks": {
-    "target": "Playbooks",
-    "note": "Product name; keep in English."
+    "target": "Playbooks"
   },
   "Boards": {
-    "target": "Boards",
-    "note": "Product name; keep in English."
+    "target": "Boards"
   },
   "Calls": {
     "target": "Calls",
@@ -179,8 +176,7 @@
     "note": "Majority keeps 'offline' (indeclinable). 'Niedostępny' appears in some server command strings."
   },
   "out of office": {
-    "target": "Poza biurem",
-    "note": "Established status name."
+    "target": "Poza biurem"
   },
   "guest": {
     "target": "gość",
@@ -450,12 +446,10 @@
     "note": "Existing translations mostly keep the loanword 'onboarding'; 'proces wprowadzania' appears descriptively. Keep 'onboarding' (masculine, declinable: 'onboardingu')."
   },
   "Town Square": {
-    "target": "Rynek",
-    "note": "Established default-channel name in server translations; translate consistently as a channel name."
+    "target": "Rynek"
   },
   "Off-Topic": {
-    "target": "Pogawędki",
-    "note": "Established default-channel name in server translations."
+    "target": "Pogawędki"
   },
   "read-only": {
     "target": "tylko do odczytu",

--- a/i18n/glossary/pl.json
+++ b/i18n/glossary/pl.json
@@ -59,9 +59,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip",
     "note": "Protocol name; never translate literally (not 'plotka')."

--- a/i18n/glossary/pt-BR.json
+++ b/i18n/glossary/pt-BR.json
@@ -1,0 +1,434 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition"
+  },
+  "Team Edition": {
+    "target": "Team Edition"
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "Product name; stays in English. The common noun 'channel' is translated as 'canal'."
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls",
+    "note": "Product name; stays in English. The common noun 'call' is translated as 'chamada'."
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "Console do Sistema",
+    "note": "Established rendering across webapp and server; capitalize both words when used as the UI area name."
+  },
+  "marketplace": {
+    "target": "Marketplace",
+    "note": "Kept in English throughout existing translations (e.g. 'Marketplace de aplicativos', 'URL do Marketplace'); masculine noun ('o Marketplace')."
+  },
+  "channel": {
+    "target": "canal",
+    "note": "Masculine; plural 'canais'."
+  },
+  "team": {
+    "target": "equipe",
+    "note": "Feminine. Consistently 'equipe' in existing translations; avoid 'time' (appears rarely, e.g. 'Time Padrão' in one server string)."
+  },
+  "post": {
+    "target": "publicação",
+    "note": "Majority rendering in newer strings. Legacy strings mix 'postagem' and untranslated 'post'; prefer 'publicação' (noun) / 'publicar' (verb)."
+  },
+  "message": {
+    "target": "mensagem"
+  },
+  "thread": {
+    "target": "tópico",
+    "note": "Clear majority across webapp, mobile, server, and Calls. A few webapp strings use 'fio' ('Seguir o fio'); avoid it."
+  },
+  "reply": {
+    "target": "responder",
+    "note": "Verb 'responder'; noun 'resposta' (e.g. 'Última resposta')."
+  },
+  "direct message": {
+    "target": "mensagem direta",
+    "note": "Capitalized 'Mensagem Direta' when used as a feature name. Do not keep the 'DM' abbreviation; spell out."
+  },
+  "group message": {
+    "target": "mensagem de grupo"
+  },
+  "mention": {
+    "target": "menção",
+    "note": "Noun 'menção'; verb 'mencionar'."
+  },
+  "notification": {
+    "target": "notificação"
+  },
+  "pin": {
+    "target": "fixar",
+    "note": "'Fixar no Canal', 'fixado', 'mensagens fixadas'. Unpin = 'desafixar'. A few server strings use 'pinadas'/'Pinar'; avoid."
+  },
+  "bookmark": {
+    "target": "marcador",
+    "note": "Noun 'marcador'; verb 'adicionar um marcador'. Established in mobile and server strings."
+  },
+  "saved messages": {
+    "target": "mensagens salvas",
+    "note": "Save = 'salvar', unsave = 'remover de salvos'. Webapp legacy strings use 'Publicações Salvas'; mobile uses 'Mensagens Salvas' — prefer 'mensagens salvas'."
+  },
+  "draft": {
+    "target": "rascunho"
+  },
+  "scheduled post": {
+    "target": "publicação agendada",
+    "note": "Majority rendering; 'programada' appears in a couple of server strings — avoid."
+  },
+  "emoji": {
+    "target": "emoji",
+    "note": "Masculine, invariable spelling; plural 'emojis'."
+  },
+  "custom emoji": {
+    "target": "emoji personalizado"
+  },
+  "reaction": {
+    "target": "reação",
+    "note": "Verb: 'reagir'."
+  },
+  "status": {
+    "target": "status",
+    "note": "Kept as 'status' (masculine, invariable) in pt-BR."
+  },
+  "custom status": {
+    "target": "status personalizado"
+  },
+  "do not disturb": {
+    "target": "Não Perturbe",
+    "note": "Established status name across webapp, mobile, and server."
+  },
+  "away": {
+    "target": "ausente"
+  },
+  "online": {
+    "target": "conectado",
+    "note": "Majority rendering for the availability status (server commands, mobile). Some webapp strings keep 'Online'; prefer 'conectado' for the status name."
+  },
+  "offline": {
+    "target": "desconectado",
+    "note": "Some webapp strings keep 'Offline'; prefer 'desconectado' for the status name."
+  },
+  "out of office": {
+    "target": "Fora do Escritório",
+    "note": "Established rendering in status modals."
+  },
+  "guest": {
+    "target": "convidado",
+    "note": "Consistent majority; one webapp string uses 'Visitante' — avoid. Same word as the past participle of 'convidar' (to invite); context usually disambiguates."
+  },
+  "member": {
+    "target": "membro"
+  },
+  "user": {
+    "target": "usuário"
+  },
+  "system admin": {
+    "target": "administrador do sistema",
+    "note": "Short label 'Admin do Sistema' also appears; prefer the full form in prose."
+  },
+  "team admin": {
+    "target": "administrador da equipe"
+  },
+  "channel admin": {
+    "target": "administrador de canal"
+  },
+  "session": {
+    "target": "sessão"
+  },
+  "sign in": {
+    "target": "fazer login",
+    "note": "Existing translations are inconsistent ('Conecte-se', 'Entrar', 'fazer login'); 'fazer login' is the overall majority. For short buttons 'Entrar' is acceptable; translate 'log in' and 'sign in' identically."
+  },
+  "sign out": {
+    "target": "sair",
+    "note": "'Log Out' is consistently 'Sair'. Translate 'log out' and 'sign out' identically."
+  },
+  "join": {
+    "target": "entrar",
+    "note": "'Entrar' for channels/teams ('Entrar no canal'); 'participar' is used for calls and open teams; avoid 'juntar-se' except for groups where it already appears."
+  },
+  "leave": {
+    "target": "sair",
+    "note": "Existing UI mixes 'Deixar o Canal' (majority for channels) and 'Sair da Equipe' (teams). Either is acceptable; keep each context internally consistent."
+  },
+  "archive": {
+    "target": "arquivar",
+    "note": "'Arquivar Canal', 'arquivado'. Note 'arquivo' also means 'file' in Portuguese; avoid ambiguous noun uses."
+  },
+  "unarchive": {
+    "target": "desarquivar"
+  },
+  "mute": {
+    "target": "silenciar",
+    "note": "For channel notifications: 'Silenciar Canal' (majority). Legacy strings use 'Mutar'/'Ativar Mudo'; avoid. Unmute = 'desativar o silêncio' or 'reativar notificações' per context."
+  },
+  "follow": {
+    "target": "seguir"
+  },
+  "unfollow": {
+    "target": "deixar de seguir"
+  },
+  "favorite": {
+    "target": "favorito",
+    "note": "Noun/category 'Favoritos'; verb 'favoritar' (already used in webapp); unfavorite = 'remover dos favoritos'."
+  },
+  "search": {
+    "target": "pesquisar",
+    "note": "Corpus mixes 'Procurar' (main search bar), 'pesquisar' (results, groups, members), and 'buscar'. 'Pesquisar'/'pesquisa' is the overall majority; noun = 'pesquisa'."
+  },
+  "integration": {
+    "target": "integração"
+  },
+  "slash command": {
+    "target": "comando slash",
+    "note": "Established rendering; 'slash' stays in English."
+  },
+  "webhook": {
+    "target": "webhook",
+    "note": "Kept in English (masculine: 'o webhook') consistently."
+  },
+  "incoming webhook": {
+    "target": "webhook de entrada"
+  },
+  "outgoing webhook": {
+    "target": "webhook de saída"
+  },
+  "trigger word": {
+    "target": "palavra gatilho",
+    "note": "Established without hyphen in existing strings; plural 'palavras gatilho'."
+  },
+  "plugin": {
+    "target": "plugin",
+    "note": "Kept in English (masculine: 'o plugin'); avoid the hyphenated 'plug-in' that appears once."
+  },
+  "bot": {
+    "target": "bot",
+    "note": "Kept in English; 'conta de bot' for bot account."
+  },
+  "role": {
+    "target": "função",
+    "note": "Consistent majority ('Função de Membro', 'Funções de Administrador'); avoid 'papel'."
+  },
+  "permission": {
+    "target": "permissão"
+  },
+  "scheme": {
+    "target": "esquema",
+    "note": "'Esquema de Permissões', 'Esquema de Equipe'."
+  },
+  "license": {
+    "target": "licença"
+  },
+  "seat": {
+    "target": "assento",
+    "note": "No existing translation found in the repos; 'assento' is the common pt-BR SaaS pricing term. 'Licença de usuário' is an acceptable descriptive alternative."
+  },
+  "trial": {
+    "target": "avaliação",
+    "note": "Corpus splits between 'avaliação' and 'teste' ('teste gratuito'); 'avaliação (gratuita)' is slightly more common in newer strings — standardize on it."
+  },
+  "workspace": {
+    "target": "espaço de trabalho",
+    "note": "Clear majority; a few server email strings keep 'workspace' — avoid."
+  },
+  "subscription": {
+    "target": "assinatura",
+    "note": "One admin sidebar string uses 'Inscrição'; prefer 'assinatura'."
+  },
+  "deactivate": {
+    "target": "desativar"
+  },
+  "invite": {
+    "target": "convidar",
+    "note": "Verb 'convidar'; noun 'convite'."
+  },
+  "invitation": {
+    "target": "convite"
+  },
+  "sidebar": {
+    "target": "barra lateral"
+  },
+  "unread": {
+    "target": "não lido",
+    "note": "Agrees in gender/number: 'mensagens não lidas', 'canais não lidos'; 'Não lidos' for the Unreads view."
+  },
+  "attachment": {
+    "target": "anexo"
+  },
+  "public channel": {
+    "target": "canal público"
+  },
+  "private channel": {
+    "target": "canal privado"
+  },
+  "shared channel": {
+    "target": "canal compartilhado"
+  },
+  "channel header": {
+    "target": "cabeçalho do canal"
+  },
+  "channel purpose": {
+    "target": "propósito do canal",
+    "note": "Majority 'propósito'; a couple of strings use 'finalidade' — avoid."
+  },
+  "system message": {
+    "target": "mensagem do sistema"
+  },
+  "persistent notification": {
+    "target": "notificação persistente"
+  },
+  "message priority": {
+    "target": "prioridade da mensagem"
+  },
+  "urgent": {
+    "target": "urgente",
+    "note": "All-caps label: 'URGENTE'."
+  },
+  "recap": {
+    "target": "resumo",
+    "note": "No existing translation in the repos. 'Resumo' is natural for AI-generated summaries; Microsoft Teams uses 'recapitulação' if a distinct word from 'summary' is required."
+  },
+  "agent": {
+    "target": "agente",
+    "note": "Masculine even when referring to the AI assistant; 'Agentes' for the feature area."
+  },
+  "burn-on-read": {
+    "target": "autodestruição após leitura",
+    "note": "No existing translation. Adjectival use: 'mensagem com autodestruição após leitura'; all-caps label: 'AUTODESTRUIÇÃO APÓS LEITURA'. Avoid literal 'queimar'."
+  },
+  "magic link": {
+    "target": "link mágico",
+    "note": "No existing translation in the repos; 'link mágico' is the established pt-BR term (e.g. Slack, Notion)."
+  },
+  "personal access token": {
+    "target": "token de acesso individual",
+    "note": "Majority in existing webapp/server strings. 'Token de acesso pessoal' (the GitHub/GitLab industry standard) appears once and is arguably better; keep 'individual' for consistency unless a global cleanup is done."
+  },
+  "announcement banner": {
+    "target": "banner de anúncio"
+  },
+  "channel banner": {
+    "target": "banner do canal"
+  },
+  "keyword": {
+    "target": "palavra-chave",
+    "note": "Plural 'palavras-chave' (invariable second element)."
+  },
+  "user group": {
+    "target": "grupo de usuários"
+  },
+  "permalink": {
+    "target": "permalink",
+    "note": "Kept in English in existing strings ('O permalink pertence...'); 'link permanente' is an acceptable alternative if translating."
+  },
+  "profile": {
+    "target": "perfil"
+  },
+  "username": {
+    "target": "nome de usuário",
+    "note": "Short form 'Usuário' is used in existing login/form labels; use the full 'nome de usuário' in prose."
+  },
+  "nickname": {
+    "target": "apelido"
+  },
+  "display name": {
+    "target": "nome de exibição",
+    "note": "Majority; 'nome para exibição' also appears in server strings — prefer 'nome de exibição'."
+  },
+  "collapsed reply threads": {
+    "target": "tópicos de resposta recolhidos",
+    "note": "Mobile currently has 'Respostas de Tópicos Recolhidos', which inverts the meaning; prefer 'tópicos de resposta recolhidos' and keep it consistent as the feature name."
+  },
+  "auto-translation": {
+    "target": "tradução automática",
+    "note": "'traduzido automaticamente' for 'auto-translated'; all-caps label: 'TRADUZIDO AUTOMATICAMENTE'."
+  },
+  "data retention": {
+    "target": "retenção de dados",
+    "note": "'Política de Retenção de Dados' for data retention policy."
+  },
+  "compliance export": {
+    "target": "exportação de conformidade"
+  },
+  "access control": {
+    "target": "controle de acesso",
+    "note": "'controle de acesso baseado em atributos' for attribute-based access control."
+  },
+  "attribute": {
+    "target": "atributo"
+  },
+  "onboarding": {
+    "target": "onboarding",
+    "note": "Kept in English in most server strings (masculine: 'o onboarding'). One webapp string uses 'Integração', which collides with 'integration' — avoid."
+  },
+  "Town Square": {
+    "target": "Town Square",
+    "note": "Existing pt-BR translations keep the default channel name in English (server default-channel string is untranslated). Keep as-is for consistency with existing workspaces."
+  },
+  "Off-Topic": {
+    "target": "Off-Topic",
+    "note": "Existing pt-BR translations keep this default channel name in English; keep as-is."
+  },
+  "read-only": {
+    "target": "somente leitura"
+  },
+  "server": {
+    "target": "servidor"
+  }
+}

--- a/i18n/glossary/pt-BR.json
+++ b/i18n/glossary/pt-BR.json
@@ -55,9 +55,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/pt-BR.json
+++ b/i18n/glossary/pt-BR.json
@@ -150,8 +150,7 @@
     "target": "status personalizado"
   },
   "do not disturb": {
-    "target": "Não Perturbe",
-    "note": "Established status name across webapp, mobile, and server."
+    "target": "Não Perturbe"
   },
   "away": {
     "target": "ausente"
@@ -165,8 +164,7 @@
     "note": "Some webapp strings keep 'Offline'; prefer 'desconectado' for the status name."
   },
   "out of office": {
-    "target": "Fora do Escritório",
-    "note": "Established rendering in status modals."
+    "target": "Fora do Escritório"
   },
   "guest": {
     "target": "convidado",
@@ -337,8 +335,7 @@
     "target": "prioridade da mensagem"
   },
   "urgent": {
-    "target": "urgente",
-    "note": "All-caps label: 'URGENTE'."
+    "target": "urgente"
   },
   "recap": {
     "target": "resumo",
@@ -350,7 +347,7 @@
   },
   "burn-on-read": {
     "target": "autodestruição após leitura",
-    "note": "No existing translation. Adjectival use: 'mensagem com autodestruição após leitura'; all-caps label: 'AUTODESTRUIÇÃO APÓS LEITURA'. Avoid literal 'queimar'."
+    "note": "No existing translation. Adjectival use: 'mensagem com autodestruição após leitura'. Avoid literal 'queimar'."
   },
   "magic link": {
     "target": "link mágico",

--- a/i18n/glossary/ro.json
+++ b/i18n/glossary/ro.json
@@ -1,0 +1,469 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition",
+    "note": "Product edition name; keep in English. Legacy webapp strings sometimes render 'Ediția Enterprise' — prefer the English name."
+  },
+  "Team Edition": {
+    "target": "Team Edition",
+    "note": "Keep in English; an old webapp string renders 'Ediție de echipă' but edition names should stay untranslated."
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "Product name; do not confuse with the common noun 'canal/canale'."
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "Consola de sistem",
+    "note": "Established in webapp ro.json ('consola de sistem'). Genitive: 'consolei de sistem'."
+  },
+  "marketplace": {
+    "target": "Marketplace",
+    "note": "Webapp ro.json is inconsistent: some labels use 'piața', others keep 'Marketplace'. Keep the English name as the primary rendering (modern Romanian software convention) and treat 'piață' occurrences as legacy."
+  },
+  "channel": {
+    "target": "canal",
+    "note": "Plural: 'canale'. Definite: 'canalul/canalele'."
+  },
+  "team": {
+    "target": "echipă",
+    "note": "Plural: 'echipe'."
+  },
+  "post": {
+    "target": "postare",
+    "note": "Noun; plural 'postări'. Verb: 'a posta'. Avoid the calque 'post/posturi' seen in a few legacy strings ('posturi fixate')."
+  },
+  "message": {
+    "target": "mesaj",
+    "note": "Plural: 'mesaje'."
+  },
+  "thread": {
+    "target": "fir",
+    "note": "Majority rendering in webapp/server ('firul', 'fir de discuție'). Inconsistencies observed: 'subiect' and 'Detalii Mesaj' for the Thread panel title — prefer 'fir' everywhere. Plural: 'fire'."
+  },
+  "reply": {
+    "target": "răspuns",
+    "note": "Noun; plural 'răspunsuri'. Verb: 'a răspunde' (button: 'Răspunde'/'Răspundeți')."
+  },
+  "direct message": {
+    "target": "mesaj direct",
+    "note": "Plural: 'mesaje directe'. Keep 'DM' untranslated if the abbreviation appears."
+  },
+  "group message": {
+    "target": "mesaj de grup",
+    "note": "Plural: 'mesaje de grup'."
+  },
+  "mention": {
+    "target": "mențiune",
+    "note": "Noun; plural 'mențiuni'. Verb: 'a menționa'. Use modern diacritics (ț not ţ)."
+  },
+  "notification": {
+    "target": "notificare",
+    "note": "Plural: 'notificări'."
+  },
+  "pin": {
+    "target": "a fixa",
+    "note": "'Fixați pe canal' (mobile), 'mesaje fixate'. Unpin: 'a anula fixarea'. Avoid untranslated 'Pin' seen in one webapp string."
+  },
+  "bookmark": {
+    "target": "marcaj",
+    "note": "Noun; plural 'marcaje'. Verb: 'a adăuga la marcaje'. No established repo rendering; standard Romanian UI term."
+  },
+  "saved messages": {
+    "target": "mesaje salvate",
+    "note": "Webapp mixes 'mesaje salvate' and 'postări salvate'; prefer 'mesaje salvate'. Save/unsave: 'a salva' / 'a elimina din salvate'."
+  },
+  "draft": {
+    "target": "schiță",
+    "note": "Plural: 'schițe'. No repo signal; standard Romanian software term (Gmail, Teams)."
+  },
+  "scheduled post": {
+    "target": "postare programată",
+    "note": "Plural: 'postări programate'. 'Scheduled message' = 'mesaj programat'."
+  },
+  "emoji": {
+    "target": "emoji",
+    "note": "Invariable loanword, already used in webapp ro.json. Plural in running text: 'emoji-uri'."
+  },
+  "custom emoji": {
+    "target": "emoji personalizat",
+    "note": "Plural: 'emoji-uri personalizate'."
+  },
+  "reaction": {
+    "target": "reacție",
+    "note": "Plural: 'reacții'. Verb 'react': 'a reacționa'."
+  },
+  "status": {
+    "target": "stare",
+    "note": "Majority rendering; webapp occasionally uses 'statut' ('să vă schimbați statutul') — prefer 'stare' consistently."
+  },
+  "custom status": {
+    "target": "stare personalizată"
+  },
+  "do not disturb": {
+    "target": "Nu deranjați",
+    "note": "Established in webapp ('Nu deranjați'). Keep the formal plural imperative."
+  },
+  "away": {
+    "target": "Plecat",
+    "note": "Established in webapp; ignore the stray 'Deplasare' mistranslation."
+  },
+  "online": {
+    "target": "Online",
+    "note": "Kept in English in existing translations; standard in Romanian UIs."
+  },
+  "offline": {
+    "target": "Offline",
+    "note": "Kept in English in existing translations."
+  },
+  "out of office": {
+    "target": "Plecat din birou",
+    "note": "Majority webapp rendering; mobile once uses 'Afară din birou' — prefer 'Plecat din birou'."
+  },
+  "guest": {
+    "target": "oaspete",
+    "note": "Plural: 'oaspeți'. Webapp mixes 'oaspete' and 'invitat'; prefer 'oaspete' — 'invitat' collides with 'invited' and produces ambiguities like 'Invitați invitați'."
+  },
+  "member": {
+    "target": "membru",
+    "note": "Plural: 'membri' (not 'membrii' unless definite)."
+  },
+  "user": {
+    "target": "utilizator",
+    "note": "Plural: 'utilizatori'."
+  },
+  "system admin": {
+    "target": "administrator de sistem",
+    "note": "Established in webapp/server."
+  },
+  "team admin": {
+    "target": "administrator de echipă"
+  },
+  "channel admin": {
+    "target": "administrator de canal"
+  },
+  "session": {
+    "target": "sesiune",
+    "note": "Plural: 'sesiuni'."
+  },
+  "sign in": {
+    "target": "a se conecta",
+    "note": "Majority webapp rendering ('vă conectați', 'Conectare'); 'autentificare' also appears — translate both 'sign in' and 'log in' as 'conectare / a se conecta'. Button label: 'Conectare'."
+  },
+  "sign out": {
+    "target": "a se deconecta",
+    "note": "Button/menu label: 'Deconectare' (established in webapp)."
+  },
+  "join": {
+    "target": "a se alătura",
+    "note": "'Alăturați-vă canalului'. For join messages, webapp also uses 'intrare' — prefer 'a se alătura' in UI actions."
+  },
+  "leave": {
+    "target": "a părăsi",
+    "note": "'Părăsiți canalul/echipa'."
+  },
+  "archive": {
+    "target": "a arhiva",
+    "note": "'Arhivați canalul'; adjective 'arhivat'."
+  },
+  "unarchive": {
+    "target": "a dezarhiva",
+    "note": "Majority webapp rendering ('Dezarhivează canalul', 'Dezarhivați'); ignore the stray 'Canal nearhivat'."
+  },
+  "mute": {
+    "target": "a pune pe silențios",
+    "note": "Channel notification muting. Existing renderings are inconsistent and poor ('Canal mut', 'muțește') — prefer 'a pune pe silențios' / 'silențios'. Distinct from muting a microphone in Calls ('a dezactiva microfonul')."
+  },
+  "follow": {
+    "target": "a urmări",
+    "note": "'Urmăriți firul' (established). Following: 'urmărit'."
+  },
+  "unfollow": {
+    "target": "a nu mai urmări",
+    "note": "'Nu mai urmăriți firul'. One webapp string wrongly reuses 'Urmărește firul' for unfollow — do not copy it."
+  },
+  "favorite": {
+    "target": "favorit",
+    "note": "Noun/adjective; plural 'favorite'. Verb: 'a adăuga la favorite'; unfavorite: 'a elimina din favorite'."
+  },
+  "search": {
+    "target": "căutare",
+    "note": "Noun; verb 'a căuta' (button: 'Caută'/'Căutați')."
+  },
+  "integration": {
+    "target": "integrare",
+    "note": "Plural: 'integrări'."
+  },
+  "slash command": {
+    "target": "comandă slash",
+    "note": "Established in webapp ('comanda slash'). Plural: 'comenzi slash'."
+  },
+  "webhook": {
+    "target": "webhook",
+    "note": "Keep untranslated (masculine: 'webhook-ul', plural 'webhook-uri'). Legacy machine translations ('bara de intrare', 'bijuteria') are errors — never reuse them."
+  },
+  "incoming webhook": {
+    "target": "webhook de intrare",
+    "note": "Plural: 'webhook-uri de intrare'."
+  },
+  "outgoing webhook": {
+    "target": "webhook de ieșire",
+    "note": "Plural: 'webhook-uri de ieșire'."
+  },
+  "trigger word": {
+    "target": "cuvânt de declanșare",
+    "note": "Follows webapp 'cuvintele tale de declanșare'. Plural: 'cuvinte de declanșare'."
+  },
+  "plugin": {
+    "target": "plugin",
+    "note": "Kept as loanword in webapp ('pluginul', 'pluginuri'). Articulate as 'plugin-ul' / plural 'plugin-uri' per current orthographic norms."
+  },
+  "bot": {
+    "target": "bot",
+    "note": "Kept in webapp ('Conturi Bot'). Plural: 'boți' or 'bot-uri'; 'cont de bot' for bot account."
+  },
+  "role": {
+    "target": "rol",
+    "note": "Plural: 'roluri'."
+  },
+  "permission": {
+    "target": "permisiune",
+    "note": "Plural: 'permisiuni'. One legacy string uses 'autorizare' — prefer 'permisiune'."
+  },
+  "scheme": {
+    "target": "schemă",
+    "note": "Plural: 'scheme'. 'Permission scheme' = 'schemă de permisiuni'."
+  },
+  "license": {
+    "target": "licență",
+    "note": "Plural: 'licențe'."
+  },
+  "seat": {
+    "target": "loc",
+    "note": "Licensed user slot; plural 'locuri'. No repo signal; standard Romanian SaaS term."
+  },
+  "trial": {
+    "target": "perioadă de probă",
+    "note": "'Free trial' = 'perioadă de probă gratuită'."
+  },
+  "workspace": {
+    "target": "spațiu de lucru",
+    "note": "Established in mobile ro.json. Plural: 'spații de lucru'."
+  },
+  "subscription": {
+    "target": "abonament"
+  },
+  "deactivate": {
+    "target": "a dezactiva",
+    "note": "'Dezactivat' for the deactivated state."
+  },
+  "invite": {
+    "target": "a invita",
+    "note": "Noun sense: 'invitație'. Button: 'Invitați'."
+  },
+  "invitation": {
+    "target": "invitație",
+    "note": "Plural: 'invitații'."
+  },
+  "sidebar": {
+    "target": "bară laterală",
+    "note": "Established in webapp ('bara laterală')."
+  },
+  "unread": {
+    "target": "necitit",
+    "note": "Feminine/plural: 'necitită/necitite'. 'Unreads' = 'mesaje necitite'."
+  },
+  "attachment": {
+    "target": "atașament",
+    "note": "Plural: 'atașamente'."
+  },
+  "public channel": {
+    "target": "canal public",
+    "note": "Plural: 'canale publice'."
+  },
+  "private channel": {
+    "target": "canal privat",
+    "note": "Plural: 'canale private'."
+  },
+  "shared channel": {
+    "target": "canal partajat",
+    "note": "Established in server strings. Plural: 'canale partajate'."
+  },
+  "channel header": {
+    "target": "antetul canalului",
+    "note": "Standalone 'Header' = 'Antet'."
+  },
+  "channel purpose": {
+    "target": "scopul canalului",
+    "note": "Established in webapp. Standalone 'Purpose' = 'Scop'."
+  },
+  "system message": {
+    "target": "mesaj de sistem",
+    "note": "Plural: 'mesaje de sistem'."
+  },
+  "persistent notification": {
+    "target": "notificare persistentă",
+    "note": "Plural: 'notificări persistente'."
+  },
+  "message priority": {
+    "target": "prioritatea mesajului",
+    "note": "Feature name usable as 'Prioritate mesaj' in compact UI."
+  },
+  "urgent": {
+    "target": "urgent",
+    "note": "Label form: 'URGENT'. Feminine: 'urgentă'."
+  },
+  "recap": {
+    "target": "recapitulare",
+    "note": "AI channel summary; plural 'recapitulări'."
+  },
+  "agent": {
+    "target": "agent",
+    "note": "AI assistant; plural 'agenți'. Same word as English."
+  },
+  "burn-on-read": {
+    "target": "autodistrugere la citire",
+    "note": "No repo signal. Label form: 'AUTODISTRUGERE LA CITIRE'; adjectival use: 'mesaj cu autodistrugere la citire' (Telegram-style convention)."
+  },
+  "magic link": {
+    "target": "link magic",
+    "note": "Plural: 'linkuri magice'."
+  },
+  "personal access token": {
+    "target": "token de acces personal",
+    "note": "Webapp mixes 'jeton de acces personal' and 'token' — prefer 'token' (established loanword in Romanian tech UI); treat 'jeton'/'indice' as legacy."
+  },
+  "announcement banner": {
+    "target": "banner de anunțuri",
+    "note": "Established in webapp."
+  },
+  "channel banner": {
+    "target": "banner de canal"
+  },
+  "keyword": {
+    "target": "cuvânt-cheie",
+    "note": "Plural: 'cuvinte-cheie'."
+  },
+  "user group": {
+    "target": "grup de utilizatori",
+    "note": "Standalone 'group' = 'grup'."
+  },
+  "permalink": {
+    "target": "permalink",
+    "note": "Kept untranslated in webapp ro.json."
+  },
+  "profile": {
+    "target": "profil"
+  },
+  "username": {
+    "target": "nume de utilizator",
+    "note": "Established in webapp; do not shorten to just 'utilizator' as some legacy strings do."
+  },
+  "nickname": {
+    "target": "pseudonim",
+    "note": "Legacy strings use 'poreclă' in an example and mistranslate the field as 'Prenume' — prefer 'pseudonim' (standard software term)."
+  },
+  "display name": {
+    "target": "nume afișat",
+    "note": "Established in webapp ('Nume afișat')."
+  },
+  "collapsed reply threads": {
+    "target": "fire de răspuns restrânse",
+    "note": "Feature name; keeps 'fir' for thread."
+  },
+  "auto-translation": {
+    "target": "traducere automată",
+    "note": "'AUTO-TRANSLATED' label: 'TRADUS AUTOMAT'."
+  },
+  "data retention": {
+    "target": "păstrarea datelor",
+    "note": "Established in webapp: 'Politica de păstrare a datelor' for data retention policy."
+  },
+  "compliance export": {
+    "target": "export de conformitate",
+    "note": "Legacy strings are garbled ('lucrare de complianță') — use 'export de conformitate' consistently."
+  },
+  "access control": {
+    "target": "controlul accesului",
+    "note": "'Access control policy' = 'politică de control al accesului'."
+  },
+  "attribute": {
+    "target": "atribut",
+    "note": "Established in webapp (LDAP/SAML strings). Plural: 'atribute'."
+  },
+  "onboarding": {
+    "target": "inițiere",
+    "note": "No repo signal. 'Inițiere' for the guided first-run experience; the English 'onboarding' is also widely understood in Romanian business software and may be kept in marketing copy."
+  },
+  "Town Square": {
+    "target": "Canalul principal",
+    "note": "Established in server ro.json as the default channel name."
+  },
+  "Off-Topic": {
+    "target": "În afara subiectului",
+    "note": "Server ro.json has 'In afara topicului' (missing diacritic, calqued 'topic'); prefer the corrected 'În afara subiectului' but note the existing channel name users may already see."
+  },
+  "read-only": {
+    "target": "doar în citire",
+    "note": "Existing renderings vary ('numai în citire', 'doar-în-citire', 'doar pentru citire'); standardize on 'doar în citire'."
+  },
+  "server": {
+    "target": "server",
+    "note": "Plural: 'servere'."
+  }
+}

--- a/i18n/glossary/ro.json
+++ b/i18n/glossary/ro.json
@@ -56,9 +56,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/ro.json
+++ b/i18n/glossary/ro.json
@@ -164,12 +164,10 @@
     "note": "Established in webapp; ignore the stray 'Deplasare' mistranslation."
   },
   "online": {
-    "target": "Online",
-    "note": "Kept in English in existing translations; standard in Romanian UIs."
+    "target": "Online"
   },
   "offline": {
-    "target": "Offline",
-    "note": "Kept in English in existing translations."
+    "target": "Offline"
   },
   "out of office": {
     "target": "Plecat din birou",
@@ -188,8 +186,7 @@
     "note": "Plural: 'utilizatori'."
   },
   "system admin": {
-    "target": "administrator de sistem",
-    "note": "Established in webapp/server."
+    "target": "administrator de sistem"
   },
   "team admin": {
     "target": "administrator de echipă"
@@ -366,7 +363,7 @@
   },
   "urgent": {
     "target": "urgent",
-    "note": "Label form: 'URGENT'. Feminine: 'urgentă'."
+    "note": "Feminine: 'urgentă'."
   },
   "recap": {
     "target": "recapitulare",
@@ -378,7 +375,7 @@
   },
   "burn-on-read": {
     "target": "autodistrugere la citire",
-    "note": "No repo signal. Label form: 'AUTODISTRUGERE LA CITIRE'; adjectival use: 'mesaj cu autodistrugere la citire' (Telegram-style convention)."
+    "note": "No repo signal. Adjectival use: 'mesaj cu autodistrugere la citire' (Telegram-style convention)."
   },
   "magic link": {
     "target": "link magic",
@@ -389,8 +386,7 @@
     "note": "Webapp mixes 'jeton de acces personal' and 'token' — prefer 'token' (established loanword in Romanian tech UI); treat 'jeton'/'indice' as legacy."
   },
   "announcement banner": {
-    "target": "banner de anunțuri",
-    "note": "Established in webapp."
+    "target": "banner de anunțuri"
   },
   "channel banner": {
     "target": "banner de canal"

--- a/i18n/glossary/ru.json
+++ b/i18n/glossary/ru.json
@@ -1,0 +1,458 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition",
+    "note": "Keep in English. Some legacy strings translate edition names (e.g. 'Командная редакция' for Team Edition); do not follow that pattern."
+  },
+  "Team Edition": {
+    "target": "Team Edition",
+    "note": "Keep in English despite legacy 'Командная редакция' appearing in about-dialog strings."
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "Product name, keep in English. The common noun 'channel' is 'канал'."
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO",
+    "note": "Keep abbreviation; when spelled out, existing strings use 'единый вход' / 'единого входа'."
+  },
+  "MFA": {
+    "target": "MFA",
+    "note": "Keep abbreviation; when spelled out, use 'многофакторная аутентификация'."
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "системная консоль",
+    "note": "Capitalize as 'Системная консоль' when used as the named UI area. Consistent in existing translations."
+  },
+  "marketplace": {
+    "target": "магазин плагинов",
+    "note": "Existing translations consistently use 'магазин плагинов'. If the context covers apps beyond plugins, 'маркетплейс' is an acceptable alternative, but prefer the established term."
+  },
+  "channel": {
+    "target": "канал",
+    "note": "Plural 'каналы'."
+  },
+  "team": {
+    "target": "команда",
+    "note": "Same word as 'command' in Russian; existing translations rely on context. Plural 'команды'."
+  },
+  "post": {
+    "target": "сообщение",
+    "note": "Existing translations render both 'post' and 'message' as 'сообщение'; do not use 'пост'."
+  },
+  "message": {
+    "target": "сообщение"
+  },
+  "thread": {
+    "target": "обсуждение",
+    "note": "Majority rendering; existing strings occasionally use 'тема' or 'ветка' — avoid those, and avoid the anglicism 'тред'. The Threads view is 'Обсуждения'."
+  },
+  "reply": {
+    "target": "ответ",
+    "note": "Verb: 'ответить'. Plural 'ответы'."
+  },
+  "direct message": {
+    "target": "личное сообщение",
+    "note": "Majority rendering (85+ occurrences); a few legacy strings use 'прямое сообщение' — avoid. Plural 'личные сообщения'."
+  },
+  "group message": {
+    "target": "групповое сообщение",
+    "note": "Plural 'групповые сообщения'."
+  },
+  "mention": {
+    "target": "упоминание",
+    "note": "Verb: 'упомянуть'. '@mention' can stay '@упоминание' or keep the @ with the username untouched."
+  },
+  "notification": {
+    "target": "уведомление"
+  },
+  "pin": {
+    "target": "закрепить",
+    "note": "Existing translations are inconsistent ('Прикрепить сообщение' in the post menu vs 'Закреплённые сообщения' in the channel header). Prefer 'закрепить' / 'закреплённые сообщения' (standard Telegram/Slack convention). Unpin: 'открепить'."
+  },
+  "bookmark": {
+    "target": "закладка",
+    "note": "Verb: 'добавить в закладки'. Consistent in existing translations."
+  },
+  "saved messages": {
+    "target": "сохранённые сообщения",
+    "note": "Save: 'сохранить'; unsave: 'убрать из сохранённых'. Existing strings write it without ё ('сохраненные')."
+  },
+  "draft": {
+    "target": "черновик",
+    "note": "Plural 'черновики'."
+  },
+  "scheduled post": {
+    "target": "запланированное сообщение",
+    "note": "Consistent with existing 'Запланированные сообщения'."
+  },
+  "emoji": {
+    "target": "эмодзи",
+    "note": "Indeclinable. Existing translations are split between 'эмодзи' and legacy 'смайлик' (custom-emoji admin strings); prefer 'эмодзи', which mobile also uses."
+  },
+  "custom emoji": {
+    "target": "пользовательский эмодзи",
+    "note": "Plural 'пользовательские эмодзи'. Legacy strings use 'пользовательский смайлик' — prefer 'эмодзи'."
+  },
+  "reaction": {
+    "target": "реакция",
+    "note": "Verb 'react': 'отреагировать' / 'добавить реакцию'."
+  },
+  "status": {
+    "target": "статус",
+    "note": "For user availability. 'Состояние' appears in existing strings only for system/billing state, not user status."
+  },
+  "custom status": {
+    "target": "пользовательский статус",
+    "note": "Consistent in existing mobile and webapp strings."
+  },
+  "do not disturb": {
+    "target": "не беспокоить",
+    "note": "Capitalized as 'Не беспокоить' when shown as a status value."
+  },
+  "away": {
+    "target": "отошёл",
+    "note": "Existing status value is 'Отошёл' (masculine past form, conventional for status labels)."
+  },
+  "online": {
+    "target": "в сети",
+    "note": "Status value 'В сети'; existing strings occasionally use 'онлайн' in prose."
+  },
+  "offline": {
+    "target": "не в сети",
+    "note": "Status value 'Не в сети'."
+  },
+  "out of office": {
+    "target": "не на работе",
+    "note": "Existing status value is 'Не на работе'."
+  },
+  "guest": {
+    "target": "гость",
+    "note": "Adjectival uses: 'гостевой доступ', 'гостевая учётная запись'."
+  },
+  "member": {
+    "target": "участник",
+    "note": "Plural 'участники'."
+  },
+  "user": {
+    "target": "пользователь"
+  },
+  "system admin": {
+    "target": "системный администратор",
+    "note": "Majority rendering (45 occurrences vs 1 'администратор системы')."
+  },
+  "team admin": {
+    "target": "администратор команды"
+  },
+  "channel admin": {
+    "target": "администратор канала"
+  },
+  "session": {
+    "target": "сеанс",
+    "note": "Existing usage is mixed: 'сеанс' (46) vs 'сессия' (31). 'Сеанс' is the slight majority and the standard Windows/Microsoft term; either is understood, but stay consistent."
+  },
+  "sign in": {
+    "target": "войти",
+    "note": "Noun 'sign-in/login': 'вход'. Translate 'log in' identically."
+  },
+  "sign out": {
+    "target": "выйти",
+    "note": "Existing 'Log Out' is 'Выйти'. Translate 'log out' identically."
+  },
+  "join": {
+    "target": "присоединиться",
+    "note": "E.g. 'присоединиться к каналу/команде'."
+  },
+  "leave": {
+    "target": "покинуть",
+    "note": "E.g. 'покинуть канал/команду'."
+  },
+  "archive": {
+    "target": "архивировать",
+    "note": "Adjective 'archived': 'архивированный' / 'заархивированный'."
+  },
+  "unarchive": {
+    "target": "разархивировать",
+    "note": "Consistent in existing translations."
+  },
+  "mute": {
+    "target": "отключить уведомления",
+    "note": "For channels (existing 'Mute Channel' = 'Отключить уведомления'). Distinct from Calls 'mute' = 'отключить звук/микрофон'. A single-word alternative 'заглушить' appears once in existing strings."
+  },
+  "follow": {
+    "target": "подписаться",
+    "note": "For threads: 'подписаться на обсуждение'. 'Following': 'подписан(ы)'."
+  },
+  "unfollow": {
+    "target": "отписаться"
+  },
+  "favorite": {
+    "target": "избранное",
+    "note": "Sidebar category 'Избранное'; verb: 'добавить в избранное'; unfavorite: 'убрать из избранного'."
+  },
+  "search": {
+    "target": "поиск",
+    "note": "Verb: 'искать' / 'найти'."
+  },
+  "integration": {
+    "target": "интеграция",
+    "note": "Plural 'интеграции'."
+  },
+  "slash command": {
+    "target": "быстрая команда",
+    "note": "Established majority rendering in existing translations (25 occurrences vs 2 'слэш-команда'). Keep even though 'слэш-команда' is more literal."
+  },
+  "webhook": {
+    "target": "вебхук",
+    "note": "Majority rendering; a few legacy strings keep English 'Webhook' — prefer the transliteration consistently."
+  },
+  "incoming webhook": {
+    "target": "входящий вебхук"
+  },
+  "outgoing webhook": {
+    "target": "исходящий вебхук"
+  },
+  "trigger word": {
+    "target": "триггерное слово",
+    "note": "Existing usage is inconsistent ('ключевое слово', 'слово-триггер', 'триггерное слово'). Prefer 'триггерное слово' to avoid colliding with 'keyword' = 'ключевое слово' in notification settings."
+  },
+  "plugin": {
+    "target": "плагин",
+    "note": "Consistent in existing translations (70 occurrences)."
+  },
+  "bot": {
+    "target": "бот",
+    "note": "Bot account: 'учётная запись бота'."
+  },
+  "role": {
+    "target": "роль"
+  },
+  "permission": {
+    "target": "разрешение",
+    "note": "Plural 'разрешения'. Permission scheme: 'схема разрешений'."
+  },
+  "scheme": {
+    "target": "схема"
+  },
+  "license": {
+    "target": "лицензия"
+  },
+  "seat": {
+    "target": "место",
+    "note": "Licensed seat; existing plural forms: 'место/места/мест'."
+  },
+  "trial": {
+    "target": "пробный период",
+    "note": "Existing strings mix 'пробный период' (the period) and 'пробная версия' (the trial product/license); use 'пробный период' for the time-limited period sense."
+  },
+  "workspace": {
+    "target": "рабочее пространство",
+    "note": "Consistent majority rendering (16 occurrences)."
+  },
+  "subscription": {
+    "target": "подписка"
+  },
+  "deactivate": {
+    "target": "деактивировать",
+    "note": "Deactivated: 'деактивирован(а)'."
+  },
+  "invite": {
+    "target": "пригласить",
+    "note": "Noun: 'приглашение'."
+  },
+  "invitation": {
+    "target": "приглашение"
+  },
+  "sidebar": {
+    "target": "боковая панель"
+  },
+  "unread": {
+    "target": "непрочитанное",
+    "note": "Adjective agrees with noun: 'непрочитанные сообщения/каналы'. The Unreads view: 'Непрочитанные'."
+  },
+  "attachment": {
+    "target": "вложение",
+    "note": "Plural 'вложения'."
+  },
+  "public channel": {
+    "target": "публичный канал",
+    "note": "Existing usage is split between 'публичный канал' and 'общий канал'; prefer 'публичный канал' because 'общий канал' collides with both 'shared channel' and the Town Square default channel name."
+  },
+  "private channel": {
+    "target": "частный канал",
+    "note": "Strong majority ('частный' 272 vs 'приватный' 34); keep 'частный канал'."
+  },
+  "shared channel": {
+    "target": "общий канал",
+    "note": "Existing rendering. Beware: 'Общий канал' is also the existing translation of the Town Square default channel name — rely on context, or use 'подключённый общий канал' in ambiguous admin prose."
+  },
+  "channel header": {
+    "target": "заголовок канала"
+  },
+  "channel purpose": {
+    "target": "назначение канала",
+    "note": "Several existing system messages mistranslate 'purpose' as 'заголовок канала' (collides with header); use 'назначение канала'."
+  },
+  "system message": {
+    "target": "системное сообщение"
+  },
+  "persistent notification": {
+    "target": "постоянное уведомление",
+    "note": "Existing rendering 'Постоянные уведомления'."
+  },
+  "message priority": {
+    "target": "приоритет сообщения",
+    "note": "Consistent in existing translations."
+  },
+  "urgent": {
+    "target": "срочно",
+    "note": "Priority label 'Срочно'; adjective form 'срочный/срочное' when modifying a noun (e.g. 'срочное упоминание')."
+  },
+  "recap": {
+    "target": "сводка",
+    "note": "No existing translation yet (new AI feature). 'Сводка' matches Russian conventions for AI activity summaries; plural 'сводки'."
+  },
+  "agent": {
+    "target": "агент",
+    "note": "Existing mention suggestion uses 'Агенты'."
+  },
+  "burn-on-read": {
+    "target": "сгорающее после прочтения",
+    "note": "No established translation yet; feature-discovery strings paraphrase ('сообщения, которые автоматически удаляются после прочтения'). For the label/adjective use 'сгорающее после прочтения (сообщение)'; the all-caps badge can be 'СГОРАЕТ ПОСЛЕ ПРОЧТЕНИЯ'."
+  },
+  "magic link": {
+    "target": "магическая ссылка",
+    "note": "Existing rendering ('доступ по магическим ссылкам')."
+  },
+  "personal access token": {
+    "target": "персональный токен доступа",
+    "note": "Existing strings mix 'персональный' and 'личный токен доступа'; prefer 'персональный токен доступа' (matches GitHub/GitLab ru convention)."
+  },
+  "announcement banner": {
+    "target": "баннер объявления",
+    "note": "Existing strings use 'баннер объявления' / 'баннер с объявлением'; one admin-permissions string mistranslates it as 'Система уведомлений' — ignore that."
+  },
+  "channel banner": {
+    "target": "баннер канала",
+    "note": "No existing translation; follows 'баннер' + genitive pattern used for announcement banner."
+  },
+  "keyword": {
+    "target": "ключевое слово",
+    "note": "Plural 'ключевые слова'. Reserved for notification keywords; use 'триггерное слово' for webhook trigger words."
+  },
+  "user group": {
+    "target": "группа пользователей",
+    "note": "Bare 'group' in group-mention context: 'группа'."
+  },
+  "permalink": {
+    "target": "постоянная ссылка",
+    "note": "Consistent in existing translations."
+  },
+  "profile": {
+    "target": "профиль"
+  },
+  "username": {
+    "target": "имя пользователя"
+  },
+  "nickname": {
+    "target": "псевдоним",
+    "note": "Majority rendering (8 vs 3 'прозвище'); avoid 'прозвище'."
+  },
+  "display name": {
+    "target": "отображаемое имя",
+    "note": "For apps/channels: 'отображаемое название'."
+  },
+  "collapsed reply threads": {
+    "target": "свёрнутые обсуждения",
+    "note": "No stable existing translation; derived from thread = 'обсуждение' and existing 'Collapsed' = 'Свёрнуто'."
+  },
+  "auto-translation": {
+    "target": "автоперевод",
+    "note": "Consistent in existing server strings; 'auto-translated' = 'переведено автоматически' or badge 'АВТОПЕРЕВОД'."
+  },
+  "data retention": {
+    "target": "хранение данных",
+    "note": "Policy: 'политика хранения данных'. Existing strings also use 'удержание' in one place — avoid."
+  },
+  "compliance export": {
+    "target": "экспорт комплаенса",
+    "note": "Majority rendering in the System Console; some strings use 'экспорт соответствия' / 'отчёты о соответствии'. Stay with 'экспорт комплаенса' for the feature name."
+  },
+  "access control": {
+    "target": "контроль доступа",
+    "note": "Attribute-based access control: 'контроль доступа на основе атрибутов (ABAC)'."
+  },
+  "attribute": {
+    "target": "атрибут",
+    "note": "Plural 'атрибуты'."
+  },
+  "onboarding": {
+    "target": "адаптация",
+    "note": "Existing rendering ('Включить адаптацию')."
+  },
+  "Town Square": {
+    "target": "Общий канал",
+    "note": "Existing server translation of the default channel name. Collides with 'shared channel' = 'общий канал'; keep capitalized as a proper channel name."
+  },
+  "Off-Topic": {
+    "target": "Флуд",
+    "note": "Existing server translation of the default channel name; keep for consistency (alternative 'Оффтопик' is not used in the repos)."
+  },
+  "read-only": {
+    "target": "только для чтения",
+    "note": "E.g. 'канал доступен только для чтения'."
+  },
+  "server": {
+    "target": "сервер"
+  }
+}

--- a/i18n/glossary/ru.json
+++ b/i18n/glossary/ru.json
@@ -153,8 +153,7 @@
     "note": "For user availability. 'Состояние' appears in existing strings only for system/billing state, not user status."
   },
   "custom status": {
-    "target": "пользовательский статус",
-    "note": "Consistent in existing mobile and webapp strings."
+    "target": "пользовательский статус"
   },
   "do not disturb": {
     "target": "не беспокоить",
@@ -222,8 +221,7 @@
     "note": "Adjective 'archived': 'архивированный' / 'заархивированный'."
   },
   "unarchive": {
-    "target": "разархивировать",
-    "note": "Consistent in existing translations."
+    "target": "разархивировать"
   },
   "mute": {
     "target": "отключить уведомления",
@@ -267,8 +265,7 @@
     "note": "Existing usage is inconsistent ('ключевое слово', 'слово-триггер', 'триггерное слово'). Prefer 'триггерное слово' to avoid colliding with 'keyword' = 'ключевое слово' in notification settings."
   },
   "plugin": {
-    "target": "плагин",
-    "note": "Consistent in existing translations (70 occurrences)."
+    "target": "плагин"
   },
   "bot": {
     "target": "бот",
@@ -296,8 +293,7 @@
     "note": "Existing strings mix 'пробный период' (the period) and 'пробная версия' (the trial product/license); use 'пробный период' for the time-limited period sense."
   },
   "workspace": {
-    "target": "рабочее пространство",
-    "note": "Consistent majority rendering (16 occurrences)."
+    "target": "рабочее пространство"
   },
   "subscription": {
     "target": "подписка"
@@ -351,8 +347,7 @@
     "note": "Existing rendering 'Постоянные уведомления'."
   },
   "message priority": {
-    "target": "приоритет сообщения",
-    "note": "Consistent in existing translations."
+    "target": "приоритет сообщения"
   },
   "urgent": {
     "target": "срочно",
@@ -395,8 +390,7 @@
     "note": "Bare 'group' in group-mention context: 'группа'."
   },
   "permalink": {
-    "target": "постоянная ссылка",
-    "note": "Consistent in existing translations."
+    "target": "постоянная ссылка"
   },
   "profile": {
     "target": "профиль"

--- a/i18n/glossary/ru.json
+++ b/i18n/glossary/ru.json
@@ -58,9 +58,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/sv.json
+++ b/i18n/glossary/sv.json
@@ -1,0 +1,456 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition"
+  },
+  "Team Edition": {
+    "target": "Team Edition"
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels"
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "systemkonsolen",
+    "note": "Existing translations overwhelmingly use 'systemkonsolen' (definite form) / 'systemkonsol'. Capitalize as 'Systemkonsolen' when used as a named UI area at sentence start or in titles."
+  },
+  "marketplace": {
+    "target": "Marketplace",
+    "note": "Usage is split: 'Marketplace' (kept in English, majority) vs 'marknadsplatsen'. Keep 'Marketplace' as the named in-product store; definite form 'Marketplace' unchanged."
+  },
+  "channel": {
+    "target": "kanal",
+    "note": "en kanal, kanalen, kanaler."
+  },
+  "team": {
+    "target": "team",
+    "note": "Neuter loanword: ett team, teamet, team (pl.), teamen. Majority of existing strings keep 'team'; a legacy minority uses 'grupp' — avoid 'grupp' here since it is needed for 'user group' (användargrupp)."
+  },
+  "post": {
+    "target": "meddelande",
+    "note": "Existing translations render both 'post' and 'message' as 'meddelande' (majority). 'inlägg' appears in some admin strings (e.g. 'Schemalagda inlägg'); prefer 'meddelande' for consistency."
+  },
+  "message": {
+    "target": "meddelande",
+    "note": "ett meddelande, meddelandet, meddelanden."
+  },
+  "thread": {
+    "target": "tråd",
+    "note": "en tråd, tråden, trådar. Threads view: 'Trådar'."
+  },
+  "reply": {
+    "target": "svar",
+    "note": "Noun: 'svar' (ett svar, svaret, svar). Verb: 'svara'."
+  },
+  "direct message": {
+    "target": "direktmeddelande",
+    "note": "Majority rendering. A couple of legacy strings use '(Privat meddelande)' — do not reuse. Sidebar category: 'DIREKTMEDDELANDEN'."
+  },
+  "group message": {
+    "target": "gruppmeddelande"
+  },
+  "mention": {
+    "target": "omnämnande",
+    "note": "Noun: 'omnämnande' (pl. 'omnämnanden'). Verb: 'omnämna' or 'nämna'."
+  },
+  "notification": {
+    "target": "notifiering",
+    "note": "Existing usage is inconsistent: 'notifiering' (majority), 'avisering', 'meddelande'. Keep 'notifiering' for consistency; 'avisering' is the standard Swedish OS-level term and would be the better choice in a coordinated cleanup. Never use 'meddelande' (collides with 'message')."
+  },
+  "pin": {
+    "target": "fästa",
+    "note": "Inconsistent today: the action is 'Fäst i kanal' but the list is 'Nålade meddelanden'. Prefer 'fästa'/'fäst' (imperative 'Fäst') throughout; unpin = 'ta bort fäst meddelande'/'lossa'."
+  },
+  "bookmark": {
+    "target": "bokmärke",
+    "note": "Noun: 'bokmärke' (ett bokmärke, bokmärken). Verb: 'bokmärka' or 'lägga till bokmärke'."
+  },
+  "saved messages": {
+    "target": "sparade meddelanden",
+    "note": "UI title: 'Sparade meddelanden'. save = 'spara', unsave = 'ta bort från sparade'."
+  },
+  "draft": {
+    "target": "utkast",
+    "note": "ett utkast, utkastet, utkast (pl.)."
+  },
+  "scheduled post": {
+    "target": "schemalagt meddelande",
+    "note": "Existing strings use 'schemalagda meddelanden/utkast' and admin title 'Schemalagda inlägg'. Prefer 'schemalagt meddelande' to align with post/message = 'meddelande'."
+  },
+  "emoji": {
+    "target": "emoji",
+    "note": "en emoji, pl. 'emojier' (or invariant 'emoji'). NOTE: existing sv.json frequently misspells this as 'emoij' — always use 'emoji'."
+  },
+  "custom emoji": {
+    "target": "anpassad emoji",
+    "note": "Existing uses 'Anpassad emoij' (typo) and 'Egna emoij'. Use 'anpassad emoji'."
+  },
+  "reaction": {
+    "target": "reaktion",
+    "note": "en reaktion, reaktioner. Verb: 'reagera'. Existing has typo 'rekationer' — do not copy."
+  },
+  "status": {
+    "target": "status",
+    "note": "en status, statusen."
+  },
+  "custom status": {
+    "target": "anpassad status"
+  },
+  "do not disturb": {
+    "target": "stör ej",
+    "note": "Status label: 'Stör ej'."
+  },
+  "away": {
+    "target": "borta",
+    "note": "Status label: 'Borta'. A legacy string uses 'Tillfälligt borta'."
+  },
+  "online": {
+    "target": "online",
+    "note": "Existing is inconsistent: 'Uppkopplad', 'Ansluten', 'Online'. Prefer 'online' (invariant, standard Swedish) — it also pairs naturally with 'offline'."
+  },
+  "offline": {
+    "target": "offline",
+    "note": "Majority rendering keeps 'Offline'."
+  },
+  "out of office": {
+    "target": "ej tillgänglig",
+    "note": "Existing UI uses 'Ej tillgänglig'. A more literal option is 'inte på kontoret'/'frånvarande', but keep the established term."
+  },
+  "guest": {
+    "target": "gäst",
+    "note": "en gäst, gäster. Tag: 'GÄST'."
+  },
+  "member": {
+    "target": "medlem",
+    "note": "en medlem, medlemmar."
+  },
+  "user": {
+    "target": "användare",
+    "note": "en användare, användare (pl.), användarna."
+  },
+  "system admin": {
+    "target": "systemadministratör"
+  },
+  "team admin": {
+    "target": "teamadministratör"
+  },
+  "channel admin": {
+    "target": "kanaladministratör",
+    "note": "Existing has typo 'Kanaladminstratör' and role-vs-activity mixup 'Kanaladministration' — use 'kanaladministratör' for the role."
+  },
+  "session": {
+    "target": "session",
+    "note": "en session, sessioner."
+  },
+  "sign in": {
+    "target": "logga in",
+    "note": "Use 'logga in' for both 'sign in' and 'log in'. Noun: 'inloggning'."
+  },
+  "sign out": {
+    "target": "logga ut",
+    "note": "Use 'logga ut' for both 'sign out' and 'log out'."
+  },
+  "join": {
+    "target": "gå med",
+    "note": "'gå med i' a channel/team (Gå med i kanalen). Calls uses 'anslut' for joining a call — keep those distinct."
+  },
+  "leave": {
+    "target": "lämna"
+  },
+  "archive": {
+    "target": "arkivera",
+    "note": "archived = 'arkiverad'."
+  },
+  "unarchive": {
+    "target": "avarkivera",
+    "note": "Existing is very inconsistent: 'avarkivera', 'återställ ... från arkiv(et)', 'dearkivera', 'packa upp', and even a mistranslation 'Arkivera kanaler' for 'Unarchive Channel'. Standardize on 'avarkivera'."
+  },
+  "mute": {
+    "target": "mjuta",
+    "note": "Existing majority uses the anglicism 'mjuta' (Mjuta/mjutad) for channel mute; a minority uses 'tysta'. Keep 'mjuta' for consistency, though 'tysta' is more standard Swedish and would be the better choice in a coordinated cleanup."
+  },
+  "follow": {
+    "target": "följa",
+    "note": "Button: 'Följ'. following = 'följer'."
+  },
+  "unfollow": {
+    "target": "sluta följa",
+    "note": "Existing: 'Sluta följa tråden'. Avoid the calque 'avfölj' seen once in Playbooks."
+  },
+  "favorite": {
+    "target": "favorit",
+    "note": "Noun: 'favorit'; sidebar category 'Favoriter'. Verb: 'markera som favorit'; unfavorite = 'ta bort från favoriter'."
+  },
+  "search": {
+    "target": "söka",
+    "note": "Verb: 'söka' (button 'Sök'). Noun: 'sökning'."
+  },
+  "integration": {
+    "target": "integration",
+    "note": "en integration, integrationer."
+  },
+  "slash command": {
+    "target": "slash-kommando",
+    "note": "Consistently 'slash-kommando(n)' in existing translations."
+  },
+  "webhook": {
+    "target": "webhook",
+    "note": "Kept in English, common gender: en webhook, webhooken, webhooks/webhookar."
+  },
+  "incoming webhook": {
+    "target": "inkommande webhook"
+  },
+  "outgoing webhook": {
+    "target": "utgående webhook"
+  },
+  "trigger word": {
+    "target": "aktiveringsord",
+    "note": "Established rendering in existing translations (9 of 11 strings)."
+  },
+  "plugin": {
+    "target": "plugin",
+    "note": "Kept in English (majority): ett plugin, pl. 'plugins' or 'plugin-program'. 'tillägg' appears in a minority of strings — avoid."
+  },
+  "bot": {
+    "target": "bot",
+    "note": "en bot, bottar/botar; bot account = 'bot-konto'."
+  },
+  "role": {
+    "target": "roll",
+    "note": "en roll, roller."
+  },
+  "permission": {
+    "target": "behörighet",
+    "note": "en behörighet, behörigheter."
+  },
+  "scheme": {
+    "target": "schema",
+    "note": "ett schema, scheman. Permission scheme = 'behörighetsschema'."
+  },
+  "license": {
+    "target": "licens",
+    "note": "en licens, licensen."
+  },
+  "seat": {
+    "target": "plats",
+    "note": "Existing renders licensed seats as 'platser' ('antalet platser i din licens')."
+  },
+  "trial": {
+    "target": "prova-på-period",
+    "note": "Majority rendering ('prova-på-period', 48 strings); 'testperiod' is a significant minority (23). Keep 'prova-på-period'."
+  },
+  "workspace": {
+    "target": "arbetsyta",
+    "note": "en arbetsyta, arbetsytan, arbetsytor. Majority rendering; some strings keep 'workspace'."
+  },
+  "subscription": {
+    "target": "prenumeration",
+    "note": "Majority; billing copy sometimes uses 'abonnemang' ('Köp ett abonnemang'). Prefer 'prenumeration'."
+  },
+  "deactivate": {
+    "target": "avaktivera",
+    "note": "deactivated = 'avaktiverad'."
+  },
+  "invite": {
+    "target": "bjuda in",
+    "note": "Verb: 'bjuda in' (imperative 'Bjud in'). Noun sense: use 'inbjudan'."
+  },
+  "invitation": {
+    "target": "inbjudan",
+    "note": "en inbjudan, inbjudningar."
+  },
+  "sidebar": {
+    "target": "sidofält",
+    "note": "Majority rendering ('sidofältet'); a few strings use 'meny'/'sidopanel' — prefer 'sidofält'."
+  },
+  "unread": {
+    "target": "oläst",
+    "note": "olästa meddelanden; Unreads view: 'Olästa'."
+  },
+  "attachment": {
+    "target": "bilaga",
+    "note": "en bilaga, bilagor. 'bifogad fil' also acceptable in running text."
+  },
+  "public channel": {
+    "target": "publik kanal",
+    "note": "Established as 'publik kanal' (not 'offentlig kanal')."
+  },
+  "private channel": {
+    "target": "privat kanal"
+  },
+  "shared channel": {
+    "target": "delad kanal"
+  },
+  "channel header": {
+    "target": "kanalens sidhuvud",
+    "note": "Inconsistent today: 'kanalens sidhuvud' (most common), 'kanalhuvudet', 'rubrik', 'header'. Standardize on 'kanalens sidhuvud' / 'sidhuvud'."
+  },
+  "channel purpose": {
+    "target": "kanalens syfte",
+    "note": "purpose = 'syfte' (majority)."
+  },
+  "system message": {
+    "target": "systemmeddelande"
+  },
+  "persistent notification": {
+    "target": "persistent notifiering",
+    "note": "Very inconsistent today: server uses 'persistenta notifieringar'; webapp variously 'återkommande/varaktiga/upprepade aviseringar'. Standardize on 'persistent notifiering' (pl. 'persistenta notifieringar') to match notification = 'notifiering'."
+  },
+  "message priority": {
+    "target": "meddelandeprioritet"
+  },
+  "urgent": {
+    "target": "brådskande",
+    "note": "Label: 'BRÅDSKANDE'."
+  },
+  "recap": {
+    "target": "sammanfattning",
+    "note": "No existing sv translation (new feature). 'sammanfattning' matches how related AI summaries are rendered; if a distinct word is needed to avoid clashing with 'summary', use 'återblick'."
+  },
+  "agent": {
+    "target": "agent",
+    "note": "en agent, agenter. Mobile strings often say 'AI-agent' — acceptable where the AI context is not obvious."
+  },
+  "burn-on-read": {
+    "target": "bränn vid läsning",
+    "note": "UI labels use 'Bränn vid läsning' / 'BRÄNN VID LÄSNING'. One admin title uses 'Förstör meddelanden efter läsning' — prefer 'bränn vid läsning'."
+  },
+  "magic link": {
+    "target": "magisk länk",
+    "note": "Existing usage is split 50/50 between keeping 'Magic Link' and 'magisk länk'. Prefer the Swedish 'magisk länk' (en magisk länk, magiska länkar)."
+  },
+  "personal access token": {
+    "target": "personligt åtkomst-token",
+    "note": "As used in existing UI ('ett personligt åtkomst-token'). A cleaner compound would be 'personlig åtkomsttoken'; keep the existing form for consistency."
+  },
+  "announcement banner": {
+    "target": "informationsbanner",
+    "note": "Majority rendering; one permissions string uses 'System-aviseringar' — avoid."
+  },
+  "channel banner": {
+    "target": "kanalbanner",
+    "note": "Existing strings phrase it as 'kanalens banner'; use 'kanalbanner' as the compact term."
+  },
+  "keyword": {
+    "target": "nyckelord",
+    "note": "ett nyckelord, nyckelorden."
+  },
+  "user group": {
+    "target": "användargrupp",
+    "note": "en användargrupp, användargrupper. Plain 'group' = 'grupp'."
+  },
+  "permalink": {
+    "target": "permalänk"
+  },
+  "profile": {
+    "target": "profil",
+    "note": "en profil, profilen."
+  },
+  "username": {
+    "target": "användarnamn"
+  },
+  "nickname": {
+    "target": "smeknamn"
+  },
+  "display name": {
+    "target": "visningsnamn"
+  },
+  "collapsed reply threads": {
+    "target": "sammanfällda svarstrådar",
+    "note": "Mobile consistently uses 'Sammanfällda svarstrådar'; one legacy webapp string says 'Dialog med Svarstrådar' — prefer the mobile rendering."
+  },
+  "auto-translation": {
+    "target": "automatisk översättning",
+    "note": "auto-translated = 'automatiskt översatt' (label 'AUTOMATISKT ÖVERSATT')."
+  },
+  "data retention": {
+    "target": "gallring",
+    "note": "Existing consistently uses the Swedish records-management term 'gallring' (gallringspolicy, gallringsjobb, gallringsschema); literal 'datalagring' appears only twice. Data retention policy = 'gallringspolicy'."
+  },
+  "compliance export": {
+    "target": "efterlevnadsexport"
+  },
+  "access control": {
+    "target": "åtkomstkontroll",
+    "note": "Access control policy = 'åtkomstkontrollpolicy'."
+  },
+  "attribute": {
+    "target": "attribut",
+    "note": "ett attribut, attributet, attribut (pl.)."
+  },
+  "onboarding": {
+    "target": "onboarding",
+    "note": "Majority keeps 'onboarding'; 'introduktion' appears in a minority of strings."
+  },
+  "Town Square": {
+    "target": "Torg",
+    "note": "Existing server translation of the default channel name is 'Torg'. Keep as-is for consistency with existing servers; 'Torget' would be more idiomatic."
+  },
+  "Off-Topic": {
+    "target": "Off-topic",
+    "note": "Existing server translation is 'Orelevant' (a misspelling of 'Irrelevant'). Prefer 'Off-topic', a common loanword in Swedish forums; 'Utanför ämnet' is an alternative."
+  },
+  "read-only": {
+    "target": "skrivskyddad",
+    "note": "skrivskyddad kanal."
+  },
+  "server": {
+    "target": "server",
+    "note": "en server, servern, servrar."
+  }
+}

--- a/i18n/glossary/sv.json
+++ b/i18n/glossary/sv.json
@@ -53,9 +53,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/sv.json
+++ b/i18n/glossary/sv.json
@@ -375,8 +375,8 @@
     "note": "Existing usage is split 50/50 between keeping 'Magic Link' and 'magisk länk'. Prefer the Swedish 'magisk länk' (en magisk länk, magiska länkar)."
   },
   "personal access token": {
-    "target": "personligt åtkomst-token",
-    "note": "As used in existing UI ('ett personligt åtkomst-token'). A cleaner compound would be 'personlig åtkomsttoken'; keep the existing form for consistency."
+    "target": "personlig åtkomsttoken",
+    "note": "Existing UI strings use the hyphenated 'personligt åtkomst-token'."
   },
   "announcement banner": {
     "target": "informationsbanner",

--- a/i18n/glossary/sv.json
+++ b/i18n/glossary/sv.json
@@ -259,8 +259,7 @@
     "target": "utgående webhook"
   },
   "trigger word": {
-    "target": "aktiveringsord",
-    "note": "Established rendering in existing translations (9 of 11 strings)."
+    "target": "aktiveringsord"
   },
   "plugin": {
     "target": "plugin",
@@ -355,8 +354,7 @@
     "target": "meddelandeprioritet"
   },
   "urgent": {
-    "target": "brådskande",
-    "note": "Label: 'BRÅDSKANDE'."
+    "target": "brådskande"
   },
   "recap": {
     "target": "sammanfattning",

--- a/i18n/glossary/tr.json
+++ b/i18n/glossary/tr.json
@@ -1,0 +1,438 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition",
+    "note": "Existing strings render it as 'Enterprise sürümü' when 'Edition' is generic ('Enterprise Edition License' -> 'Enterprise sürümü lisansı'); keep the product name itself in English."
+  },
+  "Team Edition": {
+    "target": "Team Edition",
+    "note": "Existing strings use 'Team sürümü' in running text; keep 'Team' in English, never translate it as 'Takım' here."
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "Product name; do not confuse with the common noun 'channel' = 'kanal'."
+  },
+  "Playbooks": {
+    "target": "Playbooks",
+    "note": "Product name; the common noun 'playbook' is 'senaryo' in the Playbooks plugin."
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls",
+    "note": "Product name; the common noun 'call' is 'çağrı'."
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP",
+    "note": "Also 'AD/LDAP' stays unchanged."
+  },
+  "SSO": {
+    "target": "SSO",
+    "note": "Spelled out as 'tek oturum açma' in explanatory text; keep the abbreviation in labels."
+  },
+  "MFA": {
+    "target": "MFA",
+    "note": "Spelled out as 'çok aşamalı kimlik doğrulama' in explanatory text; keep the abbreviation in labels."
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "sistem panosu",
+    "note": "Consistently 'sistem panosu' in existing translations (not 'sistem konsolu'). Capitalize only sentence-initially; Turkish UI text here uses sentence case."
+  },
+  "marketplace": {
+    "target": "mağaza",
+    "note": "'App Marketplace' = 'uygulama mağazası'."
+  },
+  "channel": {
+    "target": "kanal"
+  },
+  "team": {
+    "target": "takım"
+  },
+  "post": {
+    "target": "ileti",
+    "note": "Turkish uses 'ileti' for both 'post' and 'message'; existing translations do not distinguish them."
+  },
+  "message": {
+    "target": "ileti"
+  },
+  "thread": {
+    "target": "konu",
+    "note": "Majority rendering is 'konu'; a few mobile strings use 'ileti dizisi' — prefer 'konu'. Threads view = 'Konular'."
+  },
+  "reply": {
+    "target": "yanıt",
+    "note": "Noun: 'yanıt'; verb (buttons): 'yanıtla'. Turkish buttons use imperative verb forms."
+  },
+  "direct message": {
+    "target": "doğrudan ileti",
+    "note": "Do not use 'özel mesaj'; 'DM' is spelled out."
+  },
+  "group message": {
+    "target": "grup iletisi"
+  },
+  "mention": {
+    "target": "anma",
+    "note": "Noun: 'anma'; verb: 'anmak' (e.g. 'yalnızca anıldığınızda' = 'only when mentioned'). '@mention' = '@anma'. Do not use 'bahsetme'."
+  },
+  "notification": {
+    "target": "bildirim"
+  },
+  "pin": {
+    "target": "sabitle",
+    "note": "Verb 'sabitlemek'; 'pinned messages' = 'sabitlenmiş iletiler'; 'unpin' = 'sabitlemeyi kaldır'."
+  },
+  "bookmark": {
+    "target": "yer imi",
+    "note": "Noun: 'yer imi'; verb phrase: 'yer imi ekle'."
+  },
+  "saved messages": {
+    "target": "kaydedilmiş iletiler",
+    "note": "'save' = 'kaydet'; 'unsave' / 'Remove from Saved' = 'kaydedilmişlerden kaldır'."
+  },
+  "draft": {
+    "target": "taslak"
+  },
+  "scheduled post": {
+    "target": "zamanlanmış ileti",
+    "note": "Verb 'schedule' = 'zamanla' (e.g. 'Taslağı zamanla')."
+  },
+  "emoji": {
+    "target": "görsel ifade",
+    "note": "Long-standing repo convention; do not use the loanword 'emoji' to stay consistent with existing UI."
+  },
+  "custom emoji": {
+    "target": "özel görsel ifade"
+  },
+  "reaction": {
+    "target": "tepki",
+    "note": "Verb 'react' = 'tepki ver(mek)'."
+  },
+  "status": {
+    "target": "durum"
+  },
+  "custom status": {
+    "target": "özel durum"
+  },
+  "do not disturb": {
+    "target": "rahatsız etmeyin",
+    "note": "Sentence case in UI: 'Rahatsız etmeyin'. 'DND' is spelled out."
+  },
+  "away": {
+    "target": "uzakta"
+  },
+  "online": {
+    "target": "çevrim içi",
+    "note": "Written as two words per repo convention (TDK spelling), not 'çevrimiçi'."
+  },
+  "offline": {
+    "target": "çevrim dışı",
+    "note": "Two words, matching 'çevrim içi'."
+  },
+  "out of office": {
+    "target": "ofis dışında"
+  },
+  "guest": {
+    "target": "konuk",
+    "note": "Repo uses 'konuk', not 'misafir'."
+  },
+  "member": {
+    "target": "üye"
+  },
+  "user": {
+    "target": "kullanıcı"
+  },
+  "system admin": {
+    "target": "sistem yöneticisi",
+    "note": "'System Administrator' also 'sistem yöneticisi'; plural 'sistem yöneticileri'."
+  },
+  "team admin": {
+    "target": "takım yöneticisi"
+  },
+  "channel admin": {
+    "target": "kanal yöneticisi"
+  },
+  "session": {
+    "target": "oturum",
+    "note": "Same root as sign-in ('oturum aç'); context disambiguates."
+  },
+  "sign in": {
+    "target": "oturum aç",
+    "note": "Both 'sign in' and 'log in' are 'oturum aç' throughout; imperative for buttons ('Oturum aç'), 'oturum açın' in instructions."
+  },
+  "sign out": {
+    "target": "oturumu kapat",
+    "note": "Both 'sign out' and 'log out' are 'oturumu kapat'."
+  },
+  "join": {
+    "target": "katıl",
+    "note": "Verb 'katılmak'; takes dative: 'kanala katıl', 'takıma katıl'."
+  },
+  "leave": {
+    "target": "ayrıl",
+    "note": "Verb 'ayrılmak'; takes ablative: 'kanaldan ayrıl', 'takımdan ayrıl'."
+  },
+  "archive": {
+    "target": "arşivle",
+    "note": "'archived' = 'arşivlenmiş'."
+  },
+  "unarchive": {
+    "target": "arşivden çıkar"
+  },
+  "mute": {
+    "target": "bildirimleri kapat",
+    "note": "For channels/categories the repo renders mute as 'bildirimleri kapat' (turn off notifications), e.g. 'Mute Channel' = 'Kanal bildirimlerini kapat'; 'unmute' = 'bildirimleri aç'. Distinct from Calls microphone mute = 'sesi kapat'."
+  },
+  "follow": {
+    "target": "izle",
+    "note": "Verb 'izlemek' ('Konuyu izle'); mobile occasionally uses 'takip et' — prefer 'izle' for consistency."
+  },
+  "unfollow": {
+    "target": "izlemeyi bırak"
+  },
+  "favorite": {
+    "target": "beğendiklerime ekle",
+    "note": "Core apps: 'Favorite' = 'Beğendiklerime ekle', 'Favorites' category = 'Beğendiklerim', 'Unfavorite' = 'Beğendiklerimden kaldır'. Playbooks inconsistently uses 'sık kullanılanlar' — the core 'beğen-' family is the majority rendering."
+  },
+  "search": {
+    "target": "arama",
+    "note": "Noun: 'arama'; verb (buttons/placeholders): 'ara' / 'arayın'."
+  },
+  "integration": {
+    "target": "bütünleştirme",
+    "note": "Repo convention; do not use 'entegrasyon'."
+  },
+  "slash command": {
+    "target": "bölü komutu"
+  },
+  "webhook": {
+    "target": "internet kancası",
+    "note": "Repo consistently localizes webhook as 'internet kancası'; do not keep English 'webhook'."
+  },
+  "incoming webhook": {
+    "target": "gelen internet kancası"
+  },
+  "outgoing webhook": {
+    "target": "giden internet kancası"
+  },
+  "trigger word": {
+    "target": "tetikleyici sözcük",
+    "note": "'sözcük' (not 'kelime') per repo vocabulary."
+  },
+  "plugin": {
+    "target": "uygulama eki",
+    "note": "Repo convention; do not use 'eklenti'."
+  },
+  "bot": {
+    "target": "bot",
+    "note": "'bot account' = 'bot hesabı'."
+  },
+  "role": {
+    "target": "rol"
+  },
+  "permission": {
+    "target": "izin"
+  },
+  "scheme": {
+    "target": "şema",
+    "note": "'permission scheme' = 'izin şeması'."
+  },
+  "license": {
+    "target": "lisans"
+  },
+  "seat": {
+    "target": "koltuk",
+    "note": "'licensed seats' = 'lisanslı koltuklar'."
+  },
+  "trial": {
+    "target": "deneme",
+    "note": "'free trial' = 'ücretsiz deneme'; 'trial period' often rendered 'deneme süresi'."
+  },
+  "workspace": {
+    "target": "çalışma alanı"
+  },
+  "subscription": {
+    "target": "abonelik"
+  },
+  "deactivate": {
+    "target": "etkisizleştir",
+    "note": "Webapp (user-facing) uses 'etkisizleştir' for accounts; server strings sometimes use 'kullanımdan kaldır' (also used for disabling features). Prefer 'etkisizleştir' for user accounts."
+  },
+  "invite": {
+    "target": "davet et",
+    "note": "Verb: 'davet et'; noun: 'davet' ('Davet kodu' = invite code)."
+  },
+  "invitation": {
+    "target": "davet",
+    "note": "'invitation email' = 'davet e-postası'."
+  },
+  "sidebar": {
+    "target": "kenar çubuğu"
+  },
+  "unread": {
+    "target": "okunmamış",
+    "note": "'Unreads' as a filter/list = 'okunmamışlar'."
+  },
+  "attachment": {
+    "target": "ek dosya"
+  },
+  "public channel": {
+    "target": "herkese açık kanal",
+    "note": "Do not use 'genel kanal'."
+  },
+  "private channel": {
+    "target": "özel kanal"
+  },
+  "shared channel": {
+    "target": "paylaşılan kanal",
+    "note": "Both 'paylaşılan kanal' and 'paylaşılmış kanal' appear; 'paylaşılan kanal' is the majority."
+  },
+  "channel header": {
+    "target": "kanal başlığı"
+  },
+  "channel purpose": {
+    "target": "kanal amacı"
+  },
+  "system message": {
+    "target": "sistem iletisi"
+  },
+  "persistent notification": {
+    "target": "kalıcı bildirim"
+  },
+  "message priority": {
+    "target": "ileti önceliği"
+  },
+  "urgent": {
+    "target": "acil",
+    "note": "All-caps label: 'ACİL' (Turkish dotted İ)."
+  },
+  "recap": {
+    "target": "özet",
+    "note": "No existing tr strings for this feature yet; 'özet' matches Turkish UI convention for AI summaries. If it must be distinguished from a plain 'summary' in the same view, 'etkinlik özeti' is a safe longer form."
+  },
+  "agent": {
+    "target": "aracı",
+    "note": "Existing webapp/mobile strings use 'aracı' (e.g. 'Aracıyı seçin', 'yapay zeka aracısı'). Beware case suffixes: accusative 'aracıyı'. Despite the homonym meaning 'intermediary', keep 'aracı' for consistency."
+  },
+  "burn-on-read": {
+    "target": "okunduğunda yok edilecek",
+    "note": "Established as 'okunduğunda yok edilecek ileti(ler)' for burn-on-read messages; the bare label 'Burn-on-read' = 'Okunduğunda yok edilecek'."
+  },
+  "magic link": {
+    "target": "sihirli bağlantı"
+  },
+  "personal access token": {
+    "target": "kişisel erişim kodu",
+    "note": "Repo renders 'token' as 'kod' in this term (not 'jeton'/'belirteç')."
+  },
+  "announcement banner": {
+    "target": "duyuru bildirimi",
+    "note": "Existing strings are inconsistent ('Duyuru bildirimi', plain 'bildirim'). 'duyuru bildirimi' is the labeled form; 'duyuru şeridi' would be clearer but is not established."
+  },
+  "channel banner": {
+    "target": "kanal bildirimi",
+    "note": "Webapp majority is 'kanal bildirimi'; server strings use 'kanal duyurusu', which is arguably clearer (avoids collision with notifications) — flag for future harmonization."
+  },
+  "keyword": {
+    "target": "anahtar sözcük"
+  },
+  "user group": {
+    "target": "kullanıcı grubu",
+    "note": "Plain 'group' = 'grup'."
+  },
+  "permalink": {
+    "target": "kalıcı bağlantı"
+  },
+  "profile": {
+    "target": "profil",
+    "note": "'profile picture' = 'profil görseli' (not 'profil resmi')."
+  },
+  "username": {
+    "target": "kullanıcı adı"
+  },
+  "nickname": {
+    "target": "takma ad"
+  },
+  "display name": {
+    "target": "görüntülenecek ad",
+    "note": "Repo uses the future participle 'görüntülenecek ad' (name to be displayed), not 'görünen ad'."
+  },
+  "collapsed reply threads": {
+    "target": "daraltılmış yanıt konuları"
+  },
+  "auto-translation": {
+    "target": "otomatik çeviri",
+    "note": "'auto-translated' = 'otomatik çevrilmiş'; 'channel translations' = 'kanal çevirileri'."
+  },
+  "data retention": {
+    "target": "verileri tutma",
+    "note": "'data retention policy' = 'verileri tutma ilkesi'. Some strings use 'veri tutma'; majority is 'verileri tutma'. 'policy' = 'ilke' (not 'politika')."
+  },
+  "compliance export": {
+    "target": "uyumluluk dışa aktarma"
+  },
+  "access control": {
+    "target": "erişim denetimi",
+    "note": "'attribute-based access control (ABAC)' = 'öznitelik temelli erişim denetimi'; 'access control policy' = 'erişim denetimi ilkesi'."
+  },
+  "attribute": {
+    "target": "öznitelik"
+  },
+  "onboarding": {
+    "target": "başlamaya hazırlanma",
+    "note": "Repo renders onboarding descriptively as 'başlamaya hazırlanma / başlamaya hazırlık'; no loanword."
+  },
+  "Town Square": {
+    "target": "Meydan",
+    "note": "Established default-channel name in server i18n; keep exactly 'Meydan'."
+  },
+  "Off-Topic": {
+    "target": "Konu dışı",
+    "note": "Established default-channel name in server i18n."
+  },
+  "read-only": {
+    "target": "salt okunur"
+  },
+  "server": {
+    "target": "sunucu",
+    "note": "Beware: the Calls plugin also uses 'sunucu' for the call host; in core/server contexts 'sunucu' always means server."
+  }
+}

--- a/i18n/glossary/tr.json
+++ b/i18n/glossary/tr.json
@@ -364,8 +364,8 @@
     "note": "Repo renders 'token' as 'kod' in this term (not 'jeton'/'belirteç')."
   },
   "announcement banner": {
-    "target": "duyuru şeridi",
-    "note": "Existing strings use 'duyuru bildirimi', which collides with 'notification' = 'bildirim'; a banner is a strip ('şerit'), not a notification."
+    "target": "duyuru bildirimi",
+    "note": "Existing strings use 'duyuru bildirimi', which collides with 'notification' = 'bildirim'. A form preserving the banner sense ('duyuru şeridi') is unattested in the catalogs and needs a Turkish reviewer."
   },
   "channel banner": {
     "target": "kanal duyurusu",

--- a/i18n/glossary/tr.json
+++ b/i18n/glossary/tr.json
@@ -364,12 +364,12 @@
     "note": "Repo renders 'token' as 'kod' in this term (not 'jeton'/'belirteç')."
   },
   "announcement banner": {
-    "target": "duyuru bildirimi",
-    "note": "Existing strings are inconsistent ('Duyuru bildirimi', plain 'bildirim'). 'duyuru bildirimi' is the labeled form; 'duyuru şeridi' would be clearer but is not established."
+    "target": "duyuru şeridi",
+    "note": "Existing strings use 'duyuru bildirimi', which collides with 'notification' = 'bildirim'; a banner is a strip ('şerit'), not a notification."
   },
   "channel banner": {
-    "target": "kanal bildirimi",
-    "note": "Webapp majority is 'kanal bildirimi'; server strings use 'kanal duyurusu', which is arguably clearer (avoids collision with notifications) — flag for future harmonization."
+    "target": "kanal duyurusu",
+    "note": "Established in server strings. Webapp majority is 'kanal bildirimi', which collides with 'notification' = 'bildirim'."
   },
   "keyword": {
     "target": "anahtar sözcük"

--- a/i18n/glossary/tr.json
+++ b/i18n/glossary/tr.json
@@ -61,9 +61,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/tr.json
+++ b/i18n/glossary/tr.json
@@ -421,12 +421,10 @@
     "note": "Repo renders onboarding descriptively as 'başlamaya hazırlanma / başlamaya hazırlık'; no loanword."
   },
   "Town Square": {
-    "target": "Meydan",
-    "note": "Established default-channel name in server i18n; keep exactly 'Meydan'."
+    "target": "Meydan"
   },
   "Off-Topic": {
-    "target": "Konu dışı",
-    "note": "Established default-channel name in server i18n."
+    "target": "Konu dışı"
   },
   "read-only": {
     "target": "salt okunur"

--- a/i18n/glossary/uk.json
+++ b/i18n/glossary/uk.json
@@ -1,0 +1,459 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition",
+    "note": "Keep in English. Existing translations sometimes render it as 'Enterprise версія'; prefer the untranslated product name."
+  },
+  "Team Edition": {
+    "target": "Team Edition",
+    "note": "Keep in English. Existing translations sometimes use 'Командне видання'; prefer the untranslated product name per doNotTranslate."
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "Product name; do not confuse with the common noun 'channel' = 'канал'."
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "системна консоль",
+    "note": "Feminine noun; capitalize as 'Системна консоль' when used as the named UI area. Consistent in existing translations."
+  },
+  "marketplace": {
+    "target": "магазин плагінів",
+    "note": "Existing translations consistently use 'Магазин плагінів' (lit. 'plugin store') rather than a transliteration like 'маркетплейс'."
+  },
+  "channel": {
+    "target": "канал",
+    "note": "Masculine. Genitive 'каналу', plural 'канали'."
+  },
+  "team": {
+    "target": "команда",
+    "note": "Feminine. Same word as 'command'; context disambiguates."
+  },
+  "post": {
+    "target": "допис",
+    "note": "Masculine. Majority rendering; existing strings occasionally use 'повідомлення' or 'публікація' — prefer 'допис' to keep the post/message distinction."
+  },
+  "message": {
+    "target": "повідомлення",
+    "note": "Neuter; identical in singular and plural nominative."
+  },
+  "thread": {
+    "target": "обговорення",
+    "note": "Neuter. Consistently used in existing translations (not 'потік' or 'гілка', though 'потік' appears in a few admin strings)."
+  },
+  "reply": {
+    "target": "відповідь (ім.) / відповісти (дієсл.)",
+    "note": "Noun is feminine ('відповідь', plural 'відповіді'); verb 'відповісти' (perfective) for buttons."
+  },
+  "direct message": {
+    "target": "приватне повідомлення",
+    "note": "Majority rendering; 'особисте повідомлення' appears sporadically — use 'приватне повідомлення' everywhere. Note the same adjective is used for 'private channel' = 'приватний канал'."
+  },
+  "group message": {
+    "target": "групове повідомлення"
+  },
+  "mention": {
+    "target": "згадка (ім.) / згадати (дієсл.)",
+    "note": "Noun 'згадка' is feminine; 'згадування' also appears for the act of mentioning."
+  },
+  "notification": {
+    "target": "сповіщення",
+    "note": "Neuter. Consistently 'сповіщення', not 'повідомлення' (reserved for 'message')."
+  },
+  "pin": {
+    "target": "закріпити",
+    "note": "'unpin' = 'відкріпити'; 'pinned messages' = 'закріплені повідомлення'."
+  },
+  "bookmark": {
+    "target": "закладка (ім.) / додати в закладки (дієсл.)",
+    "note": "Feminine noun."
+  },
+  "saved messages": {
+    "target": "збережені повідомлення",
+    "note": "'save' = 'зберегти', 'unsave' = 'скасувати збереження'."
+  },
+  "draft": {
+    "target": "чернетка",
+    "note": "Feminine. Plural 'чернетки'."
+  },
+  "scheduled post": {
+    "target": "запланований допис",
+    "note": "Existing strings mix 'запланований допис', 'заплановане повідомлення', and 'запланована публікація'; standardize on 'запланований допис'."
+  },
+  "emoji": {
+    "target": "емодзі",
+    "note": "Indeclinable neuter borrowing; same form in singular and plural."
+  },
+  "custom emoji": {
+    "target": "користувацький емодзі",
+    "note": "Existing translations use 'користувацькі емодзі' (plural); adjective agrees with indeclinable 'емодзі'."
+  },
+  "reaction": {
+    "target": "реакція",
+    "note": "Feminine. 'react' = 'відреагувати' / 'додати реакцію'."
+  },
+  "status": {
+    "target": "статус"
+  },
+  "custom status": {
+    "target": "користувацький статус",
+    "note": "Majority rendering; 'власний статус' also appears occasionally."
+  },
+  "do not disturb": {
+    "target": "Не турбувати",
+    "note": "Consistent across all apps."
+  },
+  "away": {
+    "target": "Не на місці",
+    "note": "Majority rendering for the status; 'Відсутній' appears in some strings — prefer 'Не на місці' (gender-neutral)."
+  },
+  "online": {
+    "target": "В мережі",
+    "note": "Majority rendering for the status; 'Онлайн' also appears — prefer 'В мережі'."
+  },
+  "offline": {
+    "target": "Не в мережі",
+    "note": "Majority rendering; 'Офлайн' appears occasionally."
+  },
+  "out of office": {
+    "target": "Поза офісом",
+    "note": "Majority rendering; 'Не в офісі' appears once in mobile."
+  },
+  "guest": {
+    "target": "гість",
+    "note": "Masculine. 'guest access' = 'гостьовий доступ', 'guest account' = 'гостьовий обліковий запис'."
+  },
+  "member": {
+    "target": "учасник",
+    "note": "Majority rendering; 'член' appears in some strings — prefer 'учасник'."
+  },
+  "user": {
+    "target": "користувач",
+    "note": "Masculine. Genitive 'користувача'."
+  },
+  "system admin": {
+    "target": "системний адміністратор",
+    "note": "Consistent in existing translations."
+  },
+  "team admin": {
+    "target": "адміністратор команди"
+  },
+  "channel admin": {
+    "target": "адміністратор каналу"
+  },
+  "session": {
+    "target": "сесія",
+    "note": "Majority rendering; 'сеанс' also appears — prefer 'сесія'."
+  },
+  "sign in": {
+    "target": "увійти",
+    "note": "Existing translations are inconsistent: the standalone Log in button is often 'Авторизуватися', while sentences use forms of 'увійти'/'вхід'. Standardize on 'увійти' ('вхід' as noun); translate 'log in' and 'sign in' identically."
+  },
+  "sign out": {
+    "target": "вийти",
+    "note": "Consistent; noun form 'вихід'. Translate 'log out' and 'sign out' identically."
+  },
+  "join": {
+    "target": "приєднатися",
+    "note": "Followed by 'до' + genitive: 'приєднатися до каналу/команди'."
+  },
+  "leave": {
+    "target": "покинути",
+    "note": "Majority rendering ('Покинути канал'); 'залишити' also appears — prefer 'покинути'."
+  },
+  "archive": {
+    "target": "архівувати",
+    "note": "Perfective 'заархівувати' for one-shot actions; 'archived' = 'заархівовано' / 'архівний'."
+  },
+  "unarchive": {
+    "target": "розархівувати",
+    "note": "Consistent in existing translations."
+  },
+  "mute": {
+    "target": "заглушити",
+    "note": "For channel notifications. Existing strings are inconsistent ('Не сповіщати', 'Вимкнути звук', 'Заглушити канал'); use 'заглушити' for channels and reserve 'вимкнути звук' for microphone muting in Calls."
+  },
+  "follow": {
+    "target": "стежити",
+    "note": "Existing strings mix 'Відстежувати', 'Слідкувати за' and 'стежити за'; standardize on 'стежити за' + instrumental."
+  },
+  "unfollow": {
+    "target": "припинити стежити",
+    "note": "Existing strings mix 'Не слідувати за' and 'Відписатися від'; use 'припинити стежити за' for consistency with 'follow' = 'стежити'."
+  },
+  "favorite": {
+    "target": "обране (ім.) / додати в обране (дієсл.)",
+    "note": "'Favorites' category = 'Обране'; 'unfavorite' = 'вилучити з обраного'."
+  },
+  "search": {
+    "target": "пошук (ім.) / шукати (дієсл.)"
+  },
+  "integration": {
+    "target": "інтеграція",
+    "note": "Feminine."
+  },
+  "slash command": {
+    "target": "швидка команда",
+    "note": "Majority rendering in existing translations; 'слеш-команда' appears occasionally. Note ambiguity with 'команда' = team."
+  },
+  "webhook": {
+    "target": "вебхук",
+    "note": "Masculine borrowing; majority spelling. 'веб-хук' (hyphenated) and untranslated 'Webhook' also appear — standardize on 'вебхук'."
+  },
+  "incoming webhook": {
+    "target": "вхідний вебхук"
+  },
+  "outgoing webhook": {
+    "target": "вихідний вебхук"
+  },
+  "trigger word": {
+    "target": "тригерне слово",
+    "note": "Existing strings split between 'тригерне слово' and 'ключове слово'; use 'тригерне слово' to keep it distinct from 'keyword' = 'ключове слово'. Avoid the misspelling 'триггерне' found in some strings."
+  },
+  "plugin": {
+    "target": "плагін",
+    "note": "Masculine. Consistent in existing translations."
+  },
+  "bot": {
+    "target": "бот",
+    "note": "'bot account' = 'обліковий запис бота'."
+  },
+  "role": {
+    "target": "роль",
+    "note": "Feminine."
+  },
+  "permission": {
+    "target": "дозвіл",
+    "note": "Masculine. Plural 'дозволи'."
+  },
+  "scheme": {
+    "target": "схема",
+    "note": "'permission scheme' = 'схема дозволів'."
+  },
+  "license": {
+    "target": "ліцензія"
+  },
+  "seat": {
+    "target": "місце",
+    "note": "No existing translation found in repos; 'місце' (licensed seat) is the standard SaaS rendering. Use 'ліцензійне місце' where ambiguous."
+  },
+  "trial": {
+    "target": "пробний період",
+    "note": "Existing strings mix 'пробний період' and 'пробна версія'; prefer 'пробний період' for the time-limited trial."
+  },
+  "workspace": {
+    "target": "робочий простір",
+    "note": "Consistent in existing translations."
+  },
+  "subscription": {
+    "target": "підписка"
+  },
+  "deactivate": {
+    "target": "деактивувати",
+    "note": "Consistent; 'deactivated' = 'деактивовано'."
+  },
+  "invite": {
+    "target": "запросити (дієсл.) / запрошення (ім.)"
+  },
+  "invitation": {
+    "target": "запрошення",
+    "note": "Neuter."
+  },
+  "sidebar": {
+    "target": "бічна панель",
+    "note": "Consistent in existing translations."
+  },
+  "unread": {
+    "target": "непрочитане",
+    "note": "Adjective; agrees in gender/number: 'непрочитані повідомлення', 'непрочитаний канал'."
+  },
+  "attachment": {
+    "target": "вкладення",
+    "note": "Neuter; identical singular/plural nominative."
+  },
+  "public channel": {
+    "target": "публічний канал",
+    "note": "Majority rendering; 'загальнодоступний канал' appears in some admin strings — prefer 'публічний канал'."
+  },
+  "private channel": {
+    "target": "приватний канал"
+  },
+  "shared channel": {
+    "target": "спільний канал"
+  },
+  "channel header": {
+    "target": "заголовок каналу"
+  },
+  "channel purpose": {
+    "target": "призначення каналу",
+    "note": "Majority rendering in webapp; mobile occasionally uses 'мета' or mistakenly 'заголовок' — always use 'призначення каналу'."
+  },
+  "system message": {
+    "target": "системне повідомлення"
+  },
+  "persistent notification": {
+    "target": "постійне сповіщення",
+    "note": "Consistent in existing translations ('постійні сповіщення')."
+  },
+  "message priority": {
+    "target": "пріоритет повідомлення"
+  },
+  "urgent": {
+    "target": "терміново",
+    "note": "As the priority label; adjectival form 'терміновий' when modifying a noun. All-caps label: 'ТЕРМІНОВО'."
+  },
+  "recap": {
+    "target": "підсумок",
+    "note": "No existing translation in repos; 'підсумок' aligns with 'meeting summary' = 'підсумок зустрічі' in Calls. Genitive 'підсумку'."
+  },
+  "agent": {
+    "target": "агент",
+    "note": "Existing mobile strings use 'Агент' capitalized when referring to the AI feature; plural 'агенти'."
+  },
+  "burn-on-read": {
+    "target": "що зникає після прочитання",
+    "note": "Existing mobile string: 'Повідомлення, що зникає після прочитання'. For the all-caps inline label use 'ЗНИКАЄ ПІСЛЯ ПРОЧИТАННЯ' (avoid mobile's incorrect 'ПРОЧИТАТИ')."
+  },
+  "magic link": {
+    "target": "магічне посилання",
+    "note": "Grounded in existing mobile string 'Скористайтесь магічним посиланням'."
+  },
+  "personal access token": {
+    "target": "персональний токен доступу",
+    "note": "Existing strings mix 'токен' and 'маркер' for token; standardize on 'токен'."
+  },
+  "announcement banner": {
+    "target": "банер оголошень",
+    "note": "Existing strings inconsistent ('банер оголошення', 'банер з оголошеннями', 'Загальносистемні сповіщення'); standardize on 'банер оголошень'."
+  },
+  "channel banner": {
+    "target": "банер каналу",
+    "note": "Consistent in existing translations."
+  },
+  "keyword": {
+    "target": "ключове слово",
+    "note": "Plural 'ключові слова'."
+  },
+  "user group": {
+    "target": "група користувачів"
+  },
+  "permalink": {
+    "target": "постійне посилання",
+    "note": "No established rendering in repos; 'постійне посилання' is the standard Ukrainian software term."
+  },
+  "profile": {
+    "target": "профіль",
+    "note": "Masculine. 'profile picture' = 'зображення профілю'."
+  },
+  "username": {
+    "target": "ім'я користувача",
+    "note": "Existing translations use 'Логін' for the standalone field label and 'ім'я користувача' in sentences; prefer 'ім'я користувача' for consistency."
+  },
+  "nickname": {
+    "target": "псевдонім",
+    "note": "Consistent in existing translations."
+  },
+  "display name": {
+    "target": "відображуване ім'я",
+    "note": "Existing strings mix 'відображуване ім'я' and 'ім'я відображення'; prefer 'відображуване ім'я'. For channels/teams use 'відображувана назва'."
+  },
+  "collapsed reply threads": {
+    "target": "згорнуті відповіді в обговореннях",
+    "note": "Established rendering in mobile; keep as the feature name even though a more literal option would be 'згорнуті обговорення'."
+  },
+  "auto-translation": {
+    "target": "автоматичний переклад",
+    "note": "No existing rendering in repos; 'AUTO-TRANSLATED' label = 'ПЕРЕКЛАДЕНО АВТОМАТИЧНО'."
+  },
+  "data retention": {
+    "target": "зберігання даних",
+    "note": "'data retention policy' = 'політика зберігання даних' (consistent in existing translations)."
+  },
+  "compliance export": {
+    "target": "експорт відповідності",
+    "note": "Consistent in existing translations."
+  },
+  "access control": {
+    "target": "контроль доступу",
+    "note": "'attribute-based access control' = 'контроль доступу на основі атрибутів'."
+  },
+  "attribute": {
+    "target": "атрибут",
+    "note": "Masculine."
+  },
+  "onboarding": {
+    "target": "адаптація",
+    "note": "Grounded in existing 'Увімкнути Адаптацію' / 'процес адаптації'."
+  },
+  "Town Square": {
+    "target": "Загальний канал",
+    "note": "Established default-channel name in server uk.json; keep consistent everywhere."
+  },
+  "Off-Topic": {
+    "target": "Офтопік",
+    "note": "Established default-channel name in server uk.json."
+  },
+  "read-only": {
+    "target": "лише для читання",
+    "note": "Grounded: 'Цей канал доступний лише для читання.'"
+  },
+  "server": {
+    "target": "сервер",
+    "note": "Masculine. Genitive 'сервера'."
+  }
+}

--- a/i18n/glossary/uk.json
+++ b/i18n/glossary/uk.json
@@ -56,9 +56,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/uk.json
+++ b/i18n/glossary/uk.json
@@ -155,8 +155,7 @@
     "note": "Majority rendering; 'власний статус' also appears occasionally."
   },
   "do not disturb": {
-    "target": "Не турбувати",
-    "note": "Consistent across all apps."
+    "target": "Не турбувати"
   },
   "away": {
     "target": "Не на місці",
@@ -187,8 +186,7 @@
     "note": "Masculine. Genitive 'користувача'."
   },
   "system admin": {
-    "target": "системний адміністратор",
-    "note": "Consistent in existing translations."
+    "target": "системний адміністратор"
   },
   "team admin": {
     "target": "адміністратор команди"
@@ -221,8 +219,7 @@
     "note": "Perfective 'заархівувати' for one-shot actions; 'archived' = 'заархівовано' / 'архівний'."
   },
   "unarchive": {
-    "target": "розархівувати",
-    "note": "Consistent in existing translations."
+    "target": "розархівувати"
   },
   "mute": {
     "target": "заглушити",
@@ -298,8 +295,7 @@
     "note": "Existing strings mix 'пробний період' and 'пробна версія'; prefer 'пробний період' for the time-limited trial."
   },
   "workspace": {
-    "target": "робочий простір",
-    "note": "Consistent in existing translations."
+    "target": "робочий простір"
   },
   "subscription": {
     "target": "підписка"
@@ -317,8 +313,7 @@
     "note": "Neuter."
   },
   "sidebar": {
-    "target": "бічна панель",
-    "note": "Consistent in existing translations."
+    "target": "бічна панель"
   },
   "unread": {
     "target": "непрочитане",
@@ -384,8 +379,7 @@
     "note": "Existing strings inconsistent ('банер оголошення', 'банер з оголошеннями', 'Загальносистемні сповіщення'); standardize on 'банер оголошень'."
   },
   "channel banner": {
-    "target": "банер каналу",
-    "note": "Consistent in existing translations."
+    "target": "банер каналу"
   },
   "keyword": {
     "target": "ключове слово",
@@ -407,8 +401,7 @@
     "note": "Existing translations use 'Логін' for the standalone field label and 'ім'я користувача' in sentences; prefer 'ім'я користувача' for consistency."
   },
   "nickname": {
-    "target": "псевдонім",
-    "note": "Consistent in existing translations."
+    "target": "псевдонім"
   },
   "display name": {
     "target": "відображуване ім'я",
@@ -427,8 +420,7 @@
     "note": "'data retention policy' = 'політика зберігання даних' (consistent in existing translations)."
   },
   "compliance export": {
-    "target": "експорт відповідності",
-    "note": "Consistent in existing translations."
+    "target": "експорт відповідності"
   },
   "access control": {
     "target": "контроль доступу",

--- a/i18n/glossary/uk.json
+++ b/i18n/glossary/uk.json
@@ -97,8 +97,8 @@
     "note": "Neuter. Consistently used in existing translations (not 'потік' or 'гілка', though 'потік' appears in a few admin strings)."
   },
   "reply": {
-    "target": "відповідь (ім.) / відповісти (дієсл.)",
-    "note": "Noun is feminine ('відповідь', plural 'відповіді'); verb 'відповісти' (perfective) for buttons."
+    "target": "відповідь",
+    "note": "Noun is feminine (plural 'відповіді'). Verb: 'відповісти' (perfective) for buttons."
   },
   "direct message": {
     "target": "приватне повідомлення",
@@ -108,8 +108,8 @@
     "target": "групове повідомлення"
   },
   "mention": {
-    "target": "згадка (ім.) / згадати (дієсл.)",
-    "note": "Noun 'згадка' is feminine; 'згадування' also appears for the act of mentioning."
+    "target": "згадка",
+    "note": "Noun is feminine. Verb: 'згадати'; 'згадування' also appears for the act of mentioning."
   },
   "notification": {
     "target": "сповіщення",
@@ -120,8 +120,8 @@
     "note": "'unpin' = 'відкріпити'; 'pinned messages' = 'закріплені повідомлення'."
   },
   "bookmark": {
-    "target": "закладка (ім.) / додати в закладки (дієсл.)",
-    "note": "Feminine noun."
+    "target": "закладка",
+    "note": "Noun is feminine. Verb: 'додати в закладки'."
   },
   "saved messages": {
     "target": "збережені повідомлення",
@@ -237,11 +237,12 @@
     "note": "Existing strings mix 'Не слідувати за' and 'Відписатися від'; use 'припинити стежити за' for consistency with 'follow' = 'стежити'."
   },
   "favorite": {
-    "target": "обране (ім.) / додати в обране (дієсл.)",
-    "note": "'Favorites' category = 'Обране'; 'unfavorite' = 'вилучити з обраного'."
+    "target": "обране",
+    "note": "Sidebar category = 'Обране'. Verb: 'додати в обране'; 'unfavorite' = 'вилучити з обраного'."
   },
   "search": {
-    "target": "пошук (ім.) / шукати (дієсл.)"
+    "target": "пошук",
+    "note": "Verb: 'шукати'."
   },
   "integration": {
     "target": "інтеграція",
@@ -308,7 +309,8 @@
     "note": "Consistent; 'deactivated' = 'деактивовано'."
   },
   "invite": {
-    "target": "запросити (дієсл.) / запрошення (ім.)"
+    "target": "запросити",
+    "note": "Verb; noun uses 'запрошення'."
   },
   "invitation": {
     "target": "запрошення",

--- a/i18n/glossary/vi.json
+++ b/i18n/glossary/vi.json
@@ -1,0 +1,436 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition"
+  },
+  "Team Edition": {
+    "target": "Team Edition",
+    "note": "Repo once renders this as 'Phiên bản cho Nhóm'; per doNotTranslate keep the English edition name."
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "Product name only; the common noun 'channel' is 'kênh'."
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "Bảng điều khiển Hệ thống",
+    "note": "Established in vi.json; capitalize as a named UI area."
+  },
+  "marketplace": {
+    "target": "thị trường",
+    "note": "vi.json uses 'Thị trường' (e.g. 'Bật Thị trường'); capitalize when used as the feature name."
+  },
+  "channel": {
+    "target": "kênh",
+    "note": "Consistently 'kênh' throughout vi.json."
+  },
+  "team": {
+    "target": "nhóm",
+    "note": "Majority rendering (236 'nhóm' vs 33 'đội' in vi.json). Caution: 'nhóm' also translates 'group' (user group = 'nhóm người dùng', group message = 'tin nhắn nhóm'); use context or 'đội' only if disambiguation is essential — but 'nhóm' is the established default."
+  },
+  "post": {
+    "target": "bài đăng",
+    "note": "Distinct from 'message' = 'tin nhắn'; vi.json uses 'bài đăng' for post."
+  },
+  "message": {
+    "target": "tin nhắn"
+  },
+  "thread": {
+    "target": "chủ đề",
+    "note": "Established in vi.json ('Chủ đề trong', 'chủ đề chưa đọc'). Also means 'topic'; alternative 'luồng' is not used in the repo — keep 'chủ đề'."
+  },
+  "reply": {
+    "target": "trả lời",
+    "note": "Verb and noun both 'trả lời'; a reply message can be 'câu trả lời'."
+  },
+  "direct message": {
+    "target": "tin nhắn trực tiếp",
+    "note": "Consistent in vi.json; capitalize as 'Tin nhắn Trực tiếp' in headings."
+  },
+  "group message": {
+    "target": "tin nhắn nhóm"
+  },
+  "mention": {
+    "target": "đề cập",
+    "note": "Verb 'đề cập'; noun/count 'lượt đề cập' (per vi.json 'mentions' -> 'lượt đề cập')."
+  },
+  "notification": {
+    "target": "thông báo"
+  },
+  "pin": {
+    "target": "ghim",
+    "note": "unpin = 'bỏ ghim'; pinned = 'đã ghim'; pinned messages = 'tin nhắn được ghim'."
+  },
+  "bookmark": {
+    "target": "dấu trang",
+    "note": "No existing vi rendering in repo; 'dấu trang' is the standard Vietnamese UI term (browsers). Verb: 'thêm dấu trang'."
+  },
+  "saved messages": {
+    "target": "tin nhắn đã lưu",
+    "note": "vi.json is inconsistent: 'Bài đăng đã lưu' in one label but 'tin nhắn được lưu' elsewhere; prefer 'tin nhắn đã lưu' to match message = 'tin nhắn'. save = 'lưu', unsave = 'bỏ lưu'."
+  },
+  "draft": {
+    "target": "bản nháp",
+    "note": "vi.json uses short form 'nháp' in buttons ('Gửi nháp', 'Xoá nháp'); 'bản nháp' as the standalone noun."
+  },
+  "scheduled post": {
+    "target": "tin nhắn đã lên lịch",
+    "note": "No existing vi rendering; align with message = 'tin nhắn'. Verb schedule = 'lên lịch'."
+  },
+  "emoji": {
+    "target": "biểu tượng cảm xúc",
+    "note": "Consistent in vi.json."
+  },
+  "custom emoji": {
+    "target": "biểu tượng cảm xúc tùy chỉnh"
+  },
+  "reaction": {
+    "target": "phản ứng",
+    "note": "Established in vi.json; verb react = 'phản ứng' or 'thêm phản ứng'."
+  },
+  "status": {
+    "target": "trạng thái"
+  },
+  "custom status": {
+    "target": "trạng thái tùy chỉnh"
+  },
+  "do not disturb": {
+    "target": "Không làm phiền",
+    "note": "Established status label in vi.json; keep the DND abbreviation untranslated if it appears."
+  },
+  "away": {
+    "target": "Đi vắng"
+  },
+  "online": {
+    "target": "Trực tuyến"
+  },
+  "offline": {
+    "target": "Ngoại tuyến"
+  },
+  "out of office": {
+    "target": "Vắng mặt",
+    "note": "vi.json uses 'Vắng mặt' for the status label; expanded 'vắng mặt tại văn phòng' in prose."
+  },
+  "guest": {
+    "target": "khách"
+  },
+  "member": {
+    "target": "thành viên"
+  },
+  "user": {
+    "target": "người dùng"
+  },
+  "system admin": {
+    "target": "quản trị viên hệ thống",
+    "note": "vi.json labels the role 'Quản trị hệ thống'; use 'quản trị viên hệ thống' when referring to the person."
+  },
+  "team admin": {
+    "target": "quản trị viên nhóm"
+  },
+  "channel admin": {
+    "target": "quản trị viên kênh"
+  },
+  "session": {
+    "target": "phiên",
+    "note": "Also 'phiên đăng nhập' where clarity is needed (vi.json uses both)."
+  },
+  "sign in": {
+    "target": "đăng nhập",
+    "note": "Translate both 'sign in' and 'log in' as 'đăng nhập'."
+  },
+  "sign out": {
+    "target": "đăng xuất",
+    "note": "Translate both 'sign out' and 'log out' as 'đăng xuất'."
+  },
+  "join": {
+    "target": "tham gia"
+  },
+  "leave": {
+    "target": "rời khỏi",
+    "note": "'rời' alone in short buttons; 'rời khỏi kênh/nhóm' in full phrases."
+  },
+  "archive": {
+    "target": "lưu trữ",
+    "note": "archived = 'đã lưu trữ'. Caution: 'lưu trữ' also means 'store/save' in some legacy strings; for the channel action always 'lưu trữ kênh'."
+  },
+  "unarchive": {
+    "target": "hủy lưu trữ"
+  },
+  "mute": {
+    "target": "tắt thông báo",
+    "note": "vi.json is inconsistent ('Tắt tiếng kênh' vs 'Tắt thông báo'). For channels/notifications use 'tắt thông báo'; reserve 'tắt tiếng' for microphone mute in Calls. unmute = 'bật thông báo'."
+  },
+  "follow": {
+    "target": "theo dõi"
+  },
+  "unfollow": {
+    "target": "bỏ theo dõi"
+  },
+  "favorite": {
+    "target": "yêu thích",
+    "note": "Favorites category = 'Yêu thích'; unfavorite = 'bỏ yêu thích'."
+  },
+  "search": {
+    "target": "tìm kiếm"
+  },
+  "integration": {
+    "target": "tích hợp"
+  },
+  "slash command": {
+    "target": "lệnh gạch chéo",
+    "note": "Majority in vi.json; some strings leave 'Slash Commands' untranslated — prefer 'lệnh gạch chéo'."
+  },
+  "webhook": {
+    "target": "webhook",
+    "note": "Kept in English throughout vi.json."
+  },
+  "incoming webhook": {
+    "target": "webhook đến",
+    "note": "Established in vi.json."
+  },
+  "outgoing webhook": {
+    "target": "webhook đi",
+    "note": "Established in vi.json."
+  },
+  "trigger word": {
+    "target": "từ kích hoạt",
+    "note": "Established in vi.json."
+  },
+  "plugin": {
+    "target": "plugin",
+    "note": "Kept in English throughout vi.json; do not translate as 'trình cắm'."
+  },
+  "bot": {
+    "target": "bot",
+    "note": "Kept in English; bot account = 'tài khoản bot'."
+  },
+  "role": {
+    "target": "vai trò"
+  },
+  "permission": {
+    "target": "quyền"
+  },
+  "scheme": {
+    "target": "lược đồ",
+    "note": "vi.json mixes 'lược đồ' and 'sơ đồ' ('Sơ đồ quyền'); prefer 'lược đồ' for permission schemes."
+  },
+  "license": {
+    "target": "giấy phép"
+  },
+  "seat": {
+    "target": "người dùng",
+    "note": "vi.json is inconsistent ('người dùng trả phí', 'chỗ', 'ghế người dùng'). Render seat counts as 'người dùng' (e.g. '{num} người dùng'); avoid literal 'ghế'."
+  },
+  "trial": {
+    "target": "bản dùng thử",
+    "note": "'dùng thử' as verb/period ('Bắt đầu dùng thử', 'ngày dùng thử')."
+  },
+  "workspace": {
+    "target": "không gian làm việc",
+    "note": "Majority in vi.json; a few strings leave 'workspace' untranslated — prefer 'không gian làm việc'."
+  },
+  "subscription": {
+    "target": "gói đăng ký",
+    "note": "vi.json uses bare 'Đăng ký', which collides with 'sign up/register'; 'gói đăng ký' is clearer for the paid-plan sense."
+  },
+  "deactivate": {
+    "target": "hủy kích hoạt",
+    "note": "vi.json mixes 'hủy kích hoạt' and 'vô hiệu hóa'; prefer 'hủy kích hoạt' for user accounts, matching 'Deactivate' -> 'Hủy kích hoạt'."
+  },
+  "invite": {
+    "target": "mời",
+    "note": "Noun sense: use 'lời mời'."
+  },
+  "invitation": {
+    "target": "lời mời"
+  },
+  "sidebar": {
+    "target": "thanh bên",
+    "note": "Majority in vi.json; one legacy string uses 'thanh tiện ích' — prefer 'thanh bên'."
+  },
+  "unread": {
+    "target": "chưa đọc"
+  },
+  "attachment": {
+    "target": "tệp đính kèm"
+  },
+  "public channel": {
+    "target": "kênh công khai"
+  },
+  "private channel": {
+    "target": "kênh riêng tư"
+  },
+  "shared channel": {
+    "target": "kênh được chia sẻ"
+  },
+  "channel header": {
+    "target": "tiêu đề kênh"
+  },
+  "channel purpose": {
+    "target": "mục đích kênh"
+  },
+  "system message": {
+    "target": "thông báo hệ thống",
+    "note": "Established in vi.json; slight collision with notification = 'thông báo', but keep for consistency."
+  },
+  "persistent notification": {
+    "target": "thông báo liên tục",
+    "note": "No existing vi rendering; 'liên tục' conveys the repeated-until-acknowledged behavior."
+  },
+  "message priority": {
+    "target": "mức ưu tiên tin nhắn",
+    "note": "vi.json has 'Ưu tiên tin nhắn'; 'mức ưu tiên' is clearer for the noun (the priority level)."
+  },
+  "urgent": {
+    "target": "Khẩn cấp",
+    "note": "vi.json has one legacy 'Gấp'; 'Khẩn cấp' is the standard priority label in Vietnamese UIs and matches Important/Standard register."
+  },
+  "recap": {
+    "target": "bản tóm tắt",
+    "note": "No existing vi rendering (new AI feature); aligns with 'tóm tắt' = summary."
+  },
+  "agent": {
+    "target": "tác nhân",
+    "note": "No existing vi rendering. 'Tác nhân' follows Microsoft/Google Vietnamese AI terminology; 'trợ lý AI' is a friendlier alternative. Keep 'Agents' in English when used as the product/plugin name."
+  },
+  "burn-on-read": {
+    "target": "tự hủy sau khi đọc",
+    "note": "No existing vi rendering; follows Vietnamese messaging-app convention for self-destructing messages (tin nhắn tự hủy)."
+  },
+  "magic link": {
+    "target": "liên kết đăng nhập nhanh",
+    "note": "No existing vi rendering; avoid literal 'liên kết ma thuật'. Describes a passwordless email sign-in link."
+  },
+  "personal access token": {
+    "target": "mã thông báo truy cập cá nhân",
+    "note": "vi.json mixes this with shorter 'mã truy cập cá nhân'; 'mã thông báo' is the standard rendering of 'token' — prefer the full form."
+  },
+  "announcement banner": {
+    "target": "biểu ngữ thông báo",
+    "note": "Majority in vi.json; one string uses 'Banner thông báo' — prefer 'biểu ngữ thông báo'."
+  },
+  "channel banner": {
+    "target": "biểu ngữ kênh"
+  },
+  "keyword": {
+    "target": "từ khóa"
+  },
+  "user group": {
+    "target": "nhóm người dùng",
+    "note": "Established in vi.json. Note collision: 'nhóm' alone also renders 'team'."
+  },
+  "permalink": {
+    "target": "liên kết cố định",
+    "note": "No existing vi rendering; standard Vietnamese term for permanent link."
+  },
+  "profile": {
+    "target": "hồ sơ"
+  },
+  "username": {
+    "target": "tên người dùng"
+  },
+  "nickname": {
+    "target": "biệt hiệu",
+    "note": "Established in vi.json ('thêm biệt hiệu')."
+  },
+  "display name": {
+    "target": "tên hiển thị"
+  },
+  "collapsed reply threads": {
+    "target": "chủ đề trả lời được thu gọn",
+    "note": "Exact existing rendering in vi.json for 'Threaded Discussions'/collapsed threads."
+  },
+  "auto-translation": {
+    "target": "dịch tự động",
+    "note": "auto-translated (label) = 'ĐÃ DỊCH TỰ ĐỘNG'."
+  },
+  "data retention": {
+    "target": "lưu giữ dữ liệu",
+    "note": "Policy = 'chính sách lưu giữ dữ liệu' (established in vi.json)."
+  },
+  "compliance export": {
+    "target": "xuất tuân thủ",
+    "note": "Established in vi.json."
+  },
+  "access control": {
+    "target": "kiểm soát truy cập",
+    "note": "One legacy vi string renders 'Advanced Access Control' as 'Kiểm duyệt kênh' (channel moderation) — do not follow it; 'kiểm soát truy cập' is the standard term."
+  },
+  "attribute": {
+    "target": "thuộc tính",
+    "note": "Established in vi.json for LDAP/profile attributes."
+  },
+  "onboarding": {
+    "target": "hướng dẫn bắt đầu",
+    "note": "vi.json has one legacy 'giới thiệu'; 'hướng dẫn bắt đầu' better conveys the guided first-run experience."
+  },
+  "Town Square": {
+    "target": "Không gian chung",
+    "note": "Established channel-name translation in server vi.json."
+  },
+  "Off-Topic": {
+    "target": "Chủ đề ngoài lề",
+    "note": "Established channel-name translation in server vi.json."
+  },
+  "read-only": {
+    "target": "chỉ đọc"
+  },
+  "server": {
+    "target": "máy chủ"
+  }
+}

--- a/i18n/glossary/vi.json
+++ b/i18n/glossary/vi.json
@@ -240,16 +240,13 @@
     "note": "Kept in English throughout vi.json."
   },
   "incoming webhook": {
-    "target": "webhook đến",
-    "note": "Established in vi.json."
+    "target": "webhook đến"
   },
   "outgoing webhook": {
-    "target": "webhook đi",
-    "note": "Established in vi.json."
+    "target": "webhook đi"
   },
   "trigger word": {
-    "target": "từ kích hoạt",
-    "note": "Established in vi.json."
+    "target": "từ kích hoạt"
   },
   "plugin": {
     "target": "plugin",
@@ -404,16 +401,14 @@
     "note": "Policy = 'chính sách lưu giữ dữ liệu' (established in vi.json)."
   },
   "compliance export": {
-    "target": "xuất tuân thủ",
-    "note": "Established in vi.json."
+    "target": "xuất tuân thủ"
   },
   "access control": {
     "target": "kiểm soát truy cập",
     "note": "One legacy vi string renders 'Advanced Access Control' as 'Kiểm duyệt kênh' (channel moderation) — do not follow it; 'kiểm soát truy cập' is the standard term."
   },
   "attribute": {
-    "target": "thuộc tính",
-    "note": "Established in vi.json for LDAP/profile attributes."
+    "target": "thuộc tính"
   },
   "onboarding": {
     "target": "hướng dẫn bắt đầu",

--- a/i18n/glossary/vi.json
+++ b/i18n/glossary/vi.json
@@ -55,9 +55,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/vi.json
+++ b/i18n/glossary/vi.json
@@ -273,8 +273,8 @@
     "target": "giấy phép"
   },
   "seat": {
-    "target": "người dùng",
-    "note": "vi.json is inconsistent ('người dùng trả phí', 'chỗ', 'ghế người dùng'). Render seat counts as 'người dùng' (e.g. '{num} người dùng'); avoid literal 'ghế'."
+    "target": "chỗ",
+    "note": "A licensed slot, not a user: render seat counts as '{num} chỗ'. Existing strings are inconsistent ('người dùng trả phí', 'chỗ ngồi', 'ghế người dùng') and must not collapse to plain 'người dùng'."
   },
   "trial": {
     "target": "bản dùng thử",

--- a/i18n/glossary/zh-CN.json
+++ b/i18n/glossary/zh-CN.json
@@ -1,0 +1,407 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition",
+    "note": "Product edition name; existing zh-CN UI sometimes says 企业版 in marketing copy, but keep the edition name in English."
+  },
+  "Team Edition": {
+    "target": "Team Edition"
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "Product name only; the common noun 'channel' is 频道."
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls",
+    "note": "Product name only; the common noun 'call' is 通话."
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "系统控制台"
+  },
+  "marketplace": {
+    "target": "市场"
+  },
+  "channel": {
+    "target": "频道"
+  },
+  "team": {
+    "target": "团队"
+  },
+  "post": {
+    "target": "消息",
+    "note": "Existing zh-CN does not distinguish post from message; both are 消息 (e.g. 创建消息, 固定消息). Do not use 帖子."
+  },
+  "message": {
+    "target": "消息"
+  },
+  "thread": {
+    "target": "话题",
+    "note": "Established rendering is 话题, not 会话串 or 主题; Threads view = 话题."
+  },
+  "reply": {
+    "target": "回复",
+    "note": "Noun and verb are both 回复."
+  },
+  "direct message": {
+    "target": "私信",
+    "note": "Occasionally expanded to 私信消息 in descriptions; standalone 私信 is standard."
+  },
+  "group message": {
+    "target": "群组消息"
+  },
+  "mention": {
+    "target": "提及",
+    "note": "Noun and verb are both 提及; @mention = @提及 or 提及."
+  },
+  "notification": {
+    "target": "通知"
+  },
+  "pin": {
+    "target": "固定",
+    "note": "Pin to Channel = 固定至频道; pinned messages = 固定消息; unpin = 取消固定. A few legacy strings use 标记 — avoid."
+  },
+  "bookmark": {
+    "target": "书签",
+    "note": "Noun; as a verb use 添加书签."
+  },
+  "saved messages": {
+    "target": "保存的消息",
+    "note": "save = 保存, unsave = 取消保存."
+  },
+  "draft": {
+    "target": "草稿"
+  },
+  "scheduled post": {
+    "target": "计划消息",
+    "note": "Majority rendering; 定时消息/定时发送 appear in a minority of strings."
+  },
+  "emoji": {
+    "target": "表情符",
+    "note": "Majority rendering in webapp zh-CN is 表情符; 表情 and 表情符号 appear in a minority of strings and in other repos."
+  },
+  "custom emoji": {
+    "target": "自定义表情",
+    "note": "Existing UI uses 自定义表情 (without 符), inconsistent with emoji = 表情符; keep the established form."
+  },
+  "reaction": {
+    "target": "表情回应",
+    "note": "Consistently 表情回应, not bare 回应 or 反应; react (verb) = 添加表情回应."
+  },
+  "status": {
+    "target": "状态"
+  },
+  "custom status": {
+    "target": "自定义状态"
+  },
+  "do not disturb": {
+    "target": "请勿打扰"
+  },
+  "away": {
+    "target": "离开",
+    "note": "Same word as leave (离开); context disambiguates."
+  },
+  "online": {
+    "target": "在线"
+  },
+  "offline": {
+    "target": "离线"
+  },
+  "out of office": {
+    "target": "离开办公室"
+  },
+  "guest": {
+    "target": "访客"
+  },
+  "member": {
+    "target": "成员"
+  },
+  "user": {
+    "target": "用户"
+  },
+  "system admin": {
+    "target": "系统管理员"
+  },
+  "team admin": {
+    "target": "团队管理员"
+  },
+  "channel admin": {
+    "target": "频道管理员"
+  },
+  "session": {
+    "target": "会话"
+  },
+  "sign in": {
+    "target": "登录",
+    "note": "log in and sign in are both 登录."
+  },
+  "sign out": {
+    "target": "退出登录",
+    "note": "log out and sign out are both 退出登录."
+  },
+  "join": {
+    "target": "加入"
+  },
+  "leave": {
+    "target": "离开"
+  },
+  "archive": {
+    "target": "归档",
+    "note": "archived = 已归档."
+  },
+  "unarchive": {
+    "target": "取消归档"
+  },
+  "mute": {
+    "target": "静音",
+    "note": "Channel mute is 静音 (e.g. 静音频道), same word as microphone mute in Calls."
+  },
+  "follow": {
+    "target": "关注"
+  },
+  "unfollow": {
+    "target": "取消关注"
+  },
+  "favorite": {
+    "target": "收藏",
+    "note": "Verb/adjective 收藏; the Favorites sidebar category is 收藏夹."
+  },
+  "search": {
+    "target": "搜索"
+  },
+  "integration": {
+    "target": "集成"
+  },
+  "slash command": {
+    "target": "斜杠命令"
+  },
+  "webhook": {
+    "target": "Webhook",
+    "note": "Kept in English with capital W throughout existing zh-CN."
+  },
+  "incoming webhook": {
+    "target": "传入 Webhook"
+  },
+  "outgoing webhook": {
+    "target": "传出 Webhook"
+  },
+  "trigger word": {
+    "target": "触发词"
+  },
+  "plugin": {
+    "target": "插件"
+  },
+  "bot": {
+    "target": "机器人",
+    "note": "bot account = 机器人账号 (账号, not 帐号/账户)."
+  },
+  "role": {
+    "target": "角色"
+  },
+  "permission": {
+    "target": "权限"
+  },
+  "scheme": {
+    "target": "方案",
+    "note": "permission scheme = 权限方案."
+  },
+  "license": {
+    "target": "许可证"
+  },
+  "seat": {
+    "target": "席位"
+  },
+  "trial": {
+    "target": "试用"
+  },
+  "workspace": {
+    "target": "工作区"
+  },
+  "subscription": {
+    "target": "订阅"
+  },
+  "deactivate": {
+    "target": "停用"
+  },
+  "invite": {
+    "target": "邀请"
+  },
+  "invitation": {
+    "target": "邀请"
+  },
+  "sidebar": {
+    "target": "侧栏",
+    "note": "Majority is 侧栏 (24 vs 7); 侧边栏 appears in a minority of strings."
+  },
+  "unread": {
+    "target": "未读"
+  },
+  "attachment": {
+    "target": "附件"
+  },
+  "public channel": {
+    "target": "公共频道",
+    "note": "公共, not 公开."
+  },
+  "private channel": {
+    "target": "私有频道"
+  },
+  "shared channel": {
+    "target": "共享频道"
+  },
+  "channel header": {
+    "target": "频道标题"
+  },
+  "channel purpose": {
+    "target": "频道用途"
+  },
+  "system message": {
+    "target": "系统消息"
+  },
+  "persistent notification": {
+    "target": "持久通知"
+  },
+  "message priority": {
+    "target": "消息优先级"
+  },
+  "urgent": {
+    "target": "紧急"
+  },
+  "recap": {
+    "target": "回顾"
+  },
+  "agent": {
+    "target": "代理",
+    "note": "Existing UI renders AI agents as AI 代理; standalone 代理 in agent contexts. 智能体 is a common industry alternative but not used here."
+  },
+  "burn-on-read": {
+    "target": "阅后即焚"
+  },
+  "magic link": {
+    "target": "登录链接",
+    "note": "Existing zh-CN renders it simply as 登录链接 (e.g. 访客登录链接 for Guest Magic Link), describing passwordless sign-in as 免密方式. 免密登录链接 is clearer where ambiguity matters."
+  },
+  "personal access token": {
+    "target": "个人访问令牌"
+  },
+  "announcement banner": {
+    "target": "公告横幅"
+  },
+  "channel banner": {
+    "target": "频道横幅"
+  },
+  "keyword": {
+    "target": "关键词",
+    "note": "Majority is 关键词 (21 vs 6); 关键字 appears in a minority of strings."
+  },
+  "user group": {
+    "target": "用户组",
+    "note": "用户组, not 用户群组; standalone group in this sense is 组."
+  },
+  "permalink": {
+    "target": "永久链接"
+  },
+  "profile": {
+    "target": "个人资料"
+  },
+  "username": {
+    "target": "用户名"
+  },
+  "nickname": {
+    "target": "昵称"
+  },
+  "display name": {
+    "target": "显示名称",
+    "note": "显示名 also appears in a minority of strings."
+  },
+  "collapsed reply threads": {
+    "target": "话题讨论",
+    "note": "The user-facing setting title is 话题讨论 (also used for Threaded Discussions); the literal 折叠回复话题 is not used."
+  },
+  "auto-translation": {
+    "target": "自动翻译",
+    "note": "AUTO-TRANSLATED label = 自动翻译."
+  },
+  "data retention": {
+    "target": "数据保留",
+    "note": "data retention policy = 数据保留策略."
+  },
+  "compliance export": {
+    "target": "合规导出",
+    "note": "合规性导出 appears in a minority of strings."
+  },
+  "access control": {
+    "target": "访问控制",
+    "note": "Attribute-Based Access Control = 基于属性的访问控制."
+  },
+  "attribute": {
+    "target": "属性"
+  },
+  "onboarding": {
+    "target": "入职流程"
+  },
+  "Town Square": {
+    "target": "广场"
+  },
+  "Off-Topic": {
+    "target": "杂谈"
+  },
+  "read-only": {
+    "target": "只读"
+  },
+  "server": {
+    "target": "服务器"
+  }
+}

--- a/i18n/glossary/zh-CN.json
+++ b/i18n/glossary/zh-CN.json
@@ -393,7 +393,8 @@
     "target": "广场"
   },
   "Off-Topic": {
-    "target": "杂谈"
+    "target": "闲聊",
+    "note": "Established default-channel name in server zh-CN.json. '杂谈' appears only in admin prose describing the channel."
   },
   "read-only": {
     "target": "只读"

--- a/i18n/glossary/zh-CN.json
+++ b/i18n/glossary/zh-CN.json
@@ -56,9 +56,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/zh-CN.json
+++ b/i18n/glossary/zh-CN.json
@@ -228,8 +228,7 @@
     "target": "斜杠命令"
   },
   "webhook": {
-    "target": "Webhook",
-    "note": "Kept in English with capital W throughout existing zh-CN."
+    "target": "Webhook"
   },
   "incoming webhook": {
     "target": "传入 Webhook"

--- a/i18n/glossary/zh-CN.json
+++ b/i18n/glossary/zh-CN.json
@@ -390,7 +390,8 @@
     "target": "属性"
   },
   "onboarding": {
-    "target": "入职流程"
+    "target": "引导流程",
+    "note": "入职流程 means employee induction, not the product first-run experience. Established rendering is 引导 (开始引导流程)."
   },
   "Town Square": {
     "target": "广场"

--- a/i18n/glossary/zh-TW.json
+++ b/i18n/glossary/zh-TW.json
@@ -1,0 +1,412 @@
+{
+  "Mattermost": {
+    "target": "Mattermost"
+  },
+  "Enterprise Edition": {
+    "target": "Enterprise Edition",
+    "note": "Existing zh-TW UI renders the edition name as 企業版 in the About dialog; keep English when treated as a product name, 企業版 when the surrounding sentence is fully translated."
+  },
+  "Team Edition": {
+    "target": "Team Edition",
+    "note": "Existing zh-TW UI renders it as 團隊版 in the About dialog; same guidance as Enterprise Edition."
+  },
+  "Mattermost Cloud": {
+    "target": "Mattermost Cloud"
+  },
+  "Channels": {
+    "target": "Channels",
+    "note": "Product name; the common noun channel is 頻道."
+  },
+  "Playbooks": {
+    "target": "Playbooks"
+  },
+  "Boards": {
+    "target": "Boards"
+  },
+  "Calls": {
+    "target": "Calls"
+  },
+  "Markdown": {
+    "target": "Markdown"
+  },
+  "OAuth": {
+    "target": "OAuth"
+  },
+  "SAML": {
+    "target": "SAML"
+  },
+  "LDAP": {
+    "target": "LDAP"
+  },
+  "SSO": {
+    "target": "SSO"
+  },
+  "MFA": {
+    "target": "MFA"
+  },
+  "OpenID Connect": {
+    "target": "OpenID Connect"
+  },
+  "Entra ID": {
+    "target": "Entra ID"
+  },
+  "GitLab": {
+    "target": "GitLab"
+  },
+  "Elasticsearch": {
+    "target": "Elasticsearch"
+  },
+  "Bleve": {
+    "target": "Bleve"
+  },
+  "Gossip": {
+    "target": "Gossip"
+  },
+  "Actiance XML": {
+    "target": "Actiance XML"
+  },
+  "Global Relay": {
+    "target": "Global Relay"
+  },
+  "System Console": {
+    "target": "系統控制台",
+    "note": "Consistently used across existing zh-TW admin strings."
+  },
+  "marketplace": {
+    "target": "市集"
+  },
+  "channel": {
+    "target": "頻道"
+  },
+  "team": {
+    "target": "團隊"
+  },
+  "post": {
+    "target": "訊息",
+    "note": "Existing zh-TW renders both 'post' and 'message' as 訊息; do not introduce a separate word such as 貼文."
+  },
+  "message": {
+    "target": "訊息"
+  },
+  "thread": {
+    "target": "討論串"
+  },
+  "reply": {
+    "target": "回覆",
+    "note": "Noun and verb are identical in Chinese."
+  },
+  "direct message": {
+    "target": "私人訊息",
+    "note": "Established zh-TW rendering; note it uses 私人 even though 'private channel' is also 私人頻道 — context disambiguates."
+  },
+  "group message": {
+    "target": "群組訊息"
+  },
+  "mention": {
+    "target": "提及",
+    "note": "Noun and verb are identical; @mention → @提及."
+  },
+  "notification": {
+    "target": "通知"
+  },
+  "pin": {
+    "target": "釘選",
+    "note": "Majority rendering; a minority of strings use 置頂 (e.g. no_results.pinned_messages) — prefer 釘選 and converge."
+  },
+  "bookmark": {
+    "target": "書籤",
+    "note": "Verb: 加入書籤."
+  },
+  "saved messages": {
+    "target": "已儲存的訊息",
+    "note": "save → 儲存, unsave → 取消儲存."
+  },
+  "draft": {
+    "target": "草稿"
+  },
+  "scheduled post": {
+    "target": "排程訊息",
+    "note": "Per admin.posts.scheduledPosts.title; schedule (verb) → 排程."
+  },
+  "emoji": {
+    "target": "表情符號"
+  },
+  "custom emoji": {
+    "target": "自訂表情符號"
+  },
+  "reaction": {
+    "target": "反應",
+    "note": "User-facing strings use 反應 (新增反應, 反應上限); some admin/moderation strings use 互動 — prefer 反應."
+  },
+  "status": {
+    "target": "狀態"
+  },
+  "custom status": {
+    "target": "自訂狀態"
+  },
+  "do not disturb": {
+    "target": "請勿打擾"
+  },
+  "away": {
+    "target": "離開",
+    "note": "Same word as the verb 'leave' (離開); availability context makes it clear."
+  },
+  "online": {
+    "target": "線上"
+  },
+  "offline": {
+    "target": "離線"
+  },
+  "out of office": {
+    "target": "不在辦公室"
+  },
+  "guest": {
+    "target": "訪客"
+  },
+  "member": {
+    "target": "成員"
+  },
+  "user": {
+    "target": "使用者"
+  },
+  "system admin": {
+    "target": "系統管理員"
+  },
+  "team admin": {
+    "target": "團隊管理員"
+  },
+  "channel admin": {
+    "target": "頻道管理員"
+  },
+  "session": {
+    "target": "工作階段",
+    "note": "Standard Taiwan term; do not use 會話 (Simplified convention)."
+  },
+  "sign in": {
+    "target": "登入",
+    "note": "Both 'sign in' and 'log in' map to 登入."
+  },
+  "sign out": {
+    "target": "登出"
+  },
+  "join": {
+    "target": "加入"
+  },
+  "leave": {
+    "target": "離開"
+  },
+  "archive": {
+    "target": "封存",
+    "note": "archived → 已封存."
+  },
+  "unarchive": {
+    "target": "取消封存"
+  },
+  "mute": {
+    "target": "靜音",
+    "note": "Channel muting also uses 靜音 (靜音頻道 / 取消靜音頻道), same word as microphone mute in Calls."
+  },
+  "follow": {
+    "target": "追蹤"
+  },
+  "unfollow": {
+    "target": "取消追蹤"
+  },
+  "favorite": {
+    "target": "我的最愛",
+    "note": "Verb/menu action: 加入我的最愛 (Add to Favorites) / 從我的最愛中移除; standalone label sometimes shortened to 最愛."
+  },
+  "search": {
+    "target": "搜尋"
+  },
+  "integration": {
+    "target": "整合"
+  },
+  "slash command": {
+    "target": "斜線命令",
+    "note": "Majority rendering (33 vs 3 for 斜線指令); keep 斜線命令."
+  },
+  "webhook": {
+    "target": "Webhook",
+    "note": "Kept in English with capital W throughout existing zh-TW strings."
+  },
+  "incoming webhook": {
+    "target": "送入的 Webhook"
+  },
+  "outgoing webhook": {
+    "target": "寄出的 Webhook"
+  },
+  "trigger word": {
+    "target": "觸發關鍵字"
+  },
+  "plugin": {
+    "target": "擴充程式",
+    "note": "Established zh-TW rendering; do not use 外掛 or 插件."
+  },
+  "bot": {
+    "target": "機器人",
+    "note": "bot account → 機器人帳號."
+  },
+  "role": {
+    "target": "地位",
+    "note": "Majority in existing zh-TW permission strings (授予的地位); 角色 is the standard Taiwan software term and also appears — flagging as an inconsistency worth converging on 角色 in a future cleanup."
+  },
+  "permission": {
+    "target": "權限"
+  },
+  "scheme": {
+    "target": "策略",
+    "note": "Permission Scheme → 權限策略, System Scheme → 系統級策略, Team Override Scheme → 團隊級覆寫策略."
+  },
+  "license": {
+    "target": "授權"
+  },
+  "seat": {
+    "target": "席次",
+    "note": "Existing billing strings render '{n} seats' simply as '{n} 人'; keep that counting pattern, use 席次 only when a standalone noun is required."
+  },
+  "trial": {
+    "target": "試用",
+    "note": "試用版 for the trial license/edition, 試用期 for the trial period, per context."
+  },
+  "workspace": {
+    "target": "工作區"
+  },
+  "subscription": {
+    "target": "訂閱"
+  },
+  "deactivate": {
+    "target": "停用",
+    "note": "Also used for 'disable'; deactivated users occasionally rendered 停權 — prefer 停用."
+  },
+  "invite": {
+    "target": "邀請"
+  },
+  "invitation": {
+    "target": "邀請"
+  },
+  "sidebar": {
+    "target": "側邊欄"
+  },
+  "unread": {
+    "target": "未讀"
+  },
+  "attachment": {
+    "target": "附件"
+  },
+  "public channel": {
+    "target": "公開頻道"
+  },
+  "private channel": {
+    "target": "私人頻道"
+  },
+  "shared channel": {
+    "target": "共享頻道"
+  },
+  "channel header": {
+    "target": "頻道標題"
+  },
+  "channel purpose": {
+    "target": "頻道用途"
+  },
+  "system message": {
+    "target": "系統訊息"
+  },
+  "persistent notification": {
+    "target": "持續性通知"
+  },
+  "message priority": {
+    "target": "訊息優先順序"
+  },
+  "urgent": {
+    "target": "緊急",
+    "note": "One legacy priority label uses 急迫; related persistent-notification strings use 緊急 — prefer 緊急."
+  },
+  "recap": {
+    "target": "重點回顧",
+    "note": "Feature not yet translated in zh-TW; 重點回顧 chosen to avoid clashing with 摘要 (summary) and 回顧 (Playbooks retrospective)."
+  },
+  "agent": {
+    "target": "代理",
+    "note": "No existing zh-TW translation; Taiwan tech convention for AI agent is (AI) 代理. Keep 'Agents' in English where it names the plugin/product."
+  },
+  "burn-on-read": {
+    "target": "閱後即焚",
+    "note": "Established Chinese term for self-destructing messages; not yet translated in zh-TW files."
+  },
+  "magic link": {
+    "target": "魔法連結",
+    "note": "Not yet translated in zh-TW files; 魔法連結 follows common Taiwan usage for passwordless email links."
+  },
+  "personal access token": {
+    "target": "個人存取 Token",
+    "note": "Existing zh-TW keeps 'Token' in English."
+  },
+  "announcement banner": {
+    "target": "公告橫幅"
+  },
+  "channel banner": {
+    "target": "頻道橫幅",
+    "note": "Not yet translated; follows 公告橫幅 (announcement banner) pattern."
+  },
+  "keyword": {
+    "target": "關鍵字"
+  },
+  "user group": {
+    "target": "使用者群組"
+  },
+  "permalink": {
+    "target": "永久連結"
+  },
+  "profile": {
+    "target": "個人檔案",
+    "note": "Majority rendering across webapp and mobile; 個人資料 also appears — prefer 個人檔案."
+  },
+  "username": {
+    "target": "使用者名稱"
+  },
+  "nickname": {
+    "target": "暱稱"
+  },
+  "display name": {
+    "target": "顯示名稱"
+  },
+  "collapsed reply threads": {
+    "target": "摺疊回覆討論串",
+    "note": "Not yet translated in zh-TW; uses 摺疊 (collapse) per existing display-settings strings."
+  },
+  "auto-translation": {
+    "target": "自動翻譯",
+    "note": "AUTO-TRANSLATED badge → 自動翻譯."
+  },
+  "data retention": {
+    "target": "資料保留"
+  },
+  "compliance export": {
+    "target": "法遵匯出",
+    "note": "法遵 is the majority rendering for compliance (25 vs 12 for 合規)."
+  },
+  "access control": {
+    "target": "存取控制",
+    "note": "Standard Taiwan term; the attribute-based feature is not yet translated."
+  },
+  "attribute": {
+    "target": "屬性"
+  },
+  "onboarding": {
+    "target": "新手上路",
+    "note": "Per existing 「新手上路」流程 strings."
+  },
+  "Town Square": {
+    "target": "市民廣場"
+  },
+  "Off-Topic": {
+    "target": "話家常"
+  },
+  "read-only": {
+    "target": "唯讀"
+  },
+  "server": {
+    "target": "伺服器"
+  }
+}

--- a/i18n/glossary/zh-TW.json
+++ b/i18n/glossary/zh-TW.json
@@ -396,7 +396,8 @@
     "target": "市民廣場"
   },
   "Off-Topic": {
-    "target": "話家常"
+    "target": "閒聊",
+    "note": "Established default-channel name in server zh-TW.json. '話家常' appears only in admin prose describing the channel."
   },
   "read-only": {
     "target": "唯讀"

--- a/i18n/glossary/zh-TW.json
+++ b/i18n/glossary/zh-TW.json
@@ -56,9 +56,6 @@
   "Elasticsearch": {
     "target": "Elasticsearch"
   },
-  "Bleve": {
-    "target": "Bleve"
-  },
   "Gossip": {
     "target": "Gossip"
   },

--- a/i18n/glossary/zh-TW.json
+++ b/i18n/glossary/zh-TW.json
@@ -248,8 +248,8 @@
     "note": "bot account → 機器人帳號."
   },
   "role": {
-    "target": "地位",
-    "note": "Majority in existing zh-TW permission strings (授予的地位); 角色 is the standard Taiwan software term and also appears — flagging as an inconsistency worth converging on 角色 in a future cleanup."
+    "target": "角色",
+    "note": "Existing permission strings use 地位 (授予的地位), which means social standing rather than a permission set."
   },
   "permission": {
     "target": "權限"

--- a/i18n/glossary/zh-TW.json
+++ b/i18n/glossary/zh-TW.json
@@ -69,8 +69,7 @@
     "target": "Global Relay"
   },
   "System Console": {
-    "target": "系統控制台",
-    "note": "Consistently used across existing zh-TW admin strings."
+    "target": "系統控制台"
   },
   "marketplace": {
     "target": "市集"
@@ -227,8 +226,7 @@
     "note": "Majority rendering (33 vs 3 for 斜線指令); keep 斜線命令."
   },
   "webhook": {
-    "target": "Webhook",
-    "note": "Kept in English with capital W throughout existing zh-TW strings."
+    "target": "Webhook"
   },
   "incoming webhook": {
     "target": "送入的 Webhook"

--- a/i18n/glossary/zh-TW.json
+++ b/i18n/glossary/zh-TW.json
@@ -4,11 +4,11 @@
   },
   "Enterprise Edition": {
     "target": "Enterprise Edition",
-    "note": "Existing zh-TW UI renders the edition name as 企業版 in the About dialog; keep English when treated as a product name, 企業版 when the surrounding sentence is fully translated."
+    "note": "Existing zh-TW UI renders the edition name as 企業版 in the About dialog; keep the English product name."
   },
   "Team Edition": {
     "target": "Team Edition",
-    "note": "Existing zh-TW UI renders it as 團隊版 in the About dialog; same guidance as Enterprise Edition."
+    "note": "Existing zh-TW UI renders it as 團隊版 in the About dialog; keep the English product name."
   },
   "Mattermost Cloud": {
     "target": "Mattermost Cloud"


### PR DESCRIPTION
#### Summary

Translating a new product concept into 21 languages independently produces 21 different words for it. This is the agreed terminology, one file per supported locale, so that question is settled once rather than per string.

- `en.json` — the term inventory: `term -> {definition, partOfSpeech, doNotTranslate, aliases?}`
- `<locale>.json` — `term -> {target, note?}`, key set matching `en.json` exactly

Targets were derived from the majority rendering already in the locale files, then the community translation rules (German, French, Dutch), then the retired Weblate glossaries, in that order. `doNotTranslate` terms keep their English
form.

The `note` fields are the substance and where review effort is best spent: they carry inflection and usage guidance, and they record mistranslations already in the shipped catalogs so a future pass does not propagate them — for example the German glossary row rendering the Gossip protocol literally as "Klatsch und Tratsch".

Reference material only. Nothing in the build or at runtime reads any of it, and it triggers no CI.

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The changes add reference-only glossary files. They do not affect runtime behavior, build logic, APIs, or data flows.  
**QA Recommendation:** Skip manual QA. Validate JSON syntax and locale consistency through automated checks.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->