### PR TITLE
Fix errors in AD/LDAP documentation

### DIFF
--- a/docs/main/administration-guide/onboard/ad-ldap-groups-synchronization.mdx
+++ b/docs/main/administration-guide/onboard/ad-ldap-groups-synchronization.mdx
@@ -348,9 +348,11 @@ Only users that are members of groups synchronized to team are able to discover 
 
 ### Why don't users get readded to teams or channels once they have been removed from and then later re-added to the LDAP group?
 
-The implementation of group removals does not currently differentiate between users who have removed themselves or have been removed by the LDAP synchronization process. Our design optimizes for users who have removed themselves from a team or channel. In the future, we may add the ability for Admins to re-add users who have been removed and even prevent users from leaving a team or channel.
+By default, the implementation of group removals does not differentiate between users who have removed themselves or have been removed by the LDAP synchronization process. Our design optimizes for users who have removed themselves from a team or channel.
 
-Additionally, LDAP users who are not accessible to Mattermost based on filters will be removed from the groups and from group synced teams and channels. If they were removed from teams and channels then they would not be re-added to those teams and channels upon becoming subsequently reaccessible to Mattermost.
+From Mattermost v10.9, you can enable [Re-add Removed Members on Sync](/administration-guide/configure/authentication-configuration-settings#re-add-removed-members-on-sync) to have members who were previously removed by LDAP synchronization automatically re-added to group-synchronized teams or channels during a subsequent sync. This setting is disabled by default.
+
+Additionally, LDAP users who are not accessible to Mattermost based on filters will be removed from the groups and from group synced teams and channels. If they were removed from teams and channels then they would not be re-added to those teams and channels upon becoming subsequently reaccessible to Mattermost, unless Re-add Removed Members on Sync is enabled.
 
 ### How can I use LDAP attributes or Groups with OpenID?
 

--- a/docs/main/administration-guide/onboard/ad-ldap-groups-synchronization.mdx
+++ b/docs/main/administration-guide/onboard/ad-ldap-groups-synchronization.mdx
@@ -352,7 +352,7 @@ By default, the implementation of group removals does not differentiate between 
 
 From Mattermost v10.9, you can enable [Re-add Removed Members on Sync](/administration-guide/configure/authentication-configuration-settings#re-add-removed-members-on-sync) to have members who were previously removed by LDAP synchronization automatically re-added to group-synchronized teams or channels during a subsequent sync. This setting is disabled by default.
 
-Additionally, LDAP users who are not accessible to Mattermost based on filters will be removed from the groups and from group synced teams and channels. If they were removed from teams and channels then they would not be re-added to those teams and channels upon becoming subsequently reaccessible to Mattermost, unless Re-add Removed Members on Sync is enabled.
+Additionally, LDAP users who are inaccessible to Mattermost based on filters will be removed from the groups and from group-synced teams and channels. If they were removed from teams and channels then they would not be re-added to those teams and channels upon becoming subsequently reaccessible to Mattermost, unless Re-add Removed Members on Sync is enabled.
 
 ### How can I use LDAP attributes or Groups with OpenID?
 

--- a/docs/main/administration-guide/onboard/ad-ldap.mdx
+++ b/docs/main/administration-guide/onboard/ad-ldap.mdx
@@ -127,18 +127,6 @@ To configure AD/LDAP synchronization with AD/LDAP sign-in:
 
 3.  From Mattermost v10.9, you can configure Mattermost to automatically [re-add members of an LDAP group to group-synchronized teams or channels](/administration-guide/configure/authentication-configuration-settings#re-add-removed-members-on-sync) during LDAP synchronization, even if those members were previously removed. This option enables you to maintain uninterrupted collaboration and address specific organizational needs, ensuring users who were unintentionally removed due to changes in LDAP group membership, synchronization errors, or exceptions to the standard group sync rules can be seamlessly restored.
 
-> <div class="note">
->
-> <div class="title">
->
-> Note
->
-> </div>
->
-> The [mmctl ldap sync](/administration-guide/manage/mmctl-command-line-tool#mmctl-ldap-sync) command takes precedence over this server configuration setting. If you have this setting disabled, and run the mmctl command with the `--include-removed-members` flag, removed members will be re-added during LDAP synchronization.
->
-> </div>
-
 ## Configure AD/LDAP sign-in using filters
 
 Using filters assigns roles to specified users on login. To access AD/LDAP filter settings, navigate to **System Console \> Authentication \> AD/LDAP** to open the AD/LDAP wizard and go to the **User Filters** section.


### PR DESCRIPTION
#### Summary
Fixes two errors found in the AD/LDAP documentation:
- `ad-ldap.mdx` claimed the `mmctl ldap sync` command supports an `--include-removed-members` flag that overrides the `Re-add Removed Members on Sync` config setting. No such flag exists in `mmctl` — removed.
- `ad-ldap-groups-synchronization.mdx` FAQ stated that removed LDAP group members are never re-added to group-synchronized teams/channels, contradicting the `Re-add Removed Members on Sync` setting added in v10.9. Updated to reflect that this is now configurable.

#### Ticket Link
https://mattermost.rocketlane.com/#task_drawer=5000000018389.5000004864847&task_drawer_tab=conversations

#### Screenshots
N/A

#### Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The changes affect documentation only. They do not modify code, authentication, data persistence, APIs, or user-facing behavior.
**QA Recommendation:** Skip manual QA. Verify the updated documentation links and formatting.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->