### PR TITLE
Automated cherry pick of #38415

### DIFF
--- a/e2e-tests/playwright/specs/functional/system_console/abac/policies/ranked_operators.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/policies/ranked_operators.spec.ts
@@ -9,6 +9,7 @@
  * (is exactly, is not, is at least, is greater than, is at most, is less than).
  */
 
+import type {Page} from '@playwright/test';
 import type {Client4} from '@mattermost/client';
 import type {UserProfile} from '@mattermost/types/users';
 import type {UserPropertyField} from '@mattermost/types/properties';
@@ -16,6 +17,34 @@ import type {UserPropertyField} from '@mattermost/types/properties';
 import {expect, getRandomId, test} from '@mattermost/playwright-lib';
 
 import {deleteCustomProfileAttributes} from '../../../channels/custom_profile_attributes/helpers';
+import {assertAccessControlAutocompleteContains} from '../support';
+
+// Filter + real click so an off-screen ranked field is selected; click the
+// policy name to dismiss a leftover MUI overlay (the filter swallows Escape).
+async function selectAttributeInEditor(page: Page, attributeName: string) {
+    const attributeMenu = page.locator('[id^="attribute-selector-menu"]');
+    const attributeButton = page.locator('[data-testid="attributeSelectorMenuButton"]').first();
+
+    if (!(await attributeMenu.isVisible({timeout: 2000}).catch(() => false))) {
+        await attributeButton.click();
+    }
+    await expect(attributeMenu).toBeVisible();
+
+    const filterInput = attributeMenu.locator('.attribute-selector-search input');
+    await filterInput.waitFor({state: 'visible'});
+    await filterInput.fill(attributeName);
+
+    const option = attributeMenu.getByRole('menuitemradio', {name: attributeName, exact: true});
+    await expect(option).toBeVisible();
+    await option.click();
+
+    await expect(attributeButton).toContainText(attributeName);
+
+    if (await attributeMenu.isVisible().catch(() => false)) {
+        await page.locator('#admin\\.access_control\\.policy\\.edit_policy\\.policyName').click();
+    }
+    await expect(attributeMenu).toBeHidden();
+}
 
 test.describe('System Console - Membership Policy ranked operators', () => {
     let adminClient: Client4;
@@ -49,6 +78,8 @@ test.describe('System Console - Membership Policy ranked operators', () => {
         await adminClient.patchConfig({
             AccessControlSettings: {EnableAttributeBasedAccessControl: true},
         } as any);
+
+        await assertAccessControlAutocompleteContains(adminClient, [field.name]);
     });
 
     test.afterEach(async () => {
@@ -96,17 +127,7 @@ test.describe('System Console - Membership Policy ranked operators', () => {
         await addAttributeButton.click();
 
         // # Select the ranked attribute by name
-        const attributeButton = page.locator('[data-testid="attributeSelectorMenuButton"]').first();
-        if (!(await page.locator('[id^="attribute-selector-menu"]').isVisible({timeout: 2000}))) {
-            await attributeButton.click();
-        }
-        await page
-            .locator(`[id^="attribute-selector-menu"] li:has-text("${field!.name}")`)
-            .first()
-            .click({force: true});
-
-        // # Let the attribute menu and its backdrop fully close before opening the next menu
-        await expect(page.locator('[id^="attribute-selector-menu"]')).toBeHidden();
+        await selectAttributeInEditor(page, field!.name);
 
         // * The row defaults to the canonical ranked operator, "is at least"
         const operatorButton = page.locator('[data-testid="operatorSelectorMenuButton"]').first();
@@ -161,14 +182,8 @@ test.describe('System Console - Membership Policy ranked operators', () => {
             }
             await addAttributeButton.click();
 
-            if (!(await page.locator('[id^="attribute-selector-menu"]').isVisible({timeout: 2000}))) {
-                await page.locator('[data-testid="attributeSelectorMenuButton"]').first().click();
-            }
-            await page
-                .locator(`[id^="attribute-selector-menu"] li:has-text("${field!.name}")`)
-                .first()
-                .click({force: true});
-            await expect(page.locator('[id^="attribute-selector-menu"]')).toBeHidden();
+            // # Select the ranked attribute by name
+            await selectAttributeInEditor(page, field!.name);
 
             // * Defaults to "is at least"
             await expect(page.locator('[data-testid="operatorSelectorMenuButton"]').first()).toContainText(


### PR DESCRIPTION
Cherry pick of #38415 on release-11.9.

/cc  @saturninoabril

```release-note
NONE
```