### PR TITLE
Use sidebar title class for category drag handles in Cypress

### DIFF
--- a/e2e-tests/cypress/tests/integration/channels/channel_sidebar/drag_and_drop_spec.ts
+++ b/e2e-tests/cypress/tests/integration/channels/channel_sidebar/drag_and_drop_spec.ts
@@ -16,6 +16,8 @@ describe('Channel sidebar', () => {
     const SpaceKeyCode = 32;
     const DownArrowKeyCode = 40;
 
+    const categoryDragHandle = '.SidebarChannelGroupHeader_groupButton > .SidebarChannelGroupHeader_text';
+
     let teamName: string;
     let channelName: string;
 
@@ -65,8 +67,10 @@ describe('Channel sidebar', () => {
         // * Verify that we've switched to the new team
         cy.uiGetLHSHeader().findByText(teamName);
 
-        // # Get channel group button and wait for Channels to be visible since for some reason it shows up later...
-        cy.get('.SidebarChannelGroupHeader_groupButton > div[data-rfd-drag-handle-draggable-id]').should('be.visible').as('fromChannelGroup');
+        // # Wait for category headers, then grab the title drag handles
+        cy.get('.SidebarChannelGroupHeader:contains(CHANNELS)').should('be.visible');
+        cy.get('.SidebarChannelGroupHeader:contains(DIRECT MESSAGES)').should('be.visible');
+        cy.get(categoryDragHandle).should('be.visible').as('fromChannelGroup');
         cy.get('@fromChannelGroup').should('contain', 'CHANNELS');
 
         // * Verify the order is correct to begin with
@@ -80,7 +84,7 @@ describe('Channel sidebar', () => {
             trigger('keydown', {keyCode: SpaceKeyCode, force: true}).wait(TIMEOUTS.THREE_SEC);
 
         // * Verify that the elements have been re-ordered
-        cy.get('.SidebarChannelGroupHeader_groupButton > div[data-rfd-drag-handle-draggable-id]').as('toChannelGroup');
+        cy.get(categoryDragHandle).as('toChannelGroup');
         cy.get('@toChannelGroup').eq(1).should('contain', 'CHANNELS');
         cy.get('@toChannelGroup').eq(0).should('contain', 'DIRECT MESSAGES');
     });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
#### Summary
The Cypress category reorder spec failed looking for `.SidebarChannelGroupHeader_groupButton > div[data-rbd-drag-handle-draggable-id]`. That attribute is library-generated (`data-rbd-*` vs `data-rfd-*`) and is missing when the spec and server disagree on the drag-and-drop library.

Select the category title text instead — that is the actual drag handle — and wait for CHANNELS / DIRECT MESSAGES to render first.

#### Release Note
```release-note
NONE
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2864d1b-fb33-4f75-90cf-29ffa36ff525?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2864d1b-fb33-4f75-90cf-29ffa36ff525&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change affects one Cypress test and does not modify production code or shared utilities. Risk is limited to selector or rendering-timing issues in the category reorder test.

**QA Recommendation:** Manual QA is not required. Run the affected Cypress test in CI.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->