### PR TITLE
Prepackage mattermost-plugin-agents v2.4.5 (release-11.9)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -163,7 +163,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.1
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.10.1
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.4
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.5
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.1
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.6.2
@@ -177,7 +177,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.10.1%2B42a4753-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.4%2B8db0426-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.4.5%2B26dcb2b-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.3.1%2B29b4688-fips
 endif
 


### PR DESCRIPTION
#### Summary

Updates the default prepackaged [mattermost-plugin-agents](https://github.com/mattermost/mattermost-plugin-agents) artifact from **2.4.4** to **2.4.5** ([release v2.4.5](https://github.com/mattermost/mattermost-plugin-agents/releases/tag/v2.4.5)) for the `release-11.9` branch.

Both prepackaged plugin lists are updated:
- non-FIPS: `mattermost-plugin-agents-v2.4.5`
- FIPS: `mattermost-plugin-agents-v2.4.5%2B26dcb2b-fips` (`26dcb2b` is the tagged release commit)

Bundles verified on `plugins.releases.mattermost.com`.

#### Release Note

```release-note
Prepackaged the Mattermost Agents plugin at version 2.4.5 instead of 2.4.4.
```

Made with [Cursor](https://cursor.com)