### PR TITLE
Prepackage mattermost-plugin-agents v2.0.9 (release-11.7)

### DIFF
--- a/server/Makefile
+++ b/server/Makefile
@@ -162,7 +162,7 @@ PLUGIN_PACKAGES += mattermost-plugin-jira-v4.7.2
 PLUGIN_PACKAGES += mattermost-plugin-playbooks-v2.9.4
 PLUGIN_PACKAGES += mattermost-plugin-servicenow-v2.4.0
 PLUGIN_PACKAGES += mattermost-plugin-zoom-v1.13.0
-PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.8
+PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.9
 PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.8
 PLUGIN_PACKAGES += mattermost-plugin-user-survey-v1.1.1
 PLUGIN_PACKAGES += mattermost-plugin-mscalendar-v1.6.2
@@ -176,7 +176,7 @@ PLUGIN_PACKAGES += mattermost-plugin-channel-export-v1.3.0
 # the way we pre-package FIPS and non-FIPS plugins.
 ifeq ($(FIPS_ENABLED),true)
 	PLUGIN_PACKAGES  = mattermost-plugin-playbooks-v2.9.4%2B39a72fa-fips
-	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.8%2B1b17baf-fips
+	PLUGIN_PACKAGES += mattermost-plugin-agents-v2.0.9%2B5085236-fips
 	PLUGIN_PACKAGES += mattermost-plugin-boards-v9.2.8%2B6e21d1c-fips
 endif
 


### PR DESCRIPTION
#### Summary

Updates the default prepackaged [mattermost-plugin-agents](https://github.com/mattermost/mattermost-plugin-agents) artifact from **v2.0.8** to **v2.0.9** ([release v2.0.9](https://github.com/mattermost/mattermost-plugin-agents/releases/tag/v2.0.9)) for the `release-11.7` branch.

Both prepackaged plugin lists are updated:
- non-FIPS: `mattermost-plugin-agents-v2.0.9`
- FIPS: `mattermost-plugin-agents-v2.0.9%2B5085236-fips` (`5085236` is the tagged release commit)

Bundles verified on `plugins.releases.mattermost.com`.

#### Release Note

```release-note
Prepackaged the Mattermost Agents plugin at version 2.0.9 instead of 2.0.8.
```

Made with [Cursor](https://cursor.com)