### PR TITLE
Report an empty translation the way a missing one is reported

### DIFF
--- a/tools/mmgotool/commands/i18n.go
+++ b/tools/mmgotool/commands/i18n.go
@@ -80,7 +80,7 @@ var CheckEmptySrcCmd = &cobra.Command{
 var VerifyCmd = &cobra.Command{
 	Use:     "verify",
 	Short:   "Verify the non-English translation files against en.json",
-	Long:    "Checks every non-English file in i18n/ against i18n/en.json: it must load through the same go-i18n loader the server runs at startup, hold exactly the ids en.json holds, interpolate exactly the {{.Fields}} the source interpolates, and define exactly the CLDR plural categories its locale uses.",
+	Long:    "Checks every non-English file in i18n/ against i18n/en.json: it must load through the same go-i18n loader the server runs at startup, hold exactly the ids en.json holds with none left empty, interpolate exactly the {{.Fields}} the source interpolates, and define exactly the CLDR plural categories its locale uses.",
 	Example: "  i18n verify",
 	// A verification failure is a normal outcome, not a usage error.
 	SilenceUsage: true,
@@ -125,7 +125,7 @@ func init() {
 	CheckEmptySrcCmd.Flags().String("enterprise-dir", "../../enterprise", "Path to folder with the Mattermost enterprise source code")
 	CheckEmptySrcCmd.Flags().String("server-dir", "./", "Path to folder with the Mattermost server source code")
 
-	VerifyCmd.Flags().Bool("warn-missing-ids", false, "Report ids missing from a locale as warnings instead of errors")
+	VerifyCmd.Flags().Bool("warn-missing-ids", false, "Report ids missing from a locale, or present but untranslated, as warnings instead of errors")
 	VerifyCmd.Flags().String("server-dir", "./", "Path to folder with the Mattermost server source code")
 	ExtractAuthoringCmd.Flags().Bool("check", false, "Throw exit code if the authoring file is out of date instead of rewriting it")
 	ExtractAuthoringCmd.Flags().String("server-dir", "./", "Path to folder with the Mattermost server source code")
@@ -906,8 +906,8 @@ func pluralCategories(locale string) map[language.Plural]bool {
 
 // verifyLocale checks one non-English catalog, raw, against the en.json
 // items in en, returning the defects found and, separately, the ids the catalog
-// has yet to translate. Whether a missing id is a defect or merely a warning is
-// the caller's choice, via warnMissingIDs.
+// has yet to translate, whether by absence or by an empty value. Whether that is
+// a defect or merely a warning is the caller's choice, via warnMissingIDs.
 func verifyLocale(name string, raw []byte, en map[string]Item, warnMissingIDs bool) (problems, warnings []string) {
 	locale := strings.TrimSuffix(name, ".json")
 
@@ -952,6 +952,23 @@ func verifyLocale(name string, raw []byte, en map[string]Item, warnMissingIDs bo
 		source, ok := en[id]
 		if !ok {
 			problems = append(problems, fmt.Sprintf("%s: %s: extra id not in en.json", name, id))
+			continue
+		}
+
+		// An empty translation is how the translation pipeline marks an id as
+		// present but not yet translated. newTemplate("") yields a nil
+		// template, so bundle.translate returns the id -- exactly what a
+		// missing id does -- and it has to be reported for the same reason.
+		// Whitespace is deliberately not empty: " " is a real translation in a
+		// language that separates where English uses a word.
+		var text string
+		if json.Unmarshal(item.Translation, &text) == nil && text == "" {
+			msg := fmt.Sprintf("%s: %s: empty translation", name, id)
+			if warnMissingIDs {
+				warnings = append(warnings, msg)
+			} else {
+				problems = append(problems, msg)
+			}
 			continue
 		}
 

--- a/tools/mmgotool/commands/i18n_verify_test.go
+++ b/tools/mmgotool/commands/i18n_verify_test.go
@@ -165,6 +165,33 @@ func TestVerifyLocale(t *testing.T) {
 			problem:    `plural category "one" is not used by this locale`,
 		},
 
+		// An empty translation renders the raw translation id, exactly as a
+		// missing id does, so it is reported for the same reason and under the
+		// same flag.
+		{
+			name:       "empty translation is an error by default",
+			localeName: "fr.json",
+			en:         enPlain,
+			locale:     `[{"id":"a.b","translation":""}]`,
+			problem:    "a.b: empty translation",
+		},
+		{
+			name:           "empty translation is a warning under warn-missing-ids",
+			localeName:     "fr.json",
+			en:             enPlain,
+			locale:         `[{"id":"a.b","translation":""}]`,
+			warnMissingIDs: true,
+			warning:        "a.b: empty translation",
+		},
+		{
+			// A language that separates where English uses a word: " " is the
+			// translation, not the absence of one.
+			name:       "whitespace-only translation is a real translation",
+			localeName: "zh-CN.json",
+			en:         `[{"id":"a.b","translation":"at"}]`,
+			locale:     `[{"id":"a.b","translation":" "}]`,
+		},
+
 		// An empty form renders the raw translation id, so it is worse than no
 		// translation at all.
 		{

--- a/webapp/channels/scripts/check_icu.mjs
+++ b/webapp/channels/scripts/check_icu.mjs
@@ -11,6 +11,9 @@
  * than recording.
  *
  *   - the file is valid JSON and every value is a string
+ *   - no value is the empty string, which react-intl treats as falsy and
+ *     replaces with the English, so it reaches the user exactly as a missing key
+ *     does. --warn-missing-keys downgrades this too, for work in progress.
  *   - every value parses with @formatjs/icu-messageformat-parser, the parser
  *     react-intl runs in production, so "parses here" implies "parses there"
  *   - a translation never invents a variable the source does not have. An
@@ -30,9 +33,10 @@
  *
  * Key parity is a separate question from whether the entries that exist are
  * correct. An extra key, one en.json does not have, is always an error: nothing
- * will ever read it. A missing key is an error by default and a warning under
- * --warn-missing-keys, and is not a runtime defect either way, because
- * react-intl falls back to the source message.
+ * will ever read it. A missing key -- absent, or present but empty -- is an
+ * error by default and a warning under --warn-missing-keys, and is not a
+ * runtime defect either way, because react-intl falls back to the source
+ * message.
  *
  * Usage:
  *   node scripts/check_icu.mjs <i18n-dir> [--warn-missing-keys]
@@ -189,6 +193,16 @@ for (const name of localeNames) {
         }
         if (typeof message !== 'string') {
             errors.push(`${name}:${key}: value is not a string`);
+            continue;
+        }
+
+        // react-intl's formatMessage tests `if (!message)` before falling
+        // through to defaultMessage, and '' is falsy, so an empty translation
+        // renders the English exactly as a missing key does. Whitespace is
+        // deliberately not empty: ' ' is a real translation in a language that
+        // separates where English uses a word.
+        if (message === '') {
+            (warnMissingKeys ? warnings : errors).push(`${name}:${key}: empty translation`);
             continue;
         }
 

--- a/webapp/channels/scripts/check_icu.test.js
+++ b/webapp/channels/scripts/check_icu.test.js
@@ -132,6 +132,31 @@ describe('check_icu', () => {
             expect(stderr).toContain('fr.json:a.b: missing key');
             expect(stderr).toContain('1 warning(s)');
         });
+
+        // react-intl treats '' as falsy and falls back to the English, so an
+        // empty translation reaches the user exactly as a missing key does.
+        test('an empty translation is an error by default', () => {
+            const {code, stderr} = check({'a.b': 'Hello'}, {'fr.json': {'a.b': ''}});
+
+            expect(code).toBe(1);
+            expect(stderr).toContain('fr.json:a.b: empty translation');
+        });
+
+        test('an empty translation is a warning under --warn-missing-keys', () => {
+            const {code, stderr} = check({'a.b': 'Hello'}, {'fr.json': {'a.b': ''}}, {warnMissingKeys: true});
+
+            expect(code).toBe(0);
+            expect(stderr).toContain('fr.json:a.b: empty translation');
+            expect(stderr).toContain('1 warning(s)');
+        });
+
+        // ' ' is a real translation in a language that separates where English
+        // uses a word, and unlike '' it does reach the user.
+        test('a whitespace-only translation is a real translation', () => {
+            const {code} = check({'a.b': 'at'}, {'zh-CN.json': {'a.b': ' '}});
+
+            expect(code).toBe(0);
+        });
     });
 
     describe('variables and tags', () => {


### PR DESCRIPTION
#### Summary

Stacked on #38411 → #38410 → #38231. Review those first; this PR's diff is
against #38411.

An empty translation renders exactly as a missing key does, on both surfaces.
react-intl's `formatMessage` tests `if (!message)` before falling through to
`defaultMessage`, and `""` is falsy, so the webapp shows the English. go-i18n's
`newTemplate("")` returns a nil template and `bundle.translate()` ends with
`if template == nil { return translationID }`, so the server shows the id — what
it already does for an id a locale does not carry.

Both checkers reject a missing key; neither noticed an empty one. Key parity
passes, `""` parses as valid ICU, and the go-i18n loader accepts it, so an
untranslated entry only tripped a check when the source happened to carry a
variable or a `{{.Token}}` — which most strings do not.

The check goes where the missing-key check already lives, in `check_icu.mjs` and
`verifyLocale`, governed by the same `--warn-missing-keys` / `--warn-missing-ids`
flags. Those flags mean "tolerate a catalog still being worked on", and an entry
seeded but not yet translated is exactly that.

The line is drawn at exactly `""`, not whitespace. A whitespace-only value is a
real translation in a language that separates where English uses a word —
`adminConsole.list.table.exactTime.at` is `" "` in zh-CN against `"at"` in
English — and it is truthy, so unlike `""` it does reach the user.

#### QA steps

There are no empty translations in the 42 catalogs today, so this reports
nothing new until someone seeds one. Verified against the real catalogs:
`i18n-verify-translations` and `i18n verify` both still exit 0 with warnings
only, and zero empty-translation findings.

Driving `check_icu.mjs` over a fixture:

- `{"a.b": ""}` → `fr.json:a.b: empty translation`, exit 1
- same with `--warn-missing-keys` → 1 warning, exit 0
- `{"a.c": " "}` against `"at"` → not reported

#### Release Note
```release-note
NONE
```
