### PR TITLE
MM-70676: Rework file metadata preparation for post retrieval, channel bookmarks, and notification delivery

### DIFF
--- a/server/channels/api4/channel_bookmark.go
+++ b/server/channels/api4/channel_bookmark.go
@@ -6,6 +6,7 @@ package api4
 import (
 	"encoding/json"
 	"net/http"
+	"slices"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/public/shared/mlog"
@@ -479,8 +480,12 @@ func listChannelBookmarksForChannel(c *Context, w http.ResponseWriter, r *http.R
 		model.AddEventParameterToAuditRec(auditRec, "non_channel_member_access", true)
 	}
 
+	hasFileInfo := slices.ContainsFunc(bookmarks, func(bookmark *model.ChannelBookmarkWithFileInfo) bool {
+		return bookmark != nil && bookmark.FileInfo != nil
+	})
+
 	// All bookmarks belong to the same channel, so a single evaluation covers the response.
-	if !c.App.HasPermissionToFileAction(c.AppContext, c.AppContext.Session().UserId, c.AppContext.Session().Roles, c.Params.ChannelId, model.AccessControlPolicyActionDownloadFileAttachment) {
+	if hasFileInfo && !c.App.HasPermissionToFileAction(c.AppContext, c.AppContext.Session().UserId, c.AppContext.Session().Roles, c.Params.ChannelId, model.AccessControlPolicyActionDownloadFileAttachment) {
 		stripped := make([]*model.ChannelBookmarkWithFileInfo, len(bookmarks))
 		for i, bookmark := range bookmarks {
 			bookmarkCopy := bookmark.Clone()

--- a/server/channels/api4/channel_bookmark.go
+++ b/server/channels/api4/channel_bookmark.go
@@ -479,6 +479,17 @@ func listChannelBookmarksForChannel(c *Context, w http.ResponseWriter, r *http.R
 		model.AddEventParameterToAuditRec(auditRec, "non_channel_member_access", true)
 	}
 
+	// All bookmarks belong to the same channel, so a single evaluation covers the response.
+	if !c.App.HasPermissionToFileAction(c.AppContext, c.AppContext.Session().UserId, c.AppContext.Session().Roles, c.Params.ChannelId, model.AccessControlPolicyActionDownloadFileAttachment) {
+		stripped := make([]*model.ChannelBookmarkWithFileInfo, len(bookmarks))
+		for i, bookmark := range bookmarks {
+			bookmarkCopy := bookmark.Clone()
+			bookmarkCopy.FileInfo = nil
+			stripped[i] = bookmarkCopy
+		}
+		bookmarks = stripped
+	}
+
 	if err := json.NewEncoder(w).Encode(bookmarks); err != nil {
 		c.Logger.Warn("Error while writing response", mlog.Err(err))
 	}

--- a/server/channels/api4/channel_bookmark_test.go
+++ b/server/channels/api4/channel_bookmark_test.go
@@ -11,6 +11,9 @@ import (
 	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	einterfacesmocks "github.com/mattermost/mattermost/server/v8/einterfaces/mocks"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -1784,5 +1787,129 @@ func TestBoardChannelBookmarkAPIReadonly(t *testing.T) {
 		require.NotNil(t, found)
 		require.Equal(t, model.ChannelBookmarkBoard, found.Type)
 		require.Equal(t, boardTargetID, found.TargetId)
+	})
+}
+
+func TestListChannelBookmarksForChannelFileInfoABAC(t *testing.T) {
+	th := SetupConfig(t, func(cfg *model.Config) {
+		cfg.FeatureFlags.PermissionPolicies = true
+		cfg.AccessControlSettings.EnableAttributeBasedAccessControl = model.NewPointer(true)
+	}).InitBasic(t)
+
+	th.App.Srv().SetLicense(model.NewTestLicense())
+	th.Context.Session().UserId = th.BasicUser.Id
+
+	mockDownloadDecision := func(t *testing.T, allowed bool) {
+		t.Helper()
+
+		mockACS := &einterfacesmocks.AccessControlServiceInterface{}
+		mockACS.On("AccessEvaluation", mock.Anything, mock.MatchedBy(func(req model.AccessRequest) bool {
+			return req.Action == model.AccessControlPolicyActionDownloadFileAttachment
+		})).Return(model.AccessDecision{Decision: allowed}, (*model.AppError)(nil))
+
+		original := th.App.Srv().Channels().AccessControl
+		th.App.Srv().Channels().AccessControl = mockACS
+		t.Cleanup(func() {
+			th.App.Srv().Channels().AccessControl = original
+		})
+	}
+
+	miniPreview := []byte{1, 2, 3, 4}
+	file := &model.FileInfo{
+		Id:              model.NewId(),
+		ChannelId:       th.BasicChannel.Id,
+		CreatorId:       model.BookmarkFileOwner,
+		Path:            "somepath",
+		ThumbnailPath:   "thumbpath",
+		PreviewPath:     "prevPath",
+		Name:            "bookmark-secret.png",
+		Extension:       "png",
+		MimeType:        "image/png",
+		Size:            873182,
+		Width:           3076,
+		Height:          2200,
+		HasPreviewImage: true,
+		MiniPreview:     &miniPreview,
+	}
+	_, err := th.App.Srv().Store().FileInfo().Save(th.Context, file)
+	require.NoError(t, err)
+
+	fileBookmark, appErr := th.App.CreateChannelBookmark(th.Context, &model.ChannelBookmark{
+		ChannelId:   th.BasicChannel.Id,
+		DisplayName: "File bookmark",
+		Type:        model.ChannelBookmarkFile,
+		FileId:      file.Id,
+	}, "")
+	require.Nil(t, appErr)
+
+	linkBookmark, appErr := th.App.CreateChannelBookmark(th.Context, &model.ChannelBookmark{
+		ChannelId:   th.BasicChannel.Id,
+		DisplayName: "Link bookmark",
+		Type:        model.ChannelBookmarkLink,
+		LinkUrl:     "https://mattermost.com",
+	}, "")
+	require.Nil(t, appErr)
+
+	byID := func(t *testing.T, bookmarks []*model.ChannelBookmarkWithFileInfo) map[string]*model.ChannelBookmarkWithFileInfo {
+		t.Helper()
+		out := map[string]*model.ChannelBookmarkWithFileInfo{}
+		for _, bookmark := range bookmarks {
+			out[bookmark.Id] = bookmark
+		}
+		return out
+	}
+
+	t.Run("file info is stripped when the policy denies the download action", func(t *testing.T) {
+		mockDownloadDecision(t, false)
+
+		bookmarks, resp, err := th.Client.ListChannelBookmarksForChannel(context.Background(), th.BasicChannel.Id, 0)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		indexed := byID(t, bookmarks)
+		require.Contains(t, indexed, fileBookmark.Id)
+		assert.Nil(t, indexed[fileBookmark.Id].FileInfo, "file info should be stripped")
+
+		require.Contains(t, indexed, linkBookmark.Id)
+		assert.Equal(t, "https://mattermost.com", indexed[linkBookmark.Id].LinkUrl, "link bookmarks are unaffected")
+		assert.Nil(t, indexed[linkBookmark.Id].FileInfo)
+	})
+
+	t.Run("file info is returned when the policy allows the download action", func(t *testing.T) {
+		mockDownloadDecision(t, true)
+
+		bookmarks, resp, err := th.Client.ListChannelBookmarksForChannel(context.Background(), th.BasicChannel.Id, 0)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		indexed := byID(t, bookmarks)
+		require.Contains(t, indexed, fileBookmark.Id)
+		require.NotNil(t, indexed[fileBookmark.Id].FileInfo)
+		assert.Equal(t, file.Id, indexed[fileBookmark.Id].FileInfo.Id)
+		assert.NotNil(t, indexed[fileBookmark.Id].FileInfo.MiniPreview)
+
+		require.Contains(t, indexed, linkBookmark.Id)
+		assert.Nil(t, indexed[linkBookmark.Id].FileInfo)
+	})
+
+	t.Run("file info is unaffected when ABAC is disabled", func(t *testing.T) {
+		mockDownloadDecision(t, false)
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = model.NewPointer(false)
+		})
+		t.Cleanup(func() {
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				cfg.AccessControlSettings.EnableAttributeBasedAccessControl = model.NewPointer(true)
+			})
+		})
+
+		bookmarks, resp, err := th.Client.ListChannelBookmarksForChannel(context.Background(), th.BasicChannel.Id, 0)
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+
+		indexed := byID(t, bookmarks)
+		require.Contains(t, indexed, fileBookmark.Id)
+		require.NotNil(t, indexed[fileBookmark.Id].FileInfo)
 	})
 }

--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -700,11 +700,12 @@ func getPostsByIds(c *Context, w http.ResponseWriter, r *http.Request) {
 
 		post = c.App.PreparePostForClient(c.AppContext, post, &model.PreparePostForClientOpts{IncludePriority: true})
 
-		post, isMemberForCurrentPreview, sanitizeErr := c.App.SanitizePostMetadataForUser(c.AppContext, post, c.AppContext.Session().UserId)
+		sanitizedPost, isMemberForCurrentPreview, sanitizeErr := c.App.SanitizePostMetadataForUser(c.AppContext, post, c.AppContext.Session().UserId)
 		if sanitizeErr != nil {
 			c.Err = sanitizeErr
 			return
 		}
+		post = sanitizedPost
 		isMemberForAllPreviews = isMemberForAllPreviews && isMemberForCurrentPreview
 
 		post.StripActionIntegrations()

--- a/server/channels/api4/post.go
+++ b/server/channels/api4/post.go
@@ -684,6 +684,7 @@ func getPostsByIds(c *Context, w http.ResponseWriter, r *http.Request) {
 
 	var posts = []*model.Post{}
 	isMemberForAllPosts := true
+	isMemberForAllPreviews := true
 	for _, post := range postsList {
 		channel, ok := channelMap[post.ChannelId]
 		if !ok {
@@ -698,6 +699,14 @@ func getPostsByIds(c *Context, w http.ResponseWriter, r *http.Request) {
 		isMemberForAllPosts = isMemberForAllPosts && isMemberForCurrentPost
 
 		post = c.App.PreparePostForClient(c.AppContext, post, &model.PreparePostForClientOpts{IncludePriority: true})
+
+		post, isMemberForCurrentPreview, sanitizeErr := c.App.SanitizePostMetadataForUser(c.AppContext, post, c.AppContext.Session().UserId)
+		if sanitizeErr != nil {
+			c.Err = sanitizeErr
+			return
+		}
+		isMemberForAllPreviews = isMemberForAllPreviews && isMemberForCurrentPreview
+
 		post.StripActionIntegrations()
 		posts = append(posts, post)
 	}
@@ -714,8 +723,11 @@ func getPostsByIds(c *Context, w http.ResponseWriter, r *http.Request) {
 	defer c.LogAuditRec(auditRec)
 	model.AddEventParameterToAuditRec(auditRec, "post_ids", postIDs)
 
-	if !isMemberForAllPosts {
+	if !isMemberForAllPosts || !isMemberForAllPreviews {
 		model.AddEventParameterToAuditRec(auditRec, "non_channel_member_access", true)
+		if !isMemberForAllPreviews {
+			model.AddEventParameterToAuditRec(auditRec, "non_channel_member_access_on_previews", true)
+		}
 	}
 }
 

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/mattermost/mattermost/server/v8/channels/testlib"
 	"github.com/mattermost/mattermost/server/v8/channels/utils"
 	"github.com/mattermost/mattermost/server/v8/channels/utils/testutils"
+	einterfacesmocks "github.com/mattermost/mattermost/server/v8/einterfaces/mocks"
 )
 
 // Helper to enable feature with license
@@ -6124,6 +6125,126 @@ func TestGetPostsByIds(t *testing.T) {
 	_, response, err = client.GetPostsByIds(context.Background(), []string{"abc123"})
 	require.Error(t, err)
 	CheckNotFoundStatus(t, response)
+}
+
+func TestGetPostsByIdsFileMetadataABAC(t *testing.T) {
+	th := SetupConfig(t, func(cfg *model.Config) {
+		cfg.FeatureFlags.PermissionPolicies = true
+		cfg.AccessControlSettings.EnableAttributeBasedAccessControl = model.NewPointer(true)
+	}).InitBasic(t)
+
+	if *th.App.Config().FileSettings.DriverName == "" {
+		t.Skip("skipping because no file driver is enabled")
+	}
+
+	createPostWithFile := func(t *testing.T) *model.Post {
+		t.Helper()
+
+		fileResp, _, err := th.Client.UploadFile(context.Background(), []byte("data"), th.BasicChannel.Id, "test.txt")
+		require.NoError(t, err)
+		require.Len(t, fileResp.FileInfos, 1)
+
+		post, _, err := th.Client.CreatePost(context.Background(), &model.Post{
+			ChannelId: th.BasicChannel.Id,
+			Message:   "with files",
+			FileIds:   model.StringArray{fileResp.FileInfos[0].Id},
+		})
+		require.NoError(t, err)
+		return post
+	}
+
+	mockDownloadDecision := func(t *testing.T, allowed bool) {
+		t.Helper()
+
+		mockACS := &einterfacesmocks.AccessControlServiceInterface{}
+		mockACS.On("AccessEvaluation", mock.Anything, mock.MatchedBy(func(req model.AccessRequest) bool {
+			return req.Action == model.AccessControlPolicyActionDownloadFileAttachment
+		})).Return(model.AccessDecision{Decision: allowed}, (*model.AppError)(nil))
+
+		original := th.App.Srv().Channels().AccessControl
+		th.App.Srv().Channels().AccessControl = mockACS
+		t.Cleanup(func() {
+			th.App.Srv().Channels().AccessControl = original
+		})
+	}
+
+	// Posts are created before any decision is mocked so the stored posts keep their file ids.
+	postWithFile1 := createPostWithFile(t)
+	postWithFile2 := createPostWithFile(t)
+	plainPost := th.CreatePost(t)
+
+	t.Run("file metadata is stripped from every post when the policy denies the download action", func(t *testing.T) {
+		mockDownloadDecision(t, false)
+
+		posts, resp, err := th.Client.GetPostsByIds(context.Background(), []string{postWithFile1.Id, postWithFile2.Id})
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.Len(t, posts, 2)
+
+		for _, post := range posts {
+			assert.Empty(t, post.FileIds, "file ids should be stripped")
+			require.NotNil(t, post.Metadata)
+			assert.Empty(t, post.Metadata.Files, "file metadata should be stripped")
+			assert.Equal(t, 1, post.Metadata.RedactedFileCount)
+		}
+	})
+
+	t.Run("file metadata is returned when the policy allows the download action", func(t *testing.T) {
+		mockDownloadDecision(t, true)
+
+		posts, resp, err := th.Client.GetPostsByIds(context.Background(), []string{postWithFile1.Id})
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.Len(t, posts, 1)
+		assert.Len(t, posts[0].FileIds, 1)
+		require.NotNil(t, posts[0].Metadata)
+		assert.Len(t, posts[0].Metadata.Files, 1)
+		assert.Equal(t, 0, posts[0].Metadata.RedactedFileCount)
+	})
+
+	t.Run("posts without attachments are returned untouched in a denied batch", func(t *testing.T) {
+		mockDownloadDecision(t, false)
+
+		posts, resp, err := th.Client.GetPostsByIds(context.Background(), []string{postWithFile1.Id, plainPost.Id})
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.Len(t, posts, 2)
+
+		byID := map[string]*model.Post{}
+		for _, post := range posts {
+			byID[post.Id] = post
+		}
+
+		require.Contains(t, byID, plainPost.Id)
+		assert.Equal(t, plainPost.Message, byID[plainPost.Id].Message)
+		assert.Empty(t, byID[plainPost.Id].FileIds)
+		require.NotNil(t, byID[plainPost.Id].Metadata)
+		assert.Equal(t, 0, byID[plainPost.Id].Metadata.RedactedFileCount)
+
+		require.Contains(t, byID, postWithFile1.Id)
+		assert.Empty(t, byID[postWithFile1.Id].Metadata.Files)
+	})
+
+	t.Run("file metadata is unaffected when ABAC is disabled", func(t *testing.T) {
+		mockDownloadDecision(t, false)
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = model.NewPointer(false)
+		})
+		t.Cleanup(func() {
+			th.App.UpdateConfig(func(cfg *model.Config) {
+				cfg.AccessControlSettings.EnableAttributeBasedAccessControl = model.NewPointer(true)
+			})
+		})
+
+		posts, resp, err := th.Client.GetPostsByIds(context.Background(), []string{postWithFile1.Id})
+		require.NoError(t, err)
+		CheckOKStatus(t, resp)
+		require.Len(t, posts, 1)
+		assert.Len(t, posts[0].FileIds, 1)
+		require.NotNil(t, posts[0].Metadata)
+		assert.Len(t, posts[0].Metadata.Files, 1)
+	})
 }
 
 func TestGetEditHistoryForPost(t *testing.T) {

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -6158,7 +6158,10 @@ func TestGetPostsByIdsFileMetadataABAC(t *testing.T) {
 
 		mockACS := &einterfacesmocks.AccessControlServiceInterface{}
 		mockACS.On("AccessEvaluation", mock.Anything, mock.MatchedBy(func(req model.AccessRequest) bool {
-			return req.Action == model.AccessControlPolicyActionDownloadFileAttachment
+			return req.Action == model.AccessControlPolicyActionDownloadFileAttachment &&
+				req.Subject.ID == th.BasicUser.Id &&
+				req.Resource.Type == model.AccessControlPolicyTypeChannel &&
+				req.Resource.ID == th.BasicChannel.Id
 		})).Return(model.AccessDecision{Decision: allowed}, (*model.AppError)(nil))
 
 		original := th.App.Srv().Channels().AccessControl

--- a/server/channels/api4/post_test.go
+++ b/server/channels/api4/post_test.go
@@ -6153,7 +6153,7 @@ func TestGetPostsByIdsFileMetadataABAC(t *testing.T) {
 		return post
 	}
 
-	mockDownloadDecision := func(t *testing.T, allowed bool) {
+	mockDownloadDecision := func(t *testing.T, allowed bool) *einterfacesmocks.AccessControlServiceInterface {
 		t.Helper()
 
 		mockACS := &einterfacesmocks.AccessControlServiceInterface{}
@@ -6169,6 +6169,8 @@ func TestGetPostsByIdsFileMetadataABAC(t *testing.T) {
 		t.Cleanup(func() {
 			th.App.Srv().Channels().AccessControl = original
 		})
+
+		return mockACS
 	}
 
 	// Posts are created before any decision is mocked so the stored posts keep their file ids.
@@ -6177,7 +6179,7 @@ func TestGetPostsByIdsFileMetadataABAC(t *testing.T) {
 	plainPost := th.CreatePost(t)
 
 	t.Run("file metadata is stripped from every post when the policy denies the download action", func(t *testing.T) {
-		mockDownloadDecision(t, false)
+		mockACS := mockDownloadDecision(t, false)
 
 		posts, resp, err := th.Client.GetPostsByIds(context.Background(), []string{postWithFile1.Id, postWithFile2.Id})
 		require.NoError(t, err)
@@ -6190,10 +6192,11 @@ func TestGetPostsByIdsFileMetadataABAC(t *testing.T) {
 			assert.Empty(t, post.Metadata.Files, "file metadata should be stripped")
 			assert.Equal(t, 1, post.Metadata.RedactedFileCount)
 		}
+		mockACS.AssertExpectations(t)
 	})
 
 	t.Run("file metadata is returned when the policy allows the download action", func(t *testing.T) {
-		mockDownloadDecision(t, true)
+		mockACS := mockDownloadDecision(t, true)
 
 		posts, resp, err := th.Client.GetPostsByIds(context.Background(), []string{postWithFile1.Id})
 		require.NoError(t, err)
@@ -6203,10 +6206,11 @@ func TestGetPostsByIdsFileMetadataABAC(t *testing.T) {
 		require.NotNil(t, posts[0].Metadata)
 		assert.Len(t, posts[0].Metadata.Files, 1)
 		assert.Equal(t, 0, posts[0].Metadata.RedactedFileCount)
+		mockACS.AssertExpectations(t)
 	})
 
 	t.Run("posts without attachments are returned untouched in a denied batch", func(t *testing.T) {
-		mockDownloadDecision(t, false)
+		mockACS := mockDownloadDecision(t, false)
 
 		posts, resp, err := th.Client.GetPostsByIds(context.Background(), []string{postWithFile1.Id, plainPost.Id})
 		require.NoError(t, err)
@@ -6226,10 +6230,16 @@ func TestGetPostsByIdsFileMetadataABAC(t *testing.T) {
 
 		require.Contains(t, byID, postWithFile1.Id)
 		assert.Empty(t, byID[postWithFile1.Id].Metadata.Files)
+		mockACS.AssertExpectations(t)
 	})
 
 	t.Run("file metadata is unaffected when ABAC is disabled", func(t *testing.T) {
-		mockDownloadDecision(t, false)
+		mockACS := &einterfacesmocks.AccessControlServiceInterface{}
+		original := th.App.Srv().Channels().AccessControl
+		th.App.Srv().Channels().AccessControl = mockACS
+		t.Cleanup(func() {
+			th.App.Srv().Channels().AccessControl = original
+		})
 
 		th.App.UpdateConfig(func(cfg *model.Config) {
 			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = model.NewPointer(false)
@@ -6247,6 +6257,7 @@ func TestGetPostsByIdsFileMetadataABAC(t *testing.T) {
 		assert.Len(t, posts[0].FileIds, 1)
 		require.NotNil(t, posts[0].Metadata)
 		assert.Len(t, posts[0].Metadata.Files, 1)
+		mockACS.AssertNotCalled(t, "AccessEvaluation", mock.Anything, mock.Anything)
 	})
 }
 

--- a/server/channels/app/channel_bookmark.go
+++ b/server/channels/app/channel_bookmark.go
@@ -45,6 +45,7 @@ func (a *App) CreateChannelBookmark(rctx request.CTX, newBookmark *model.Channel
 		return nil, model.NewAppError("CreateChannelBookmark", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(jsonErr)
 	}
 	message.Add("bookmark", string(bookmarkJSON))
+	a.setupBroadcastHookForAbacBookmarks(message, bookmark.ChannelId, "bookmark", bookmark)
 	a.Publish(message)
 	return bookmark, nil
 }
@@ -99,6 +100,7 @@ func (a *App) UpdateChannelBookmark(rctx request.CTX, updateBookmark *model.Chan
 		return nil, model.NewAppError("UpdateChannelBookmark", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(jsonErr)
 	}
 	message.Add("bookmarks", string(bookmarkJSON))
+	a.setupBroadcastHookForAbacBookmarks(message, updateBookmark.ChannelId, "bookmarks", response.Updated, response.Deleted)
 	a.Publish(message)
 
 	return response, nil
@@ -120,6 +122,7 @@ func (a *App) DeleteChannelBookmark(bookmarkId, connectionId string) (*model.Cha
 		return nil, model.NewAppError("DeleteChannelBookmark", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(jsonErr)
 	}
 	message.Add("bookmark", string(bookmarkJSON))
+	a.setupBroadcastHookForAbacBookmarks(message, bookmark.ChannelId, "bookmark", bookmark)
 	a.Publish(message)
 
 	return bookmark, nil
@@ -146,6 +149,7 @@ func (a *App) UpdateChannelBookmarkSortOrder(bookmarkId, channelId string, newIn
 		return nil, model.NewAppError("UpdateSortOrder", "api.marshal_error", nil, "", http.StatusInternalServerError).Wrap(jsonErr)
 	}
 	message.Add("bookmarks", string(bookmarkJSON))
+	a.setupBroadcastHookForAbacBookmarks(message, channelId, "bookmarks", bookmarks...)
 	a.Publish(message)
 
 	return bookmarks, nil

--- a/server/channels/app/channel_bookmark_test.go
+++ b/server/channels/app/channel_bookmark_test.go
@@ -4,12 +4,15 @@
 package app
 
 import (
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
+	einterfacesmocks "github.com/mattermost/mattermost/server/v8/einterfaces/mocks"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
 
@@ -626,5 +629,194 @@ func TestUpdateChannelBookmarkSortOrder(t *testing.T) {
 	t.Run("change order of bookmarks error when bookmark not found", func(t *testing.T) {
 		_, appErr = th.App.UpdateChannelBookmarkSortOrder(model.NewId(), channelId, int64(0), "")
 		assert.NotNil(t, appErr)
+	})
+}
+
+func TestChannelBookmarkBroadcastsFileInfoABAC(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		cfg.FeatureFlags.PermissionPolicies = true
+		cfg.AccessControlSettings.EnableAttributeBasedAccessControl = model.NewPointer(true)
+	})
+
+	_, appErr := th.App.AddUserToChannel(th.Context, th.BasicUser2, th.BasicChannel, false)
+	require.Nil(t, appErr)
+
+	th.Context.Session().UserId = th.BasicUser.Id
+
+	mockDownloadDecision := func(t *testing.T, allowed bool) {
+		t.Helper()
+
+		mockACS := &einterfacesmocks.AccessControlServiceInterface{}
+		mockACS.On("AccessEvaluation", mock.Anything, mock.MatchedBy(func(req model.AccessRequest) bool {
+			return req.Action == model.AccessControlPolicyActionDownloadFileAttachment
+		})).Return(model.AccessDecision{Decision: allowed}, (*model.AppError)(nil))
+
+		original := th.App.Srv().Channels().AccessControl
+		th.App.Srv().Channels().AccessControl = mockACS
+		t.Cleanup(func() {
+			th.App.Srv().Channels().AccessControl = original
+		})
+	}
+
+	createFile := func(t *testing.T) *model.FileInfo {
+		t.Helper()
+
+		miniPreview := []byte{1, 2, 3, 4}
+		file := &model.FileInfo{
+			Id:              model.NewId(),
+			ChannelId:       th.BasicChannel.Id,
+			CreatorId:       model.BookmarkFileOwner,
+			Path:            "somepath",
+			ThumbnailPath:   "thumbpath",
+			PreviewPath:     "prevPath",
+			Name:            "bookmark-secret.png",
+			Extension:       "png",
+			MimeType:        "image/png",
+			Size:            873182,
+			Width:           3076,
+			Height:          2200,
+			HasPreviewImage: true,
+			MiniPreview:     &miniPreview,
+		}
+		_, err := th.App.Srv().Store().FileInfo().Save(th.Context, file)
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, th.App.Srv().Store().FileInfo().PermanentDelete(th.Context, file.Id))
+		})
+		return file
+	}
+
+	nextEvent := func(t *testing.T, messages chan *model.WebSocketEvent, eventType model.WebsocketEventType) *model.WebSocketEvent {
+		t.Helper()
+
+		for {
+			select {
+			case msg := <-messages:
+				if msg.EventType() == eventType {
+					return msg
+				}
+			case <-time.After(10 * time.Second):
+				t.Fatalf("timed out waiting for %s event", eventType)
+				return nil
+			}
+		}
+	}
+
+	// hasFileInfo reports whether any bookmark in the event payload still carries file info.
+	hasFileInfo := func(t *testing.T, msg *model.WebSocketEvent, field string) bool {
+		t.Helper()
+
+		raw, ok := msg.GetData()[field].(string)
+		require.True(t, ok, "event should carry a %s payload", field)
+
+		var decoded any
+		require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
+
+		var walk func(value any) bool
+		walk = func(value any) bool {
+			switch typed := value.(type) {
+			case map[string]any:
+				if file, found := typed["file"]; found && file != nil {
+					return true
+				}
+				for key, nested := range typed {
+					if key == "file" {
+						continue
+					}
+					if walk(nested) {
+						return true
+					}
+				}
+			case []any:
+				for _, item := range typed {
+					if walk(item) {
+						return true
+					}
+				}
+			}
+			return false
+		}
+
+		return walk(decoded)
+	}
+
+	bookmarkEvents := []model.WebsocketEventType{
+		model.WebsocketEventChannelBookmarkCreated,
+		model.WebsocketEventChannelBookmarkUpdated,
+		model.WebsocketEventChannelBookmarkDeleted,
+		model.WebsocketEventChannelBookmarkSorted,
+	}
+
+	// exerciseBookmarkLifecycle drives the four bookmark broadcasts and reports, per event,
+	// whether the recipient received file info.
+	exerciseBookmarkLifecycle := func(t *testing.T) map[model.WebsocketEventType]bool {
+		t.Helper()
+
+		messages, closeWS := connectFakeWebSocket(t, th, th.BasicUser2.Id, "", bookmarkEvents)
+		defer closeWS()
+
+		file := createFile(t)
+		created, appErr := th.App.CreateChannelBookmark(th.Context, createBookmark("File bookmark", model.ChannelBookmarkFile, th.BasicChannel.Id, file.Id), "")
+		require.Nil(t, appErr)
+
+		result := map[model.WebsocketEventType]bool{}
+		result[model.WebsocketEventChannelBookmarkCreated] = hasFileInfo(t, nextEvent(t, messages, model.WebsocketEventChannelBookmarkCreated), "bookmark")
+
+		toUpdate := created.Clone()
+		toUpdate.DisplayName = "File bookmark renamed"
+		_, appErr = th.App.UpdateChannelBookmark(th.Context, toUpdate, "")
+		require.Nil(t, appErr)
+		result[model.WebsocketEventChannelBookmarkUpdated] = hasFileInfo(t, nextEvent(t, messages, model.WebsocketEventChannelBookmarkUpdated), "bookmarks")
+
+		otherFile := createFile(t)
+		_, appErr = th.App.CreateChannelBookmark(th.Context, createBookmark("Second file bookmark", model.ChannelBookmarkFile, th.BasicChannel.Id, otherFile.Id), "")
+		require.Nil(t, appErr)
+		nextEvent(t, messages, model.WebsocketEventChannelBookmarkCreated)
+
+		_, appErr = th.App.UpdateChannelBookmarkSortOrder(created.Id, th.BasicChannel.Id, 1, "")
+		require.Nil(t, appErr)
+		result[model.WebsocketEventChannelBookmarkSorted] = hasFileInfo(t, nextEvent(t, messages, model.WebsocketEventChannelBookmarkSorted), "bookmarks")
+
+		_, appErr = th.App.DeleteChannelBookmark(created.Id, "")
+		require.Nil(t, appErr)
+		result[model.WebsocketEventChannelBookmarkDeleted] = hasFileInfo(t, nextEvent(t, messages, model.WebsocketEventChannelBookmarkDeleted), "bookmark")
+
+		return result
+	}
+
+	t.Run("denied recipient receives no bookmark file info on any broadcast", func(t *testing.T) {
+		mockDownloadDecision(t, false)
+
+		for event, hasFile := range exerciseBookmarkLifecycle(t) {
+			assert.False(t, hasFile, "%s should not carry file info for a denied recipient", event)
+		}
+	})
+
+	t.Run("allowed recipient still receives bookmark file info on every broadcast", func(t *testing.T) {
+		mockDownloadDecision(t, true)
+
+		for event, hasFile := range exerciseBookmarkLifecycle(t) {
+			assert.True(t, hasFile, "%s should carry file info for an allowed recipient", event)
+		}
+	})
+
+	t.Run("link bookmarks are broadcast unchanged to a denied recipient", func(t *testing.T) {
+		mockDownloadDecision(t, false)
+
+		messages, closeWS := connectFakeWebSocket(t, th, th.BasicUser2.Id, "", bookmarkEvents)
+		defer closeWS()
+
+		created, appErr := th.App.CreateChannelBookmark(th.Context, createBookmark("Link bookmark", model.ChannelBookmarkLink, th.BasicChannel.Id, ""), "")
+		require.Nil(t, appErr)
+
+		msg := nextEvent(t, messages, model.WebsocketEventChannelBookmarkCreated)
+		raw, ok := msg.GetData()["bookmark"].(string)
+		require.True(t, ok)
+		assert.Contains(t, raw, created.Id)
+		assert.Contains(t, raw, "https://mattermost.com")
+		assert.False(t, hasFileInfo(t, msg, "bookmark"))
 	})
 }

--- a/server/channels/app/channel_bookmark_test.go
+++ b/server/channels/app/channel_bookmark_test.go
@@ -6,6 +6,7 @@ package app
 import (
 	"encoding/json"
 	"fmt"
+	"slices"
 	"testing"
 	"time"
 
@@ -731,11 +732,7 @@ func TestChannelBookmarkBroadcastsFileInfoABAC(t *testing.T) {
 					}
 				}
 			case []any:
-				for _, item := range typed {
-					if walk(item) {
-						return true
-					}
-				}
+				return slices.ContainsFunc(typed, walk)
 			}
 			return false
 		}

--- a/server/channels/app/post.go
+++ b/server/channels/app/post.go
@@ -1175,16 +1175,7 @@ func (a *App) publishWebsocketEventForPost(rctx request.CTX, post *model.Post, m
 // setupBroadcastHookForAbacFiles registers abacFilesBroadcastHook when ABAC is active and
 // the post has file attachments. Skipped for burn-on-read posts (handled by their own hook).
 func (a *App) setupBroadcastHookForAbacFiles(post *model.Post, message *model.WebSocketEvent) {
-	if a.Srv().Channels().AccessControl == nil {
-		return
-	}
-
-	cfg := a.Config().AccessControlSettings.EnableAttributeBasedAccessControl
-	if cfg == nil || !*cfg {
-		return
-	}
-
-	if !a.Config().FeatureFlags.PermissionPolicies {
+	if !a.abacFileActionsActive() {
 		return
 	}
 

--- a/server/channels/app/post_persistent_notification.go
+++ b/server/channels/app/post_persistent_notification.go
@@ -410,6 +410,7 @@ func (a *App) sendPersistentNotifications(post *model.Post, channel *model.Chann
 			}
 
 			message.Add("mentions", model.ArrayToJSON(desktopUsers))
+			a.setupBroadcastHookForAbacFiles(post, message)
 			a.Publish(message)
 		}
 	}

--- a/server/channels/app/post_persistent_notification_test.go
+++ b/server/channels/app/post_persistent_notification_test.go
@@ -4,12 +4,14 @@
 package app
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
 	"github.com/mattermost/mattermost/server/public/model"
 	"github.com/mattermost/mattermost/server/v8/channels/store"
 	storemocks "github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
+	einterfacesmocks "github.com/mattermost/mattermost/server/v8/einterfaces/mocks"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -537,5 +539,110 @@ func TestSendPersistentNotificationsBotSenderNotInChannel(t *testing.T) {
 			require.NotNil(c, persistentPostNotification)
 			assert.Greater(c, persistentPostNotification.SentCount, int16(0))
 		}, 5*time.Second, 100*time.Millisecond)
+	})
+}
+
+func TestSendPersistentNotificationsFileMetadataABAC(t *testing.T) {
+	mainHelper.Parallel(t)
+
+	runCase := func(t *testing.T, allowed bool) *model.Post {
+		t.Helper()
+
+		th := Setup(t).InitBasic(t)
+
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.FeatureFlags.PermissionPolicies = true
+			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = model.NewPointer(true)
+		})
+
+		_, appErr := th.App.AddUserToChannel(th.Context, th.BasicUser2, th.BasicChannel, false)
+		require.Nil(t, appErr)
+
+		miniPreview := []byte{1, 2, 3, 4}
+		file := &model.FileInfo{
+			Id:              model.NewId(),
+			ChannelId:       th.BasicChannel.Id,
+			CreatorId:       th.BasicUser.Id,
+			Path:            "somepath",
+			ThumbnailPath:   "thumbpath",
+			PreviewPath:     "prevPath",
+			Name:            "notification-secret.png",
+			Extension:       "png",
+			MimeType:        "image/png",
+			Size:            873182,
+			Width:           3076,
+			Height:          2200,
+			HasPreviewImage: true,
+			MiniPreview:     &miniPreview,
+		}
+		_, err := th.App.Srv().Store().FileInfo().Save(th.Context, file)
+		require.NoError(t, err)
+
+		post := &model.Post{
+			UserId:    th.BasicUser.Id,
+			ChannelId: th.BasicChannel.Id,
+			Message:   "urgent " + "@" + th.BasicUser2.Username,
+			FileIds:   model.StringArray{file.Id},
+			Metadata: &model.PostMetadata{
+				Priority: &model.PostPriority{
+					Priority:                model.NewPointer(model.PostPriorityUrgent),
+					PersistentNotifications: model.NewPointer(true),
+				},
+			},
+			// Simulate old timestamp so persistent notifications are sent right away
+			CreateAt: time.Now().Add(-5 * time.Minute).UnixMilli(),
+		}
+		_, _, appErr = th.App.CreatePost(th.Context, post, th.BasicChannel, model.CreatePostFlags{})
+		require.Nil(t, appErr)
+
+		mockACS := &einterfacesmocks.AccessControlServiceInterface{}
+		mockACS.On("AccessEvaluation", mock.Anything, mock.MatchedBy(func(req model.AccessRequest) bool {
+			return req.Action == model.AccessControlPolicyActionDownloadFileAttachment
+		})).Return(model.AccessDecision{Decision: allowed}, (*model.AppError)(nil))
+		th.App.Srv().Channels().AccessControl = mockACS
+
+		messages, closeWS := connectFakeWebSocket(t, th, th.BasicUser2.Id, "", []model.WebsocketEventType{model.WebsocketEventPersistentNotificationTriggered})
+		defer closeWS()
+
+		var received *model.WebSocketEvent
+		for range 10 {
+			require.NoError(t, th.App.SendPersistentNotifications())
+
+			select {
+			case msg := <-messages:
+				received = msg
+			case <-time.After(2 * time.Second):
+			}
+
+			if received != nil {
+				break
+			}
+		}
+		require.NotNil(t, received, "expected a persistent_notification_triggered event")
+
+		postJSON, ok := received.GetData()["post"].(string)
+		require.True(t, ok)
+
+		var notifiedPost model.Post
+		require.NoError(t, json.Unmarshal([]byte(postJSON), &notifiedPost))
+		return &notifiedPost
+	}
+
+	t.Run("file metadata is stripped when the policy denies the download action", func(t *testing.T) {
+		notifiedPost := runCase(t, false)
+
+		assert.Empty(t, notifiedPost.FileIds, "file ids should be stripped")
+		require.NotNil(t, notifiedPost.Metadata)
+		assert.Empty(t, notifiedPost.Metadata.Files, "file metadata should be stripped")
+		assert.Equal(t, 1, notifiedPost.Metadata.RedactedFileCount)
+	})
+
+	t.Run("file metadata is delivered when the policy allows the download action", func(t *testing.T) {
+		notifiedPost := runCase(t, true)
+
+		assert.Len(t, notifiedPost.FileIds, 1)
+		require.NotNil(t, notifiedPost.Metadata)
+		require.Len(t, notifiedPost.Metadata.Files, 1)
+		assert.Equal(t, 0, notifiedPost.Metadata.RedactedFileCount)
 	})
 }

--- a/server/channels/app/post_persistent_notification_test.go
+++ b/server/channels/app/post_persistent_notification_test.go
@@ -597,7 +597,10 @@ func TestSendPersistentNotificationsFileMetadataABAC(t *testing.T) {
 
 		mockACS := &einterfacesmocks.AccessControlServiceInterface{}
 		mockACS.On("AccessEvaluation", mock.Anything, mock.MatchedBy(func(req model.AccessRequest) bool {
-			return req.Action == model.AccessControlPolicyActionDownloadFileAttachment
+			return req.Action == model.AccessControlPolicyActionDownloadFileAttachment &&
+				req.Subject.ID == th.BasicUser2.Id &&
+				req.Resource.Type == model.AccessControlPolicyTypeChannel &&
+				req.Resource.ID == th.BasicChannel.Id
 		})).Return(model.AccessDecision{Decision: allowed}, (*model.AppError)(nil))
 		th.App.Srv().Channels().AccessControl = mockACS
 

--- a/server/channels/app/web_broadcast_hooks.go
+++ b/server/channels/app/web_broadcast_hooks.go
@@ -25,6 +25,7 @@ const (
 	broadcastBurnOnRead         = "burn_on_read"
 	broadcastBurnOnReadReaction = "burn_on_read_reaction"
 	broadcastAbacFiles          = "abac_files"
+	broadcastAbacBookmarks      = "abac_bookmarks"
 	broadcastOnlyChannelAdmins  = "only_channel_admins"
 )
 
@@ -38,6 +39,7 @@ func (s *Server) makeBroadcastHooks() map[string]platform.BroadcastHook {
 		broadcastBurnOnRead:         &burnOnReadBroadcastHook{},
 		broadcastBurnOnReadReaction: &burnOnReadReactionBroadcastHook{},
 		broadcastAbacFiles:          &abacFilesBroadcastHook{},
+		broadcastAbacBookmarks:      &abacBookmarksBroadcastHook{},
 		broadcastOnlyChannelAdmins:  &onlyChannelAdminsBroadcastHook{},
 	}
 }
@@ -504,6 +506,127 @@ func (h *abacFilesBroadcastHook) stripFilesFromMessage(msg *platform.HookedWebSo
 		msg.Event().Reject()
 	}
 	return nil
+}
+
+type abacBookmarksBroadcastHook struct{}
+
+func useAbacBookmarksHook(message *model.WebSocketEvent, channelID, field string) {
+	message.GetBroadcast().AddHook(broadcastAbacBookmarks, map[string]any{
+		"channel_id": channelID,
+		"field":      field,
+	})
+}
+
+// abacFileActionsActive reports whether ABAC file action policies are evaluated on this server.
+func (a *App) abacFileActionsActive() bool {
+	if a.Srv().Channels().AccessControl == nil {
+		return false
+	}
+
+	cfg := a.Config().AccessControlSettings.EnableAttributeBasedAccessControl
+	if cfg == nil || !*cfg {
+		return false
+	}
+
+	return a.Config().FeatureFlags.PermissionPolicies
+}
+
+// setupBroadcastHookForAbacBookmarks registers abacBookmarksBroadcastHook when ABAC is active
+// and at least one of the broadcast bookmarks carries file info.
+func (a *App) setupBroadcastHookForAbacBookmarks(message *model.WebSocketEvent, channelID, field string, bookmarks ...*model.ChannelBookmarkWithFileInfo) {
+	if !a.abacFileActionsActive() {
+		return
+	}
+
+	hasFileInfo := false
+	for _, bookmark := range bookmarks {
+		if bookmark != nil && bookmark.FileInfo != nil {
+			hasFileInfo = true
+			break
+		}
+	}
+	if !hasFileInfo {
+		return
+	}
+
+	useAbacBookmarksHook(message, channelID, field)
+}
+
+// Process strips bookmark file info for recipients denied the download_file_attachment action.
+// Once a deny decision is made, any serialisation failure rejects the event for that recipient.
+func (h *abacBookmarksBroadcastHook) Process(msg *platform.HookedWebSocketEvent, webConn *platform.WebConn, args map[string]any) error {
+	channelID, err := getTypedArg[string](args, "channel_id")
+	if err != nil {
+		return errors.Wrap(err, "Invalid channel_id value passed to abacBookmarksBroadcastHook")
+	}
+
+	field, err := getTypedArg[string](args, "field")
+	if err != nil {
+		return errors.Wrap(err, "Invalid field value passed to abacBookmarksBroadcastHook")
+	}
+
+	// The ABAC evaluator resolves role from rctx.Session(), not Subject.Role.
+	// Fail-secure: if the session is nil we cannot evaluate permissions, so strip file info.
+	session := webConn.GetSession()
+	if session != nil {
+		rctx := request.EmptyContext(webConn.Platform.Log()).WithSession(session)
+		if webConn.Suite.HasPermissionToFileAction(rctx, webConn.UserId, session.Roles, channelID, model.AccessControlPolicyActionDownloadFileAttachment) {
+			return nil
+		}
+	}
+
+	rawJSON, ok := msg.Get(field).(string)
+	if !ok {
+		mlog.Warn("abacBookmarksBroadcastHook: no bookmark payload in message; rejecting event",
+			mlog.String("user_id", webConn.UserId),
+			mlog.String("field", field),
+		)
+		msg.Event().Reject()
+		return nil
+	}
+
+	var payload any
+	if jsonErr := json.Unmarshal([]byte(rawJSON), &payload); jsonErr != nil {
+		mlog.Warn("abacBookmarksBroadcastHook: failed to deserialise bookmark payload; rejecting event",
+			mlog.String("user_id", webConn.UserId),
+			mlog.Err(jsonErr),
+		)
+		msg.Event().Reject()
+		return nil
+	}
+
+	stripBookmarkFileInfo(payload)
+
+	updatedJSON, jsonErr := json.Marshal(payload)
+	if jsonErr != nil {
+		mlog.Warn("abacBookmarksBroadcastHook: failed to marshal bookmark payload; rejecting event",
+			mlog.String("user_id", webConn.UserId),
+			mlog.Err(jsonErr),
+		)
+		msg.Event().Reject()
+		return nil
+	}
+
+	msg.Add(field, string(updatedJSON))
+	return nil
+}
+
+// stripBookmarkFileInfo walks a decoded bookmark payload of any shape and clears every "file" entry.
+func stripBookmarkFileInfo(value any) {
+	switch typed := value.(type) {
+	case map[string]any:
+		for key, nested := range typed {
+			if key == "file" {
+				typed[key] = nil
+				continue
+			}
+			stripBookmarkFileInfo(nested)
+		}
+	case []any:
+		for _, item := range typed {
+			stripBookmarkFileInfo(item)
+		}
+	}
 }
 
 // onlyChannelAdminsBroadcastHook narrows a channel-scoped broadcast to the

--- a/server/channels/app/web_broadcast_hooks_test.go
+++ b/server/channels/app/web_broadcast_hooks_test.go
@@ -1156,3 +1156,279 @@ func TestSetupBroadcastHookForAbacFiles(t *testing.T) {
 		assert.Empty(t, hooks, "AccessControl is nil in test env — hook not registered")
 	})
 }
+
+func TestAbacBookmarksBroadcastHook_Process(t *testing.T) {
+	mainHelper.Parallel(t)
+	hook := &abacBookmarksBroadcastHook{}
+
+	userID := model.NewId()
+	channelID := model.NewId()
+
+	makeBookmark := func(withFile bool) *model.ChannelBookmarkWithFileInfo {
+		bookmark := &model.ChannelBookmarkWithFileInfo{
+			ChannelBookmark: &model.ChannelBookmark{
+				Id:          model.NewId(),
+				ChannelId:   channelID,
+				DisplayName: "bookmark",
+				Type:        model.ChannelBookmarkLink,
+				LinkUrl:     "https://mattermost.com",
+			},
+		}
+		if withFile {
+			fileID := model.NewId()
+			bookmark.Type = model.ChannelBookmarkFile
+			bookmark.LinkUrl = ""
+			bookmark.FileId = fileID
+			bookmark.FileInfo = &model.FileInfo{
+				Id:          fileID,
+				ChannelId:   channelID,
+				Name:        "secret.png",
+				Extension:   "png",
+				MimeType:    "image/png",
+				MiniPreview: &[]byte{1, 2, 3, 4},
+			}
+		}
+		return bookmark
+	}
+
+	makeMessage := func(t *testing.T, event model.WebsocketEventType, field string, payload any) *platform.HookedWebSocketEvent {
+		t.Helper()
+		payloadJSON, err := json.Marshal(payload)
+		require.NoError(t, err)
+		ev := model.NewWebSocketEvent(event, "", channelID, "", nil, "")
+		ev.Add(field, string(payloadJSON))
+		return platform.MakeHookedWebSocketEvent(ev)
+	}
+
+	makeArgs := func(field string) map[string]any {
+		return map[string]any{
+			"channel_id": channelID,
+			"field":      field,
+		}
+	}
+
+	makeWebConn := func(t *testing.T, allowed bool) *platform.WebConn {
+		t.Helper()
+		mockSuite := &platform_mocks.SuiteIFace{}
+		mockSuite.On("HasPermissionToFileAction", mock.Anything, userID, mock.AnythingOfType("string"), channelID, model.AccessControlPolicyActionDownloadFileAttachment).Return(allowed)
+		wc := &platform.WebConn{
+			UserId:   userID,
+			Platform: &platform.PlatformService{},
+			Suite:    mockSuite,
+		}
+		wc.SetSession(&model.Session{UserId: userID, Roles: model.SystemUserRoleId})
+		return wc
+	}
+
+	decode := func(t *testing.T, msg *platform.HookedWebSocketEvent, field string) any {
+		t.Helper()
+		raw, ok := msg.Get(field).(string)
+		require.True(t, ok)
+		var decoded any
+		require.NoError(t, json.Unmarshal([]byte(raw), &decoded))
+		return decoded
+	}
+
+	// requireNoFileInfo walks the decoded payload and asserts no "file" object survived.
+	var requireNoFileInfo func(t *testing.T, value any)
+	requireNoFileInfo = func(t *testing.T, value any) {
+		t.Helper()
+		switch typed := value.(type) {
+		case map[string]any:
+			if file, ok := typed["file"]; ok {
+				assert.Nil(t, file, "file info should be stripped")
+			}
+			for key, nested := range typed {
+				if key == "file" {
+					continue
+				}
+				requireNoFileInfo(t, nested)
+			}
+		case []any:
+			for _, item := range typed {
+				requireNoFileInfo(t, item)
+			}
+		}
+	}
+
+	t.Run("denied user: single bookmark payload has file info stripped", func(t *testing.T) {
+		bookmark := makeBookmark(true)
+		msg := makeMessage(t, model.WebsocketEventChannelBookmarkCreated, "bookmark", bookmark)
+
+		err := hook.Process(msg, makeWebConn(t, false), makeArgs("bookmark"))
+		require.NoError(t, err)
+		require.False(t, msg.Event().IsRejected())
+
+		raw, _ := msg.Get("bookmark").(string)
+		assert.NotContains(t, raw, "mini_preview")
+		assert.NotContains(t, raw, "secret.png")
+		assert.Contains(t, raw, bookmark.Id, "the bookmark itself is still delivered")
+		requireNoFileInfo(t, decode(t, msg, "bookmark"))
+	})
+
+	t.Run("denied user: array payload has file info stripped from every entry", func(t *testing.T) {
+		bookmarks := []*model.ChannelBookmarkWithFileInfo{makeBookmark(true), makeBookmark(false), makeBookmark(true)}
+		msg := makeMessage(t, model.WebsocketEventChannelBookmarkSorted, "bookmarks", bookmarks)
+
+		err := hook.Process(msg, makeWebConn(t, false), makeArgs("bookmarks"))
+		require.NoError(t, err)
+		require.False(t, msg.Event().IsRejected())
+
+		raw, _ := msg.Get("bookmarks").(string)
+		assert.NotContains(t, raw, "mini_preview")
+		assert.NotContains(t, raw, "secret.png")
+
+		decoded, ok := decode(t, msg, "bookmarks").([]any)
+		require.True(t, ok)
+		require.Len(t, decoded, 3)
+		requireNoFileInfo(t, decoded)
+	})
+
+	t.Run("denied user: updated/deleted wrapper payload has file info stripped from both entries", func(t *testing.T) {
+		response := &model.UpdateChannelBookmarkResponse{
+			Updated: makeBookmark(true),
+			Deleted: makeBookmark(true),
+		}
+		msg := makeMessage(t, model.WebsocketEventChannelBookmarkUpdated, "bookmarks", response)
+
+		err := hook.Process(msg, makeWebConn(t, false), makeArgs("bookmarks"))
+		require.NoError(t, err)
+		require.False(t, msg.Event().IsRejected())
+
+		raw, _ := msg.Get("bookmarks").(string)
+		assert.NotContains(t, raw, "mini_preview")
+		assert.NotContains(t, raw, "secret.png")
+
+		decoded, ok := decode(t, msg, "bookmarks").(map[string]any)
+		require.True(t, ok)
+		require.Contains(t, decoded, "updated")
+		require.Contains(t, decoded, "deleted")
+		requireNoFileInfo(t, decoded)
+	})
+
+	t.Run("allowed user: payload is unchanged", func(t *testing.T) {
+		bookmark := makeBookmark(true)
+		msg := makeMessage(t, model.WebsocketEventChannelBookmarkCreated, "bookmark", bookmark)
+		before, _ := msg.Get("bookmark").(string)
+
+		err := hook.Process(msg, makeWebConn(t, true), makeArgs("bookmark"))
+		require.NoError(t, err)
+		require.False(t, msg.Event().IsRejected())
+
+		after, _ := msg.Get("bookmark").(string)
+		assert.Equal(t, before, after)
+		assert.Contains(t, after, "mini_preview")
+	})
+
+	t.Run("nil session: fail-secure, file info stripped", func(t *testing.T) {
+		bookmark := makeBookmark(true)
+		msg := makeMessage(t, model.WebsocketEventChannelBookmarkCreated, "bookmark", bookmark)
+
+		wc := &platform.WebConn{
+			UserId:   userID,
+			Platform: &platform.PlatformService{},
+		}
+		// Do NOT call wc.SetSession — session remains nil
+
+		err := hook.Process(msg, wc, makeArgs("bookmark"))
+		require.NoError(t, err)
+		require.False(t, msg.Event().IsRejected())
+
+		raw, _ := msg.Get("bookmark").(string)
+		assert.NotContains(t, raw, "mini_preview")
+		requireNoFileInfo(t, decode(t, msg, "bookmark"))
+	})
+
+	t.Run("denied user: malformed payload rejects the event", func(t *testing.T) {
+		ev := model.NewWebSocketEvent(model.WebsocketEventChannelBookmarkCreated, "", channelID, "", nil, "")
+		ev.Add("bookmark", "{not json")
+		msg := platform.MakeHookedWebSocketEvent(ev)
+
+		err := hook.Process(msg, makeWebConn(t, false), makeArgs("bookmark"))
+		require.NoError(t, err)
+		assert.True(t, msg.Event().IsRejected(), "event must be rejected when the payload cannot be sanitised")
+	})
+
+	t.Run("denied user: missing payload field rejects the event", func(t *testing.T) {
+		ev := model.NewWebSocketEvent(model.WebsocketEventChannelBookmarkCreated, "", channelID, "", nil, "")
+		msg := platform.MakeHookedWebSocketEvent(ev)
+
+		err := hook.Process(msg, makeWebConn(t, false), makeArgs("bookmark"))
+		require.NoError(t, err)
+		assert.True(t, msg.Event().IsRejected())
+	})
+
+	t.Run("missing channel_id arg: returns error", func(t *testing.T) {
+		msg := makeMessage(t, model.WebsocketEventChannelBookmarkCreated, "bookmark", makeBookmark(true))
+
+		err := hook.Process(msg, makeWebConn(t, true), map[string]any{"field": "bookmark"})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "channel_id")
+	})
+
+	t.Run("missing field arg: returns error", func(t *testing.T) {
+		msg := makeMessage(t, model.WebsocketEventChannelBookmarkCreated, "bookmark", makeBookmark(true))
+
+		err := hook.Process(msg, makeWebConn(t, true), map[string]any{"channel_id": channelID})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "field")
+	})
+}
+
+func TestSetupBroadcastHookForAbacBookmarks(t *testing.T) {
+	mainHelper.Parallel(t)
+	th := Setup(t).InitBasic(t)
+
+	bookmarkWithFile := &model.ChannelBookmarkWithFileInfo{
+		ChannelBookmark: &model.ChannelBookmark{
+			Id:        model.NewId(),
+			ChannelId: th.BasicChannel.Id,
+			Type:      model.ChannelBookmarkFile,
+			FileId:    model.NewId(),
+		},
+		FileInfo: &model.FileInfo{Id: model.NewId(), Name: "file.png", Extension: "png"},
+	}
+
+	linkBookmark := &model.ChannelBookmarkWithFileInfo{
+		ChannelBookmark: &model.ChannelBookmark{
+			Id:        model.NewId(),
+			ChannelId: th.BasicChannel.Id,
+			Type:      model.ChannelBookmarkLink,
+			LinkUrl:   "https://mattermost.com",
+		},
+	}
+
+	t.Run("when ABAC is disabled: hook NOT registered", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(false)
+		})
+
+		message := model.NewWebSocketEvent(model.WebsocketEventChannelBookmarkCreated, "", th.BasicChannel.Id, "", nil, "")
+		th.App.setupBroadcastHookForAbacBookmarks(message, th.BasicChannel.Id, "bookmark", bookmarkWithFile)
+
+		assert.Empty(t, message.GetBroadcast().BroadcastHooks)
+	})
+
+	t.Run("when AccessControl is nil: hook NOT registered", func(t *testing.T) {
+		// In test setup without enterprise, AccessControl is nil.
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
+		})
+
+		message := model.NewWebSocketEvent(model.WebsocketEventChannelBookmarkCreated, "", th.BasicChannel.Id, "", nil, "")
+		th.App.setupBroadcastHookForAbacBookmarks(message, th.BasicChannel.Id, "bookmark", bookmarkWithFile)
+
+		assert.Empty(t, message.GetBroadcast().BroadcastHooks)
+	})
+
+	t.Run("when no bookmark carries file info: hook NOT registered", func(t *testing.T) {
+		th.App.UpdateConfig(func(cfg *model.Config) {
+			cfg.AccessControlSettings.EnableAttributeBasedAccessControl = new(true)
+		})
+
+		message := model.NewWebSocketEvent(model.WebsocketEventChannelBookmarkCreated, "", th.BasicChannel.Id, "", nil, "")
+		th.App.setupBroadcastHookForAbacBookmarks(message, th.BasicChannel.Id, "bookmark", linkBookmark, nil)
+
+		assert.Empty(t, message.GetBroadcast().BroadcastHooks)
+	})
+}


### PR DESCRIPTION
## Ticket Link

Fixes [MM-70676](https://mattermost.atlassian.net/browse/MM-70676).

```release-note
Updated file metadata preparation for post retrieval, channel bookmarks, and notification delivery.
```

[MM-70676]: https://mattermost.atlassian.net/browse/MM-70676?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ