### PR TITLE
MM-70595: Restrict advanced logging settings to non-API config sources

### DIFF
--- a/docs/main/administration-guide/configure/environment-configuration-settings.mdx
+++ b/docs/main/administration-guide/configure/environment-configuration-settings.mdx
@@ -2973,6 +2973,7 @@ Enable debug logs by changing the [file log level](#file-log-level) to `DEBUG` t
 - Logs are recorded asynchronously to reduce latency to the caller.
 - Advanced logging supports hot-reloading of logger configuration.
 - From Mattermost v11.4, file paths specified in `AdvancedLoggingJSON` configurations should be within the directory specified by the `MM_LOG_PATH` environment variable. See [log path restrictions](/administration-guide/manage/logging#log-path-restrictions) for details.
+- This setting can only be changed using `config.json`, an environment variable, or `mmctl --local`. It's read-only in the System Console, and a REST API request that tries to change it is silently ignored. See [settings that can't be changed through the API](/administration-guide/manage/logging#settings-that-cant-be-changed-through-the-api) for details.
 
 </Note>
 
@@ -3232,7 +3233,8 @@ When `FileEnabled` is set to **true**, then the [audit file name](#audit-file-na
 
 <Note>
 
-When [output audit logs to file](#output-audit-logs-to-file) is enabled, the file name must be set. To configure file rotation and advanced audit log output, use the [AdvancedLoggingJSON](#output-audit-logs-to-multiple-targets) setting.
+- When [output audit logs to file](#output-audit-logs-to-file) is enabled, the file name must be set. To configure file rotation and advanced audit log output, use the [AdvancedLoggingJSON](#output-audit-logs-to-multiple-targets) setting.
+- This setting can only be changed using `config.json`, an environment variable, or `mmctl --local`. It's read-only in the System Console, and a REST API request that tries to change it is silently ignored. See [settings that can't be changed through the API](/administration-guide/manage/logging#settings-that-cant-be-changed-through-the-api) for details.
 
 </Note>
 
@@ -3271,6 +3273,7 @@ When [output audit logs to file](#output-audit-logs-to-file) is enabled, the fil
 - See the [Mattermost logging](/administration-guide/manage/logging) documentation for details on advanced logging configuration. These targets have been chosen as they support the vast majority of log aggregators, and other log analysis tools, without needing additional software installed.
 - Audit logs are recorded asynchronously to reduce latency to the caller.
 - Advanced audit logging supports hot-reloading of logger configuration.
+- This setting can only be changed using `config.json`, an environment variable, or `mmctl --local`. It's read-only in the System Console, and a REST API request that tries to change it is silently ignored. See [settings that can't be changed through the API](/administration-guide/manage/logging#settings-that-cant-be-changed-through-the-api) for details.
 
 </Note>
 

--- a/docs/main/administration-guide/manage/logging.mdx
+++ b/docs/main/administration-guide/manage/logging.mdx
@@ -373,6 +373,18 @@ See the [troubleshooting](/deployment-guide/server/troubleshooting#log-files-not
 
 ------------------------------------------------------------------------------------------------------------------------
 
+## Settings that can't be changed through the API
+
+The following settings can only be changed using `config.json`, an environment variable, or `mmctl --local`:
+
+- `LogSettings.AdvancedLoggingJSON`
+- `ExperimentalAuditSettings.AdvancedLoggingJSON`
+- `ExperimentalAuditSettings.FileName`
+
+They're read-only in the System Console. The REST API accepts a request that tries to change them but it silently keeps the stored value, so a remote `mmctl config set` on one of these settings reports success without changing anything.
+
+------------------------------------------------------------------------------------------------------------------------
+
 ## Advanced logging
 
 <PlanAvailability slug="entry-ent" />

--- a/server/channels/api4/config.go
+++ b/server/channels/api4/config.go
@@ -162,6 +162,15 @@ func updateConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 	// Do not allow import directory to be changed through the API
 	*cfg.ImportSettings.Directory = *appCfg.ImportSettings.Directory
 
+	// Do not allow the advanced logging configuration, or the audit log file name, to be
+	// changed through the API: they choose which files the server writes to. They are managed
+	// via the configuration file, environment variables, or mmctl --local.
+	// The json.RawMessage assignments shallow-copy the slice header. So be careful if there
+	// are concurrent modifications to the slice.
+	cfg.LogSettings.AdvancedLoggingJSON = appCfg.LogSettings.AdvancedLoggingJSON
+	cfg.ExperimentalAuditSettings.AdvancedLoggingJSON = appCfg.ExperimentalAuditSettings.AdvancedLoggingJSON
+	*cfg.ExperimentalAuditSettings.FileName = *appCfg.ExperimentalAuditSettings.FileName
+
 	// Do not allow marketplace URL to be toggled through the API if EnableUploads are disabled.
 	if cfg.PluginSettings.EnableUploads != nil && !*appCfg.PluginSettings.EnableUploads {
 		*cfg.PluginSettings.MarketplaceURL = *appCfg.PluginSettings.MarketplaceURL
@@ -318,6 +327,18 @@ func patchConfig(c *Context, w http.ResponseWriter, r *http.Request) {
 		c.Err = model.NewAppError("patchConfig", "api.config.update_config.not_allowed_security.app_error", map[string]any{"Name": "ImportSettings.Directory"}, "", http.StatusForbidden)
 		return
 	}
+
+	// Do not allow the advanced logging configuration, or the audit log file name, to be
+	// changed through the API: they choose which files the server writes to. They are managed
+	// via the configuration file, environment variables, or mmctl --local.
+	//
+	// Dropping them from the patch makes the merge below keep the stored values, mirroring the
+	// full update endpoint. Rejecting instead is not an option here: the System Console
+	// resubmits the whole config on every save, and a nil json.RawMessage still serializes as
+	// null, so these fields arrive on saves that have nothing to do with logging.
+	cfg.LogSettings.AdvancedLoggingJSON = nil
+	cfg.ExperimentalAuditSettings.AdvancedLoggingJSON = nil
+	cfg.ExperimentalAuditSettings.FileName = nil
 
 	// Do not allow marketplace URL to be toggled if plugin uploads are disabled.
 	if cfg.PluginSettings.MarketplaceURL != nil && cfg.PluginSettings.EnableUploads != nil {

--- a/server/channels/api4/config_test.go
+++ b/server/channels/api4/config_test.go
@@ -340,6 +340,50 @@ func TestUpdateConfig(t *testing.T) {
 		})
 	})
 
+	t.Run("Should not be able to modify logging settings that resolve to filesystem paths", func(t *testing.T) {
+		advancedLogging := json.RawMessage(`{"pwned":{"type":"file","format":"plain","levels":[{"id":5,"name":"debug"}],"options":{"filename":"/tmp/pwned.log"}}}`)
+
+		// Audit targets are validated against the audit levels, so they cannot reuse the
+		// standard levels above.
+		advancedAuditLogging := json.RawMessage(`{"pwned":{"type":"file","format":"plain","levels":[{"id":100,"name":"audit-api"}],"options":{"filename":"/tmp/pwned-audit.log"}}}`)
+
+		t.Run("sysadmin", func(t *testing.T) {
+			oldLogging := th.App.Config().LogSettings.AdvancedLoggingJSON
+			oldAuditLogging := th.App.Config().ExperimentalAuditSettings.AdvancedLoggingJSON
+			oldAuditFileName := *th.App.Config().ExperimentalAuditSettings.FileName
+
+			cfg2 := th.App.Config().Clone()
+			cfg2.LogSettings.AdvancedLoggingJSON = advancedLogging
+			cfg2.ExperimentalAuditSettings.AdvancedLoggingJSON = advancedAuditLogging
+			*cfg2.ExperimentalAuditSettings.FileName = "/tmp/pwned-audit.log"
+
+			cfg2, _, err = th.SystemAdminClient.UpdateConfig(context.Background(), cfg2)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(oldLogging), string(cfg2.LogSettings.AdvancedLoggingJSON))
+			assert.JSONEq(t, string(oldAuditLogging), string(cfg2.ExperimentalAuditSettings.AdvancedLoggingJSON))
+			assert.Equal(t, oldAuditFileName, *cfg2.ExperimentalAuditSettings.FileName)
+
+			assert.JSONEq(t, string(oldLogging), string(th.App.Config().LogSettings.AdvancedLoggingJSON))
+			assert.JSONEq(t, string(oldAuditLogging), string(th.App.Config().ExperimentalAuditSettings.AdvancedLoggingJSON))
+			assert.Equal(t, oldAuditFileName, *th.App.Config().ExperimentalAuditSettings.FileName)
+		})
+
+		t.Run("local mode", func(t *testing.T) {
+			oldLogging := th.App.Config().LogSettings.AdvancedLoggingJSON
+			defer th.App.UpdateConfig(func(cfg *model.Config) {
+				cfg.LogSettings.AdvancedLoggingJSON = oldLogging
+			})
+
+			cfg2 := th.App.Config().Clone()
+			cfg2.LogSettings.AdvancedLoggingJSON = advancedLogging
+
+			cfg2, _, err = th.LocalClient.UpdateConfig(context.Background(), cfg2)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(advancedLogging), string(cfg2.LogSettings.AdvancedLoggingJSON))
+			assert.JSONEq(t, string(advancedLogging), string(th.App.Config().LogSettings.AdvancedLoggingJSON))
+		})
+	})
+
 	t.Run("System Admin should not be able to clear Site URL", func(t *testing.T) {
 		siteURL := cfg.ServiceSettings.SiteURL
 		defer th.App.UpdateConfig(func(cfg *model.Config) { cfg.ServiceSettings.SiteURL = siteURL })
@@ -881,6 +925,104 @@ func TestPatchConfig(t *testing.T) {
 				})
 			}
 		})
+
+		t.Run("not allowing to change logging paths via api, unless local mode", func(t *testing.T) {
+			advancedLogging := json.RawMessage(`{"pwned":{"type":"file","format":"plain","levels":[{"id":5,"name":"debug"}],"options":{"filename":"/tmp/pwned.log"}}}`)
+
+			// Audit targets are validated against the audit levels, so they cannot reuse the
+			// standard levels above.
+			advancedAuditLogging := json.RawMessage(`{"pwned":{"type":"file","format":"plain","levels":[{"id":100,"name":"audit-api"}],"options":{"filename":"/tmp/pwned-audit.log"}}}`)
+
+			for name, config := range map[string]model.Config{
+				"LogSettings.AdvancedLoggingJSON": {LogSettings: model.LogSettings{
+					AdvancedLoggingJSON: advancedLogging,
+				}},
+				"ExperimentalAuditSettings.AdvancedLoggingJSON": {ExperimentalAuditSettings: model.ExperimentalAuditSettings{
+					AdvancedLoggingJSON: advancedAuditLogging,
+				}},
+				"ExperimentalAuditSettings.FileName": {ExperimentalAuditSettings: model.ExperimentalAuditSettings{
+					FileName: new("/tmp/pwned-audit.log"),
+				}},
+			} {
+				t.Run(name, func(t *testing.T) {
+					oldCfg := th.App.Config().Clone()
+					defer th.App.UpdateConfig(func(cfg *model.Config) {
+						cfg.LogSettings.AdvancedLoggingJSON = oldCfg.LogSettings.AdvancedLoggingJSON
+						cfg.ExperimentalAuditSettings.AdvancedLoggingJSON = oldCfg.ExperimentalAuditSettings.AdvancedLoggingJSON
+						*cfg.ExperimentalAuditSettings.FileName = *oldCfg.ExperimentalAuditSettings.FileName
+					})
+
+					// The request always succeeds: through the API the setting is silently kept
+					// at its stored value, while local mode applies it.
+					_, resp, err := client.PatchConfig(context.Background(), &config)
+					require.NoError(t, err)
+					CheckOKStatus(t, resp)
+
+					newCfg := th.App.Config()
+					if client == th.LocalClient {
+						assert.NotEqual(t, string(oldCfg.LogSettings.AdvancedLoggingJSON)+string(oldCfg.ExperimentalAuditSettings.AdvancedLoggingJSON)+*oldCfg.ExperimentalAuditSettings.FileName,
+							string(newCfg.LogSettings.AdvancedLoggingJSON)+string(newCfg.ExperimentalAuditSettings.AdvancedLoggingJSON)+*newCfg.ExperimentalAuditSettings.FileName,
+							"local mode should have applied the change")
+						return
+					}
+
+					assert.Equal(t, string(oldCfg.LogSettings.AdvancedLoggingJSON), string(newCfg.LogSettings.AdvancedLoggingJSON))
+					assert.Equal(t, string(oldCfg.ExperimentalAuditSettings.AdvancedLoggingJSON), string(newCfg.ExperimentalAuditSettings.AdvancedLoggingJSON))
+					assert.Equal(t, *oldCfg.ExperimentalAuditSettings.FileName, *newCfg.ExperimentalAuditSettings.FileName)
+				})
+			}
+		})
+
+	})
+
+	// Both logging subtests below run against this stored value.
+	storedAdvancedLogging := json.RawMessage(`{"file1":{"type":"file","format":"json","levels":[{"id":5,"name":"debug"}],"options":{"filename":"mattermost.log"}}}`)
+	storeAdvancedLogging := func(t *testing.T) {
+		oldLogging := th.App.Config().LogSettings.AdvancedLoggingJSON
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.LogSettings.AdvancedLoggingJSON = storedAdvancedLogging
+		})
+		t.Cleanup(func() {
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				cfg.LogSettings.AdvancedLoggingJSON = oldLogging
+			})
+		})
+	}
+
+	t.Run("patching a logging path setting keeps the stored value whatever is submitted", func(t *testing.T) {
+		stored := storedAdvancedLogging
+		storeAdvancedLogging(t)
+
+		for name, submitted := range map[string]json.RawMessage{
+			// An attempt to change the setting.
+			"different filename": json.RawMessage(`{"file1":{"type":"file","format":"json","levels":[{"id":5,"name":"debug"}],"options":{"filename":"/tmp/pwned.log"}}}`),
+			"additional target":  json.RawMessage(`{"file1":{"type":"file","format":"json","levels":[{"id":5,"name":"debug"}],"options":{"filename":"mattermost.log"}},"file2":{"type":"file","format":"json","levels":[{"id":5,"name":"debug"}],"options":{"filename":"/tmp/pwned.log"}}}`),
+			"non-object JSON":    json.RawMessage(`"/tmp/advancedlogging.conf"`),
+			"cleared":            json.RawMessage(`{}`),
+
+			// Shapes that arrive on saves which have nothing to do with logging, because the
+			// System Console resubmits the whole config every time. "null" is also what any typed
+			// client sends when it isn't setting the field: it has no omitempty, so a nil
+			// json.RawMessage still serializes as null.
+			"reformatted and reordered": json.RawMessage("{\n  \"file1\": {\n    \"format\": \"json\",\n    \"levels\": [{\"name\": \"debug\", \"id\": 5}],\n    \"options\": {\"filename\": \"mattermost.log\"},\n    \"type\": \"file\"\n  }\n}"),
+			"null":                      json.RawMessage(`null`),
+			"nil raw json":              nil,
+			"identical":                 stored,
+		} {
+			t.Run(name, func(t *testing.T) {
+				config := model.Config{LogSettings: model.LogSettings{
+					AdvancedLoggingJSON: submitted,
+				}}
+
+				_, resp, err := th.SystemAdminClient.PatchConfig(context.Background(), &config)
+				require.NoError(t, err)
+				CheckOKStatus(t, resp)
+
+				// The stored value must survive byte-for-byte, so a patch can neither change the
+				// setting nor rewrite its representation.
+				assert.Equal(t, string(stored), string(th.App.Config().LogSettings.AdvancedLoggingJSON))
+			})
+		}
 	})
 
 	t.Run("Should not be able to modify PluginSettings.MarketplaceURL if EnableUploads is disabled", func(t *testing.T) {

--- a/server/channels/api4/config_test.go
+++ b/server/channels/api4/config_test.go
@@ -972,7 +972,6 @@ func TestPatchConfig(t *testing.T) {
 				})
 			}
 		})
-
 	})
 
 	// Both logging subtests below run against this stored value.

--- a/webapp/channels/src/components/admin_console/admin_definition.tsx
+++ b/webapp/channels/src/components/admin_console/admin_definition.tsx
@@ -2185,7 +2185,8 @@ const AdminDefinition: AdminDefinitionType = {
                                 ),
                             },
                             placeholder: defineMessage({id: 'admin.log.AdvancedLoggingJSONPlaceholder', defaultMessage: 'Enter your JSON configuration'}),
-                            isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.ENVIRONMENT.LOGGING)),
+                            isDisabled: true,
+                            isManagedExternally: true,
                             validate: (value) => {
                                 const valid = new ValidationResult(true, '');
                                 if (!value) {
@@ -6561,7 +6562,17 @@ const AdminDefinition: AdminDefinitionType = {
                             key: 'ExperimentalAuditSettings.FileEnabled',
                             label: defineMessage({id: 'admin.audit_logging_experimental.file_enabled.title', defaultMessage: 'File Enabled'}),
                             help_text: defineMessage({id: 'admin.audit_logging_experimental.file_enabled.help_text', defaultMessage: 'Choose whether audit logs are written locally to a file or not.'}),
-                            isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
+                            isDisabled: it.any(
+                                it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
+
+                                // Enabling this requires a file name, which is not writable through
+                                // the System Console, so without one the page could not be saved.
+                                // Turning it back off stays available.
+                                it.all(
+                                    it.configIsFalse('ExperimentalAuditSettings', 'FileEnabled'),
+                                    it.configIsFalse('ExperimentalAuditSettings', 'FileName'),
+                                ),
+                            ),
                             isHidden: it.licensedForFeature('Cloud'),
                         },
                         {
@@ -6569,10 +6580,8 @@ const AdminDefinition: AdminDefinitionType = {
                             key: 'ExperimentalAuditSettings.FileName',
                             label: defineMessage({id: 'admin.audit_logging_experimental.file_name.title', defaultMessage: 'File Name'}),
                             help_text: defineMessage({id: 'admin.audit_logging_experimental.file_name.help_text', defaultMessage: 'The name of the file to write to.'}),
-                            isDisabled: it.any(
-                                it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
-                                it.stateIsFalse('ExperimentalAuditSettings.FileEnabled'),
-                            ),
+                            isDisabled: true,
+                            isManagedExternally: true,
                             isHidden: it.licensedForFeature('Cloud'),
                         },
                         {
@@ -6592,7 +6601,8 @@ const AdminDefinition: AdminDefinitionType = {
                                 ),
                             },
                             placeholder: defineMessage({id: 'admin.log.AdvancedLoggingJSONPlaceholder', defaultMessage: 'Enter your JSON configuration'}),
-                            isDisabled: it.not(it.userHasWritePermissionOnResource(RESOURCE_KEYS.EXPERIMENTAL.FEATURES)),
+                            isDisabled: true,
+                            isManagedExternally: true,
                             validate: (value) => {
                                 const valid = new ValidationResult(true, '');
                                 if (!value) {

--- a/webapp/channels/src/components/admin_console/managed_externally.tsx
+++ b/webapp/channels/src/components/admin_console/managed_externally.tsx
@@ -1,0 +1,16 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+export default function ManagedExternally(): JSX.Element {
+    return (
+        <div className='alert alert-warning'>
+            <FormattedMessage
+                id='admin.managed_externally'
+                defaultMessage='This setting can only be changed through the configuration file, an environment variable, or mmctl --local. It cannot be changed through the System Console.'
+            />
+        </div>
+    );
+}

--- a/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
+++ b/webapp/channels/src/components/admin_console/schema_admin_settings.tsx
@@ -24,6 +24,7 @@ import DropdownSetting from 'components/admin_console/dropdown_setting';
 import FileUploadSetting from 'components/admin_console/file_upload_setting';
 import GeneratedSetting from 'components/admin_console/generated_setting';
 import JobsTable from 'components/admin_console/jobs';
+import ManagedExternally from 'components/admin_console/managed_externally';
 import MultiSelectSetting from 'components/admin_console/multiselect_settings';
 import RadioSetting from 'components/admin_console/radio_setting';
 import RemoveFileSetting from 'components/admin_console/remove_file_setting';
@@ -686,7 +687,7 @@ export class SchemaAdminSettings extends React.PureComponent<SchemaAdminSettings
             value = this.state[setting.key] ?? (typeof setting.default === 'function' ? setting.default(value, this.props.config, this.state) : setting.default || '');
         }
 
-        let footer = null;
+        let footer = setting.isManagedExternally ? <ManagedExternally/> : null;
         if (setting.validate) {
             const err = setting.validate(value).error(this.props.intl);
             footer = err ? (

--- a/webapp/channels/src/components/admin_console/types.ts
+++ b/webapp/channels/src/components/admin_console/types.ts
@@ -60,6 +60,11 @@ type AdminDefinitionSettingBase = {
     isHidden?: Check;
     isDisabled?: Check;
 
+    // Renders a notice that the setting is only writable through the configuration file, an
+    // environment variable or mmctl --local. Only wired for the text, longtext and number
+    // settings built by buildTextSetting in schema_admin_settings; ignored by other types.
+    isManagedExternally?: boolean;
+
     // Danger callout when isEnabled is true. Wired for bool/text settings in schema_admin_settings and ldap_boolean_setting.
     production_warning?: AdminDefinitionSettingProductionWarning;
 };

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -2232,6 +2232,7 @@
   "admin.manage_tokens.userAccessTokensIdLabel": "Token ID: ",
   "admin.manage_tokens.userAccessTokensNameLabel": "Token Description: ",
   "admin.manage_tokens.userAccessTokensNone": "No personal access tokens.",
+  "admin.managed_externally": "This setting can only be changed through the configuration file, an environment variable, or mmctl --local. It cannot be changed through the System Console.",
   "admin.member_list_group.name": "Name",
   "admin.member_list_group.notFound": "No users found",
   "admin.membership_policies.page_title": "Membership Policies",


### PR DESCRIPTION
#### Summary

The advanced logging settings determine which files the server writes to, so they are infrastructure-level configuration rather than application configuration. This restricts them to the configuration file, environment variables, and `mmctl --local`:

- `LogSettings.AdvancedLoggingJSON`
- `ExperimentalAuditSettings.AdvancedLoggingJSON`
- `ExperimentalAuditSettings.FileName`

Both `PUT /api/v4/config` and `PUT /api/v4/config/patch` now keep the stored value instead of applying a submitted one, following the existing `PluginSettings.SignaturePublicKeyFiles` precedent in the same handlers. Rejecting the request outright is not viable: the System Console resubmits the whole config on every save, and these fields have no `omitempty`, so a client that never sets them still sends `null` — a reject rule would fail unrelated config saves.

Local mode is unaffected: `config_local.go` has its own handlers, so `mmctl --local` retains full write access. Environment variables already take precedence, since the config store re-applies them on every save.

In the System Console the three fields are read-only, with a notice pointing at the supported config sources. `ExperimentalAuditSettings.FileEnabled` is additionally disabled while no file name is configured, because enabling it without one produces a validation error the admin cannot resolve from the console.

QA steps:

1. `PUT /api/v4/config/patch` changing any of the three settings → 200, stored value unchanged.
2. Same change via `mmctl --local config patch` → applied.
3. `PUT /api/v4/config` with a modified value → 200, value unchanged.
4. In **System Console > Environment > Logging** and **Compliance > Audit Logging**, confirm the fields are read-only and that saving other settings on those pages still succeeds.

#### Screenshots

| Before | After |
|--------|--------|
| <img width="1200" height="1223" alt="mm70595-audit-before" src="https://github.com/user-attachments/assets/4be20801-daed-45b2-9743-538083b81edf" /> | <img width="1200" height="1223" alt="mm70595-audit-after" src="https://github.com/user-attachments/assets/6e128740-f3aa-4d88-b149-02f06e94589e" /> |
| <img width="920" height="164" alt="mm70595-before-advanced-logging" src="https://github.com/user-attachments/assets/3c3ba9ca-455d-4d6a-a21b-74eeaba2b79f" /> | <img width="920" height="230" alt="mm70595-after-advanced-logging" src="https://github.com/user-attachments/assets/56be65aa-1820-400b-b46e-7366e9555dbd" /> |
| <img width="1680" height="1050" alt="mm70595-before-logging-page" src="https://github.com/user-attachments/assets/d3c88da7-9f68-48f1-9640-ec9242c6cb5e" /> | <img width="1680" height="1050" alt="mm70595-after-logging-page" src="https://github.com/user-attachments/assets/8138ae96-8022-415f-baed-f304b1372f1f" /> | 

#### Ticket Link

Fixes: https://mattermost.atlassian.net/browse/MM-70595

#### Release Note

```release-note
Restricted LogSettings.AdvancedLoggingJSON, ExperimentalAuditSettings.AdvancedLoggingJSON and ExperimentalAuditSettings.FileName to the configuration file, environment variables and mmctl --local. These settings are now read-only in the System Console, and REST API requests that change them keep the stored value.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The changes span REST API configuration handling and System Console settings. Automated tests cover the affected API paths, but configuration-source precedence and UI behavior remain user-facing risks.
**QA Recommendation:** Manual QA is not required. Rely on the automated coverage.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->