### PR TITLE
Show emoji autocomplete suggestions before the custom emoji fetch completes

### DIFF
--- a/webapp/channels/src/components/suggestion/emoticon_provider.test.tsx
+++ b/webapp/channels/src/components/suggestion/emoticon_provider.test.tsx
@@ -3,14 +3,22 @@
 
 import type {CustomEmoji, Emoji} from '@mattermost/types/emojis';
 
+import {autocompleteCustomEmojis} from 'mattermost-redux/actions/emojis';
+
 import {getEmojiMap, getRecentEmojisNames} from 'selectors/emojis';
+import store from 'stores/redux_store';
 
 import EmojiMap from 'utils/emoji_map';
 
 import EmoticonProvider, {
     MIN_EMOTICON_LENGTH,
     EMOJI_CATEGORY_SUGGESTION_BLOCKLIST,
+    CUSTOM_EMOJI_AUTOCOMPLETE_LIMIT,
 } from './emoticon_provider';
+
+jest.mock('mattermost-redux/actions/emojis', () => ({
+    autocompleteCustomEmojis: jest.fn((name: string) => ({type: 'MOCK_AUTOCOMPLETE', name})),
+}));
 
 jest.mock('selectors/emojis', () => ({
     getEmojiMap: jest.fn(),
@@ -220,5 +228,95 @@ describe('components/EmoticonProvider', () => {
             'thumbsdown',
             'thumbsdown-custom',
         ]);
+    });
+
+    describe('with custom emoji enabled', () => {
+        type Deferred = {resolve: (value: unknown) => void};
+        let dispatches: Deferred[];
+
+        beforeEach(() => {
+            dispatches = [];
+            mockedGetEmojiMap.mockReturnValue(emojiMap);
+            mockedGetRecentEmojisNames.mockReturnValue([]);
+            jest.spyOn(store, 'getState').mockReturnValue({
+                entities: {
+                    general: {config: {EnableCustomEmoji: 'true'}},
+                    preferences: {myPreferences: {}},
+                },
+            } as unknown as ReturnType<typeof store.getState>);
+            jest.spyOn(store, 'dispatch').mockImplementation((() => {
+                return new Promise((resolve) => {
+                    dispatches.push({resolve});
+                });
+            }) as unknown as typeof store.dispatch);
+        });
+
+        afterEach(() => {
+            jest.restoreAllMocks();
+        });
+
+        const flushPromises = () => new Promise((resolve) => setTimeout(resolve));
+
+        it('should suggest local emojis before the server responds', () => {
+            const provider = new EmoticonProvider();
+
+            provider.handlePretextChanged(':thu', resultsCallback);
+
+            expect(resultsCallback).toHaveBeenCalledTimes(1);
+            expect(autocompleteCustomEmojis).toHaveBeenCalledWith('thu');
+        });
+
+        it('should suggest again once the server responds', async () => {
+            const provider = new EmoticonProvider();
+
+            provider.handlePretextChanged(':thu', resultsCallback);
+            dispatches[0].resolve({data: []});
+            await flushPromises();
+
+            expect(resultsCallback).toHaveBeenCalledTimes(2);
+            expect(resultsCallback.mock.calls[1][0].matchedPretext).toBe(':thu');
+        });
+
+        it('should ignore a server response for a superseded prefix', async () => {
+            const provider = new EmoticonProvider();
+
+            provider.handlePretextChanged(':th', resultsCallback);
+            provider.handlePretextChanged(':thu', resultsCallback);
+            expect(resultsCallback).toHaveBeenCalledTimes(2);
+
+            dispatches[0].resolve({data: []});
+            await flushPromises();
+            expect(resultsCallback).toHaveBeenCalledTimes(2);
+
+            dispatches[1].resolve({data: []});
+            await flushPromises();
+            expect(resultsCallback).toHaveBeenCalledTimes(3);
+            expect(resultsCallback.mock.calls[2][0].matchedPretext).toBe(':thu');
+        });
+
+        it('should not fetch again when extending a prefix the server fully answered', async () => {
+            const provider = new EmoticonProvider();
+
+            provider.handlePretextChanged(':th', resultsCallback);
+            dispatches[0].resolve({data: []});
+            await flushPromises();
+
+            provider.handlePretextChanged(':thu', resultsCallback);
+            expect(autocompleteCustomEmojis).toHaveBeenCalledTimes(1);
+
+            provider.handlePretextChanged(':li', resultsCallback);
+            expect(autocompleteCustomEmojis).toHaveBeenCalledTimes(2);
+        });
+
+        it('should fetch again when extending a prefix that hit the server limit', async () => {
+            const provider = new EmoticonProvider();
+
+            provider.handlePretextChanged(':th', resultsCallback);
+            dispatches[0].resolve({data: new Array(CUSTOM_EMOJI_AUTOCOMPLETE_LIMIT).fill({})});
+            await flushPromises();
+
+            provider.handlePretextChanged(':thu', resultsCallback);
+            expect(autocompleteCustomEmojis).toHaveBeenCalledTimes(2);
+        });
     });
 });

--- a/webapp/channels/src/components/suggestion/emoticon_provider.tsx
+++ b/webapp/channels/src/components/suggestion/emoticon_provider.tsx
@@ -23,6 +23,10 @@ import type {SuggestionProps} from './suggestion';
 export const MIN_EMOTICON_LENGTH = 2;
 export const EMOJI_CATEGORY_SUGGESTION_BLOCKLIST = ['skintone'];
 
+// Based on api4.EmojiMaxAutocompleteItems on the server. Since the server only does prefix matches, a
+// response below this limit means the store already has every custom emoji matching any longer prefix.
+export const CUSTOM_EMOJI_AUTOCOMPLETE_LIMIT = 100;
+
 type EmojiItem = {
     emoji: Emoji;
     name: string;
@@ -53,9 +57,12 @@ const EmoticonSuggestion = React.forwardRef<HTMLLIElement, SuggestionProps<Emoji
 EmoticonSuggestion.displayName = 'EmoticonSuggestion';
 
 export default class EmoticonProvider extends Provider {
+    private fullyFetchedPrefix: string;
+
     constructor() {
         super();
 
+        this.fullyFetchedPrefix = '';
         this.triggerCharacter = ':';
     }
 
@@ -84,13 +91,32 @@ export default class EmoticonProvider extends Provider {
             }
         }
 
-        if (store.getState().entities.general.config.EnableCustomEmoji === 'true') {
-            store.dispatch(autocompleteCustomEmojis(partialName)).then(() => this.findAndSuggestEmojis(text, partialName, resultsCallback));
-        } else {
-            this.findAndSuggestEmojis(text, partialName, resultsCallback);
+        this.startNewRequest(partialName);
+        this.findAndSuggestEmojis(text, partialName, resultsCallback);
+
+        if (this.shouldFetchCustomEmojis(partialName)) {
+            store.dispatch(autocompleteCustomEmojis(partialName)).then(({data}) => {
+                if (!data || partialName !== this.latestPrefix) {
+                    return;
+                }
+
+                if (data.length < CUSTOM_EMOJI_AUTOCOMPLETE_LIMIT) {
+                    this.fullyFetchedPrefix = partialName;
+                }
+
+                this.findAndSuggestEmojis(text, partialName, resultsCallback);
+            });
         }
 
         return true;
+    }
+
+    shouldFetchCustomEmojis(partialName: string) {
+        if (store.getState().entities.general.config.EnableCustomEmoji !== 'true') {
+            return false;
+        }
+
+        return !this.fullyFetchedPrefix || !partialName.startsWith(this.fullyFetchedPrefix);
     }
 
     formatEmojis(emojis: EmojiItem[]) {

--- a/webapp/channels/src/packages/mattermost-redux/src/actions/emojis.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/actions/emojis.ts
@@ -239,7 +239,7 @@ export function searchCustomEmojis(term: string, options: any = {}, loadUsers = 
     };
 }
 
-export function autocompleteCustomEmojis(name: string): ActionFuncAsync {
+export function autocompleteCustomEmojis(name: string): ActionFuncAsync<CustomEmoji[]> {
     return async (dispatch, getState) => {
         let data;
         try {


### PR DESCRIPTION
#### Summary
When custom emoji are enabled, `EmoticonProvider` waited for the `autocompleteCustomEmojis` request to finish before showing any suggestions, so every keystroke in the emoji autocomplete paid a full server round trip on top of the suggestion box debounce. The at-mention and channel providers already show local results synchronously and refine them when the server responds, and this change makes the emoji provider behave the same way.

It also skips the fetch when the typed prefix extends one the server already answered with fewer than `EmojiMaxAutocompleteItems` results. Since the server does prefix matching, such a response means the store already holds every custom emoji for any longer prefix. New custom emoji still show up because they arrive over the `emoji_added` websocket event.

`autocompleteCustomEmojis` gains a `CustomEmoji[]` return type so the provider can read the result length; sibling actions in the file are already typed this way.

#### Ticket Link
None

#### Screenshots
N/A

#### Release Note
```release-note
Emoji autocomplete now shows suggestions immediately instead of waiting for the custom emoji request to complete.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟡 Medium

**Regression Risk:** The change affects user-facing emoji autocomplete across the provider and Redux action layers. Automated tests cover stale responses, local suggestions, and fetch conditions.

**QA Recommendation:** Manual QA can be skipped. Automated test coverage is sufficient.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->