### PR TITLE
MM-69498: Add docs for post delivery audit logging

### DIFF
--- a/docs/main/administration-guide/comply/comply-index.mdx
+++ b/docs/main/administration-guide/comply/comply-index.mdx
@@ -11,4 +11,5 @@ Mattermost is purpose-built to help enterprises keep sensitive data safe and com
 - [Export channel data](/administration-guide/comply/export-mattermost-channel-data) - Migrate data between systems and back data up for operational continuity.
 - [Legal hold](/administration-guide/comply/legal-hold) - Preserve relevant Mattermost information when litigation is anticipated.
 - [Custom terms of service](/administration-guide/comply/custom-terms-of-service) - Require users to accept your own terms before they can access Mattermost.
-- [Audit log JSON schema](/administration-guide/comply/embedded-json-audit-log-schema) - Learn how to configure Mattermost audit logging using a JSON object.
+- [Audit log JSON schema](/administration-guide/comply/embedded-json-audit-log-schema) - Learn the JSON structure of Mattermost audit log entries.
+- [Post delivery audit logging](/administration-guide/comply/post-delivery-audit-logging) - Record an audit log entry each time a message is delivered to a user, to establish which users a given message reached.

--- a/docs/main/administration-guide/comply/embedded-json-audit-log-schema.mdx
+++ b/docs/main/administration-guide/comply/embedded-json-audit-log-schema.mdx
@@ -564,6 +564,33 @@ From Mattermost v11.5.0, audit log entries for posts and content access events i
 
 </Note>
 
+### Post Delivery Events
+
+Mattermost v12.0 introduces the `postDelivered` audit log event, which records each delivery of a message's content to a user or an integration. It's emitted only when [post delivery audit logging](/administration-guide/comply/post-delivery-audit-logging) is enabled, which is disabled by default. Unlike the other audit log events on this page, `postDelivered` is emitted at the dedicated `audit-delivery` log level and so requires its own audit log target. See that page for the record format, the payload fields, and the full set of delivery mechanisms.
+
+<table style={{width: '85%'}}>
+<colgroup>
+<col style={{width: '28%'}} />
+<col style={{width: '56%'}} />
+</colgroup>
+<thead>
+<tr>
+<th><strong>Event Name</strong></th>
+<th><strong>Description</strong></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>postDelivered</code></td>
+<td>Delivering post content to a user or integration</td>
+</tr>
+<tr>
+<td><code>updateDeliveryTrackingConfig</code></td>
+<td>Updating the post delivery audit logging configuration</td>
+</tr>
+</tbody>
+</table>
+
 ### Authentication and Security Events
 
 <table style={{width: '86%'}}>

--- a/docs/main/administration-guide/comply/post-delivery-audit-logging.mdx
+++ b/docs/main/administration-guide/comply/post-delivery-audit-logging.mdx
@@ -19,7 +19,7 @@ Post delivery audit logging requires all of the following:
 
 - A Mattermost Enterprise Advanced license.
 - The [feature flag](https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values) `MM_FEATUREFLAGS_POSTDELIVERYTRACKING`, which is disabled by default. **Restart the server after enabling the feature flag**.
-- Advanced Logging \> Advanced Logging to be enabled
+- Advanced audit logging configured at **System Console \> Compliance \> Audit Logging \> Advanced Logging**.
 - An audit log target that consumes the `audit-delivery` log level in the advanced audit log config.
 
 <Important>
@@ -62,7 +62,7 @@ DeliveryTrackingSettings.Enable is enabled but no configured audit log target co
 
 ## Enable post delivery audit logging
 
-In the System Console, enable post delivery audit logging and choose the channels that deliveries are recorded in by going to **Site Configuration \> Data Spillage Handling \> Post Delivery Audit Logging**. See [Post delivery audit logging](/administration-guide/manage/admin/content-flagging#post-delivery-audit-logging) for the steps, and [Content flagging](/administration-guide/configure/site-configuration-settings#content-flagging) for the corresponding `config.json` settings and environment variables.
+In the System Console, enable post delivery audit logging and choose the channels that deliveries are recorded in by going to **Site Configuration \> Data Spillage Handling \> Post Delivery Audit Logging**. See [Post delivery audit logging](/administration-guide/manage/admin/content-flagging#post-delivery-audit-logging) for the steps, and [site configuration settings](/administration-guide/configure/site-configuration-settings#enable-post-delivery-audit-logging) for the corresponding `config.json` settings and environment variables.
 
 ## Record format
 

--- a/docs/main/administration-guide/comply/post-delivery-audit-logging.mdx
+++ b/docs/main/administration-guide/comply/post-delivery-audit-logging.mdx
@@ -1,0 +1,183 @@
+---
+title: "Post delivery audit logging"
+---
+<PlanAvailability slug="entry-adv" />
+
+From Mattermost v12.0, Mattermost can record an audit log entry each time a message's content is delivered to a user or to an integration. These records let you establish which users a given message was delivered to, and by what means.
+
+<Note>
+
+Post delivery audit logging is currently in [Beta](/administration-guide/manage/feature-labels#beta).
+
+</Note>
+
+Delivery records are ordinary audit log records, written through the existing audit logging pipeline to whichever audit log targets you've configured.
+
+## Before you begin
+
+Post delivery audit logging requires all of the following:
+
+- A Mattermost Enterprise Advanced license.
+- The [feature flag](https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values) `MM_FEATUREFLAGS_POSTDELIVERYTRACKING`, which is disabled by default. **Restart the server after enabling the feature flag**.
+- Advanced Logging \> Advanced Logging to be enabled
+- An audit log target that consumes the `audit-delivery` log level in the advanced audit log config.
+
+<Important>
+
+Enabling post delivery audit logging on its own produces no output. Delivery records are discarded until an audit log target consumes the `audit-delivery` log level. Configure the target before you enable the feature. The log volume increases substantially once these audit logs are enabled.
+
+</Important>
+
+## Configure an audit log target
+
+Delivery records are written at the `audit-delivery` log level, ID `104`. Unlike the other [audit log levels](/administration-guide/manage/logging#log-levels), `audit-delivery` isn't written by the built-in audit log file target, so enabling `ExperimentalAuditSettings.FileEnabled` doesn't capture delivery records. Add a target that consumes level `104` to `ExperimentalAuditSettings.AdvancedLoggingJSON` instead. See [advanced logging](/administration-guide/manage/logging#advanced-logging) for the available target types and options.
+
+We recommend a dedicated target, so that the volume of delivery records doesn't overwhelm your other audit records. The example below writes delivery records to their own file, rotated at 100 MB, with up to 10,000 records buffered in memory while writing:
+
+``` JSON
+{
+    "post-delivery-audit": {
+        "type": "file",
+        "format": "json",
+        "levels": [
+            { "id": 104, "name": "audit-delivery" }
+        ],
+        "options": {
+            "filename": "./logs/post-delivery-audit.log",
+            "max_size": 100,
+            "max_age": 0,
+            "max_backups": 0,
+            "compress": true
+        },
+        "maxqueuesize": 10000
+    }
+}
+```
+
+If post delivery audit logging is enabled and no audit log target consumes the `audit-delivery` level, the configuration remains valid, delivery records are discarded, and Mattermost logs the following warning at startup and whenever the configuration changes:
+
+``` text
+DeliveryTrackingSettings.Enable is enabled but no configured audit log target consumes the audit-delivery level; post delivery audit records will be discarded. Add a target for the level via ExperimentalAuditSettings.AdvancedLoggingJSON.
+```
+
+## Enable post delivery audit logging
+
+In the System Console, enable post delivery audit logging and choose the channels that deliveries are recorded in by going to **Site Configuration \> Data Spillage Handling \> Post Delivery Audit Logging**. See [Post delivery audit logging](/administration-guide/manage/admin/content-flagging#post-delivery-audit-logging) for the steps, and [Content flagging](/administration-guide/configure/site-configuration-settings#content-flagging) for the corresponding `config.json` settings and environment variables.
+
+## Record format
+
+Each delivery is recorded as a `postDelivered` audit log record. The `status` of the record is always `success`.
+
+**The recipient of the message is the actor of the record**, in `actor.user_id`. There's no separate recipient field. This lets you group records by actor to answer "what was delivered to this user". Deliveries to a plugin or to an outgoing webhook have no human recipient, so `actor.user_id` is empty and `meta.plugin_id` or `meta.webhook_id` identifies the integration instead.
+
+The `meta` object identifies what was delivered and how. Unlike audit records emitted from a REST API request, delivery records carry no `api_path` or `cluster_id` in `meta`.
+
+A message delivered to a user through the Mattermost REST API:
+
+``` json
+{
+    "timestamp": "2026-08-12 14:03:11.482 Z",
+    "event_name": "postDelivered",
+    "status": "success",
+    "actor": {
+        "user_id": "hx4k9m2qzbfytr7wn6cbd3jvse",
+        "session_id": "",
+        "client": "",
+        "ip_address": ""
+    },
+    "meta": {
+        "post_id": "xpw97hf6kfncirzhqisb5sym7e",
+        "channel_id": "pfis7ycuy78o7m3zebajmxqeuo",
+        "mechanism": "product"
+    },
+    "error": {}
+}
+```
+
+The same message delivered to a plugin, with no human recipient:
+
+``` json
+{
+    "timestamp": "2026-08-12 14:03:11.509 Z",
+    "event_name": "postDelivered",
+    "status": "success",
+    "actor": {
+        "user_id": "",
+        "session_id": "",
+        "client": "",
+        "ip_address": ""
+    },
+    "meta": {
+        "post_id": "xpw97hf6kfncirzhqisb5sym7e",
+        "channel_id": "pfis7ycuy78o7m3zebajmxqeuo",
+        "mechanism": "plugin",
+        "plugin_id": "com.mattermost.example-plugin"
+    },
+    "error": {}
+}
+```
+
+See the [audit log JSON schema](/administration-guide/comply/embedded-json-audit-log-schema) for the fields common to every Mattermost audit log record.
+
+## Payload fields
+
+The `meta` object of a `postDelivered` record contains the following fields. The recipient isn't in `meta` — the recipient is the actor of the record, in `actor.user_id`.
+
+| **Field name** | **Data type** | **Description** |
+|----|----|----|
+| post_id | string | Always present. The unique identifier of the message whose content was delivered. |
+| channel_id | string | Always present. The unique identifier of the channel that the message belongs to. |
+| mechanism | string | Always present. How the message content reached the recipient. See [delivery mechanisms](#delivery-mechanisms) for the possible values. |
+| plugin_id | string | Present for `plugin` deliveries only. The plugin that the message content was passed to. |
+| webhook_id | string | Present for `outgoing_webhook` deliveries only. The outgoing webhook that the message content was sent to. |
+| via_post_id | string | Present for `permalink_preview` deliveries only. The message that embedded the permalink preview. |
+| via_channel_id | string | Present for `permalink_preview` deliveries only. The channel containing the message that embedded the permalink preview. |
+
+## Delivery mechanisms
+
+The `mechanism` field records how the message content reached the recipient. It's always one of the following seven values:
+
+| **Value** | **Delivery** |
+|----|----|
+| `product` | Any read of message content through the Mattermost REST API. This covers channel loads, thread and reply views, search results, direct fetches of a message by ID, pinned messages, saved messages, and message edit history. |
+| `post_broadcast` | A new or edited message pushed over WebSocket to connected channel members. |
+| `permalink_preview` | A message rendered as a permalink preview inside another message. |
+| `email` | Message content included in a notification email. |
+| `push` | Message content included in a push notification payload, and the acknowledgement fetch that retrieves content for an ID-only push notification. |
+| `outgoing_webhook` | Message content sent to an outgoing webhook. |
+| `plugin` | A message passed to a plugin's `MessageWillBePosted` or `MessageWillBeUpdated` hook, or read through the plugin API. |
+
+<Note>
+
+Channel loads, thread views, search results, and direct message fetches all share the `product` value. They aren't reported as separate mechanisms.
+
+</Note>
+
+## What isn't recorded
+
+The following are never recorded:
+
+- **The message author**: A user never receives a delivery record for their own message.
+- **System messages and ephemeral messages**.
+- **Burn-on-read messages**.
+- **Direct and group messages**: These channels are never eligible, including when deliveries are recorded in all channels.
+- **Generic push notifications**: A push notification that doesn't include message content records nothing. When push notifications are configured to send only IDs, the delivery is recorded when the device fetches the content.
+- **Plugins reading from the database**: A plugin that reads messages directly from the database, rather than through the plugin API or a message hook, can't be observed and isn't recorded.
+
+Messages posted by bots and by outgoing webhooks are recorded like any other message.
+
+## Interpret delivery records
+
+Mattermost records one entry for each message delivered to each recipient, with no batching. A channel load that returns 100 messages produces 100 records, and a new message broadcast to 40 connected channel members produces 40 records.
+
+Delivery records are an append-only event stream, not a deduplicated list of who has seen a message. The same combination of user, message, and mechanism recurs, because every time a user revisits a channel the same page of messages is delivered again. Each record is a genuine delivery with its own timestamp.
+
+Deduplicate on `actor.user_id`, `meta.post_id`, and `meta.mechanism` to get one entry per recipient, message, and delivery mechanism, taking the earliest timestamp in each group as the first delivery by that mechanism. A recipient who received the same message by more than one mechanism — for example `push` and then `product` — has one entry per mechanism.
+
+To reduce that to a distinct list of the users a message reached, drop `meta.mechanism` from the key and deduplicate on `actor.user_id` and `meta.post_id` alone.
+
+Keep the following in mind when working with delivery records:
+
+- **Delivery isn't proof of reading**: A record means Mattermost transmitted the message content to an endpoint the recipient could read it from. It doesn't mean anyone read it. A user with email notifications configured to include message content is recorded as a delivery even if they never opened Mattermost.
+- **Records aren't guaranteed to be complete**: Audit logging is asynchronous, so records still queued in memory are lost if the server stops uncleanly. A controlled shutdown flushes the queue. This is existing audit logging behaviour that applies to all audit log levels.
+- **Permalink previews follow the previewed message**: Whether a permalink preview delivery is recorded depends on the channel of the message being previewed, not the channel of the message containing the preview. A preview of a message in a recorded channel is recorded even when the preview is rendered in a channel that isn't. Without this, a recorded message could be read by permalinking it into any other channel. Mattermost renders one level of permalink preview, so one level is recorded.

--- a/docs/main/administration-guide/configure/environment-configuration-settings.mdx
+++ b/docs/main/administration-guide/configure/environment-configuration-settings.mdx
@@ -3271,6 +3271,7 @@ When [output audit logs to file](#output-audit-logs-to-file) is enabled, the fil
 - See the [Mattermost logging](/administration-guide/manage/logging) documentation for details on advanced logging configuration. These targets have been chosen as they support the vast majority of log aggregators, and other log analysis tools, without needing additional software installed.
 - Audit logs are recorded asynchronously to reduce latency to the caller.
 - Advanced audit logging supports hot-reloading of logger configuration.
+- From Mattermost v12.0, the `audit-delivery` log level isn't written by the built-in audit log file target, so [post delivery audit records](/administration-guide/comply/post-delivery-audit-logging#configure-an-audit-log-target) are discarded unless you add a target here whose `levels` list includes `{"id": 104, "name": "audit-delivery"}`.
 
 </Note>
 

--- a/docs/main/administration-guide/configure/site-configuration-settings.mdx
+++ b/docs/main/administration-guide/configure/site-configuration-settings.mdx
@@ -2074,6 +2074,73 @@ Access the following configuration settings in the System Console by going to **
 </tbody>
 </table>
 
+From Mattermost v12.0, the following settings control post delivery audit logging, which records an audit log entry for each delivery of a message in an eligible channel. Delivery records require an audit log target that consumes the `audit-delivery` log level. See [Post delivery audit logging](/administration-guide/comply/post-delivery-audit-logging) for details.
+
+<Important>
+
+Post delivery audit logging is currently in [Beta](/administration-guide/manage/feature-labels#beta). It requires the [feature flag](https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values) `MM_FEATUREFLAGS_POSTDELIVERYTRACKING`, which is disabled by default, and a server restart after you enable it. It also requires an audit log target that consumes the `audit-delivery` log level.
+
+</Important>
+
+### Enable post delivery audit logging
+
+<table>
+<colgroup>
+<col style={{width: '35%'}} />
+<col style={{width: '64%'}} />
+</colgroup>
+<tbody>
+<tr>
+<td><ul><li><strong>true</strong>: An audit log entry is recorded each time a message is delivered to a user.</li><li><strong>false</strong>: <strong>(Default)</strong> Message deliveries aren't recorded.</li></ul></td>
+<td><ul><li>System Config path: <strong>Site Configuration &gt; Data Spillage Handling</strong></li><li><code>config.json</code> setting: <code>DeliveryTrackingSettings</code> &gt; <code>Enable</code> &gt; <code>false</code></li><li>Environment variable: <code>MM_DELIVERYTRACKINGSETTINGS_ENABLE</code></li></ul></td>
+</tr>
+</tbody>
+</table>
+
+Delivery records are written to the audit log only, and aren't surfaced anywhere in the Mattermost interface.
+
+<Warning>
+
+Delivery records are discarded unless an audit log target consumes the `audit-delivery` log level. Setting this to **true** without configuring such a target records nothing, and Mattermost doesn't block the configuration. See [Post delivery audit logging](/administration-guide/comply/post-delivery-audit-logging).
+
+</Warning>
+
+### Record deliveries in
+
+<table>
+<colgroup>
+<col style={{width: '35%'}} />
+<col style={{width: '64%'}} />
+</colgroup>
+<tbody>
+<tr>
+<td><ul><li><strong>true</strong>: <strong>(Default)</strong> Deliveries are recorded in all eligible channels.</li><li><strong>false</strong>: Deliveries are recorded only in the selected channels.</li></ul></td>
+<td><ul><li>System Config path: <strong>Site Configuration &gt; Data Spillage Handling</strong></li><li><code>config.json</code> setting: <code>DeliveryTrackingSettings</code> &gt; <code>EnableForAllChannels</code> &gt; <code>true</code></li><li>Environment variable: <code>MM_DELIVERYTRACKINGSETTINGS_ENABLEFORALLCHANNELS</code></li></ul></td>
+</tr>
+</tbody>
+</table>
+
+<Note>
+
+Recording deliveries in all eligible channels is the most complete option, and also the most expensive. Direct and group messages are never eligible, regardless of this setting.
+
+</Note>
+
+### Channels to record deliveries in
+
+<table>
+<colgroup>
+<col style={{width: '35%'}} />
+<col style={{width: '64%'}} />
+</colgroup>
+<tbody>
+<tr>
+<td><p>The channels in which message deliveries are recorded. Applies only when <strong>Record deliveries in</strong> is set to <strong>Selected channels</strong>, in which case at least one channel is required.</p><p>Stored in the database, so there's no <code>config.json</code> setting and no environment variable. Manage the list in the System Console, or through the <code>/api/v4/delivery_tracking/config</code> API endpoints.</p><p>Direct and group message channels can't be selected.</p></td>
+<td><ul><li>System Config path: <strong>Site Configuration &gt; Data Spillage Handling</strong></li><li><code>config.json</code> setting: N/A</li><li>Environment variable: N/A</li></ul></td>
+</tr>
+</tbody>
+</table>
+
 ------------------------------------------------------------------------------------------------------------------------
 
 ## File sharing and downloads

--- a/docs/main/administration-guide/manage/admin/content-flagging.mdx
+++ b/docs/main/administration-guide/manage/admin/content-flagging.mdx
@@ -232,9 +232,9 @@ To enable post delivery audit logging:
 
 5.  With **Selected channels** set, use **Channels to record deliveries in** to select the channels. Direct and group message channels can't be selected. Recording starts when you save and applies to eligible message content delivered from then on, including existing messages delivered through later channel loads, searches, and fetches.
 
-**Enable post delivery audit logging** and **Record deliveries in** can also be configured via the [config.json file or through environment variables](/administration-guide/configure/site-configuration-settings#content-flagging).
+**Enable post delivery audit logging** and **Record deliveries in** can also be configured via the [config.json file or through environment variables](/administration-guide/configure/site-configuration-settings#enable-post-delivery-audit-logging).
 
-The list of channels isn't stored in `config.json`. Mattermost stores it in the database, so manage it either in the System Console or through the `/api/v4/delivery_tracking/config` API endpoints. A `PUT` request that omits `ChannelIds` leaves the stored list unchanged, and an empty array clears it. See the [Mattermost API reference](https://api.mattermost.com/).
+The list of channels isn't stored in `config.json`. Mattermost stores it in the database, so manage it either in the System Console or through the `/api/v4/delivery_tracking/config` API endpoints. A `PUT` request that omits `ChannelIds` leaves the stored list unchanged. An empty array clears the list when **Record deliveries in** is set to **All channels**, and is rejected when it's set to **Selected channels**, because at least one channel is required. See the [Mattermost API reference](https://api.mattermost.com/).
 
 <Tip>
 

--- a/docs/main/administration-guide/manage/admin/content-flagging.mdx
+++ b/docs/main/administration-guide/manage/admin/content-flagging.mdx
@@ -56,6 +56,14 @@ Alternatively, you can configure Data Spillage Handling via the [config.json fil
     - **Require reviewers to add comment**: Set to **True** to require reviewers to add a comment when resolving a quarantine.
     - **Hide message from channel while it is being reviewed**: Set to **True** to automatically hide quarantined messages from the channel until reviews are complete. If a root post is quarantined, the entire thread is hidden.
 
+4.  Under **Post Delivery Audit Logging**, record each user, plugin, and outgoing webhook that a message is delivered to:
+
+    - **Enable post delivery audit logging**: Set to **True** to record an audit log entry for each delivery of a message in an eligible channel. These records are written to the audit log only, and aren't surfaced anywhere in the Mattermost interface.
+    - **Record deliveries in**: Select **All channels**, or select **Selected channels** to limit recording to specific channels.
+    - **Channels to record deliveries in**: With **Selected channels** set, select the channels in which deliveries are recorded.
+
+    Direct and group message channels are never eligible, regardless of **Record deliveries in**. See [Post delivery audit logging](#post-delivery-audit-logging) for details.
+
 <Tip>
 
 We recommend enabling **Hide message from channel while it is being reviewed** and require comments from both reporters and reviewers to maintain transparency, accountability, and an auditable record of actions.
@@ -187,6 +195,52 @@ When any step reports **Partial** or **Failed**, the report displays an *incompl
 The post deletion report is the single source of truth for post-removal auditing. It isn't stored elsewhere in the System Console, so the reviewer thread containing the report should be retained in line with your organization's audit retention policy.
 
 </Note>
+
+## Post delivery audit logging
+
+From Mattermost v12.0, Mattermost can record an audit log entry for each delivery of a message in an eligible channel, so that you can establish which users, plugins, and outgoing webhooks a given message was delivered to. Direct and group message channels are never eligible. Delivery records add storage and processing cost, so enable them only where they're needed.
+
+<Note>
+
+Post delivery audit logging is currently in [Beta](/administration-guide/manage/feature-labels#beta).
+
+</Note>
+
+Delivery records are written to the audit log only. They aren't surfaced anywhere in the Mattermost interface, and they aren't included in any Mattermost report. To use them, ingest them with the same pipeline you use for the rest of your Mattermost audit log.
+
+<Important>
+
+Post delivery audit logging requires the [feature flag](https://developers.mattermost.com/contribute/more-info/server/feature-flags/#changing-feature-flag-values) `MM_FEATUREFLAGS_POSTDELIVERYTRACKING`, which is disabled by default, and a server restart after you enable it.
+
+</Important>
+
+<Warning>
+
+Delivery records are discarded unless an audit log target consumes the `audit-delivery` log level. Enabling the setting without configuring such a target records nothing, and Mattermost doesn't block the configuration. Configure the target first.
+
+</Warning>
+
+To enable post delivery audit logging:
+
+1.  Add an audit log target that consumes the `audit-delivery` log level. See [Post delivery audit logging](/administration-guide/comply/post-delivery-audit-logging).
+2.  Go to **System Console \> Site Configuration \> Data Spillage Handling**, and find **Post Delivery Audit Logging**.
+3.  Set **Enable post delivery audit logging** to **True**.
+4.  Set **Record deliveries in**:
+
+    - **All channels**: Deliveries are recorded in every eligible channel. This is the most complete option, and the most expensive.
+    - **Selected channels**: Deliveries are recorded only in the eligible channels you select. At least one channel is required.
+
+5.  With **Selected channels** set, use **Channels to record deliveries in** to select the channels. Direct and group message channels can't be selected. Recording starts when you save and applies to eligible message content delivered from then on, including existing messages delivered through later channel loads, searches, and fetches.
+
+**Enable post delivery audit logging** and **Record deliveries in** can also be configured via the [config.json file or through environment variables](/administration-guide/configure/site-configuration-settings#content-flagging).
+
+The list of channels isn't stored in `config.json`. Mattermost stores it in the database, so manage it either in the System Console or through the `/api/v4/delivery_tracking/config` API endpoints. A `PUT` request that omits `ChannelIds` leaves the stored list unchanged, and an empty array clears it. See the [Mattermost API reference](https://api.mattermost.com/).
+
+<Tip>
+
+See [Post delivery audit logging](/administration-guide/comply/post-delivery-audit-logging) for the format of a delivery record, every delivery mechanism that's recorded, what isn't recorded, and how to interpret the records.
+
+</Tip>
 
 ## Best practice recommendations
 

--- a/docs/main/administration-guide/manage/logging.mdx
+++ b/docs/main/administration-guide/manage/logging.mdx
@@ -403,7 +403,7 @@ Advanced logging options can be configured to:
 <Tabs>
 <TabItem value="multi-line-json" label="Multi-line JSON">
 
-In the example below, file output is written to `./logs/audit.log` in plain text and includes all audit log levels & events. Older logs are kept for 1 day, and up to a total of 10 backup log files are kept at a time. Logs are rotated using gzip when the maximum size of the log file reaches 500 MB. A maximum of 1000 audit records can be queued/buffered while writing to the file.
+In the example below, file output is written to `./logs/audit.log` in plain text and includes audit log levels 100-103 and their events. Older logs are kept for 1 day, and up to a total of 10 backup log files are kept at a time. Logs are rotated using gzip when the maximum size of the log file reaches 500 MB. A maximum of 1000 audit records can be queued/buffered while writing to the file.
 
 #### v11 or later
 
@@ -491,9 +491,9 @@ Advanced logging configuration can be pointed to a filespec to another configura
 
 The separate configuration file includes the multi-line JSON instead.
 
-In the example below, the first output is written to the console in plain text and includes all audit log levels, events, and command outputs. A pipe `|` delimiter is placed between fields.
+In the example below, the first output is written to the console in plain text and includes audit log levels 100-103, their events, and command outputs. A pipe `|` delimiter is placed between fields.
 
-A second output is written to `./logs/audit.log` in plain text in a machine-readable JSON format and includes all audit log levels, events, and command outputs. Older logs are kept for 1 day, and up to a total of 10 backup log files are kept at a time. Logs are rotated using GZIP when the maximum size of the log file reaches 500 MB. A maximum of 1000 audit records can be queued/buffered while writing to the file.
+A second output is written to `./logs/audit.log` in plain text in a machine-readable JSON format and includes audit log levels 100-103, their events, and command outputs. Older logs are kept for 1 day, and up to a total of 10 backup log files are kept at a time. Logs are rotated using GZIP when the maximum size of the log file reaches 500 MB. A maximum of 1000 audit records can be queued/buffered while writing to the file.
 
 Contents of `audit_log_config.json` file:
 

--- a/docs/main/administration-guide/manage/logging.mdx
+++ b/docs/main/administration-guide/manage/logging.mdx
@@ -60,6 +60,8 @@ From Mattermost v11.3, AdvancedLoggingJSON configuration includes enhanced valid
 - Audit logging configurations reject standard log levels (`debug`, `info`, `warn`, `error`, `fatal`, `panic`, etc.)
 - Configuration validation occurs at startup and when updating settings, preventing invalid log level combinations
 
+From Mattermost v12.0, standard logging configurations also reject the `audit-delivery` log level.
+
 </Note>
 
 ## Console logs
@@ -239,7 +241,7 @@ You can use the sample JSON below as a starting point.
 
 By default, Mattermost doesn't write audit logs locally to a file on the server, and the ability to enable audit logging in Mattermost is currently in [Beta](/administration-guide/manage/feature-labels#beta).
 
-You can enable and customize advanced audit logging in Mattermost to record activities and events performed within Mattermost, such as user access to the Mattermost REST API or mmctl. Audit logs are recorded asynchronously to reduce latency to the caller, and are stored separately from general logging. During short spans of inability to write to targets, the audit records buffer in memory with a configurable maximum record cap. Based on typical audit record volumes, it could take many minutes to fill the buffer. After that, the records are dropped, and the record drop event is logged.
+You can enable and customize advanced audit logging in Mattermost to record activities and events performed within Mattermost, such as user access to the Mattermost REST API or mmctl. Audit logs are recorded asynchronously to reduce latency to the caller, and are stored separately from general logging. During short spans of inability to write to targets, the audit records buffer in memory with a configurable maximum record cap. Based on typical audit record volumes, it could take many minutes to fill the buffer. After that, the records are dropped, and the record drop event is logged. From Mattermost v12.0, this shared audit queue holds up to 10,000 records, increased from 1,000. It's separate from the per-target `maxqueuesize` option, which caps the queue of an individual output target and is unchanged.
 
 <Note>
 
@@ -845,8 +847,19 @@ The following log levels support audit logs:
 <td><code>audit-cli</code></td>
 <td>CLI operations</td>
 </tr>
+<tr>
+<td>104</td>
+<td><code>audit-delivery</code></td>
+<td>Deliveries of message content to users, plugins, and outgoing webhooks in eligible channels. Direct and group message channels are never eligible. Available from Mattermost v12.0. This log level generates considerably more records than any other audit log level.</td>
+</tr>
 </tbody>
 </table>
+
+<Warning>
+
+The `audit-delivery` log level isn't written by the built-in audit log file target, so enabling `ExperimentalAuditSettings.FileEnabled` doesn't capture delivery records — they're discarded. To capture them, add a target whose `levels` list includes `{"id": 104, "name": "audit-delivery"}` to `ExperimentalAuditSettings.AdvancedLoggingJSON`. See [Post delivery audit logging](/administration-guide/comply/post-delivery-audit-logging).
+
+</Warning>
 
 The following log levels support application logs:
 

--- a/docs/site/scripts/gen-documentation-sidebar.mjs
+++ b/docs/site/scripts/gen-documentation-sidebar.mjs
@@ -844,6 +844,7 @@ const ADMIN_COMPLY_ORDER = [
   'legal-hold',
   'custom-terms-of-service',
   'embedded-json-audit-log-schema',
+  'post-delivery-audit-logging',
 ];
 
 const ADMIN_COMPLY_HIDDEN = new Set([]);


### PR DESCRIPTION
#### Summary
Added docs for post delivery audit logs.

This migrates [mattermost/docs#9142](https://github.com/mattermost/docs/pull/9142) into the monorepo `docs/` tree, converting the content from RST to MDX. The wording is carried over unchanged; only the markup and cross-references were converted:

- **New page** `docs/main/administration-guide/comply/post-delivery-audit-logging.mdx`, covering prerequisites, configuring an `audit-delivery` audit log target, the `postDelivered` record format, payload fields, delivery mechanisms, what isn't recorded, and how to interpret the records. Registered in `ADMIN_COMPLY_ORDER` in the sidebar generator (the monorepo equivalent of the RST `toctree` entry).
- **Compliance index** — new bullet for the page, and the updated description for the audit log JSON schema entry.
- **Audit log JSON schema** — new **Post Delivery Events** section documenting `postDelivered` and `updateDeliveryTrackingConfig`.
- **Logging** — the `audit-delivery` (ID `104`) log level, the warning that the built-in file target doesn't write delivery records, the larger shared audit queue, and that standard logging configs reject `audit-delivery`.
- **Site configuration settings** — the `DeliveryTrackingSettings` settings (`Enable`, `EnableForAllChannels`, and the database-backed channel list).
- **Environment configuration settings** — a note on the advanced audit logging target that delivery records need.
- **Data Spillage Handling** — the System Console steps for enabling post delivery audit logging.

Conversion notes:
- RST admonitions became the `<Note>` / `<Important>` / `<Warning>` / `<Tip>` MDX components, and the `entry-adv` badge include became `<PlanAvailability slug="entry-adv" />`.
- `:doc:` / `:ref:` cross-references became absolute paths with heading anchors.
- The `.. config:setting::` directives have no counterpart in the monorepo docs site (nothing in `docs/` uses them), so only the corresponding headings and settings tables were carried over.

Verified with `npm run build` in `docs/site` — the build succeeds and none of the new links or anchors appear in the broken-anchor warnings.

#### Ticket Link
Fixes https://mattermost.atlassian.net/browse/MM-69498

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The changes affect documentation and navigation metadata only. They do not modify application behavior, APIs, data persistence, or critical flows.

**QA Recommendation:** Skip manual product QA. Run the documentation build and link checks.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->