### PR TITLE
Clarify that the LDAP Admin Filter applies only at AD/LDAP sign-in

### DIFF
--- a/docs/main/administration-guide/configure/authentication-configuration-settings.mdx
+++ b/docs/main/administration-guide/configure/authentication-configuration-settings.mdx
@@ -655,7 +655,7 @@ If this setting is `false`, no additional users are designated as system admins 
 </colgroup>
 <tbody>
 <tr>
-<td><p>This setting accepts an AD/LDAP filter that designates the selected users as system admins. Users are promoted to this role on their next sign-in or on the next scheduled AD/LDAP sync.</p><p>If the Admin Filter is removed, users who are currently logged in retain their Admin role until their next sign-in.</p><p>String input.</p></td>
+<td><p>This setting accepts an AD/LDAP filter that designates the selected users as system admins. Users are promoted to this role on their next AD/LDAP sign-in. This filter isn't evaluated during scheduled AD/LDAP synchronization, and it doesn't apply to users who authenticate with SAML, even when <strong>Enable Synchronizing SAML Accounts With AD/LDAP</strong> is enabled. Use the SAML <strong>Admin Attribute</strong> setting to designate system admins for SAML-authenticated users.</p><p>If the Admin Filter is removed, users who are currently logged in retain their Admin role until their next sign-in.</p><p>String input.</p></td>
 <td><ul><li>System Config path: <strong>Authentication &gt; AD/LDAP</strong></li><li><code>config.json</code> setting: <code>LdapSettings</code> &gt; <code>AdminFilter</code></li><li>Environment variable: <code>MM_LDAPSETTINGS_ADMINFILTER</code></li></ul></td>
 </tr>
 </tbody>
@@ -1038,6 +1038,7 @@ In line with Microsoft ADFS guidance, we recommend [configuring intranet forms-b
 
 - AD/LDAP synchronization must be enabled and configured through the settings under **Authentication \> AD/LDAP**.
 - Prior to Mattermost v10.9, users not present on the LDAP server could log in, but would be deactivated on the next LDAP sync.
+- Synchronization updates user attributes only. It doesn't change a user's system admin role. The AD/LDAP **Admin Filter** isn't applied to SAML-authenticated users; use the SAML **Admin Attribute** setting to designate system admins instead.
 - See [AD/LDAP Setup](/administration-guide/onboard/ad-ldap) to learn more about configuring AD/LDAP.
 
 </Note>

--- a/docs/main/administration-guide/onboard/ad-ldap.mdx
+++ b/docs/main/administration-guide/onboard/ad-ldap.mdx
@@ -194,6 +194,12 @@ If the Admin Filter is set to `false`, the member's role as system admin is reta
 
 When this filter isn't in use, members can be manually promoted/demoted via **System Console \> User Management**.
 
+<Note>
+
+The Admin Filter is evaluated only when a user signs in with AD/LDAP credentials. It isn't evaluated during scheduled AD/LDAP synchronization, and it doesn't apply to users who authenticate with SAML, even when **Enable Synchronizing SAML Accounts With AD/LDAP** is enabled. To designate system admins for SAML-authenticated users, use the [SAML Admin Attribute](/administration-guide/onboard/sso-saml#admin-attribute) instead.
+
+</Note>
+
 ## Configure AD/LDAP deployments with multiple domains
 
 Organizations using multiple domains can integrate with Mattermost using a "Forest" configuration to bring together multiple domains. Please see [Forests as Collections of Domain Controllers that Trust Each Other](https://learn.microsoft.com/en-us/previous-versions/windows/it-pro/windows-server-2003/cc759073(v=ws.10)?redirectedfrom=MSDN) for more information.

--- a/docs/main/administration-guide/onboard/sso-saml.mdx
+++ b/docs/main/administration-guide/onboard/sso-saml.mdx
@@ -73,6 +73,8 @@ Existing members that are identified by this attribute will be promoted from mem
 
 If the `admin` attribute is set to `false` the member's role as system admin is retained. However if the attribute is removed/changed, system admins that were promoted via the attribute will be demoted to members and will not retain access to the System Console. When this attribute is not in use, system admins can be manually promoted/demoted in **System Console \> User Management**.
 
+The Admin Attribute is the only way to designate system admins for SAML-authenticated users. The AD/LDAP [Admin Filter](/administration-guide/onboard/ad-ldap#admin-filter) doesn't apply to them, even when **Enable Synchronizing SAML Accounts With AD/LDAP** is enabled.
+
 </Note>
 
 ## Configuration assistance

--- a/docs/main/administration-guide/onboard/sso-saml.mdx
+++ b/docs/main/administration-guide/onboard/sso-saml.mdx
@@ -73,7 +73,7 @@ Existing members that are identified by this attribute will be promoted from mem
 
 If the `admin` attribute is set to `false` the member's role as system admin is retained. However if the attribute is removed/changed, system admins that were promoted via the attribute will be demoted to members and will not retain access to the System Console. When this attribute is not in use, system admins can be manually promoted/demoted in **System Console \> User Management**.
 
-The Admin Attribute is the only way to designate system admins for SAML-authenticated users. The AD/LDAP [Admin Filter](/administration-guide/onboard/ad-ldap#admin-filter) doesn't apply to them, even when **Enable Synchronizing SAML Accounts With AD/LDAP** is enabled.
+Aside from manually promoting users in **System Console \> User Management**, the Admin Attribute is the only way to designate system admins for SAML-authenticated users. The AD/LDAP [Admin Filter](/administration-guide/onboard/ad-ldap#admin-filter) doesn't apply to them, even when **Enable Synchronizing SAML Accounts With AD/LDAP** is enabled.
 
 </Note>
 


### PR DESCRIPTION
#### Summary

The Authentication configuration settings page stated that users matching the AD/LDAP **Admin Filter** are promoted to system admin "on their next sign-in **or on the next scheduled AD/LDAP sync**." The second half is not accurate, and the page was also silent on how the filter interacts with SAML-authenticated users. This came up from a customer on v11.7.10 using SAML with `SamlSettings.EnableSyncWithLdap=true`, whose Admin Filter matched their AD admin group but never promoted the user.

Tracing the code in `mattermost/enterprise` (identical on `release-11.7` and `master`):

- `updateUserRoleIfNecessary` (`ldap/ldap.go`) is the only place `LdapSettings.EnableAdminFilter` drives `system_admin`, and its only callers are `LdapInterfaceImpl.DoLogin` and `createNewUserFromLdap` — both in the AD/LDAP login path.
- The `is-admin` determination itself lives in `findLdapUserEntry` (`ldap/ldap_session.go`), reachable only via `findUser` during login.
- The sync job's user phases (`phase4SyncLdapUsers` / `phase5SyncSamlUsers` → `phaseSyncUsers` → `updateMMUserFromLdap` → `updateUserFromLdap`) compare username, email, auth data, names, nickname, position, and `DeleteAt`. Roles are not synced, and `updateUserRoleIfNecessary` is never called from the job. The Admin Filter appears in `getLdapUserFilter` only so admin-matching entries aren't excluded from the search results; it carries no role semantics there.
- `SamlInterfaceImpl.DoLogin` calls `GetLDAPUserForMMUser` purely as an existence check and discards the returned LDAP user, including the `system_admin` role it may carry. SAML role changes come solely from `SamlSettings.EnableAdminAttribute` + `AdminAttribute`.

So the filter is evaluated only at AD/LDAP sign-in, never during scheduled sync, and never for SAML users. The in-product help text (`admin.ldap.adminFilterFilterDescHover`) already says "upon next login" and matches the code; only the docs were wrong.

Changes:

- **authentication-configuration-settings.mdx** — Correct the Admin Filter description, and add a bullet to the "Enable synchronizing SAML accounts with AD/LDAP" note clarifying that sync updates attributes only.
- **ad-ldap.mdx** — Add a note to the Admin Filter section covering the sync and SAML cases, linking to the SAML Admin Attribute.
- **sso-saml.mdx** — State in the Admin Attribute section that it is the only mechanism for SAML-authenticated users.

Prose-only changes to existing MDX structures; I did not run a full Docusaurus site build.

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** These prose-only changes do not modify authentication behavior or shared code. Incorrect documentation could cause user confusion, but it cannot cause runtime regressions.  
**QA Recommendation:** Skip manual functional QA. Verify that the affected MDX pages render correctly.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->