### PR TITLE
Document the in-repo translation workflow, and add the translate-i18n skill

### DIFF
--- a/.claude/skills/translate-i18n/SKILL.md
+++ b/.claude/skills/translate-i18n/SKILL.md
@@ -1,0 +1,222 @@
+---
+name: translate-i18n
+description: Fill missing translations across all 21 supported locales by fanning out one subagent per locale. Use when en.json has gained keys that the locale catalogs do not have — after a feature lands, after merging master, or when `npm run i18n-verify-translations` / `make i18n-verify` reports missing keys.
+---
+
+# Parallel i18n translation
+
+[`i18n/AGENTS.md`](../../../i18n/AGENTS.md) is the brief for translating *one*
+locale. This is the recipe for doing all 21 at once without the result being
+inconsistent slop.
+
+The shape is: **describe → agree terminology → fan out → validate → apply.**
+The middle step is the one people skip, and it is the one that decides whether
+21 locales use the same word for a new product concept.
+
+Everything below assumes the repository root (the directory containing
+`server/` and `webapp/`). Scripts live in `scripts/` next to this file.
+
+## Which model
+
+Use the strongest model available for every step, and set it explicitly on
+each agent rather than inheriting — if the session is running something
+lesser, upgrade for this work.
+
+A bad translation is very hard to recover from. It passes every checker here,
+ships in a language the reviewer does not read, and is usually found by a
+user. Nothing downstream will catch it, so pay for the best output at the
+point it is produced.
+
+## 0. Establish the gap
+
+Extract, sync the catalogs to `en.json`, then measure.
+
+```bash
+cd webapp/channels && npm run i18n-extract && cd -
+cd server && make i18n-extract && cd -
+node .claude/skills/translate-i18n/scripts/apply_translations.mjs /tmp/i18n-run
+node .claude/skills/translate-i18n/scripts/build_manifest.mjs /tmp/i18n-run
+```
+
+Running `apply_translations.mjs` with nothing to apply is the sync: it seeds
+every `en.json` key that a catalog lacks as `""`, and prunes every key
+`en.json` no longer has. Afterwards each catalog holds exactly `en.json`'s keys,
+so **untranslated is a value, not a missing key** — and that makes the gap a
+per-locale fact rather than a union across all 21.
+
+`build_manifest.mjs` reads it back off the catalogs and writes
+`/tmp/i18n-run/gaps/<locale>.json`, one worklist per locale with the English and
+the description already merged in, plus `new_keys.json` holding the union for the
+description and glossary passes. If it reports zero, there is nothing to do.
+
+Read three numbers, not one:
+
+- **untranslated** — the work. 300 keys is a normal feature merge; 5,000 means
+  something else went wrong and fanning out will just multiply it.
+- **removed** — keys `en.json` dropped. Expected after a merge, but a key you did
+  not expect to lose means `en.json` is wrong.
+- **seeded** — keys the catalogs never had. Compare it against **removed**: if the
+  two are equal and the strings look related, that is a rename, not new work.
+
+## 1. Descriptions
+
+A translator cannot render `Select` or `No recent session` without knowing
+where it appears. Every new key needs a description in the authoring catalog
+first.
+
+```bash
+cd webapp/channels && npm run i18n-extract-authoring && cd -
+cd server && make i18n-extract-authoring && cd -
+```
+
+That adds the new keys with empty descriptions. Fill them by spawning agents
+over chunks of ~100 keys, each instructed to **find the actual usage in
+source** rather than paraphrase the English. Chunk so no agent handles more
+than it can search carefully.
+
+A description must say where the string appears, what each placeholder refers
+to, and any disambiguation a translator needs (noun or verb? title or body?
+admin or end user?). It must not restate the English.
+
+This step reliably surfaces bugs — hardcoded English constants, wrong
+prepositions, typos — because it is the first time anyone reads every new
+string next to its call site. Fix the English before translating it.
+
+Rebuild the manifest afterwards. The worklists carry the descriptions, so ones
+written now are only in the files the agents read if you regenerate them — and if
+you fixed any English, re-extract first:
+
+```bash
+node .claude/skills/translate-i18n/scripts/build_manifest.mjs /tmp/i18n-run
+```
+
+## 2. Glossary candidates — do not skip this
+
+Run the glossary pass described in
+[`i18n/AGENTS.md`](../../../i18n/AGENTS.md#glossary-candidates). One agent
+proposes new terms; you agree them; they land in `i18n/glossary/` **before**
+any locale agent starts.
+
+Skipping this is the single highest-cost mistake available here. Twenty-one
+agents translating "exposure report" with no glossary entry will produce
+twenty-one different terms, each individually defensible, and no checker will
+notice.
+
+## 3. Fan out, one agent per locale
+
+One agent per locale, not one agent per batch of locales. Translation quality
+drops when a single agent context-switches between languages, and per-locale
+agents can each calibrate against their own existing catalog.
+
+Give every agent:
+
+- the repository root, and an instruction to read `i18n/AGENTS.md` first
+- `i18n/glossary/<locale>.json` plus `i18n/glossary/en.json`
+- `/tmp/i18n-run/gaps/<locale>.json` — that locale's worklist alone, English
+  and descriptions already merged in. It is deliberately not the union: a locale
+  that already has a string is not asked for it again, and the validator in step
+  4 checks the answer against this file
+- **that locale's plural categories for both surfaces** — the table in
+  `i18n/AGENTS.md` differs between webapp and server for `es`, `fr`, `it` and
+  `pt-BR`, and an agent that guesses will fail `mmgotool i18n verify`
+- an instruction to calibrate register against the existing
+  `webapp/channels/src/i18n/<locale>.json`
+- a single output path, `{"webapp": {...}, "server": {...}}`
+
+Tell each agent to write only to its output path and to modify no repository
+file. Twenty-one agents editing catalogs concurrently will corrupt them.
+
+Locales worth extra care in the prompt: `fr` and `it` (apostrophe elision
+before tags), `ja`/`ko`/`zh-*`/`vi` (single plural category), `pl`/`ru`/`uk`
+(four categories), `hu`/`tr`/`ko` (agglutination and particles — tell them to
+rephrase rather than suffix an interpolated value), `fa` (RTL), and `en-AU`
+(localisation, not translation — most strings should come back unchanged).
+
+## 4. Validate before applying
+
+```bash
+node .claude/skills/translate-i18n/scripts/validate_translations.mjs /tmp/i18n-run <locale>
+```
+
+Checks key parity, ICU parse with the runtime parser, variable and tag parity
+in both directions, argument-type parity, plural categories for the locale,
+the apostrophe trap, and English left untranslated. Run it per locale and fix
+before applying — a bad file caught here costs one agent, caught after
+applying it costs a catalog.
+
+"Identical to English" is reported as a warning, not an error, because product
+names, protocol acronyms and pure-placeholder strings legitimately match. Read
+the list; do not assume.
+
+## 5. Apply and verify for real
+
+```bash
+node .claude/skills/translate-i18n/scripts/apply_translations.mjs /tmp/i18n-run
+cd webapp/channels && npm run i18n-verify-translations && cd -
+cd tools/mmgotool && go run . i18n verify --server-dir=../../server && cd -
+```
+
+This is the same command as step 0 — it is one pipeline, run twice. Every catalog
+on both surfaces goes through the same four phases whatever the payload contains:
+
+1. **add** the translations the payload supplies. An existing translation is never
+   overwritten, so re-running is safe.
+2. **seed** every remaining `en.json` key as `""`.
+3. **sort** with the comparator that orders `en.json` for that surface — the
+   webapp reuses `webapp/channels/scripts/formatter.js`, the server matches
+   mmgotool's plain byte-wise ordering. The two are genuinely different.
+4. **prune** the keys `en.json` no longer has, recording what they said in
+   `/tmp/i18n-run/pruned/<locale>.json`.
+
+It preserves the 2-space/trailing-newline convention and only writes a file
+whose content actually changed, so a run with nothing to do leaves no diff.
+
+The **untranslated** count is what tells you whether you are finished. It should
+be zero here; anything else is a key an agent skipped, still sitting in the
+catalog as `""`. Go back and get it translated rather than reverting it — the
+checkers will not let it merge either way.
+
+Pruning is the normal way a key retired from `en.json` leaves the catalogs —
+a rename upstream orphans the old id in all 21 — so it needs no flag and is not
+an error. Read the summary anyway: every removal is counted and named there,
+and a key you did not expect to lose is the signal that `en.json` is wrong.
+
+The two verify commands are what CI runs. They must pass with no flags.
+
+## Pitfalls
+
+- **Do not let agents edit catalogs directly.** Collect JSON, apply centrally.
+- **Do not skip step 2.** See above.
+- **Balanced apostrophes are sometimes load-bearing.** `'<blank>'` in a source
+  string is deliberate ICU escaping; see the note in `i18n/AGENTS.md`.
+- **`en-AU` is not a translation.** Expect ~2 changed strings out of 300, and
+  be suspicious of an agent that returns more.
+- **Agents self-report success.** Every one will tell you it validated its own
+  output. Run step 4 anyway; that is the whole point of having a checker in
+  the repository rather than in a prompt.
+- **An empty string is a placeholder, not a translation.** It is safe to leave in
+  a working tree — react-intl treats `""` as falsy and falls back to the English,
+  and go-i18n's `newTemplate("")` yields a nil template so the server returns the
+  id — which is to say it renders exactly as a missing key does. It is not safe to
+  ship, and both checkers reject it, so a half-finished run cannot merge. Note the
+  line is drawn at exactly `""`: `" "` is a real translation in a language that
+  separates where English uses a word, and is left alone.
+- **A key that vanished may have been renamed, not retired.** When upstream
+  moves an id, step 0 reports it as both **seeded** and **removed** — two
+  unrelated-looking numbers for one rename. Before translating, compare the old
+  and new English; `/tmp/i18n-run/pruned/<locale>.json` still holds what each
+  locale said. If the English is unchanged, carry the existing translation over to
+  the new id instead of paying 21 agents to reinvent it.
+- **Translate only what is missing.** `build_manifest.mjs` deliberately emits
+  only the gap, and `apply_translations.mjs` refuses to overwrite. Resist
+  widening the scope to "improve" existing translations in the same pass: two
+  independent runs over the same 200 strings agreed just 38% of the time, both
+  structurally valid. Re-translating produces a large diff that is neither
+  better nor reviewable.
+- **A second run is not a review.** For the same reason, you cannot check a
+  translation by generating another one and diffing — you will get a 60%
+  difference on correct output. The checkers verify structure; only a speaker
+  verifies meaning.
+- **Expect en-AU to produce a wall of warnings.** Almost every string is
+  legitimately identical to English, so the validator's "identical to English"
+  warning fires ~290 times. That is the expected result, not a failure.

--- a/.claude/skills/translate-i18n/scripts/apply_translations.mjs
+++ b/.claude/skills/translate-i18n/scripts/apply_translations.mjs
@@ -1,0 +1,253 @@
+// Bring the shipped locale catalogs into line with en.json, and fill in whatever
+// translations the agents produced.
+//
+//   node apply_translations.mjs <workdir> [repo-root]
+//
+// Reads every <workdir>/translations/<locale>.json of the shape
+//   {"webapp": {"<key>": "<translation>"}, "server": {"<id>": "<translation>"}}
+//
+// Every catalog on both surfaces goes through the same four phases, whatever the
+// payload happens to contain -- so running it with no payload at all is the
+// pre-flight sync, and running it with payloads is the apply:
+//
+//   a) add    the translations the payload supplies
+//   b) seed   every remaining en.json key as "", so it is present but untranslated
+//   c) sort   with the same comparator that orders en.json for that surface
+//   d) prune  the keys en.json no longer has
+//
+// The point of (b) is that afterwards a catalog holds exactly en.json's keys and
+// nothing else, so "untranslated" is a value rather than a shape: an empty string
+// is the gap, and build_manifest.mjs reads it straight off the catalog per locale.
+// The empty string is safe to leave in a working tree -- react-intl treats it as
+// falsy and falls back to the English defaultMessage, and go-i18n's newTemplate("")
+// yields a nil template so bundle.translate() returns the id -- which is to say it
+// renders exactly as an absent key does. It is not safe to *ship*, and both
+// checkers reject it for that reason.
+//
+// An existing translation is never overwritten, so re-running is safe. Pruning is
+// simply how a key retired from en.json leaves the catalogs -- it needs no flag and
+// is not an error -- but it is counted and named in the summary, and the entries it
+// drops are written to <workdir>/pruned/<locale>.json so a rename can be traced
+// back to the translation it orphaned.
+import fs from 'fs';
+import path from 'path';
+import {pathToFileURL} from 'url';
+
+const [workdir, rootArg] = process.argv.slice(2);
+if (!workdir) {
+    console.error('usage: node apply_translations.mjs <workdir> [repo-root]');
+    process.exit(2);
+}
+if (!fs.existsSync(workdir)) {
+    console.error(`missing workdir ${workdir}`);
+    process.exit(2);
+}
+const ROOT = path.resolve(rootArg || '.');
+const inDir = `${workdir}/translations`;
+
+// The two surfaces do not order en.json the same way, so each brings its own
+// comparator rather than inheriting en.json's literal array order. webapp reuses
+// the formatter that generates en.json (case-insensitive, '_' before '.');
+// server matches mmgotool's `result[i].Id < result[j].Id` in
+// tools/mmgotool/commands/i18n.go, which is plain and case-sensitive.
+const formatterPath = `${ROOT}/webapp/channels/scripts/formatter.js`;
+if (!fs.existsSync(formatterPath)) {
+    console.error(`missing ${formatterPath} — webapp catalogs are sorted with its comparator`);
+    process.exit(2);
+}
+const {compareMessages} = await import(pathToFileURL(formatterPath).href);
+
+const SURFACES = {
+    webapp: {
+        dir: `${ROOT}/webapp/channels/src/i18n`,
+        list: false,
+        cmp: (a, b) => compareMessages({key: a}, {key: b}),
+    },
+    server: {
+        dir: `${ROOT}/server/i18n`,
+        list: true,
+        cmp: (a, b) => (a < b ? -1 : (a > b ? 1 : 0)),
+    },
+};
+
+// Exactly the empty string, not whitespace: " " is a legitimate translation in a
+// language that separates where English uses a word, and the checkers draw the
+// line in the same place.
+const untranslated = (v) => v === undefined || v === '';
+
+const serialize = (map, keys, list) => {
+    const entries = keys.map((k) => [k, map.get(k)]);
+    const body = list ? entries.map(([id, translation]) => ({id, translation})) : Object.fromEntries(entries);
+    return JSON.stringify(body, null, 2) + '\n';
+};
+
+const payloads = {};
+if (fs.existsSync(inDir)) {
+    for (const f of fs.readdirSync(inDir).filter((x) => x.endsWith('.json'))) {
+        payloads[path.basename(f, '.json')] = JSON.parse(fs.readFileSync(path.join(inDir, f), 'utf8'));
+    }
+}
+
+const skipped = [];
+const stats = {};
+const pruned = {};
+
+for (const [surface, cfg] of Object.entries(SURFACES)) {
+    const enRaw = JSON.parse(fs.readFileSync(`${cfg.dir}/en.json`, 'utf8'));
+    const enSet = new Set(cfg.list ? enRaw.map((e) => e.id) : Object.keys(enRaw));
+
+    const locales = fs.readdirSync(cfg.dir).
+        filter((f) => f.endsWith('.json') && f !== 'en.json').
+        map((f) => path.basename(f, '.json')).
+        sort();
+    const have = new Set(locales);
+
+    // A payload naming a locale this surface has no catalog for is a typo worth
+    // hearing about, not something to pass over in silence.
+    for (const [loc, payload] of Object.entries(payloads)) {
+        if (have.has(loc)) continue;
+        if (Object.keys(payload[surface] || {}).length) {
+            skipped.push(`${loc}/${surface}: no catalog at ${cfg.dir}/${loc}.json`);
+        }
+    }
+
+    const st = {
+        catalogs: locales.length,
+        added: 0,
+        addedKeys: new Set(),
+        seeded: 0,
+        untranslated: 0,
+        untranslatedLocales: new Set(),
+        reordered: 0,
+        removed: 0,
+        removedKeys: new Map(),
+        written: 0,
+    };
+
+    for (const locale of locales) {
+        const p = `${cfg.dir}/${locale}.json`;
+        const rawText = fs.readFileSync(p, 'utf8');
+        const raw = JSON.parse(rawText);
+        const map = cfg.list ? new Map(raw.map((e) => [e.id, e.translation])) : new Map(Object.entries(raw));
+        const originalOrder = [...map.keys()];
+        const originalSet = new Set(originalOrder);
+
+        // (a) add
+        for (const [k, v] of Object.entries((payloads[locale] || {})[surface] || {})) {
+            if (!enSet.has(k)) { skipped.push(`${locale}/${surface}: ${k} not in en.json`); continue; }
+            if (!untranslated(map.get(k))) { skipped.push(`${locale}/${surface}: ${k} already translated`); continue; }
+            if (typeof v !== 'string' || !v.trim()) { skipped.push(`${locale}/${surface}: ${k} empty`); continue; }
+            map.set(k, v);
+            st.added++;
+            st.addedKeys.add(k);
+        }
+
+        // (b) seed
+        for (const k of enSet) {
+            if (map.has(k)) continue;
+            map.set(k, '');
+            st.seeded++;
+        }
+
+        // (c) sort, then (d) prune
+        const kept = [];
+        const dropped = {};
+        for (const k of [...map.keys()].sort(cfg.cmp)) {
+            if (enSet.has(k)) {
+                kept.push(k);
+                if (untranslated(map.get(k))) {
+                    st.untranslated++;
+                    st.untranslatedLocales.add(locale);
+                }
+                continue;
+            }
+            dropped[k] = map.get(k);
+            map.delete(k);
+            st.removed++;
+            st.removedKeys.set(k, (st.removedKeys.get(k) || 0) + 1);
+        }
+        if (Object.keys(dropped).length) {
+            pruned[locale] = pruned[locale] || {};
+            pruned[locale][surface] = dropped;
+        }
+
+        // Count a catalog as reordered only when keys it already held had to move
+        // relative to each other; inserting a new key mid-file is not a reorder.
+        const keptSet = new Set(kept);
+        const wasOrdered = originalOrder.filter((k) => keptSet.has(k)).join('\n');
+        const nowOrdered = kept.filter((k) => originalSet.has(k)).join('\n');
+        if (wasOrdered !== nowOrdered) st.reordered++;
+
+        const after = serialize(map, kept, cfg.list);
+        if (after !== rawText) {
+            fs.writeFileSync(p, after);
+            st.written++;
+        }
+    }
+
+    stats[surface] = st;
+}
+
+// The entries pruning dropped are the only record of what a translation used to
+// say once the key is gone. Rename detection needs them; so does anyone asking
+// why a locale lost a string.
+const prunedDir = `${workdir}/pruned`;
+if (Object.keys(pruned).length) {
+    fs.mkdirSync(prunedDir, {recursive: true});
+    for (const [locale, body] of Object.entries(pruned)) {
+        fs.writeFileSync(`${prunedDir}/${locale}.json`, JSON.stringify(body, null, 2) + '\n');
+    }
+}
+
+if (!Object.keys(payloads).length) {
+    console.log(`no payloads in ${inDir} — sync only\n`);
+}
+
+const row = (label, n, note) => console.log(`  ${label.padEnd(13)}${String(n).padStart(6)}  ${note}`.trimEnd());
+
+for (const [surface, st] of Object.entries(stats)) {
+    console.log(`${surface}: ${st.catalogs} catalogs`);
+
+    let addedNote = '';
+    if (st.added) {
+        addedNote = st.added === st.addedKeys.size * st.catalogs ?
+            `(${st.addedKeys.size} keys x ${st.catalogs} locales)` :
+            `(${st.addedKeys.size} distinct keys)`;
+    }
+    row('added', st.added, addedNote);
+    row('seeded', st.seeded, st.seeded ? 'keys added as "" — present but untranslated' : '');
+    row('sorted', st.reordered, st.reordered ? 'catalogs reordered' : 'already in en.json order');
+    row('removed', st.removed, st.removed ? 'not in en.json:' : '');
+
+    if (st.removed) {
+        const keys = [...st.removedKeys.entries()];
+        const shown = keys.slice(0, 8);
+        const width = Math.max(...shown.map(([k]) => k.length));
+        for (const [k, n] of shown) console.log(`     ${k.padEnd(width)}  x${n}`);
+        if (keys.length > shown.length) console.log(`     ... and ${keys.length - shown.length} more keys`);
+    }
+
+    row('untranslated', st.untranslated, st.untranslated ?
+        `empty across ${st.untranslatedLocales.size} ${st.untranslatedLocales.size === 1 ? "locale" : "locales"} — this is the gap to translate` :
+        'every catalog is complete');
+    row('written', st.written, 'catalogs changed on disk');
+    console.log('');
+}
+
+if (Object.keys(pruned).length) {
+    console.log(`pruned entries recorded in ${prunedDir}/ (${Object.keys(pruned).length} locales)\n`);
+}
+
+console.log(`skipped ${skipped.length}${skipped.length ? ':' : ''}`);
+skipped.slice(0, 20).forEach((x) => console.log(`  ${x}`));
+if (skipped.length > 20) console.log(`  ... and ${skipped.length - 20} more`);
+
+const outstanding = Object.values(stats).reduce((a, st) => a + st.untranslated, 0);
+if (outstanding) {
+    console.log(`\n${outstanding} untranslated entries remain — build the per-locale worklists:`);
+    console.log(`  node .claude/skills/translate-i18n/scripts/build_manifest.mjs ${workdir}`);
+} else {
+    console.log('\nnow run the real checkers:');
+    console.log('  cd webapp/channels && npm run i18n-verify-translations');
+    console.log('  cd tools/mmgotool && go run . i18n verify --server-dir=../../server');
+}

--- a/.claude/skills/translate-i18n/scripts/build_manifest.mjs
+++ b/.claude/skills/translate-i18n/scripts/build_manifest.mjs
@@ -1,0 +1,112 @@
+// Read the gap straight off the catalogs and write the worklists the translation
+// agents consume.
+//
+//   node build_manifest.mjs <workdir> [repo-root]
+//
+// Run apply_translations.mjs first. It seeds every en.json key into every catalog
+// as "", so by the time this runs a key is untranslated iff its value is the empty
+// string -- a property of one locale's catalog, not of the set of catalogs. That is
+// what makes a per-locale worklist possible: a locale that already has a string
+// does not get asked for it again.
+//
+// Writes:
+//   <workdir>/new_keys.json      union across locales, for the description and
+//                                glossary passes that reason about the whole set
+//   <workdir>/gaps/<locale>.json that locale's worklist alone, same shape
+//
+// Both are {"webapp": {"<key>": {"english", "description"}}, "server": {...}}.
+// Descriptions come from the i18n-authoring catalogs when present.
+import fs from 'fs';
+import path from 'path';
+
+const workdir = process.argv[2];
+if (!workdir) {
+    console.error('usage: node build_manifest.mjs <workdir> [repo-root]');
+    process.exit(2);
+}
+
+const ROOT = path.resolve(process.argv[3] || '.');
+const SURFACES = {
+    webapp: {dir: `${ROOT}/webapp/channels/src/i18n`, authoring: `${ROOT}/webapp/channels/src/i18n-authoring/en-with-description.json`, list: false},
+    server: {dir: `${ROOT}/server/i18n`, authoring: `${ROOT}/server/i18n-authoring/en-with-description.json`, list: true},
+};
+
+// Matches apply_translations.mjs and both checkers: exactly the empty string, not
+// whitespace. " " is a real translation in a language that separates where English
+// uses a word.
+const untranslated = (v) => v === undefined || v === '';
+
+const union = {};
+const perLocaleGaps = {};
+let extras = 0;
+
+for (const [surface, cfg] of Object.entries(SURFACES)) {
+    if (!fs.existsSync(cfg.dir)) {
+        console.error(`missing ${cfg.dir} — run from the repository root or pass it as argv[3]`);
+        process.exit(2);
+    }
+    const enRaw = JSON.parse(fs.readFileSync(`${cfg.dir}/en.json`, 'utf8'));
+    const en = cfg.list ? new Map(enRaw.map((e) => [e.id, e.translation])) : new Map(Object.entries(enRaw));
+
+    let descriptions = new Map();
+    if (fs.existsSync(cfg.authoring)) {
+        const a = JSON.parse(fs.readFileSync(cfg.authoring, 'utf8'));
+        descriptions = cfg.list ?
+            new Map(a.map((e) => [e.id, e.description || ''])) :
+            new Map(Object.entries(a).map(([k, v]) => [k, v.description || '']));
+    }
+
+    const entry = (k) => ({english: en.get(k), description: descriptions.get(k) || ''});
+
+    const locales = fs.readdirSync(cfg.dir).
+        filter((f) => f.endsWith('.json') && f !== 'en.json').
+        map((f) => path.basename(f, '.json')).
+        sort();
+
+    const missing = new Set();
+    const counts = [];
+    for (const locale of locales) {
+        const raw = JSON.parse(fs.readFileSync(`${cfg.dir}/${locale}.json`, 'utf8'));
+        const have = cfg.list ? new Map(raw.map((e) => [e.id, e.translation])) : new Map(Object.entries(raw));
+
+        // en.json order, so a worklist reads in the same order as the catalog.
+        const gap = [...en.keys()].filter((k) => untranslated(have.get(k)));
+        gap.forEach((k) => missing.add(k));
+        counts.push([locale, gap.length]);
+
+        if (gap.length) {
+            perLocaleGaps[locale] = perLocaleGaps[locale] || {};
+            perLocaleGaps[locale][surface] = Object.fromEntries(gap.map((k) => [k, entry(k)]));
+        }
+
+        // Nothing should survive apply_translations.mjs's prune. If something has,
+        // this manifest was built against a catalog that never went through it.
+        const extra = [...have.keys()].filter((k) => !en.has(k));
+        if (extra.length) {
+            extras += extra.length;
+            console.log(`  ${locale}: ${extra.length} keys not in en.json — run apply_translations.mjs first`);
+        }
+    }
+
+    union[surface] = Object.fromEntries([...en.keys()].filter((k) => missing.has(k)).map((k) => [k, entry(k)]));
+
+    const total = counts.reduce((a, [, n]) => a + n, 0);
+    const undescribed = Object.values(union[surface]).filter((v) => !v.description).length;
+    console.log(`${surface}: ${Object.keys(union[surface]).length} distinct keys untranslated in at least one of ${locales.length} locales`);
+    console.log(`  total entries to translate: ${total}`);
+    if (total) {
+        const worst = counts.filter(([, n]) => n).sort((a, b) => b[1] - a[1]);
+        console.log(`  ${worst.map(([l, n]) => `${l}:${n}`).join('  ')}`);
+    }
+    if (undescribed) console.log(`  WARNING: ${undescribed} have no description — run step 1 before translating`);
+}
+
+fs.mkdirSync(`${workdir}/gaps`, {recursive: true});
+fs.writeFileSync(`${workdir}/new_keys.json`, JSON.stringify(union, null, 2));
+for (const [locale, body] of Object.entries(perLocaleGaps)) {
+    fs.writeFileSync(`${workdir}/gaps/${locale}.json`, JSON.stringify(body, null, 2));
+}
+
+console.log(`\nwrote ${workdir}/new_keys.json`);
+console.log(`wrote ${Object.keys(perLocaleGaps).length} per-locale worklists to ${workdir}/gaps/`);
+if (extras) console.log(`\n${extras} entries are in a catalog but not en.json; this manifest does not account for them`);

--- a/.claude/skills/translate-i18n/scripts/validate_translations.mjs
+++ b/.claude/skills/translate-i18n/scripts/validate_translations.mjs
@@ -1,0 +1,128 @@
+// Validate one locale's agent output before it touches a catalog.
+//
+//   node validate_translations.mjs <workdir> <locale> [repo-root]
+//
+// Reads that locale's worklist -- <workdir>/gaps/<locale>.json, the keys it alone
+// is missing -- and the agent's answer in <workdir>/translations/<locale>.json.
+// Falls back to the union manifest for a workdir built before per-locale worklists
+// existed. Exits non-zero on any error. Warnings are printed but do not fail.
+import fs from 'fs';
+import path from 'path';
+import {createRequire} from 'module';
+
+const [workdir, locale, rootArg] = process.argv.slice(2);
+if (!workdir || !locale) {
+    console.error('usage: node validate_translations.mjs <workdir> <locale> [repo-root]');
+    process.exit(2);
+}
+const ROOT = path.resolve(rootArg || '.');
+
+// The runtime parser only resolves from inside the webapp workspace; using it
+// (rather than a newer copy) is what makes "parses here" mean "parses there".
+const {parse} = createRequire(`${ROOT}/webapp/channels/package.json`)('@formatjs/icu-messageformat-parser');
+
+// The per-locale worklist is the authority: a locale that already had a string is
+// not asked for it, so requiring the union here would fail every agent that
+// correctly returned less than the union.
+const gapPath = `${workdir}/gaps/${locale}.json`;
+const input = JSON.parse(fs.readFileSync(fs.existsSync(gapPath) ? gapPath : `${workdir}/new_keys.json`, 'utf8'));
+const out = JSON.parse(fs.readFileSync(`${workdir}/translations/${locale}.json`, 'utf8'));
+
+const TYPES = {1: 'argument', 2: 'number', 3: 'date', 4: 'time', 5: 'select', 6: 'plural', 8: 'tag'};
+function argTypes(ast, m = new Map()) {
+    for (const el of ast) {
+        if (TYPES[el.type] && el.value !== undefined) {
+            if (!m.has(el.value)) m.set(el.value, new Set());
+            m.get(el.value).add(TYPES[el.type]);
+        }
+        if (el.options) for (const o of Object.values(el.options)) argTypes(o.value, m);
+        if (el.children) argTypes(el.children, m);
+    }
+    return m;
+}
+// Collect the option keys of every plural node in an AST.
+function pluralCategories(ast, out = []) {
+    for (const el of ast) {
+        if (el.type === 6 && el.options) out.push({cats: Object.keys(el.options)});
+        if (el.options) for (const o of Object.values(el.options)) pluralCategories(o.value, out);
+        if (el.children) pluralCategories(el.children, out);
+    }
+    return out;
+}
+
+const goTokens = (s) => new Set([...String(s).matchAll(/\{\{\s*\.([A-Za-z0-9_]+)\s*\}\}/g)].map((m) => m[1]));
+const icuCats = new Intl.PluralRules(locale).resolvedOptions().pluralCategories;
+
+const errors = [];
+const warnings = [];
+
+for (const surface of ['webapp', 'server']) {
+    const want = Object.keys(input[surface] || {});
+    const got = out[surface] || {};
+
+    for (const k of want) if (!(k in got)) errors.push(`${surface}:${k}: missing from output`);
+    for (const k of Object.keys(got)) if (!want.includes(k)) errors.push(`${surface}:${k}: not in the manifest`);
+
+    for (const [k, v] of Object.entries(got)) {
+        if (!want.includes(k)) continue;
+        const src = input[surface][k].english;
+        if (typeof v !== 'string' || !v.trim()) { errors.push(`${surface}:${k}: empty`); continue; }
+        if (v === src) warnings.push(`${surface}:${k}: identical to English`);
+
+        if (surface === 'server') {
+            const a = goTokens(src), b = goTokens(v);
+            for (const t of b) if (!a.has(t)) errors.push(`${surface}:${k}: invented {{.${t}}}`);
+            for (const t of a) if (!b.has(t)) errors.push(`${surface}:${k}: dropped {{.${t}}}`);
+            continue;
+        }
+
+        let sa, ta;
+        try { sa = argTypes(parse(src, {ignoreTag: false, requiresOtherClause: true})); }
+        catch { errors.push(`${surface}:${k}: SOURCE does not parse — fix en.json first`); continue; }
+        try { ta = argTypes(parse(v, {ignoreTag: false, requiresOtherClause: true})); }
+        catch (e) { errors.push(`${surface}:${k}: does not parse: ${String(e.message).split('\n')[0]}`); continue; }
+
+        for (const a of ta.keys()) if (!sa.has(a)) errors.push(`${surface}:${k}: invented variable/tag "${a}"`);
+        for (const a of sa.keys()) if (!ta.has(a)) errors.push(`${surface}:${k}: dropped variable/tag "${a}"`);
+        for (const [a, ts] of ta) {
+            const st = sa.get(a);
+            if (st) for (const t of ts) if (!st.has(t)) errors.push(`${surface}:${k}: "${a}" used as ${t}, source uses ${[...st].join('/')}`);
+        }
+
+        // A balanced pair in the source is deliberate escaping; only flag a
+        // pair the translation introduced on its own.
+        if (/'[<{]/.test(v) && !/'[<{]/.test(src)) {
+            errors.push(`${surface}:${k}: ASCII apostrophe before ICU syntax opens a quoted literal`);
+        }
+
+        // Read plural categories off the AST. A regex cannot do this: the
+        // first '}' it meets closes a branch, not the plural.
+        for (const {cats} of pluralCategories(parse(v, {ignoreTag: false, requiresOtherClause: true}))) {
+            if (!cats.includes('other')) errors.push(`${surface}:${k}: plural has no "other" branch`);
+            for (const c of cats) {
+                if (c.startsWith('=')) continue; // explicit literal match, always allowed
+                if (!icuCats.includes(c)) errors.push(`${surface}:${k}: plural category "${c}" is not used by ${locale}`);
+            }
+            // ICU silently falls back to `other`, so a missing category is a
+            // grammar bug rather than a crash — surface it without failing.
+            const absent = icuCats.filter((c) => !cats.includes(c));
+            if (absent.length) warnings.push(`${surface}:${k}: plural omits ${absent.join('/')} — ${locale} needs ${icuCats.join('/')}, ICU will fall back to other`);
+        }
+    }
+}
+
+const w = Object.keys(out.webapp || {}).length;
+const s = Object.keys(out.server || {}).length;
+console.log(`${locale}: ${w} webapp + ${s} server`);
+if (warnings.length) {
+    console.log(`  warnings (${warnings.length}) — check these are product names, acronyms or pure placeholders:`);
+    warnings.slice(0, 10).forEach((x) => console.log(`    ${x}`));
+    if (warnings.length > 10) console.log(`    ... and ${warnings.length - 10} more`);
+}
+if (errors.length) {
+    console.error(`  ERRORS (${errors.length}):`);
+    errors.slice(0, 25).forEach((x) => console.error(`    ${x}`));
+    if (errors.length > 25) console.error(`    ... and ${errors.length - 25} more`);
+    process.exit(1);
+}
+console.log('  errors: none');

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,13 @@
 Explicitly import subdirectory instruction files that must always be in context:
 @server/AGENTS.md
 
+## Translations
+
+Any change that adds or alters a user-facing string must ship its translations
+for all 21 non-English locales in the same pull request. There is no external
+translation service. See [`i18n/AGENTS.md`](./i18n/AGENTS.md) for the workflow,
+the rules CI enforces, and the per-locale plural categories.
+
 ## Pull Requests
 
 When creating a pull request, follow `.github/PULL_REQUEST_TEMPLATE.md` exactly:

--- a/i18n/AGENTS.md
+++ b/i18n/AGENTS.md
@@ -1,0 +1,237 @@
+# Translating Mattermost strings
+
+Translations live in this repository and ship in the **same pull request** as
+the English string they translate. There is no external translation service and
+no follow-up PR: a PR that adds or changes a user-facing string is not finished
+until all 21 non-English catalogs carry it.
+
+That is only reasonable because you are expected to do it with an AI agent.
+This document is the brief for that agent. Work through it top to bottom for the
+surface you are changing.
+
+Filling a large gap across all 21 locales at once — after a feature lands, or
+after merging master — is a fan-out job with its own failure modes. The
+`translate-i18n` skill in `.claude/skills/` has the recipe and the scripts.
+
+## Supported locales
+
+Twenty-two, identical on both surfaces:
+
+```
+bg  de  en  en-AU  es  fa  fr  hu  it  ja  ko  nl
+pl  pt-BR  ro  ru  sv  tr  uk  vi  zh-CN  zh-TW
+```
+
+`en` is the source. `fa` is right-to-left. The list is pinned by
+`TestSupportedLocalesAreInSync`, which fails if the catalogs, the Go
+`supportedLocales` list and the webapp `languages` map ever disagree — so adding
+or removing a locale is a deliberate, multi-file change, not something to do in
+passing.
+
+## Where things live
+
+| | Webapp | Server |
+|---|---|---|
+| Catalogs | `webapp/channels/src/i18n/<locale>.json` | `server/i18n/<locale>.json` |
+| Shape | flat `"key": "message"` | list of `{"id", "translation"}` |
+| Message syntax | ICU MessageFormat (react-intl) | Go `text/template` + plural maps |
+| Descriptions | `webapp/channels/src/i18n-authoring/en-with-description.json` | `server/i18n-authoring/en-with-description.json` |
+| Glossary | [`i18n/glossary/`](./glossary/) | same |
+
+The `i18n-authoring/` catalogs are the translator context: every key paired with
+a description of where the string appears and how it is used. They are not
+shipped. Read the description for a key before translating it — it is usually
+the difference between a correct translation and a plausible one.
+
+## Workflow
+
+### Webapp
+
+```bash
+cd webapp/channels
+npm run i18n-extract            # regenerate src/i18n/en.json from source
+npm run i18n-extract-authoring  # add the new keys to the authoring catalog
+```
+
+Then, in order:
+
+1. **Write a description** for every key `i18n-extract-authoring` added with an
+   empty one. Say where the string appears and what the variables refer to, not
+   what the English says. Find the actual call site rather than paraphrasing —
+   that is what makes a description worth having, and it is the only point in
+   the process where somebody reads every new string next to the code that
+   shows it. Two rules earn their keep:
+   - **If the string quotes a name, say whether that name is localized.** A
+     string like `the "Clearance" attribute` is unanswerable from the English
+     alone, and every locale will guess differently. Check whether the code
+     hardcodes it (`CLEARANCE_FIELD_DISPLAY_NAME` did) and write the answer
+     down.
+   - **When you resolve an ambiguity, put the answer in the description.** The
+     description is read by 21 translators; a question you answer once there is
+     a question nobody re-derives.
+2. **Fix the English first.** Step 1 routinely turns up typos, wrong
+   prepositions and ambiguous source strings. Correct them before translating,
+   so the mistake is not carried into 21 locales. Note where the English lives:
+   the webapp's `en.json` is **generated**, so fix the `defaultMessage` in
+   source and re-extract; the server's `en.json` is **hand-maintained**, so
+   edit it directly.
+3. **Run the [glossary candidate pass](#glossary-candidates)** before any
+   translation starts.
+4. **Translate** the new or changed keys into all 21 non-English catalogs,
+   inserting each key in its existing sort position.
+5. **Verify**: `npm run i18n-verify-translations`
+
+### Server
+
+```bash
+cd server
+make i18n-extract               # regenerate i18n/en.json from source
+make i18n-extract-authoring     # add the new ids to the authoring catalog
+```
+
+Then the same five steps, and verify with `make i18n-verify`.
+
+## Glossary candidates
+
+Do this **before** translating, not after. It is the difference between one
+agreed term and twenty-one independently invented ones.
+
+New features introduce new product vocabulary — "exposure report", "clearance
+attribute", "membership policy". Nothing in the checkers can see terminology,
+so if a term is not in [`i18n/glossary/`](./glossary/) when translation starts,
+each locale coins its own. Every one will be defensible and no two will match,
+and the inconsistency is invisible until a user reports it.
+
+The pass:
+
+1. Read the new English strings and pull out the noun phrases that name a
+   product concept — a feature, a UI surface, an entity, a role, a state.
+   Ignore ordinary English.
+2. Drop any term already in `i18n/glossary/en.json`, including its `aliases`.
+3. Drop any term that already appears in shipped strings and already has a
+   settled rendering in the catalogs — grep for it before deciding it is new.
+   An established term does not need a glossary entry to stay consistent.
+4. What is left is the candidate list. For each, propose an `en.json` entry:
+
+   ```json
+   "exposure report": {
+     "definition": "The CSV report listing who was exposed to a flagged post.",
+     "partOfSpeech": "noun",
+     "doNotTranslate": false
+   }
+   ```
+
+   Set `doNotTranslate: true` for brand names, protocol acronyms, and anything
+   the product renders in English regardless of locale — including strings the
+   code hardcodes.
+5. **Get the candidate list agreed before continuing.** This is a product
+   vocabulary decision, not a translation decision.
+6. Once agreed, each locale supplies its `target` in `i18n/glossary/<locale>.json`
+   as the first thing it does, then translates using it. The key sets of
+   `en.json` and every locale file must match exactly.
+
+If a term is genuinely one-off — it appears in a single string and will never
+recur — say so and skip it. The glossary is for vocabulary, not for every noun.
+
+## Rules the checkers enforce
+
+Both checkers are deterministic and run in CI. Getting these right the first
+time is faster than iterating against the error output.
+
+**Both surfaces**
+
+- Key parity: every catalog holds exactly the keys `en.json` holds. No extras,
+  none missing.
+- No empty translation. `""` is how the tooling marks a key as present but not
+  yet translated, and both runtimes fall back as if the key were absent, so it
+  fails for the same reason a missing key does. A whitespace-only value like
+  `" "` is a real translation in a language that separates where English uses a
+  word, and is allowed.
+- Never invent a variable or tag the source does not have. It throws at format
+  time (webapp) or renders `<no value>` (server).
+- Never drop one either. The message still renders, it just silently loses a
+  value or a link.
+- Preserve the file's formatting: 2-space indent, existing key order, trailing
+  newline. Match the surrounding entries exactly.
+
+**Webapp (ICU)**
+
+- Every `plural` and `select` needs an `other` branch.
+- Keep each variable's type. `{count, plural, ...}` may not become `{count}` —
+  it parses and renders, and silently stops pluralizing.
+- **Apostrophes.** In ICU, an ASCII `'` immediately before `<` or `{` opens a
+  quoted literal that swallows the tag or variable and everything after it. The
+  message still parses, so nothing catches it at runtime. Write `l’<link>` with
+  a typographic apostrophe, or `l''<link>` to escape. This has broken French and
+  Italian strings before.
+- **But a balanced pair is deliberate escaping.** When the *source* wraps
+  something in ASCII apostrophes — `'<blank>'` in
+  `admin.cluster.OverrideHostnameDesc` — that is how it makes `<blank>` render
+  as literal text instead of parsing as a tag. Reproduce it byte for byte.
+  Deleting the apostrophes, or replacing them with `’`, makes the message throw
+  `UNCLOSED_TAG`. The checker only flags a `'<` the *translation* introduced,
+  so it will not catch you removing one that was already there.
+- There is no way to exempt a key. A translation that deviates from its source
+  is either wrong, or the source is encoding English grammar the other
+  languages cannot follow — and both are worth fixing rather than recording.
+
+**Server (Go)**
+
+- `{{.Field}}` tokens must match the source exactly, both directions.
+- A plural translation must define **exactly** the categories its locale uses —
+  no missing ones and no extra ones. This is stricter than the webapp.
+
+## Plural categories
+
+The two runtimes do not agree, so use the right column for the surface you are
+editing. The webapp column is what the language actually needs; the server
+column is what `mmgotool i18n verify` requires.
+
+| Locale | Webapp (ICU / CLDR) | Server (go-i18n) |
+|---|---|---|
+| bg, de, en, en-AU, fa, hu, nl, sv, tr | one, other | one, other |
+| es, fr, it, pt-BR | one, many, other | **one, other** |
+| ja, ko, vi, zh-CN, zh-TW | other | other |
+| pl, ru, uk | one, few, many, other | one, few, many, other |
+| ro | one, few, other | one, few, other |
+
+The `many` category for `es`, `fr`, `it` and `pt-BR` is a newer CLDR addition
+that the server's vendored go-i18n does not have. Adding a `many` branch to a
+server catalog for those locales fails verification; a stale one in `pt-BR` was
+a real bug.
+
+## Quality
+
+- **Use the glossary.** [`i18n/glossary/`](./glossary/) fixes the target term
+  for core product vocabulary per locale, and marks the terms that stay in
+  English. Its `note` fields record known mistranslations that earlier passes
+  got wrong — do not reintroduce them.
+- **Never paste English into a non-English catalog.** Every check here passes on
+  a catalog full of English, so nothing will catch it. If a string genuinely has
+  no translation in a language, it still needs a considered decision, not a copy.
+- Match the register of the surrounding strings in that catalog rather than
+  translating the English literally.
+- Leave placeholders, markup tags and code identifiers untranslated. The
+  recurring cases, so you do not have to deliberate over them every time: theme
+  brand names (Denim, Sapphire, Quartz, Indigo, Onyx), protocol and product
+  acronyms (`AD/LDAP`, `SAML`, `OAuth`), config keys and field names, and
+  strings that are nothing but placeholders (`{source}: {value}`). These come
+  back byte-identical to English and that is correct.
+- **Right-to-left (`fa`): watch bidi-mirrored characters.** A literal `→` in an
+  RTL sentence renders pointing left. That is the correct reading direction but
+  the opposite of the English visually, and no checker can see it. Prefer
+  wording that does not depend on the glyph's direction.
+- **Do not re-translate a string that already has a translation** unless it is
+  wrong or its English changed. Two independent AI passes over the same 200
+  strings agreed only 38% of the time — both valid, just different word
+  choices. Re-translating churns the catalogs without improving them.
+
+## Do not
+
+- Hand-edit `webapp/channels/src/i18n/imports.ts`. Run
+  `npm run gen-lang-imports` from `webapp/`.
+- Add non-locale files to `server/i18n/` or `webapp/channels/src/i18n/`. Both
+  directories are scanned wholesale by tooling that assumes every `.json` in
+  them is a catalog. Authoring material goes in the sibling `i18n-authoring/`
+  directory; guidance goes in the `AGENTS.md` already there.
+- Edit `en.json` by hand to add a key. Change the source string and re-extract.

--- a/server/AGENTS.md
+++ b/server/AGENTS.md
@@ -2,7 +2,9 @@
 
 Never run `go mod tidy` directly. Always run `make modules-tidy` instead — it excludes private enterprise imports that would otherwise break the tidy.
 
-After editing `i18n/en.json`, always run `make i18n-extract` — it regenerates the file with strings in the required order.
+After editing `i18n/en.json`, always run `make i18n-extract` — it regenerates the file with strings in the required order. Then run `make i18n-extract-authoring` to bring `i18n-authoring/en-with-description.json` back into lockstep, and fill in a description for any id it adds with an empty one.
+
+Adding or changing a string is not finished there: its translations for all 21 non-English locales ship in the same pull request. The [repository translation guide](../i18n/AGENTS.md) has the workflow, the rules CI enforces, and the per-locale plural categories — note that the server's vendored go-i18n requires a different plural category set than current CLDR for `es`, `fr`, `it` and `pt-BR`.
 
 Prefer request-scoped loggers when logging from request paths. If a method needs to log and does not have access to the request logger, it is reasonable to add `request.CTX` to the method signature when the caller can provide it.
 In the store layer, do not use `context.Context` in store method signatures. Use `request.CTX` and only call `rctx.Context()` inside internals that require a standard `context.Context`.

--- a/server/i18n/AGENTS.md
+++ b/server/i18n/AGENTS.md
@@ -1,0 +1,27 @@
+# AGENTS.md
+
+These are the shipped server translation catalogs, one go-i18n
+`[{"id", "translation"}]` JSON file per locale. **Read
+[`i18n/AGENTS.md`](../../i18n/AGENTS.md) at the repository root before editing
+any of them** — it covers the whole workflow, the rules CI enforces, and the
+plural categories per locale.
+
+The short version:
+
+- Translations ship in the same PR as the English string. All 21 non-English
+  catalogs, every time.
+- `en.json` is generated. Change the source string and run `make i18n-extract`
+  from `server`; never edit it by hand.
+- Translator context for each id lives in
+  [`../i18n-authoring/en-with-description.json`](../i18n-authoring/). Read the
+  description before translating, and write one for ids you add.
+- Messages are Go `text/template`. `{{.Field}}` tokens must match the source
+  exactly, in both directions.
+- A plural translation must define **exactly** the categories its locale uses in
+  the server's vendored go-i18n — which for `es`, `fr`, `it` and `pt-BR` is
+  `one, other`, with no `many`, unlike current CLDR. See the table in the root
+  guide.
+- Check your work with `make i18n-verify`.
+- Only locale catalogs belong in this directory. The server registers every
+  supported-locale `.json` here at startup, and `mmgotool i18n clean-empty`
+  rewrites them.

--- a/webapp/channels/src/i18n/AGENTS.md
+++ b/webapp/channels/src/i18n/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+These are the shipped webapp translation catalogs, one flat `"key": "message"`
+JSON file per locale. **Read [`i18n/AGENTS.md`](../../../../i18n/AGENTS.md) at
+the repository root before editing any of them** — it covers the whole
+workflow, the rules CI enforces, and the plural categories per locale.
+
+The short version:
+
+- Translations ship in the same PR as the English string. All 21 non-English
+  catalogs, every time.
+- `en.json` is generated. Change the source string and run
+  `npm run i18n-extract` from `webapp/channels`; never edit it by hand.
+- Translator context for each key lives in
+  [`../i18n-authoring/en-with-description.json`](../i18n-authoring/). Read the
+  description before translating, and write one for keys you add.
+- Messages are ICU MessageFormat. The trap is an ASCII apostrophe immediately
+  before `<` or `{`: it opens a quoted literal that swallows the rest of the
+  message and still parses. Use `’` or `''`.
+- Check your work with `npm run i18n-verify-translations`.
+- Only locale catalogs belong in this directory. `gen_lang_imports.mjs` turns
+  every `.json` here into a shipped language.


### PR DESCRIPTION
#### Summary

Stacked on #38412 → #38411 → #38410 → #38231. Review those first; this PR's diff
is against #38412.

Translations are authored in the repository now rather than round-tripped through
an external service, and nothing said how. The checkers state what is wrong once
a translation exists; they do not tell you how to produce one, which plural
categories your locale needs, or that the two runtimes disagree about that.

`i18n/AGENTS.md` is the brief for translating one locale: where catalogs live,
the workflow per surface, the glossary pass, the rules each checker enforces and
why, the per-locale plural categories, and a "do not" list. The four pointer
files — root, server, and one in each catalog directory — exist so the guide is
found from wherever someone is working.

The `translate-i18n` skill is the recipe for doing all 21 locales at once:
describe the new keys, agree terminology before any locale agent starts, fan out
one agent per locale, validate, then apply. Three scripts do the mechanical parts
so the agents only ever translate.

The guide and the skill reference each other, which is why they land together.

#### QA steps

- Every command either doc tells you to run exists on this branch: `make
  i18n-extract`, `make i18n-extract-authoring`, `make i18n-verify`, `npm run
  i18n-extract`, `npm run i18n-extract-authoring`, `npm run
  i18n-verify-translations`, `npm run gen-lang-imports`.
- The plural table's server column is verified against the shipped verifier: a
  Spanish catalog with `one, many, other` is rejected with `plural category
  "many" is not used by this locale`, and `one, other` passes. `ja` takes `other`
  alone, `pl` takes `one, few, many, other`, `ro` takes `one, few, other`.
- All relative links between the docs resolve.

Both are reference material — nothing in the build or at runtime reads either,
and neither triggers CI.

#### Release Note
```release-note
NONE
```
