### PR TITLE
Fix cloud preview modal vertical centering

### DIFF
--- a/webapp/channels/src/components/cloud_preview_modal/preview_modal_controller.scss
+++ b/webapp/channels/src/components/cloud_preview_modal/preview_modal_controller.scss
@@ -1,10 +1,6 @@
 .preview-modal-controller {
     &.modal-dialog {
-        &.GenericModal {
-            margin-top: calc(50vh - 307px);
-        }
         width: 640px;
-        height: 614px;
     }
 
     &__footer {


### PR DESCRIPTION
#### Summary
The cloud preview introduction modal sat at the bottom of the page instead of being vertically centered.

`GenericModal` now fills the overlay and flex-centers its dialog. The preview modal still applied a leftover `margin-top: calc(50vh - 307px)` hack (and an unused fixed height) from the old positioning model, which pushed the full-height dialog down.

This removes those overrides so the modal uses GenericModal's default center alignment. Width remains 640px.
Before:
<img width="3179" height="1271" alt="image" src="https://github.com/user-attachments/assets/22409ad1-b934-4651-ac9c-bb2f85f8194c" />

After:
<img width="2185" height="1191" alt="image" src="https://github.com/user-attachments/assets/f6339b67-bad2-4b85-a1f9-9794462ae6bb" />

#### Release Note
```release-note
Fixed the cloud preview introduction modal so it is vertically centered instead of sitting at the bottom of the page.
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to one modal stylesheet and does not affect shared utilities, APIs, or critical flows. The main risk is incorrect modal positioning in untested viewport sizes.

**QA Recommendation:** Manual QA is not required because automated coverage includes login, reopening, and varied desktop viewport sizes.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->