### PR TITLE
[E2E/Playwright] Add SSO test infrastructure, clean up feature-flag baseline

### DIFF
--- a/e2e-tests/playwright/README.md
+++ b/e2e-tests/playwright/README.md
@@ -37,6 +37,8 @@ PW_USE_TESTCONTAINERS=true MM_ENV=MM_LICENSE='<your-license-key>' npm run test
 
 Containers are reused across invocations by default (`PW_TESTCONTAINERS_REUSE=true`) instead of being recreated every run — tear the stack down explicitly when you're done with `npm run testcontainers:down`. Set `PW_TESTCONTAINERS_REUSE=false` for a one-off run that tears itself down when it finishes. Use `npm run testcontainers:up` to just bring the stack up (or confirm an existing one's still reachable) without running any tests.
 
+The Mattermost container itself publishes to a **fixed host port, `8055`**, not a random one like every other service here — see `lib/README.md`'s Testcontainers section for why.
+
 See `lib/README.md` for every available environment variable.
 
 #### 2. Install dependencies and run the test.

--- a/e2e-tests/playwright/lib/README.md
+++ b/e2e-tests/playwright/lib/README.md
@@ -165,7 +165,11 @@ Selects `testcontainers` mode — Playwright brings up the server + dependencies
 | `PW_MINIO_URL`                       | Minio URL (only used when `minio` is started)                                                                                                                                                                         | `http://localhost:9000`                                      |
 | `PW_AZURITE_URL`                     | Azurite URL (only used when `azurite` is started)                                                                                                                                                                     | `http://localhost:10000`                                     |
 
-In `testcontainers` mode, these host/port defaults are never actually used — Testcontainers always assigns its own dynamic port or network alias per run, so a `testcontainers`-mode run can never collide with a same-machine `external`-mode session using the fixed defaults above. Tear a reused stack down explicitly with `npm run testcontainers:down` (from the `playwright/` package).
+In `testcontainers` mode, these host/port defaults above are never actually used — Testcontainers assigns its own dynamic port or network alias per run for every one of these services, so a `testcontainers`-mode run can never collide with a same-machine `external`-mode session using the fixed defaults above.
+
+The one exception is the **Mattermost server container itself**, which publishes to a **fixed host port, `8055`** (`MATTERMOST_FIXED_HOST_PORT` in `lib/src/containers/constants.ts`) rather than a dynamic one. This is deliberately not `8065` (the `external`-mode/`PW_BASE_URL` default above), so a `testcontainers`-mode run still doesn't collide with a locally-run dev server on the same machine. The fixed port exists so `testConfig.baseURL` stays stable across a `restartMattermostContainer()` call — some settings (e.g. `ServiceSettings.SiteURL`, via `pw.ensureSiteUrl()`) depend on that stability to converge at all; a dynamic port would go stale the instant a restart replaced the container. This assumes one Mattermost `testcontainers` stack per host at a time (already true of `PW_TESTCONTAINERS_REUSE`'s single-stack model); CI runs each matrix job on its own isolated runner, so it doesn't collide there either.
+
+Tear a reused stack down explicitly with `npm run testcontainers:down` (from the `playwright/` package).
 
 ## Accessibility Testing
 

--- a/e2e-tests/playwright/lib/src/containers/constants.ts
+++ b/e2e-tests/playwright/lib/src/containers/constants.ts
@@ -21,6 +21,10 @@ export const INBUCKET_POP3_PORT = 10110;
 
 export const MATTERMOST_ALIAS = 'server';
 export const MATTERMOST_PORT = 8065;
+// Fixed host-side port the container publishes MATTERMOST_PORT to (see mattermost_container.ts) -
+// deliberately not 8065, the conventional port a locally-run dev server (`make run`, external
+// mode) already listens on, so both can run on the same machine at once without colliding.
+export const MATTERMOST_FIXED_HOST_PORT = 8055;
 
 // Interactive-message/dialog callback sidecar shared with Cypress. Always started, like
 // postgres/inbucket — not gated behind testcontainersServices.
@@ -38,6 +42,10 @@ export const KEYCLOAK_PORT = 8080;
 export const KEYCLOAK_REALM = 'mattermost';
 export const KEYCLOAK_ADMIN_USER = 'admin';
 export const KEYCLOAK_ADMIN_PASSWORD = 'admin';
+
+// Matches the `mattermost-openid` client's clientId/secret in keycloak-realm-export.json.
+export const KEYCLOAK_OPENID_CLIENT_ID = 'mattermost-openid';
+export const KEYCLOAK_OPENID_CLIENT_SECRET = '9Y7dykcoA9luTC77XtXxOu9UbNx3rhj6';
 
 export const ELASTICSEARCH_ALIAS = 'elasticsearch';
 export const ELASTICSEARCH_PORT = 9200;

--- a/e2e-tests/playwright/lib/src/containers/env_baseline.ts
+++ b/e2e-tests/playwright/lib/src/containers/env_baseline.ts
@@ -1,8 +1,17 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
+import {MATTERMOST_ALIAS, MATTERMOST_PORT} from './constants';
+
 // Test-oriented MM_* config the Mattermost server container starts with by default,
 // merged under testConfig.serverEnv (MM_ENV) so callers can still override any of it.
+//
+// MM_SERVICESETTINGS_SITEURL defaults to the Docker network alias (the server's own view of
+// itself, reachable by its own container - see default_config.ts's ServiceSettings.SiteURL
+// comment) but, unlike mattermost_container.ts's structuralEnv(), lives at this overridable tier
+// on purpose: a caller that genuinely needs the running server's SiteURL to be host-reachable
+// (e.g. pw.ensureServerEnv('MM_SERVICESETTINGS_SITEURL', testConfig.baseURL), for an OAuth-style
+// flow whose redirect_uri a plain browser must be able to follow) can flip it via a restart.
 export const SERVER_ENV_BASELINE: Record<string, string> = {
     MM_SERVICEENVIRONMENT: 'test',
     MM_CLUSTERSETTINGS_READONLYCONFIG: 'false',
@@ -16,12 +25,5 @@ export const SERVER_ENV_BASELINE: Record<string, string> = {
     MM_SERVICESETTINGS_ENABLELOCALMODE: 'true',
     MM_SERVICESETTINGS_ENABLESECURITYFIXALERT: 'false',
     MM_SERVICESETTINGS_ENABLETESTING: 'true',
-    // Feature flags this test suite needs on, off by default in the server
-    MM_FEATUREFLAGS_ATTRIBUTEVALUEMASKING: 'true',
-    MM_FEATUREFLAGS_PERMISSIONPOLICIES: 'true',
-    MM_FEATUREFLAGS_PROPERTYFIELDRANK: 'true',
-    MM_FEATUREFLAGS_RECURRINGSCHEDULEDPOSTS: 'true',
-    MM_FEATUREFLAGS_RESOURCEATTRIBUTESINPOLICIES: 'true',
-    MM_FEATUREFLAGS_TEAMMEMBERSHIPACCESSCONTROL: 'true',
-    MM_FEATUREFLAGS_WYSIWYGEDITOR: 'true',
+    MM_SERVICESETTINGS_SITEURL: `http://${MATTERMOST_ALIAS}:${MATTERMOST_PORT}`,
 };

--- a/e2e-tests/playwright/lib/src/containers/mattermost_container.ts
+++ b/e2e-tests/playwright/lib/src/containers/mattermost_container.ts
@@ -11,6 +11,7 @@ import {
     INBUCKET_SMTP_PORT,
     MATTERMOST_DATA_DIR,
     MATTERMOST_ALIAS,
+    MATTERMOST_FIXED_HOST_PORT,
     MATTERMOST_PORT,
     POSTGRES_ALIAS,
     POSTGRES_DB,
@@ -60,8 +61,6 @@ function structuralEnv(): Record<string, string> {
         MM_SQLSETTINGS_DATASOURCE: POSTGRES_DSN,
         MM_EMAILSETTINGS_SMTPSERVER: INBUCKET_ALIAS,
         MM_EMAILSETTINGS_SMTPPORT: String(INBUCKET_SMTP_PORT),
-        // Required at boot so prepackaged plugins (Agents, etc.) can activate without waiting for a later patchConfig.
-        MM_SERVICESETTINGS_SITEURL: `http://${MATTERMOST_ALIAS}:${MATTERMOST_PORT}`,
         ...(process.env.MM_LICENSE ? {MM_LICENSE: process.env.MM_LICENSE} : {}),
         // Replaces the baseline for this key: appends mock file-server hosts (host.docker.internal
         // and the bridge gateway IP, set by startStack() once the network is up).
@@ -113,7 +112,15 @@ export async function startMattermostContainer(
             .withLabels(TESTCONTAINERS_LABELS)
             // Ensures host.docker.internal resolves to the Docker host (via host-gateway).
             .withExtraHosts([{host: 'host.docker.internal', ipAddress: 'host-gateway'}])
-            .withExposedPorts(MATTERMOST_PORT)
+            // Fixed rather than a random host port: a random port changes on every
+            // restartMattermostContainer() call, which would make a host-reachable
+            // ServiceSettings.SiteURL (see server_env.ts's ensureSiteUrl()) stale the moment a
+            // fresh container replaces the old one. Not MATTERMOST_PORT (8065) itself, so this
+            // doesn't collide with a locally-run dev server (`make run`, external mode) on the
+            // same machine. Assumes one Mattermost testcontainers stack per host at a time, same
+            // as PW_TESTCONTAINERS_REUSE's existing single-stack-per-machine model; CI runs each
+            // matrix job on its own isolated runner, so this doesn't collide there either.
+            .withExposedPorts({container: MATTERMOST_PORT, host: MATTERMOST_FIXED_HOST_PORT})
             .withEnvironment(env)
             // Bind-mounted unconditionally so local-disk FileSettings data (server/build/Dockerfile's
             // VOLUME ["/mattermost/data", ...]) survives restartMattermostContainer()'s docker rm -f

--- a/e2e-tests/playwright/lib/src/server/feature_flags.ts
+++ b/e2e-tests/playwright/lib/src/server/feature_flags.ts
@@ -22,21 +22,21 @@ import {testConfig} from '@/test_config';
  */
 export async function ensureFeatureFlag(flagName: string, value: boolean): Promise<void> {
     const envValue = String(value);
-    const {adminClient} = await getAdminClient();
-    const config = await adminClient.getConfig();
-    if (String(config.FeatureFlags?.[flagName]) === envValue) {
-        // Already matches - nothing to restart, even against an external server.
-        return;
-    }
-
-    if (!testConfig.useTestContainers) {
-        test.skip(true, 'Skipping test - feature flag restart requires PW_USE_TESTCONTAINERS=true');
-        return;
-    }
-
-    const envKey = `MM_FEATUREFLAGS_${flagName.toUpperCase()}`;
 
     try {
+        const {adminClient} = await getAdminClient();
+        const config = await adminClient.getConfig();
+        if (String(config.FeatureFlags?.[flagName]) === envValue) {
+            // Already matches - nothing to restart, even against an external server.
+            return;
+        }
+
+        if (!testConfig.useTestContainers) {
+            test.skip(true, 'Skipping test - feature flag restart requires PW_USE_TESTCONTAINERS=true');
+            return;
+        }
+
+        const envKey = `MM_FEATUREFLAGS_${flagName.toUpperCase()}`;
         const env = {[envKey]: envValue};
         if (!bootEnvMatches(env)) {
             await restartMattermostContainer(env);

--- a/e2e-tests/playwright/lib/src/server/feature_flags.ts
+++ b/e2e-tests/playwright/lib/src/server/feature_flags.ts
@@ -21,13 +21,20 @@ import {testConfig} from '@/test_config';
  * takes effect.
  */
 export async function ensureFeatureFlag(flagName: string, value: boolean): Promise<void> {
+    const envValue = String(value);
+    const {adminClient} = await getAdminClient();
+    const config = await adminClient.getConfig();
+    if (String(config.FeatureFlags?.[flagName]) === envValue) {
+        // Already matches - nothing to restart, even against an external server.
+        return;
+    }
+
     if (!testConfig.useTestContainers) {
         test.skip(true, 'Skipping test - feature flag restart requires PW_USE_TESTCONTAINERS=true');
         return;
     }
 
     const envKey = `MM_FEATUREFLAGS_${flagName.toUpperCase()}`;
-    const envValue = String(value);
 
     try {
         const env = {[envKey]: envValue};
@@ -35,9 +42,8 @@ export async function ensureFeatureFlag(flagName: string, value: boolean): Promi
             await restartMattermostContainer(env);
         }
 
-        const {adminClient} = await getAdminClient();
-        const config = await adminClient.getConfig();
-        const actual = config.FeatureFlags?.[flagName];
+        const restartedConfig = await adminClient.getConfig();
+        const actual = restartedConfig.FeatureFlags?.[flagName];
         if (String(actual) !== envValue) {
             throw new Error(`Feature flag "${flagName}" is "${String(actual)}" after restart, expected "${envValue}".`);
         }

--- a/e2e-tests/playwright/lib/src/server/index.ts
+++ b/e2e-tests/playwright/lib/src/server/index.ts
@@ -53,7 +53,17 @@ export {
     ensureOpenldap,
 } from './openldap';
 export type {LdapUser} from './openldap';
-export {createKeycloakUser, deleteKeycloakUser, samlServerConfig, ensureKeycloak} from './keycloak';
+export {
+    generateKeycloakUser,
+    createKeycloakUser,
+    deleteKeycloakUser,
+    suspendKeycloakUser,
+    samlServerConfig,
+    keycloakSamlDescriptorUrl,
+    ensureKeycloak,
+    openidServerConfig,
+    ensureKeycloakOpenId,
+} from './keycloak';
 export type {KeycloakUser} from './keycloak';
 export {listMinioObjectKeys, ensureMinio} from './minio';
 export {elasticsearchServerConfig, ensureElasticsearch} from './elasticsearch';
@@ -62,6 +72,7 @@ export {ensureAzurite, listAzuriteBlobNames} from './azurite';
 export {ensureLocalFile, listMattermostDataFiles} from './filestore';
 export {ensurePostgresSearch} from './postgres_search';
 export {ensureFeatureFlag} from './feature_flags';
+export {ensureServerEnv, ensureSiteUrl} from './server_env';
 export {runMmctl, runMmctlLocal, ensureMmctl} from './mmctl';
 export type {MmctlResult} from './mmctl';
 export {upgradeServerImage} from './version';

--- a/e2e-tests/playwright/lib/src/server/keycloak.ts
+++ b/e2e-tests/playwright/lib/src/server/keycloak.ts
@@ -9,6 +9,8 @@ import {
     KEYCLOAK_ADMIN_PASSWORD,
     KEYCLOAK_ADMIN_USER,
     KEYCLOAK_ALIAS,
+    KEYCLOAK_OPENID_CLIENT_ID,
+    KEYCLOAK_OPENID_CLIENT_SECRET,
     KEYCLOAK_PORT,
     KEYCLOAK_REALM,
 } from '../containers/constants';
@@ -16,6 +18,7 @@ import {
 import {getAdminClient} from './init';
 
 import {testConfig} from '@/test_config';
+import {getRandomId} from '@/util';
 
 export type KeycloakUser = {
     username: string;
@@ -24,6 +27,18 @@ export type KeycloakUser = {
     lastName: string;
     password: string;
 };
+
+/** Generates a directory-only Keycloak user's fields - createKeycloakUser() still creates it. */
+export function generateKeycloakUser(prefix = 'user'): KeycloakUser {
+    const randomId = getRandomId();
+    return {
+        username: `${prefix}${randomId}`,
+        email: `${prefix}${randomId}@mmtest.com`,
+        firstName: `Firstname-${randomId}`,
+        lastName: `Lastname-${randomId}`,
+        password: 'Password1',
+    };
+}
 
 async function getAdminToken(): Promise<string> {
     const response = await fetch(`${testConfig.keycloakUrl}/realms/master/protocol/openid-connect/token`, {
@@ -71,6 +86,19 @@ export async function createKeycloakUser(user: KeycloakUser): Promise<string> {
     return userId;
 }
 
+/** Disables the Keycloak user (`enabled: false`), so Keycloak itself refuses further logins. */
+export async function suspendKeycloakUser(userId: string): Promise<void> {
+    const token = await getAdminToken();
+    const response = await fetch(`${testConfig.keycloakUrl}/admin/realms/${KEYCLOAK_REALM}/users/${userId}`, {
+        method: 'PUT',
+        headers: {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'},
+        body: JSON.stringify({enabled: false}),
+    });
+    if (!response.ok) {
+        throw new Error(`Failed to suspend Keycloak user: ${response.status} ${await response.text()}`);
+    }
+}
+
 export async function deleteKeycloakUser(userId: string): Promise<void> {
     const token = await getAdminToken();
     const response = await fetch(`${testConfig.keycloakUrl}/admin/realms/${KEYCLOAK_REALM}/users/${userId}`, {
@@ -90,7 +118,7 @@ const SAML_SERVICE_PROVIDER_ID = 'mattermost';
 // which the browser follows directly and so must be reachable from the host instead. Only the
 // certificate from this response is used; its embedded URLs reflect the alias host, not the one
 // the browser needs.
-function keycloakSamlDescriptorUrl(): string {
+export function keycloakSamlDescriptorUrl(): string {
     return `http://${KEYCLOAK_ALIAS}:${KEYCLOAK_PORT}/realms/${KEYCLOAK_REALM}/protocol/saml/descriptor`;
 }
 
@@ -117,6 +145,9 @@ export async function samlServerConfig(adminClient: Client4): Promise<Partial<Ad
         Verify: true,
         Encrypt: false,
         SignRequest: false,
+        // Reset explicitly: a prior test (e.g. saml_ldap_sync.spec.ts) may have turned this on,
+        // and with it on a SAML user absent from LDAP fails to log in at all.
+        EnableSyncWithLdap: false,
         IdpURL: `${testConfig.keycloakUrl}/realms/${KEYCLOAK_REALM}/protocol/saml`,
         IdpDescriptorURL: `${testConfig.keycloakUrl}/realms/${KEYCLOAK_REALM}`,
         ServiceProviderIdentifier: SAML_SERVICE_PROVIDER_ID,
@@ -147,5 +178,86 @@ export async function ensureKeycloak(): Promise<void> {
         await adminClient.patchConfig({SamlSettings: config});
     } catch (error) {
         test.skip(true, `Skipping test - Keycloak SAML setup failed: ${String(error)}`);
+    }
+}
+
+/**
+ * Fixes the realm's issuer identity to the host-reachable Keycloak URL, regardless of which
+ * hostname (host-mapped or Testcontainers alias) a given request actually arrived on.
+ *
+ * Keycloak (KC_HOSTNAME_STRICT=false) otherwise ties an access token's validity to whichever
+ * hostname received the request that issued it. AuthEndpoint below is host-reachable (so the
+ * OpenID button works the same for a real browser as it does for Playwright's), but
+ * TokenEndpoint/UserAPIEndpoint must dial the Testcontainers alias, since only that address is
+ * reachable from inside the server's own container - without a fixed issuer, that hostname
+ * mismatch would make the server's userinfo call fail with `invalid_token` even though the token
+ * exchange itself succeeds.
+ */
+async function ensureKeycloakRealmFrontendUrl(): Promise<void> {
+    const token = await getAdminToken();
+    const realmUrl = `${testConfig.keycloakUrl}/admin/realms/${KEYCLOAK_REALM}`;
+
+    const response = await fetch(realmUrl, {headers: {Authorization: `Bearer ${token}`}});
+    if (!response.ok) {
+        throw new Error(`Failed to read Keycloak realm: ${response.status} ${await response.text()}`);
+    }
+    const realm = await response.json();
+
+    if (realm.attributes?.frontendUrl === testConfig.keycloakUrl) {
+        return;
+    }
+
+    realm.attributes = {...realm.attributes, frontendUrl: testConfig.keycloakUrl};
+    const putResponse = await fetch(realmUrl, {
+        method: 'PUT',
+        headers: {Authorization: `Bearer ${token}`, 'Content-Type': 'application/json'},
+        body: JSON.stringify(realm),
+    });
+    if (!putResponse.ok) {
+        throw new Error(`Failed to set Keycloak realm frontend URL: ${putResponse.status} ${await putResponse.text()}`);
+    }
+}
+
+/**
+ * Points the server at the `mattermost-openid` client already provisioned in
+ * keycloak-realm-export.json. AuthEndpoint is browser-facing - any browser, not just
+ * Playwright's, can reach it and start the login - while TokenEndpoint/UserAPIEndpoint are
+ * called by the server itself, so they use the Testcontainers network alias instead (see
+ * ensureKeycloakRealmFrontendUrl() for why that hostname difference doesn't break token
+ * validation). DiscoveryEndpoint is left empty on purpose: when set, the server resolves
+ * endpoints from it instead of the explicit ones above, server-side, which would bypass this
+ * split entirely.
+ */
+export function openidServerConfig(): Partial<AdminConfig['OpenIdSettings']> {
+    return {
+        Enable: true,
+        Id: KEYCLOAK_OPENID_CLIENT_ID,
+        Secret: KEYCLOAK_OPENID_CLIENT_SECRET,
+        Scope: 'openid profile email',
+        AuthEndpoint: `${testConfig.keycloakUrl}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/auth`,
+        TokenEndpoint: `http://${KEYCLOAK_ALIAS}:${KEYCLOAK_PORT}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/token`,
+        UserAPIEndpoint: `http://${KEYCLOAK_ALIAS}:${KEYCLOAK_PORT}/realms/${KEYCLOAK_REALM}/protocol/openid-connect/userinfo`,
+        DiscoveryEndpoint: '',
+        ButtonText: 'Keycloak OpenID',
+        UsePreferredUsername: true,
+    };
+}
+
+/**
+ * Checks Keycloak was started this run, points the server's OpenID settings at it, and skips the
+ * test if either step fails, instead of failing on an unmet precondition.
+ */
+export async function ensureKeycloakOpenId(): Promise<void> {
+    if (!testConfig.testcontainersServices.includes('keycloak')) {
+        test.skip(true, 'Skipping test - keycloak not started (set PW_TESTCONTAINERS_SERVICES=keycloak)');
+        return;
+    }
+
+    try {
+        await ensureKeycloakRealmFrontendUrl();
+        const {adminClient} = await getAdminClient();
+        await adminClient.patchConfig({OpenIdSettings: openidServerConfig()});
+    } catch (error) {
+        test.skip(true, `Skipping test - Keycloak OpenID setup failed: ${String(error)}`);
     }
 }

--- a/e2e-tests/playwright/lib/src/server/server_env.ts
+++ b/e2e-tests/playwright/lib/src/server/server_env.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import {test} from '@playwright/test';
+
+import {bootEnvMatches, restartMattermostContainer} from '../containers/stack';
+
+import {getAdminClient} from './init';
+
+import {testConfig} from '@/test_config';
+
+/**
+ * Restarts the server with a single MM_* env var set to `value` if it isn't already - the same
+ * boot-only-setting restart ensureFeatureFlag()/ensureMinio() use, generalized to an arbitrary
+ * key, for settings that only take effect at boot and can't be changed via patchConfig on a
+ * running server.
+ *
+ * Only checks bootEnvOverrides bookkeeping (what this process asked for), not the server's
+ * actual reported config. That's fine for most boot-only settings, but a few keys (see
+ * mattermost_container.ts's structuralEnv()) are always recomputed by the container startup code
+ * itself and win over anything passed here regardless, so this can't be used to change them - a
+ * caller touching one of those needs its own post-restart check against the real config to catch
+ * that rather than trusting this function silently worked.
+ */
+export async function ensureServerEnv(key: string, value: string): Promise<void> {
+    if (!testConfig.useTestContainers) {
+        test.skip(true, 'Skipping test - server env restart requires PW_USE_TESTCONTAINERS=true');
+        return;
+    }
+
+    try {
+        const env = {[key]: value};
+        if (!bootEnvMatches(env)) {
+            await restartMattermostContainer(env);
+        }
+    } catch (error) {
+        test.skip(true, `Skipping test - server env "${key}" restart failed: ${String(error)}`);
+    }
+}
+
+/**
+ * Restarts the server with ServiceSettings.SiteURL set to the host-reachable baseURL, if it
+ * isn't already, and confirms the running server actually reports that value - skipping the test
+ * otherwise, instead of failing on an unmet precondition.
+ *
+ * Unlike most boot-only settings, this one persists once set: restartMattermostContainer() merges
+ * env rather than replacing it, so every other spec sharing this reused server afterward also
+ * sees the host-facing SiteURL until something restarts it back to the alias (see
+ * env_baseline.ts). Only call this from a spec that genuinely needs a host-reachable SiteURL for
+ * the rest of the run (e.g. an OAuth-style flow a plain browser must be able to follow) - not
+ * something to reach for casually.
+ */
+export async function ensureSiteUrl(): Promise<void> {
+    if (!testConfig.useTestContainers) {
+        test.skip(true, 'Skipping test - SiteURL restart requires PW_USE_TESTCONTAINERS=true');
+        return;
+    }
+
+    try {
+        const env = {MM_SERVICESETTINGS_SITEURL: testConfig.baseURL};
+        if (!bootEnvMatches(env)) {
+            await restartMattermostContainer(env);
+        }
+
+        const {adminClient} = await getAdminClient();
+        const config = await adminClient.getConfig();
+        if (config.ServiceSettings.SiteURL !== testConfig.baseURL) {
+            throw new Error(
+                `ServiceSettings.SiteURL is "${config.ServiceSettings.SiteURL}" after restart, expected ` +
+                    `"${testConfig.baseURL}".`,
+            );
+        }
+    } catch (error) {
+        test.skip(true, `Skipping test - SiteURL check failed: ${String(error)}`);
+    }
+}

--- a/e2e-tests/playwright/lib/src/test_fixture.ts
+++ b/e2e-tests/playwright/lib/src/test_fixture.ts
@@ -23,8 +23,8 @@ import {
     createKeycloakUser,
     createLdapUser,
     createMockAIAgent,
-    createNewUserProfile,
     createNewTeam,
+    createNewUserProfile,
     createRandomChannel,
     createRandomPost,
     createRandomTeam,
@@ -32,39 +32,46 @@ import {
     createUserWithAttributes,
     deleteKeycloakUser,
     deleteLdapUser,
+    elasticsearchServerConfig,
     enableAIBridgeTestMode,
-    listMinioObjectKeys,
-    ensureMinio,
     ensureAzurite,
-    listAzuriteBlobNames,
-    ensureLocalFile,
-    listMattermostDataFiles,
-    ensurePostgresSearch,
+    ensureElasticsearch,
     ensureFeatureFlag,
-    generateLdapUser,
-    getAIBridgeMock,
-    getAdminClient,
-    initSetup,
-    isOutsideRemoteUserHour,
-    ldapServerConfig,
+    ensureKeycloak,
+    ensureKeycloakOpenId,
+    ensureLocalFile,
+    ensureMinio,
+    ensureMmctl,
     ensureOpenldap,
+    ensureOpensearch,
+    ensurePostgresSearch,
+    ensureServerEnv,
+    ensureSiteUrl,
+    generateKeycloakUser,
+    generateLdapUser,
+    getAdminClient,
+    getAIBridgeMock,
+    initSetup,
+    installAndEnablePlugin,
+    isOutsideRemoteUserHour,
+    isPluginActive,
+    keycloakSamlDescriptorUrl,
+    ldapServerConfig,
+    listAzuriteBlobNames,
+    listMattermostDataFiles,
+    listMinioObjectKeys,
     makeClient,
+    openidServerConfig,
+    opensearchServerConfig,
     recapCompletion,
     resetAIBridgeMock,
     rewriteCompletion,
-    installAndEnablePlugin,
-    isPluginActive,
-    samlServerConfig,
-    ensureKeycloak,
-    elasticsearchServerConfig,
-    opensearchServerConfig,
-    ensureElasticsearch,
-    ensureOpensearch,
     runMmctl,
-    ensureMmctl,
+    samlServerConfig,
+    saveUpgradePhaseLogs,
+    suspendKeycloakUser,
     updateLdapUser,
     upgradeServerImage,
-    saveUpgradePhaseLogs,
 } from './server';
 import {
     toBeFocusedWithFocusVisible,
@@ -142,30 +149,37 @@ export class PlaywrightExtended {
     readonly isPluginActive;
 
     // ./server/openldap, ./server/keycloak, ./server/elasticsearch, ./server/opensearch, ./server/minio
-    readonly generateLdapUser;
-    readonly createLdapUser;
-    readonly updateLdapUser;
-    readonly deleteLdapUser;
-    readonly ldapServerConfig;
-    readonly ensureOpenldap;
     readonly createKeycloakUser;
+    readonly createLdapUser;
     readonly deleteKeycloakUser;
-    readonly samlServerConfig;
-    readonly ensureKeycloak;
+    readonly deleteLdapUser;
     readonly elasticsearchServerConfig;
-    readonly opensearchServerConfig;
-    readonly ensureElasticsearch;
-    readonly ensureOpensearch;
-    readonly listMinioObjectKeys;
-    readonly ensureMinio;
     readonly ensureAzurite;
-    readonly ensureLocalFile;
-    readonly listMattermostDataFiles;
-    readonly ensurePostgresSearch;
+    readonly ensureElasticsearch;
     readonly ensureFeatureFlag;
-    readonly listAzuriteBlobNames;
-    readonly runMmctl;
+    readonly ensureKeycloak;
+    readonly ensureKeycloakOpenId;
+    readonly ensureLocalFile;
+    readonly ensureMinio;
     readonly ensureMmctl;
+    readonly ensureOpenldap;
+    readonly ensureOpensearch;
+    readonly ensurePostgresSearch;
+    readonly ensureServerEnv;
+    readonly ensureSiteUrl;
+    readonly generateKeycloakUser;
+    readonly generateLdapUser;
+    readonly keycloakSamlDescriptorUrl;
+    readonly ldapServerConfig;
+    readonly listAzuriteBlobNames;
+    readonly listMattermostDataFiles;
+    readonly listMinioObjectKeys;
+    readonly openidServerConfig;
+    readonly opensearchServerConfig;
+    readonly runMmctl;
+    readonly samlServerConfig;
+    readonly suspendKeycloakUser;
+    readonly updateLdapUser;
 
     // ./server/version
     readonly upgradeServerImage;
@@ -208,9 +222,14 @@ export class PlaywrightExtended {
 
     // unauthenticated page
     readonly loginPage;
+    readonly keycloakLoginPage;
     readonly landingLoginPage;
     readonly signupPage;
     readonly resetPasswordPage;
+
+    // Same default page as above, post-login - for specs that authenticate it directly (e.g. a
+    // real browser SSO flow) rather than via testBrowser.login()'s separate context.
+    readonly channelsPage;
 
     readonly hasSeenLandingPage;
 
@@ -247,30 +266,37 @@ export class PlaywrightExtended {
         this.isPluginActive = isPluginActive;
 
         // ./server/openldap, ./server/keycloak, ./server/elasticsearch, ./server/opensearch, ./server/minio
-        this.generateLdapUser = generateLdapUser;
-        this.createLdapUser = createLdapUser;
-        this.updateLdapUser = updateLdapUser;
-        this.deleteLdapUser = deleteLdapUser;
-        this.ldapServerConfig = ldapServerConfig;
-        this.ensureOpenldap = ensureOpenldap;
         this.createKeycloakUser = createKeycloakUser;
+        this.createLdapUser = createLdapUser;
         this.deleteKeycloakUser = deleteKeycloakUser;
-        this.samlServerConfig = samlServerConfig;
-        this.ensureKeycloak = ensureKeycloak;
+        this.deleteLdapUser = deleteLdapUser;
         this.elasticsearchServerConfig = elasticsearchServerConfig;
-        this.opensearchServerConfig = opensearchServerConfig;
-        this.ensureElasticsearch = ensureElasticsearch;
-        this.ensureOpensearch = ensureOpensearch;
-        this.listMinioObjectKeys = listMinioObjectKeys;
-        this.ensureMinio = ensureMinio;
         this.ensureAzurite = ensureAzurite;
-        this.ensureLocalFile = ensureLocalFile;
-        this.listMattermostDataFiles = listMattermostDataFiles;
-        this.ensurePostgresSearch = ensurePostgresSearch;
+        this.ensureElasticsearch = ensureElasticsearch;
         this.ensureFeatureFlag = ensureFeatureFlag;
-        this.listAzuriteBlobNames = listAzuriteBlobNames;
-        this.runMmctl = runMmctl;
+        this.ensureKeycloak = ensureKeycloak;
+        this.ensureKeycloakOpenId = ensureKeycloakOpenId;
+        this.ensureLocalFile = ensureLocalFile;
+        this.ensureMinio = ensureMinio;
         this.ensureMmctl = ensureMmctl;
+        this.ensureOpenldap = ensureOpenldap;
+        this.ensureOpensearch = ensureOpensearch;
+        this.ensurePostgresSearch = ensurePostgresSearch;
+        this.ensureServerEnv = ensureServerEnv;
+        this.ensureSiteUrl = ensureSiteUrl;
+        this.generateKeycloakUser = generateKeycloakUser;
+        this.generateLdapUser = generateLdapUser;
+        this.keycloakSamlDescriptorUrl = keycloakSamlDescriptorUrl;
+        this.ldapServerConfig = ldapServerConfig;
+        this.listAzuriteBlobNames = listAzuriteBlobNames;
+        this.listMattermostDataFiles = listMattermostDataFiles;
+        this.listMinioObjectKeys = listMinioObjectKeys;
+        this.openidServerConfig = openidServerConfig;
+        this.opensearchServerConfig = opensearchServerConfig;
+        this.runMmctl = runMmctl;
+        this.samlServerConfig = samlServerConfig;
+        this.suspendKeycloakUser = suspendKeycloakUser;
+        this.updateLdapUser = updateLdapUser;
 
         // ./server/version
         this.upgradeServerImage = upgradeServerImage;
@@ -286,9 +312,13 @@ export class PlaywrightExtended {
 
         // unauthenticated page
         this.loginPage = new pages.LoginPage(page);
+        this.keycloakLoginPage = new pages.KeycloakLoginPage(page);
         this.landingLoginPage = new pages.LandingLoginPage(page, isMobile);
         this.signupPage = new pages.SignupPage(page);
         this.resetPasswordPage = new pages.ResetPasswordPage(page);
+
+        // Same default page as above, post-login
+        this.channelsPage = new pages.ChannelsPage(page);
 
         // ./mock_browser_api
         this.stubNotification = stubNotification;
@@ -322,9 +352,9 @@ export class PlaywrightExtended {
             userWithAttributes: createUserWithAttributes,
         };
 
-        this.hasSeenLandingPage = async () => {
+        this.hasSeenLandingPage = async (url = '/') => {
             // Visit the base URL to be able to set the localStorage
-            await page.goto('/');
+            await page.goto(url);
             return waitUntilLocalStorageIsSet(page, '__landingPageSeen__', 'true');
         };
     }

--- a/e2e-tests/playwright/lib/src/ui/pages/index.ts
+++ b/e2e-tests/playwright/lib/src/ui/pages/index.ts
@@ -2,6 +2,7 @@
 // See LICENSE.txt for license information.
 
 import ChannelsPage from './channels';
+import KeycloakLoginPage from './keycloak_login';
 import LandingLoginPage from './landing_login';
 import LoginPage from './login';
 import RecapsPage from './recaps';
@@ -15,6 +16,7 @@ import ContentReviewPage from './content_review_dm';
 
 const pages = {
     ChannelsPage,
+    KeycloakLoginPage,
     LandingLoginPage,
     LoginPage,
     RecapsPage,
@@ -32,6 +34,7 @@ export {
     ChannelsPage,
     ContentReviewPage,
     DraftsPage,
+    KeycloakLoginPage,
     LandingLoginPage,
     LoginPage,
     RecapsPage,

--- a/e2e-tests/playwright/lib/src/ui/pages/keycloak_login.ts
+++ b/e2e-tests/playwright/lib/src/ui/pages/keycloak_login.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
+// See LICENSE.txt for license information.
+
+import type {Page} from '@playwright/test';
+
+// Keycloak's own hosted login form (not part of the Mattermost webapp). Its element ids are
+// Keycloak's default theme, stable across releases, unlike its (locale-dependent) label text.
+export default class KeycloakLoginPage {
+    readonly page: Page;
+
+    readonly usernameInput;
+    readonly passwordInput;
+    readonly signInButton;
+    readonly errorMessage;
+    readonly accountDisabledMessage;
+
+    constructor(page: Page) {
+        this.page = page;
+
+        this.usernameInput = page.locator('#username');
+        this.passwordInput = page.locator('#password');
+        this.signInButton = page.locator('#kc-login');
+        this.errorMessage = page.locator('#input-error');
+        this.accountDisabledMessage = page.getByText('Account is disabled, contact your administrator.');
+    }
+
+    async login(username: string, password: string) {
+        await this.usernameInput.fill(username);
+        await this.passwordInput.fill(password);
+        await this.signInButton.click();
+    }
+}

--- a/e2e-tests/playwright/lib/src/ui/pages/login.ts
+++ b/e2e-tests/playwright/lib/src/ui/pages/login.ts
@@ -17,12 +17,14 @@ export default class LoginPage {
     readonly loginPlaceholder;
     readonly loginWithAdLdapPlaceholder;
     readonly samlLoginButton;
+    readonly openIdLoginButton;
     readonly passwordInput;
     readonly passwordToggleButton;
     readonly signInButton;
     readonly createAccountLink;
     readonly forgotPasswordLink;
     readonly userErrorLabel;
+    readonly errorBanner;
 
     readonly header;
     readonly footer;
@@ -37,12 +39,18 @@ export default class LoginPage {
         this.loginPlaceholder = page.getByPlaceholder('Email or Username');
         this.loginWithAdLdapPlaceholder = page.getByRole('textbox', {name: 'Email, Username or AD/LDAP Username'});
         this.samlLoginButton = page.locator('#saml');
+        // Accessible name is the configurable ButtonText, so it isn't stable across tests -
+        // matches the samlLoginButton locator above for the same reason.
+        this.openIdLoginButton = page.locator('#openid');
         this.passwordInput = page.locator('#input_password-input');
         this.passwordToggleButton = page.locator('#password_toggle');
         this.signInButton = page.getByRole('button', {name: 'Log in'});
         this.createAccountLink = page.getByRole('link', {name: "Don't have an account?"});
         this.forgotPasswordLink = page.getByText('Forgot your password?');
         this.userErrorLabel = page.getByText('Please enter your email or username');
+        // No accessible role/label - AlertBanner is a plain styled div, and its message text
+        // varies by config (which login-id types are enabled).
+        this.errorBanner = page.locator('.AlertBanner.danger');
 
         this.header = new components.MainHeader(page.getByTestId('hfroute-header'));
         this.footer = new components.Footer(page.getByTestId('hfroute-footer'));
@@ -55,8 +63,8 @@ export default class LoginPage {
         await expect(this.passwordInput).toBeVisible();
     }
 
-    async goto() {
-        await this.page.goto('/login');
+    async goto(url = '/login') {
+        await this.page.goto(url);
     }
 
     async login(user: UserProfile, useUsername = true) {

--- a/e2e-tests/playwright/specs/functional/channels/scheduled_messages/scheduled_messages.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/scheduled_messages/scheduled_messages.spec.ts
@@ -78,7 +78,7 @@ test(
     'creates weekly recurring scheduled message from channel without showing the channel indicator',
     {tag: '@scheduled_messages'},
     async ({pw}) => {
-        await pw.skipIfFeatureFlagNotSet('RecurringScheduledPosts', true);
+        await pw.ensureFeatureFlag('RecurringScheduledPosts', true);
 
         const draftMessage = `Weekly Scheduled Draft ${pw.random.id()}`;
 
@@ -238,7 +238,7 @@ test(
     'reschedules weekly recurring scheduled message from scheduled posts page and keeps weekly recurrence',
     {tag: '@scheduled_messages'},
     async ({pw}) => {
-        await pw.skipIfFeatureFlagNotSet('RecurringScheduledPosts', true);
+        await pw.ensureFeatureFlag('RecurringScheduledPosts', true);
 
         const draftMessage = `Weekly Scheduled Draft ${pw.random.id()}`;
 

--- a/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/autocomplete.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/autocomplete.spec.ts
@@ -7,6 +7,10 @@ const TAGS = {tag: ['@channels', '@wysiwyg_editor']};
 const AUTOCOMPLETE_ROUTE = /\/api\/v4\/teams\/[^/]+\/channels\/autocomplete/;
 
 test.describe('WYSIWYG editor - autocomplete suggestions', TAGS, () => {
+    test.beforeEach(async ({pw}) => {
+        await pw.ensureFeatureFlag('WysiwygEditor', true);
+    });
+
     test('slash command autocomplete opens and completes on Enter', async ({pw}) => {
         const {user, userClient, team} = await pw.initSetup();
         await setWysiwygUserPreference(userClient, user.id, true);

--- a/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/composing.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/composing.spec.ts
@@ -6,6 +6,10 @@ import {expect, setWysiwygUserPreference, test, WysiwygEditor} from '@mattermost
 const TAGS = {tag: ['@channels', '@wysiwyg_editor']};
 
 test.describe('WYSIWYG editor - composing and posting', TAGS, () => {
+    test.beforeEach(async ({pw}) => {
+        await pw.ensureFeatureFlag('WysiwygEditor', true);
+    });
+
     test('posts a plain-text message', async ({pw}) => {
         const {user, userClient, team} = await pw.initSetup();
         await setWysiwygUserPreference(userClient, user.id, true);

--- a/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/formatting_bar.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/formatting_bar.spec.ts
@@ -6,6 +6,10 @@ import {expect, setWysiwygUserPreference, test, WysiwygEditor} from '@mattermost
 const TAGS = {tag: ['@channels', '@wysiwyg_editor']};
 
 test.describe('WYSIWYG editor - formatting bar', TAGS, () => {
+    test.beforeEach(async ({pw}) => {
+        await pw.ensureFeatureFlag('WysiwygEditor', true);
+    });
+
     test('bold and italic toolbar buttons wrap the selection', async ({pw}) => {
         const {user, userClient, team} = await pw.initSetup();
         await setWysiwygUserPreference(userClient, user.id, true);

--- a/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/gating.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/gating.spec.ts
@@ -1,13 +1,15 @@
 // Copyright (c) 2015-present Mattermost, Inc. All Rights Reserved.
 // See LICENSE.txt for license information.
 
-// The WysiwygEditor feature flag is read-only at runtime on local dev servers,
-// so it must be set at server start with MM_FEATUREFLAGS_WYSIWYGEDITOR=true.
-// These tests only toggle the per-user preference.
+// These tests only toggle the per-user preference; the server flag is enabled below.
 
 import {expect, setWysiwygUserPreference, test, WysiwygEditor} from '@mattermost/playwright-lib';
 
 const TAGS = {tag: ['@channels', '@wysiwyg_editor']};
+
+test.beforeEach(async ({pw}) => {
+    await pw.ensureFeatureFlag('WysiwygEditor', true);
+});
 
 test('MM-69305 WYSIWYG editor is not mounted when user preference is off', TAGS, async ({pw}) => {
     const {user, team} = await pw.initSetup();

--- a/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/markdown.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/markdown.spec.ts
@@ -6,6 +6,10 @@ import {expect, setWysiwygUserPreference, test, WysiwygEditor} from '@mattermost
 const TAGS = {tag: ['@channels', '@wysiwyg_editor']};
 
 test.describe('WYSIWYG editor - markdown-as-you-type rich text', TAGS, () => {
+    test.beforeEach(async ({pw}) => {
+        await pw.ensureFeatureFlag('WysiwygEditor', true);
+    });
+
     test('bold, italic, and strikethrough marks render inline', async ({pw}) => {
         const {user, userClient, team} = await pw.initSetup();
         await setWysiwygUserPreference(userClient, user.id, true);

--- a/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/paste.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/paste.spec.ts
@@ -6,6 +6,10 @@ import {expect, setWysiwygUserPreference, test, WysiwygEditor} from '@mattermost
 const TAGS = {tag: ['@channels', '@wysiwyg_editor']};
 
 test.describe('WYSIWYG editor - paste', TAGS, () => {
+    test.beforeEach(async ({pw}) => {
+        await pw.ensureFeatureFlag('WysiwygEditor', true);
+    });
+
     test('pasting plain markdown parses into formatted content', async ({pw}) => {
         const {user, userClient, team} = await pw.initSetup();
         await setWysiwygUserPreference(userClient, user.id, true);

--- a/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/rhs.spec.ts
+++ b/e2e-tests/playwright/specs/functional/channels/wysiwyg_editor/rhs.spec.ts
@@ -6,6 +6,10 @@ import {expect, setWysiwygUserPreference, test, WysiwygEditor} from '@mattermost
 const TAGS = {tag: ['@channels', '@wysiwyg_editor']};
 
 test.describe('WYSIWYG editor - RHS reply composer', TAGS, () => {
+    test.beforeEach(async ({pw}) => {
+        await pw.ensureFeatureFlag('WysiwygEditor', true);
+    });
+
     test('WYSIWYG replaces the classic composer in the RHS thread', async ({pw}) => {
         const {user, userClient, team} = await pw.initSetup();
         await setWysiwygUserPreference(userClient, user.id, true);

--- a/e2e-tests/playwright/specs/functional/system_console/abac/resource_attributes/authoring.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/resource_attributes/authoring.spec.ts
@@ -21,7 +21,7 @@ import {createChannelTextField, createParentPolicyViaAPI, expectAssignTeamsDenie
 test.describe('ABAC resource.attributes - authoring', {tag: ['@abac', '@abac_resource_attributes']}, () => {
     test('accepts a parent policy mixing user and resource attributes', async ({pw}) => {
         await pw.skipIfNoLicense();
-        await pw.skipIfFeatureFlagNotSet('ResourceAttributesInPolicies', true);
+        await pw.ensureFeatureFlag('ResourceAttributesInPolicies', true);
 
         const {adminClient} = await pw.initSetup();
         await enableUserManagedAttributes(adminClient);
@@ -43,7 +43,7 @@ test.describe('ABAC resource.attributes - authoring', {tag: ['@abac', '@abac_res
 
     test('rejects has(resource.attributes.*) at check time', async ({pw}) => {
         await pw.skipIfNoLicense();
-        await pw.skipIfFeatureFlagNotSet('ResourceAttributesInPolicies', true);
+        await pw.ensureFeatureFlag('ResourceAttributesInPolicies', true);
 
         const {adminClient} = await pw.initSetup();
         await enableUserManagedAttributes(adminClient);
@@ -66,7 +66,7 @@ test.describe('ABAC resource.attributes - authoring', {tag: ['@abac', '@abac_res
 
     test('rejects assigning a resource parent to a team', async ({pw}) => {
         await pw.skipIfNoLicense();
-        await pw.skipIfFeatureFlagNotSet('ResourceAttributesInPolicies', true);
+        await pw.ensureFeatureFlag('ResourceAttributesInPolicies', true);
 
         const {adminClient, team} = await pw.initSetup();
         await enableUserManagedAttributes(adminClient);

--- a/e2e-tests/playwright/specs/functional/system_console/abac/resource_attributes/masking.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/resource_attributes/masking.spec.ts
@@ -26,7 +26,7 @@ import {createChannelTextField, expectMaskedTokenRejected} from './helpers';
 test.describe('ABAC resource.attributes - masking write path', {tag: ['@abac', '@abac_masking']}, () => {
     test('rejects saving a resource.attributes condition carrying the masked sentinel', async ({pw}) => {
         await pw.skipIfNoLicense();
-        await pw.skipIfFeatureFlagNotSet('ResourceAttributesInPolicies', true);
+        await pw.ensureFeatureFlag('ResourceAttributesInPolicies', true);
 
         // The sentinel rejection under test lives inside the server's
         // AttributeValueMasking branch, so the flag has to be on. It cannot be

--- a/e2e-tests/playwright/specs/functional/system_console/abac/resource_attributes/membership_sync.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/resource_attributes/membership_sync.spec.ts
@@ -37,7 +37,7 @@ test.describe('ABAC resource.attributes - membership sync', {tag: ['@abac', '@ab
     test('mixed user/resource scalar policy syncs and enforces joins', async ({pw}) => {
         test.setTimeout(120000);
         await pw.skipIfNoLicense();
-        await pw.skipIfFeatureFlagNotSet('ResourceAttributesInPolicies', true);
+        await pw.ensureFeatureFlag('ResourceAttributesInPolicies', true);
 
         const {adminClient, team} = await pw.initSetup();
         await enableUserManagedAttributes(adminClient);
@@ -100,7 +100,7 @@ test.describe('ABAC resource.attributes - membership sync', {tag: ['@abac', '@ab
     test('deny-on-miss removes all members when the channel attribute is absent', async ({pw}) => {
         test.setTimeout(120000);
         await pw.skipIfNoLicense();
-        await pw.skipIfFeatureFlagNotSet('ResourceAttributesInPolicies', true);
+        await pw.ensureFeatureFlag('ResourceAttributesInPolicies', true);
 
         const {adminClient, team} = await pw.initSetup();
         await enableUserManagedAttributes(adminClient);

--- a/e2e-tests/playwright/specs/functional/system_console/abac/resource_attributes/multiselect_sync.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/resource_attributes/multiselect_sync.spec.ts
@@ -40,7 +40,7 @@ test.describe('ABAC resource.attributes - multiselect targets', {tag: ['@abac', 
     test('has any of syncs and enforces on list intersection', async ({pw}) => {
         test.setTimeout(120000);
         await pw.skipIfNoLicense();
-        await pw.skipIfFeatureFlagNotSet('ResourceAttributesInPolicies', true);
+        await pw.ensureFeatureFlag('ResourceAttributesInPolicies', true);
 
         const {adminClient, team} = await pw.initSetup();
         await enableUserManagedAttributes(adminClient);
@@ -98,7 +98,7 @@ test.describe('ABAC resource.attributes - multiselect targets', {tag: ['@abac', 
     test('has all of syncs and enforces on channel-list subset', async ({pw}) => {
         test.setTimeout(120000);
         await pw.skipIfNoLicense();
-        await pw.skipIfFeatureFlagNotSet('ResourceAttributesInPolicies', true);
+        await pw.ensureFeatureFlag('ResourceAttributesInPolicies', true);
 
         const {adminClient, team} = await pw.initSetup();
         await enableUserManagedAttributes(adminClient);

--- a/e2e-tests/playwright/specs/functional/system_console/abac/resource_attributes/test_picker.spec.ts
+++ b/e2e-tests/playwright/specs/functional/system_console/abac/resource_attributes/test_picker.spec.ts
@@ -33,7 +33,7 @@ test.describe('ABAC resource.attributes - test picker', {tag: ['@abac', '@abac_r
     test('picker resolves a resource rule against the chosen channel', async ({pw}) => {
         test.setTimeout(120000);
         await pw.skipIfNoLicense();
-        await pw.skipIfFeatureFlagNotSet('ResourceAttributesInPolicies', true);
+        await pw.ensureFeatureFlag('ResourceAttributesInPolicies', true);
 
         const {adminUser, adminClient, team} = await pw.initSetup();
         await enableUserManagedAttributes(adminClient);


### PR DESCRIPTION
## Summary
- First PR in a stack adding Playwright E2E coverage for SSO/Auth/OpenID via Keycloak (see follow-up PRs for the actual OIDC/SAML/LDAP specs).
- Adds the Keycloak/LDAP server helpers, `KeycloakLoginPage` page object, and `LoginPage` additions (`openIdLoginButton`, `errorBanner`) that the SSO specs depend on.
- Pins the Testcontainers Mattermost container to a fixed host port (8055) and moves `ServiceSettings.SiteURL` to an overridable config tier, so `pw.ensureSiteUrl()` can make it host-reachable for OAuth-style redirects without relying on the Testcontainers-internal Docker alias.
- Adds `pw.ensureServerEnv()` / `pw.ensureSiteUrl()` (generic "set env var, restart if needed" helpers, mirroring `pw.ensureFeatureFlag()`).
- Moves feature-flag defaults out of the global `SERVER_ENV_BASELINE` and into `pw.ensureFeatureFlag()` calls at the specs that actually need them; deletes 4 flags that were already at their production default (no-ops).

## Test plan
- [x] `npm run check` (lint, prettier, tsc, lint:test-docs) passes
- [x] Directly-touched ABAC/scheduled-messages/WYSIWYG specs (41 tests) pass after the flag-baseline change
- [x] Spot-checked other ABAC areas relying on the deleted flags (36 tests) still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟠 Medium

**Regression Risk:** Changes affect shared Playwright fixtures, server helpers, feature-flag setup, and authentication test infrastructure. Planned SSO paths remain untested in this PR.

**QA Recommendation:** Run automated checks and perform focused manual validation of Keycloak startup, login setup, and host-reachable OAuth redirects.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->