### PR TITLE
chore(deps): bump anthropics/claude-code-action v1.0.70 → v1.0.210

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -34,7 +34,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@26ec041249acb0a944c0a47b6c0c13f05dbc5b44 # v1.0.70
+        uses: anthropics/claude-code-action@a874e9ecd7bb36efdad65429c6b35815f5a08f10 # v1.0.210
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           model: claude-sonnet-4-20250514


### PR DESCRIPTION
#### Summary
Picks up the setup-bun cache fix from anthropics/claude-code-action#1580 (released in v1.0.188). The upstream setup-bun step used a deterministic key (Bun version) that isn't ref-aware, so every second-and-subsequent run against the same PR ref hit a 409 on save; @actions/cache treated the HTML error body as transient and burned ~20–30s on 5 retries plus emitted a noisy warning per PR push.
v1.0.210 passes `no-cache: true` to oven-sh/setup-bun. The 35 MB Bun binary downloads in 2–3s, so this is a net wallclock win and removes the warning.
Refs:
- anthropics/claude-code-action#1580
- anthropics/claude-code-action#1252
- https://github.com/anthropics/claude-code-action/releases/tag/v1.0.210
- https://github.com/mattermost/mattermost-test-automation-toolkit/pull/4

#### Ticket Link
https://github.com/mattermost/mattermost/actions

#### Release Note

```release-note
NONE
```

