### PR TITLE
Stabilize ranked operators Playwright E2E spec

### DIFF
--- a/e2e-tests/playwright/specs/functional/system_console/abac/policies/ranked_operators.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/policies/ranked_operators.spec.ts
@@ -9,6 +9,7 @@
  * (is exactly, is not, is at least, is greater than, is at most, is less than).
  */
 
+import type {Page} from '@playwright/test';
 import type {Client4} from '@mattermost/client';
 import type {UserProfile} from '@mattermost/types/users';
 import type {UserPropertyField} from '@mattermost/types/properties_user';
@@ -16,6 +17,34 @@ import type {UserPropertyField} from '@mattermost/types/properties_user';
 import {expect, getRandomId, test} from '@mattermost/playwright-lib';
 
 import {deleteCustomProfileAttributes} from '../../../channels/custom_profile_attributes/helpers';
+import {assertAccessControlAutocompleteContains} from '../support';
+
+// Filter + real click so an off-screen ranked field is selected; click the
+// policy name to dismiss a leftover MUI overlay (the filter swallows Escape).
+async function selectAttributeInEditor(page: Page, attributeName: string) {
+    const attributeMenu = page.locator('[id^="attribute-selector-menu"]');
+    const attributeButton = page.locator('[data-testid="attributeSelectorMenuButton"]').first();
+
+    if (!(await attributeMenu.isVisible({timeout: 2000}).catch(() => false))) {
+        await attributeButton.click();
+    }
+    await expect(attributeMenu).toBeVisible();
+
+    const filterInput = attributeMenu.locator('.attribute-selector-search input');
+    await filterInput.waitFor({state: 'visible'});
+    await filterInput.fill(attributeName);
+
+    const option = attributeMenu.getByRole('menuitemradio', {name: attributeName, exact: true});
+    await expect(option).toBeVisible();
+    await option.click();
+
+    await expect(attributeButton).toContainText(attributeName);
+
+    if (await attributeMenu.isVisible().catch(() => false)) {
+        await page.locator('#admin\\.access_control\\.policy\\.edit_policy\\.policyName').click();
+    }
+    await expect(attributeMenu).toBeHidden();
+}
 
 test.describe('System Console - Membership Policy ranked operators', () => {
     let adminClient: Client4;
@@ -49,6 +78,8 @@ test.describe('System Console - Membership Policy ranked operators', () => {
         await adminClient.patchConfig({
             AccessControlSettings: {EnableAttributeBasedAccessControl: true},
         } as any);
+
+        await assertAccessControlAutocompleteContains(adminClient, [field.name]);
     });
 
     test.afterEach(async () => {
@@ -96,17 +127,7 @@ test.describe('System Console - Membership Policy ranked operators', () => {
         await addAttributeButton.click();
 
         // # Select the ranked attribute by name
-        const attributeButton = page.locator('[data-testid="attributeSelectorMenuButton"]').first();
-        if (!(await page.locator('[id^="attribute-selector-menu"]').isVisible({timeout: 2000}))) {
-            await attributeButton.click();
-        }
-        await page
-            .locator(`[id^="attribute-selector-menu"] li:has-text("${field!.name}")`)
-            .first()
-            .click({force: true});
-
-        // # Let the attribute menu and its backdrop fully close before opening the next menu
-        await expect(page.locator('[id^="attribute-selector-menu"]')).toBeHidden();
+        await selectAttributeInEditor(page, field!.name);
 
         // * The row defaults to the canonical ranked operator, "is at least"
         const operatorButton = page.locator('[data-testid="operatorSelectorMenuButton"]').first();
@@ -161,14 +182,8 @@ test.describe('System Console - Membership Policy ranked operators', () => {
             }
             await addAttributeButton.click();
 
-            if (!(await page.locator('[id^="attribute-selector-menu"]').isVisible({timeout: 2000}))) {
-                await page.locator('[data-testid="attributeSelectorMenuButton"]').first().click();
-            }
-            await page
-                .locator(`[id^="attribute-selector-menu"] li:has-text("${field!.name}")`)
-                .first()
-                .click({force: true});
-            await expect(page.locator('[id^="attribute-selector-menu"]')).toBeHidden();
+            // # Select the ranked attribute by name
+            await selectAttributeInEditor(page, field!.name);
 
             // * Defaults to "is at least"
             await expect(page.locator('[data-testid="operatorSelectorMenuButton"]').first()).toContainText(


### PR DESCRIPTION
#### Summary
Ref: https://test-io.test.mattermost.com/reports/r/01a08412-4262-75f2-9a2b-2b054876e8c9

Fixes a flaky master FIPS Playwright failure in `ranked_operators.spec.ts` ("shows ranked comparison operators for a ranked attribute").

Force-clicking the MUI attribute menu skipped scroll-into-view, so a ranked field below native/session attributes could miss `onSelect`. The menu then stayed open (`toBeHidden` failed) or closed without applying the type, leaving the default `"is"` operator instead of `"is at least"`.

The spec now filters the menu, clicks without force, waits for the attribute name on the trigger, and dismisses any leftover overlay before asserting operators.

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to one Playwright E2E spec and does not affect production code or shared utilities. The main risk is limited to ranked-operator test behavior.

**QA Recommendation:** Manual QA is not required. Rely on the automated E2E coverage.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->