### PR TITLE
Fix search indexing for posts saved through SaveMultiple

### DIFF
--- a/server/channels/store/searchlayer/post_layer.go
+++ b/server/channels/store/searchlayer/post_layer.go
@@ -110,6 +110,17 @@ func (s SearchPostStore) Save(rctx request.CTX, post *model.Post) (*model.Post, 
 	return npost, err
 }
 
+func (s SearchPostStore) SaveMultiple(rctx request.CTX, posts []*model.Post) ([]*model.Post, int, error) {
+	nposts, errIdx, err := s.PostStore.SaveMultiple(rctx, posts)
+
+	if err == nil {
+		for _, npost := range nposts {
+			s.indexPost(rctx, npost)
+		}
+	}
+	return nposts, errIdx, err
+}
+
 func (s SearchPostStore) Delete(rctx request.CTX, postId string, date int64, deletedByID string) error {
 	err := s.PostStore.Delete(rctx, postId, date, deletedByID)
 	if err != nil {

--- a/server/channels/store/searchlayer/post_layer_test.go
+++ b/server/channels/store/searchlayer/post_layer_test.go
@@ -1,0 +1,146 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+package searchlayer_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/public/shared/request"
+	"github.com/mattermost/mattermost/server/v8/channels/store/searchlayer"
+	"github.com/mattermost/mattermost/server/v8/channels/store/storetest/mocks"
+	"github.com/mattermost/mattermost/server/v8/platform/services/searchengine"
+	semocks "github.com/mattermost/mattermost/server/v8/platform/services/searchengine/mocks"
+)
+
+const harnessTeamID = "team-index-harness"
+
+// postIndexHarness composes the search layer over a mocked base store and a
+// mocked search engine, and records every post ID handed to engine.IndexPost.
+//
+// Synchronization decision: the engine mock reports IsIndexingSync() == true.
+// runIndexFn (layer.go) then executes the index function inline and calls
+// RefreshIndexes before returning, so by the time Save/SaveMultiple returns,
+// every IndexPost call has already happened. No sleeps, no polling.
+type postIndexHarness struct {
+	layer     *searchlayer.SearchStore
+	postStore *mocks.PostStore
+	engine    *semocks.SearchEngineInterface
+	indexed   []string
+}
+
+func newPostIndexHarness(t *testing.T) *postIndexHarness {
+	t.Helper()
+	h := &postIndexHarness{}
+
+	baseStore := &mocks.Store{}
+	h.postStore = &mocks.PostStore{}
+	channelStore := &mocks.ChannelStore{}
+	baseStore.On("Post").Return(h.postStore)
+	baseStore.On("Channel").Return(channelStore)
+	baseStore.On("Team").Return(&mocks.TeamStore{})
+	baseStore.On("User").Return(&mocks.UserStore{})
+	baseStore.On("FileInfo").Return(&mocks.FileInfoStore{})
+
+	channelStore.On("Get", mock.AnythingOfType("string"), true).Return(
+		func(id string, _ bool) *model.Channel {
+			return &model.Channel{Id: id, TeamId: harnessTeamID, Type: model.ChannelTypeOpen}
+		}, nil)
+
+	h.engine = &semocks.SearchEngineInterface{}
+	h.engine.On("IsActive").Return(true)
+	h.engine.On("IsHealthy").Return(true)
+	h.engine.On("IsIndexingEnabled").Return(true)
+	h.engine.On("IsIndexingSync").Return(true)
+	h.engine.On("RefreshIndexes", mock.Anything).Return(nil).Maybe()
+	h.engine.On("GetName").Return("mock-engine").Maybe()
+	h.engine.On("IndexPost", mock.Anything, harnessTeamID, string(model.ChannelTypeOpen)).
+		Run(func(args mock.Arguments) {
+			h.indexed = append(h.indexed, args.Get(0).(*model.Post).Id)
+		}).Return(nil).Maybe()
+
+	cfg := &model.Config{}
+	cfg.SetDefaults()
+	broker := searchengine.NewBroker(cfg)
+	broker.RegisterElasticsearchEngine(h.engine)
+
+	h.layer = searchlayer.NewSearchLayer(baseStore, broker, cfg)
+	return h
+}
+
+// Control: the existing single-post path indexes the post returned by the
+// underlying store, under its own ID.
+func TestSearchPostStore_SaveIndexesPost(t *testing.T) {
+	h := newPostIndexHarness(t)
+	rctx := request.TestContext(t)
+
+	input := &model.Post{ChannelId: "chan-1", UserId: "user-1", Message: "hello"}
+	saved := &model.Post{Id: model.NewId(), ChannelId: "chan-1", UserId: "user-1", Message: "hello"}
+	h.postStore.On("Save", mock.Anything, input).Return(saved, nil)
+
+	got, err := h.layer.Post().Save(rctx, input)
+	require.NoError(t, err)
+	require.Same(t, saved, got)
+	require.Equal(t, []string{saved.Id}, h.indexed)
+}
+
+// Requirement (admin console, "Enable Elasticsearch for indexing": "When true,
+// indexing of new posts occurs automatically"): a batch save is a save of new
+// posts, so every eligible post in the batch must be indexed, each under its
+// own ID, and the exclusions of the single-save path still apply.
+func TestSearchPostStore_SaveMultipleIndexesEachEligiblePost(t *testing.T) {
+	h := newPostIndexHarness(t)
+	rctx := request.TestContext(t)
+
+	input := []*model.Post{
+		{ChannelId: "chan-1", UserId: "user-1", Message: "first"},
+		{ChannelId: "chan-1", UserId: "user-1", Message: "second"},
+		{ChannelId: "chan-1", UserId: "user-1", Message: "ephemeral", Type: model.PostTypeBurnOnRead},
+		{ChannelId: "chan-1", UserId: "user-1", Message: "card", Type: model.PostTypeCard},
+	}
+	returned := []*model.Post{
+		{Id: model.NewId(), ChannelId: "chan-1", UserId: "user-1", Message: "first"},
+		{Id: model.NewId(), ChannelId: "chan-1", UserId: "user-1", Message: "second"},
+		{Id: model.NewId(), ChannelId: "chan-1", UserId: "user-1", Message: "ephemeral", Type: model.PostTypeBurnOnRead},
+		{Id: model.NewId(), ChannelId: "chan-1", UserId: "user-1", Message: "card", Type: model.PostTypeCard},
+	}
+	h.postStore.On("SaveMultiple", mock.Anything, input).Return(returned, -1, nil)
+
+	got, errIdx, err := h.layer.Post().SaveMultiple(rctx, input)
+	require.NoError(t, err)
+	require.Equal(t, -1, errIdx, "success index must pass through unchanged")
+	require.Equal(t, returned, got, "saved posts must pass through unchanged")
+
+	// Identity: exactly the two eligible posts, each once, under their own IDs.
+	// ElementsMatch also rejects a duplicate or a missing entry.
+	require.ElementsMatch(t, []string{returned[0].Id, returned[1].Id}, h.indexed,
+		"batch save must index each eligible post exactly once")
+	require.NotContains(t, h.indexed, returned[2].Id, "burn-on-read post must not be indexed")
+	require.NotContains(t, h.indexed, returned[3].Id, "card post must not be indexed")
+}
+
+// Error contract (sqlstore SaveMultiple): on failure the store returns the
+// index of the offending post (or -1 for transaction failures) and an error.
+// The search layer must pass both through unchanged and index nothing.
+func TestSearchPostStore_SaveMultiplePropagatesErrorWithoutIndexing(t *testing.T) {
+	h := newPostIndexHarness(t)
+	rctx := request.TestContext(t)
+
+	input := []*model.Post{
+		{ChannelId: "chan-1", UserId: "user-1", Message: "first"},
+		{Id: "preset-id", ChannelId: "chan-1", UserId: "user-1", Message: "second"},
+	}
+	storeErr := errors.New("invalid input: post id")
+	h.postStore.On("SaveMultiple", mock.Anything, input).Return(nil, 1, storeErr)
+
+	got, errIdx, err := h.layer.Post().SaveMultiple(rctx, input)
+	require.ErrorIs(t, err, storeErr)
+	require.Equal(t, 1, errIdx)
+	require.Nil(t, got)
+	require.Empty(t, h.indexed, "nothing may be indexed when the batch save fails")
+}

--- a/server/enterprise/elasticsearch/elasticsearch/batch_save_indexing_test.go
+++ b/server/enterprise/elasticsearch/elasticsearch/batch_save_indexing_test.go
@@ -1,0 +1,79 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.enterprise for license information.
+
+package elasticsearch
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/mattermost/mattermost/server/public/model"
+	"github.com/mattermost/mattermost/server/v8/channels/api4"
+)
+
+// Posts saved through the store's batch path must be
+// findable on a live Elasticsearch engine, without a manual reindex.
+// Requires the test containers (postgres, elasticsearch, redis) from `make start-docker`.
+//
+// Synchronization: LiveIndexingBatchSize = 1 makes IsIndexingSync() true, so
+// runIndexFn indexes inline and refreshes the index before Save/SaveMultiple
+// return. The search helper refreshes once more explicitly; there is no sleep.
+func TestBatchSaveIsSearchableOnLiveEngine(t *testing.T) {
+	th := api4.SetupEnterprise(t).InitBasic(t)
+	th.App.UpdateConfig(func(cfg *model.Config) {
+		// Keep this test's indexes separate from other tests and local instances.
+		*cfg.ElasticsearchSettings.IndexPrefix = "batch-save-" + model.NewId() + "-"
+		*cfg.ElasticsearchSettings.EnableIndexing = true
+		*cfg.ElasticsearchSettings.EnableSearching = true
+		*cfg.ElasticsearchSettings.LiveIndexingBatchSize = 1
+		*cfg.SqlSettings.DisableDatabaseSearch = true
+	})
+	th.App.Srv().SetLicense(model.NewTestLicense())
+	th.App.SearchEngine().RegisterElasticsearchEngine(&ElasticsearchInterfaceImpl{Platform: th.Server.Platform()})
+	es := th.App.SearchEngine().ElasticsearchEngine
+	require.Nil(t, es.Start(context.Background()))
+	t.Cleanup(func() { _ = es.Stop() })
+	t.Cleanup(func() { require.Nil(t, es.PurgeIndexes(th.Context)) })
+	require.Nil(t, es.PurgeIndexes(th.Context))
+	require.Nil(t, es.RefreshIndexes(th.Context))
+	require.True(t, es.IsActive(), "engine must be active")
+	require.True(t, es.IsHealthy(), "engine must be healthy")
+	require.True(t, es.IsIndexingSync(), "test relies on synchronous live indexing")
+
+	posts := th.App.Srv().Store().Post()
+	channels := model.ChannelList{th.BasicChannel}
+	search := func(term string) []string {
+		require.Nil(t, es.RefreshIndexes(th.Context))
+		ids, _, appErr := es.SearchPosts(channels, []*model.SearchParams{{Terms: term}}, 0, 20)
+		require.Nil(t, appErr)
+		return ids
+	}
+	newPost := func() *model.Post {
+		return &model.Post{UserId: th.BasicUser.Id, ChannelId: th.BasicChannel.Id, Message: model.NewId()}
+	}
+
+	// Control: the single-save path is searchable.
+	single := newPost()
+	savedSingle, err := posts.Save(th.Context, single)
+	require.NoError(t, err)
+	require.Equal(t, []string{savedSingle.Id}, search(savedSingle.Message), "control: single Save must be searchable")
+
+	// Batch of two eligible posts.
+	batch := []*model.Post{newPost(), newPost()}
+	saved, errIdx, err := posts.SaveMultiple(th.Context, batch)
+	require.NoError(t, err)
+	require.Equal(t, -1, errIdx)
+	require.Len(t, saved, 2)
+
+	// Both rows are in the database ...
+	for _, p := range saved {
+		got, gerr := posts.GetSingle(th.Context, p.Id, false)
+		require.NoError(t, gerr)
+		require.Equal(t, p.Id, got.Id)
+	}
+	// ... and each must be findable under its own ID.
+	require.Equal(t, []string{saved[0].Id}, search(saved[0].Message), "batch post A must be searchable after SaveMultiple")
+	require.Equal(t, []string{saved[1].Id}, search(saved[1].Message), "batch post B must be searchable after SaveMultiple")
+}


### PR DESCRIPTION
#### Summary

Posts created through `PostStore.SaveMultiple` can be persisted without being added to the search index. The search layer wraps `Save`, but previously inherited `SaveMultiple` directly from the underlying store. Bulk-import creation paths call `SaveMultiple`, so they bypassed the indexing performed for an ordinary single-post save.

Add a `SearchPostStore.SaveMultiple` wrapper that indexes each returned post after a successful save. It reuses `indexPost`, preserving the existing `burn_on_read` and `card` exclusions and engine scheduling. The returned posts, error index, and error are passed through unchanged; a failed batch save triggers no indexing. The production change is 11 added lines and does not modify deletion paths, configuration, or schema.

**Regression coverage**

- Three search-layer tests cover the existing single-save path, the exact IDs of eligible batch posts (including exclusions), and error propagation without indexing. The batch-indexing assertions use the saved posts returned by the underlying store, rather than the unsaved inputs.
- An Elasticsearch integration test verifies that both batch posts exist in the database and are searchable under their own IDs, with a single-save control. It uses a test license, disables database search, selects synchronous indexing, and explicitly checks index refresh. Each run uses a unique index prefix and removes its indexes during cleanup.

**Local validation**

Checked against `master` at `87168644a4`:

| Check | Without the production fix | With the production fix |
| --- | --- | --- |
| Search-layer regression tests, with `-race` | Batch test failed because the expected indexed IDs were missing; single-save and error controls passed | Entire `searchlayer` package passed, including the existing configuration-race test |
| Live Elasticsearch regression | Both batch rows existed in the database, but post A was absent from search results | Both batch posts and the single-save control were searchable |

The before-fix runs used Go's `-overlay` to compile the regression tests against the base version of `post_layer.go`. Both returned test exit code 1 for the expected assertion; the fixed runs returned 0. Formatting and `git diff --check` also passed.

To run the checks from a clean test shell with the repository's test database configuration:

```sh
cd server
make setup-go-work
make start-docker ENABLED_DOCKER_SERVICES="postgres minio elasticsearch redis" DOCKER_SERVICES_OVERRIDE=true
go test -race ./channels/store/searchlayer/ -count=1
MM_ELASTICSEARCHSETTINGS_CONNECTIONURL=http://localhost:9200 \
  go test ./enterprise/elasticsearch/elasticsearch/ \
  -run '^TestBatchSaveIsSearchableOnLiveEngine$' -count=1 -v
```

**Draft review scope**

The regression is reproduced at the store/search-engine boundary. Full `mmctl` import followed by Elasticsearch search through the application, asynchronous indexing, and large-import throughput have not been validated. Please confirm that imported posts should use the same live-indexing path as ordinary saves, including the additional per-post work during large imports. This change does not backfill previously unindexed posts.

This contribution was developed with AI assistance; the diff and test behavior were checked locally. It is submitted as a draft for scope and implementation feedback, with upstream CI and maintainer review still pending.

#### Release Note

```release-note
Fixed missing search indexing for newly created posts saved through the batch save path used by bulk imports.
```
