### PR TITLE
Honour FileSettings.ExtractContent on search engine indexing process

### DIFF
--- a/server/enterprise/elasticsearch/common/indexing_job.go
+++ b/server/enterprise/elasticsearch/common/indexing_job.go
@@ -520,11 +520,15 @@ func (worker *IndexerWorker) IndexFilesBatch(logger mlog.LoggerIFace, progress I
 }
 
 func (worker *IndexerWorker) BulkIndexFiles(files []*model.FileForIndexing, progress IndexingProgress) (*model.FileInfo, *model.AppError) {
+	extractContent := *worker.jobServer.Config().FileSettings.ExtractContent
 	for _, file := range files {
 		indexName := *worker.jobServer.Config().ElasticsearchSettings.IndexPrefix + IndexBaseFiles
 
 		if file.ShouldIndex() {
 			searchFile := ESFileFromFileForIndexing(file)
+			if !extractContent {
+				searchFile.Content = ""
+			}
 
 			data, err := json.Marshal(searchFile)
 			if err != nil {


### PR DESCRIPTION
## Summary

The bulk Elasticsearch/OpenSearch indexing job previously sent whatever was stored in `FileInfo.Content` to the search index, ignoring the `FileSettings.ExtractContent` setting entirely. This meant that toggling the setting off had no effect on a subsequent full re-index: content extracted while the setting was `true` would remain searchable even after switching to `false`.

With this change, `BulkIndexFiles` reads `ExtractContent` once per batch and clears the `content` field on each `ESFile` document when the setting is `false`, so the index state always reflects the current configuration.

## Behaviour nuances

**When `ExtractContent` is `false`:**
- Files are still indexed (metadata: name, extension, channel, creator, timestamps).
- The `content` field sent to ES/OS is always `""`, regardless of what is stored in `FileInfo.Content` in the database.
- A bulk re-index while the setting is off will actively overwrite previously-indexed content with an empty string, removing it from search results.

**Re-enabling `ExtractContent` after a period of it being `false`:**

Files uploaded while the setting was disabled will have an empty `Content` column in the database (extraction was skipped at upload time). A bulk re-index alone is not enough to make their bodies searchable again. The correct recovery sequence is:

1. Run the content extraction job to populate `FileInfo.Content` for those files:
   ```
   mmctl extract run
   ```
2. Run a full ES/OS re-index to pick up the newly extracted content.

## Test plan

- [ ] Enable ES/OS indexing and `ExtractContent`, upload files, verify full-text search works.
- [ ] Disable `ExtractContent`, run a full re-index, verify file body search no longer returns results (filename search still works).
- [ ] Re-enable `ExtractContent`, run `mmctl extract run`, then run a full re-index, verify file body search works again for previously-uploaded files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change affects bulk file indexing and indexed content visibility. The scope is isolated, but incorrect setting handling could remove searchable content.

**QA Recommendation:** Perform targeted manual QA for disabled and re-enabled content extraction flows.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->