### PR TITLE
Normalize changelog generator output and handle major-version rollover

### DIFF
--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -329,15 +329,20 @@ def normalize_formatting(text: str) -> str:
     # 1. Remove standalone horizontal rules.
     text = re.sub(r"(?m)^[ \t]*(?:-{3,}|\*{3,}|_{3,})[ \t]*$\n?", "", text)
 
-    # 2. Normalize bullet indentation (2 -> 1, 4 -> 3; odd indents already correct).
-    def _fix_indent(match: re.Match) -> str:
-        spaces, marker = match.group(1), match.group(2)
-        n = len(spaces)
-        if n > 0 and n % 2 == 0:
-            n -= 1
-        return " " * n + marker
+    # 2. Normalize bullet indentation to the changelog's two levels: one space for
+    #    top-level bullets, three for nested ones. Models variously emit 0/2, 1/3 or
+    #    2/4, so the shallowest bullet present is treated as top level and anything
+    #    deeper as nested. A fixed threshold cannot work here: two spaces means
+    #    top-level in a 2/4 fragment but nested in a 0/2 one.
+    bullet_re = re.compile(r"(?m)^( *)(- )")
+    indents = [len(m.group(1)) for m in bullet_re.finditer(text)]
+    if indents:
+        base = min(indents)
 
-    text = re.sub(r"(?m)^( *)(- )", _fix_indent, text)
+        def _fix_indent(match: re.Match) -> str:
+            return (" " if len(match.group(1)) == base else "   ") + match.group(2)
+
+        text = bullet_re.sub(_fix_indent, text)
 
     # 3. Close the gap between ### Improvements and its blog post line.
     text = re.sub(r"(?m)^(### Improvements)[ \t]*\n\s*\n(?=See )", r"\1\n", text)

--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -66,20 +66,35 @@ SYSTEM_PROMPT = """You are an expert technical writer and copyeditor for Matterm
 
 Here are your instructions:
 
-1.  **Section structure:** Use `###` for top-level sections and `####` for subsections. Only include sections that have relevant content — do not output empty sections. Do NOT add horizontal rules or line separators between sections. Do NOT add a blank line between a section/subsection heading and its first bullet point.
+1.  **Section structure:** Use `###` for top-level sections and `####` for subsections. Only include sections that have relevant content — do not output empty sections. NEVER output a horizontal rule (`---`) between sections or anywhere else. Do NOT add a blank line between a section/subsection heading and its first bullet point.
 
     Top-level sections and their subsections, in this order:
 
     - `### Upgrade Impact` — for changes that affect upgrading, with subsections as applicable:
-        - `#### Database Schema Changes` — schema migrations such as new tables, new columns, changed columns, or new indexes. Example items: "Added a new ``Watermarks`` table.", "Added a new column ``DeleteAt`` to the ``ChannelMembers`` table."
+        - `#### Database Schema Changes` — schema migrations such as new tables, new columns, changed columns, or new indexes. Lead with a single summary bullet, then nest each individual change beneath it. Use this exact shape:
+
+           - The following schema changes are included in the VERSION release. No database downtime is expected for this upgrade.
+             - Added a new ``Watermarks`` table.
+             - Added a new column ``DeleteAt`` to the ``ChannelMembers`` table.
+
+          (Write the real version number in place of VERSION. The summary bullet uses one space; each change uses three.)
         - `#### config.json` — new or changed configuration settings. Use this exact block format for each plan grouping (no blank line between the `#### config.json` heading and the description paragraph, and no blank line between the description paragraph and the first bullet):
           New setting options were added to ``config.json``. Below is a list of the additions and their default values on install. The settings can be modified in ``config.json``, or the System Console when available.
-          - **Changes to Enterprise Advanced plan:**
-            - Under ``ExperimentalSettings`` in ``config.json``, added ``EnableWatermark`` configuration setting to add watermarking toggle in the server.
+           - **Changes to Enterprise Advanced plan:**
+             - Under ``ExperimentalSettings`` in ``config.json``, added ``EnableWatermark`` configuration setting to add watermarking toggle in the server.
+           - Removed ``LdapSettings.LoginButtonColor`` configuration setting from the database.
 
-          Adapt the plan name (e.g. "Changes to All plans:", "Changes to Enterprise plan:", "Changes to Enterprise Advanced plan:") and list each setting change as a bullet under the appropriate plan heading.
+          Adapt the plan name (e.g. "Changes to All plans:", "Changes to Enterprise plans:", "Changes to Enterprise Advanced plan:") and nest each setting change beneath the appropriate plan bullet. Plan bullets use one space; the settings beneath them use three. Removed settings are listed as top-level one-space bullets, not under a plan grouping.
         - `#### Compatibility` — minimum version requirement changes for browsers, OS, or clients. Example: "Updated minimum Edge and Chrome versions to 146+."
-    - `### Improvements` — for new features and enhancements only. Do NOT place items beginning with "Fixed..." here — those belong in Bug Fixes. Begin this section with the line `See BLOG_POST_LINK on the highlights in our latest release.` (use the exact placeholder `BLOG_POST_LINK` — it will be replaced automatically with a Markdown link), followed by a blank line before the first `####` subsection heading. Then add subsections as applicable:
+    - `### Improvements` — for new features and enhancements only. Do NOT place items beginning with "Fixed..." here — those belong in Bug Fixes. The line immediately after the `### Improvements` heading — with NO blank line between them — must be `See BLOG_POST_LINK on the highlights in our latest release.` (use the exact placeholder `BLOG_POST_LINK`; it is replaced automatically with a Markdown link). Then a blank line, then the first `####` subsection heading. It must look exactly like this:
+
+      ### Improvements
+      See BLOG_POST_LINK on the highlights in our latest release.
+
+      #### User Interface
+       - First item.
+
+      Subsections, as applicable:
         - `#### User Interface` — user interface and UX changes and new visual features. Pre-packaged plugin version updates go at the TOP of this subsection, before other items. Always write "user interface" in full — never abbreviate as "UI".
         - `#### Plugins/Integrations` — plugin and integration improvements (use as a separate subsection when there are enough items to warrant it)
         - `#### Administration` — System Console features, logging, support packet changes
@@ -112,7 +127,13 @@ Here are your instructions:
     - Feature flags (e.g., ``MM_FEATUREFLAGS_CJKSEARCH``)
     - Package names in Open Source Components (e.g., ``x/text``)
 
-5.  **Markdown formatting:** Indent each bullet point with two spaces (e.g., `  - item`). Ensure correct and clean Markdown syntax throughout. Do not insert horizontal rules (`---`) or any other separators between sections. Do not add a blank line between a section/subsection heading and its first bullet point.
+5.  **Markdown formatting — indentation is exact:**
+    - Top-level bullets are indented with exactly ONE space: ` - item`
+    - Nested bullets are indented with exactly THREE spaces: `   - nested item`
+    - Never use two or four spaces. This applies to every section without exception.
+    - NEVER output a horizontal rule (`---`) or any other separator line anywhere in the output. Sections are separated by their headings alone. A `---` line will corrupt the document.
+    - Do not add a blank line between a section/subsection heading and the first line beneath it, whether that line is a bullet or a paragraph.
+    - Do add a single blank line before each new heading.
 
 6.  **MDX safety:** The changelog is an `.mdx` file, so raw `{`, `}`, and `<` characters are parsed as JSX and will break the docs build. Therefore:
     - Never output a bare `{` or `}` in prose. If a release note needs braces, wrap the text in double backticks (e.g. ``{"key": "value"}``) so it becomes inline code.
@@ -278,6 +299,42 @@ def polish_with_ai(raw_notes: list[str]) -> str:
     return response.content[0].text.strip()
 
 
+def normalize_formatting(text: str) -> str:
+    """Deterministically correct formatting details the AI commonly gets wrong.
+
+    The system prompt specifies all of these, but model compliance is not guaranteed,
+    and each of these mistakes produces a visibly wrong diff. Fixing them here is
+    cheap and reliable.
+
+      1. Strip horizontal rules (``---``), which must never appear in a changelog entry.
+      2. Normalize bullet indentation to the changelog convention of one space for
+         top-level bullets and three for nested ones. The model tends to emit the
+         even-numbered two/four-space variant, so any even indent is reduced by one.
+      3. Remove a blank line between the ``### Improvements`` heading and the blog
+         post line that must immediately follow it.
+    """
+    # 1. Remove standalone horizontal rules.
+    text = re.sub(r"(?m)^[ \t]*(?:-{3,}|\*{3,}|_{3,})[ \t]*$\n?", "", text)
+
+    # 2. Normalize bullet indentation (2 -> 1, 4 -> 3; odd indents already correct).
+    def _fix_indent(match: re.Match) -> str:
+        spaces, marker = match.group(1), match.group(2)
+        n = len(spaces)
+        if n > 0 and n % 2 == 0:
+            n -= 1
+        return " " * n + marker
+
+    text = re.sub(r"(?m)^( *)(- )", _fix_indent, text)
+
+    # 3. Close the gap between ### Improvements and its blog post line.
+    text = re.sub(r"(?m)^(### Improvements)[ \t]*\n\s*\n(?=See )", r"\1\n", text)
+
+    # 4. Collapse runs of blank lines (removing a rule can leave a doubled gap).
+    text = re.sub(r"\n{3,}", "\n\n", text)
+
+    return text
+
+
 def normalize_go_version(go_version: str) -> str:
     """Normalize a Go version string to v-prefixed form.
 
@@ -431,7 +488,7 @@ def main():
             go_section = f"### Go Version\n - {version_short} uses the same Go version as the previous release."
 
     if all_notes:
-        polished = polish_with_ai(all_notes)
+        polished = normalize_formatting(polish_with_ai(all_notes))
         blog_url = os.environ.get("BLOG_POST_URL", "").strip()
         if not blog_url:
             # Auto-construct short URL (no patch suffix): v11.6.0 → mattermost-v11-6-is-now-available

--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -312,7 +312,20 @@ def normalize_formatting(text: str) -> str:
          even-numbered two/four-space variant, so any even indent is reduced by one.
       3. Remove a blank line between the ``### Improvements`` heading and the blog
          post line that must immediately follow it.
+
+    MDX safety: rule 1 would otherwise strip the ``---`` delimiters of a YAML
+    frontmatter block, which MDX requires at the very start of the file. This is
+    normally called only on the AI-generated fragment (which has no frontmatter),
+    but a leading frontmatter block is detected and preserved verbatim so the
+    function is also safe if it is ever applied to whole file contents.
     """
+    # Split off and protect a leading YAML frontmatter block.
+    frontmatter = ""
+    fm_match = re.match(r"\A---\n.*?\n---\n", text, re.DOTALL)
+    if fm_match:
+        frontmatter = fm_match.group(0)
+        text = text[fm_match.end():]
+
     # 1. Remove standalone horizontal rules.
     text = re.sub(r"(?m)^[ \t]*(?:-{3,}|\*{3,}|_{3,})[ \t]*$\n?", "", text)
 
@@ -330,9 +343,46 @@ def normalize_formatting(text: str) -> str:
     text = re.sub(r"(?m)^(### Improvements)[ \t]*\n\s*\n(?=See )", r"\1\n", text)
 
     # 4. Collapse runs of blank lines (removing a rule can leave a doubled gap).
+    #    At least one blank line is always kept, which MDX needs around JSX blocks.
     text = re.sub(r"\n{3,}", "\n\n", text)
 
-    return text
+    return frontmatter + text
+
+
+# Regions of Markdown whose contents must never be escaped: inline code spans
+# (double- or single-backtick) and Markdown link destinations.
+_MDX_PROTECTED_RE = re.compile(r"``[^`]*``|`[^`]*`|\]\([^)]*\)")
+
+
+def escape_mdx_unsafe(text: str) -> str:
+    """Backslash-escape characters that MDX would parse as JSX.
+
+    In MDX an unescaped ``{`` opens a JSX expression and ``<`` followed by a letter,
+    ``/`` or ``!`` opens a JSX element, so release-note prose containing text such as
+    ``<plugin ID>`` or ``{"status": "ok"}`` fails the docs build. The system prompt
+    instructs the model to wrap such text in backticks, but compliance is not
+    guaranteed and the failure mode is a broken build, so escape defensively.
+
+    Only applied to the AI-generated fragment — never to whole file contents, which
+    legitimately contain JSX components such as <Note> and <Important>.
+
+    ``}`` is deliberately left alone: escaping ``{`` alone is sufficient to prevent a
+    JSX expression, and a bare ``}`` is harmless. This also keeps the generated
+    heading anchor ``\\{#release-v11-9-feature-release}`` intact.
+    """
+    def _escape(segment: str) -> str:
+        segment = re.sub(r"(?<!\\)\{", r"\\{", segment)
+        segment = re.sub(r"(?<!\\)<(?=[A-Za-z/!])", r"\\<", segment)
+        return segment
+
+    parts = []
+    last = 0
+    for match in _MDX_PROTECTED_RE.finditer(text):
+        parts.append(_escape(text[last:match.start()]))
+        parts.append(match.group(0))   # protected region, copied verbatim
+        last = match.end()
+    parts.append(_escape(text[last:]))
+    return "".join(parts)
 
 
 def normalize_go_version(go_version: str) -> str:
@@ -488,7 +538,9 @@ def main():
             go_section = f"### Go Version\n - {version_short} uses the same Go version as the previous release."
 
     if all_notes:
-        polished = normalize_formatting(polish_with_ai(all_notes))
+        # normalize_formatting fixes layout; escape_mdx_unsafe makes the prose
+        # MDX-safe. Both are applied to the AI fragment only, never to file contents.
+        polished = escape_mdx_unsafe(normalize_formatting(polish_with_ai(all_notes)))
         blog_url = os.environ.get("BLOG_POST_URL", "").strip()
         if not blog_url:
             # Auto-construct short URL (no patch suffix): v11.6.0 → mattermost-v11-6-is-now-available

--- a/.github/scripts/generate_changelog.py
+++ b/.github/scripts/generate_changelog.py
@@ -354,9 +354,16 @@ def normalize_formatting(text: str) -> str:
     return frontmatter + text
 
 
-# Regions of Markdown whose contents must never be escaped: inline code spans
-# (double- or single-backtick) and Markdown link destinations.
-_MDX_PROTECTED_RE = re.compile(r"``[^`]*``|`[^`]*`|\]\([^)]*\)")
+# Regions of Markdown whose contents must never be escaped. Fenced blocks are listed
+# first so they are consumed whole: an inline-code alternative would otherwise match
+# across a fence that contains backticks and protect the wrong spans.
+_MDX_PROTECTED_RE = re.compile(
+    r"```[\s\S]*?```"     # fenced code block (backticks)
+    r"|~~~[\s\S]*?~~~"    # fenced code block (tildes)
+    r"|``[^`]*``"         # inline code span (double backtick)
+    r"|`[^`]*`"           # inline code span (single backtick)
+    r"|\]\([^)]*\)"       # Markdown link destination
+)
 
 
 def escape_mdx_unsafe(text: str) -> str:


### PR DESCRIPTION
#### Summary

Updates `.github/scripts/generate_changelog.py` and `.github/workflows/generate-changelog.yml` so generated changelog entries match the established format in `docs/main/product-overview/mattermost-v11-changelog.mdx`, cannot break the docs build, cannot be silently truncated, and land in the right file with the right heading when the major version rolls over.

Broken changelog formatting: https://github.com/mattermost/mattermost/pull/38477/changes
Expected changelog formatting: https://github.com/mattermost/mattermost/pull/38133/changes#diff-4134e7af6537a5699850e62a6f9c9a614b6fbbc4af2eb086e2a1c150c59b6384

**`SYSTEM_PROMPT` changes**

- **Bullet indentation.** The previous rule asked for two-space bullets, which does not match the changelog file. It now states the real convention explicitly: exactly one space for top-level bullets, exactly three for nested ones, with no exceptions.
- **Database Schema Changes.** Given an explicit shape — a summary bullet naming the release and stating the downtime expectation, with each individual change nested beneath it — instead of two loose example strings.
- **`config.json`.** The example block gains a removed-setting entry, and the rule now spells out that removed settings are top-level bullets rather than nested under a plan grouping. Plan-name guidance corrected to "Changes to Enterprise plans:".
- **Improvements.** The section is now shown verbatim so the `BLOG_POST_LINK` line lands immediately after the heading with no blank line between them.
- **Horizontal rules.** A `---` line corrupts the MDX document, so the prohibition is strengthened to an explicit NEVER in both the section-structure rule and the markdown-formatting rule.
- **Identifier fidelity.** A v12.0 run shortened the endpoint `/api/v4/ephemeral_mode/cleanup` to `/cleanup`. Endpoint paths, configuration setting names, command names, table and column names, and feature flags must now be reproduced from the raw note in full, with an explicit instruction never to abbreviate a path to its last segment or drop a setting's group prefix.

**New `normalize_formatting()` — layout**

The prompt specifies the layout rules, but model compliance is not guaranteed and each mistake produces a visibly wrong diff, so the output gets a deterministic pass:

1. Strips standalone horizontal rules.
2. Normalizes bullet indentation to one space for top-level bullets and two more per nesting level (1/3/5).
3. Closes a blank line between `### Improvements` and its blog post line.
4. Collapses the blank-line runs that rule removal can leave behind, always keeping at least one.

On rule 2, a fixed threshold cannot work: models variously emit 0/2, 1/3 or 2/4, and two spaces means top-level in a 2/4 fragment but nested in a 0/2 one. So the distinct indents present are **ranked**, and level *n* maps to `1 + 2n` spaces. Ranking happens **per list block** — blocks being delimited by lines that are neither bullets nor bullet continuations — for two reasons:

- Sections are generated independently and can disagree on base indent. A fragment-wide minimum would demote an already-correct top-level bullet to nested purely because another section started one space shallower.
- Ranking rather than comparing against the minimum keeps a three-level list at three levels, instead of collapsing its two deepest levels into one. The changelog convention is three levels (1/3/5), and `docs/main/product-overview/mattermost-v12-changelog.mdx` uses all three.

Rule 1 would otherwise strip the `---` delimiters of a YAML frontmatter block, which MDX requires at the very start of a file. A leading frontmatter block is split off and restored verbatim, so the function is safe even if applied to whole file contents rather than just the generated fragment.

**New `escape_mdx_unsafe()` — MDX safety**

In MDX an unescaped `{` opens a JSX expression, and `<` followed by a letter, `/` or `!` opens a JSX element. Release-note prose containing text like `<plugin ID>` or `{"status": "ok"}` therefore fails the docs build. The prompt already asks the model to backtick such text, but the failure mode is a broken build, so this escapes defensively:

- Backslash-escapes bare `{`, and bare `<` when followed by a letter, `/` or `!`.
- Copies protected regions verbatim: inline code spans (double- and single-backtick) and Markdown link destinations.
- Uses a negative lookbehind so already-escaped text is not double-escaped.
- Leaves closing `}` alone — escaping the opening brace is enough to prevent a JSX expression, and this keeps the generated heading anchor intact.

Pipeline order at the single call site:

```python
raw_polished, ai_polished = polish_with_ai(all_notes)
polished = escape_mdx_unsafe(normalize_formatting(raw_polished))
```

Escaping runs before `BLOG_POST_LINK` substitution and Go Version injection, so the Markdown link and the backticked Go version are inserted afterwards and are never touched by the escape pass.

**Guard: truncated output**

`polish_with_ai()` capped output at 4096 tokens and never inspected `stop_reason`, so a response that overran the cap was cut off mid-output and written to the changelog as a half-finished sentence. This is the script's worst failure mode, because it does not look like an error — just a shorter changelog. A full release comfortably exceeds the old cap: the v12.0 entry is roughly 32k characters, about 8k tokens.

- `max_tokens` is raised to `MAX_OUTPUT_TOKENS = 16384`, and a `max_tokens` stop reason is now a hard error naming the cap rather than a silently short result.
- `check_for_truncation()` is the backstop for a truncation arriving any other way. It runs on the assembled entry, immediately before it is written, and raises if any bullet ends without terminal punctuation.

The check has to allow the endings that legitimately occur in this changelog, or it would block every run. Not flagged: a bare inline code span (the lists of removed `config.json` setting names), a fully bold label (`- **Changes to All plans:**`, and the `- **10.12.3, released 2025-11-17**` dot-release labels), a Markdown link or parenthetical, a bare URL, and a bullet whose text continues on the following line. Calibrated against the existing v10, v11 and v12 changelogs: **zero** flagged across all 2,702 bullets.

It runs on AI-polished prose only. The no-API-key fallback emits PR authors' raw release notes verbatim, and those routinely end without a full stop — 4 of the 71 notes on the v12.0.0 milestone do, "Fixed deeplink routing" among them — so checking that path would fail runs over notes that are not truncated at all. `polish_with_ai()` therefore returns whether it actually polished, and the check is gated on that.

**Major-version rollover**

The changelog file was hardcoded to `mattermost-v11-changelog.mdx` in two places in the workflow, so dispatching for v12.0.0 would have written the v12 entry to the top of the v11 changelog, and `mattermost-v12-changelog.mdx` would have had to be created by hand first. Both manual steps are gone:

- The workflow resolves `docs/main/product-overview/mattermost-v${MAJOR}-changelog.mdx` from the version in a `Resolve changelog path` step, feeding both `CHANGELOG_PATH` and the `CHANGELOG_FILE` used by the Create Pull Request step.
- `changelog_path_for_version()` derives the same path inside the script, so `CHANGELOG_PATH` is now an override rather than a requirement. The previous fallback was a fixed `CHANGELOG.md` — which exists at the repository root — so a direct invocation would have appended the entry there silently. `major_version()` now raises on a version it cannot parse instead of returning an empty string and producing `mattermost-v-changelog.mdx`. The resolved file is printed so a wrong path is visible in the run log.
- `insert_changelog_entry()` scaffolds a missing or empty file from `CHANGELOG_HEADER_TEMPLATE` — frontmatter, the `common-esr-support-upgrade` import, and the `<Important>` / `<Note>` blocks, mirroring the v11 file — because an MDX file without frontmatter fails the docs build. It creates the parent directory if needed. The template keeps `HEADER_END_MARKER` verbatim, since that is what subsequent inserts anchor on.
- On the first run against a new major file there is no previous entry to read the Go version from, so `previous_major_changelog_path()` falls back to the previous major's changelog rather than emitting "uses the same Go version as the previous release".

**Release type: `major`**

The `release_type` dispatch input offered only `feature` and `esr`, but a vX.0 release is neither. Generating v12.0 therefore produced the heading "Feature Release" and the anchor `#release-v12-0-feature-release`; both had to be corrected by hand, and four docs pages deep-link to `#release-v12-0-major-release` (`mattermost-server-releases`, `mattermost-mobile-releases`, `mattermost-desktop-releases`, and `software-hardware-requirements`).

- `major` is added as a third choice, mapping to the heading label "Major Release".
- The label and the slug previously appeared as two separate literals per branch, which is what let them be wrong independently. The slug is now derived from the label (lowercased, spaces to dashes) via a single `RELEASE_LABELS` table, so they cannot drift: "Major Release" → `#release-v12-0-major-release`, matching the convention already used by the v10.0 and v11.0 entries.
- A vX.0 version generated under any release type other than `major` prints a warning naming the heading and anchor it is about to write. It warns rather than fails, so a deliberate choice is still possible.

**Guard: version vs milestone**

The milestone selects which PRs are collected and the version selects both the entry heading and the file it is written to, so a mismatch files one release's notes under another's. The job's first step compares their major versions and exits non-zero before anything is generated. It compares majors only, so a deliberate v11.10.0 / v11.9.0 pairing still runs. Both inputs are bound to `env:` rather than interpolated into the script body — a `${{ }}` expression is substituted before bash runs, so a value containing shell metacharacters would otherwise execute as code alongside the write-scoped app token. The `Create Pull Request` step was given the same treatment.

#### Ticket Link

N/A

#### Testing

`python3 -m py_compile` passes. The new functions were exercised directly:

`normalize_formatting()` — horizontal rule stripped (`---`, `***` and `___` forms); `### Improvements` gap closed; blank-line runs collapsed to one; YAML frontmatter delimiters preserved while an inner `---` is still stripped; empty input, bullet-free input and a bullet continuation line all handled without change to their content.

`normalize_formatting()` indentation, level depths asserted on the output:

| Input | Output levels |
|:---|:---|
| uniform 2/4 | 1/3 |
| already 1/3 | 1/3 (unchanged) |
| flat at 0 | all 1 |
| dot-release 0/2 | 1/3 |
| three-level 0/2/4 | 1/3/5 (not flattened) |
| two sections, both 2/4 | 1/3, 1/3 |
| section at 0 and section at 1 | all top-level 1 (no false nesting) |

The last two rows are the per-block cases: both fail under a fragment-wide minimum, and the three-level row fails under minimum-relative comparison.

`escape_mdx_unsafe()` — bare `<plugin ID>` escaped; bare `{"status": "ok"}` escaped; double- and single-backtick code spans untouched; Markdown link destinations untouched; `<` before a digit not escaped (so "fewer than 5 <10 items" is left alone); closing `}` left alone; already-escaped input not double-escaped; `</Note>` escaped; a fenced code block passes through unchanged; the heading anchor `\{#release-v11-9-feature-release}` unchanged.

`check_for_truncation()` — raises on a bullet cut mid-word, on one cut after a whole word, and on a truncated nested bullet. Does not raise on: a normal sentence, a bare `` ``config.setting`` `` code span, a fully bold plan label, a dot-release label, a bullet ending in a Markdown link, a bullet ending in a bare URL, a summary bullet ending in `:` before its nested list, a bullet continued on the next line, the generated Go Version bullet, the `mmctl` deprecation lines, empty input, and bullet-free input. Run over the full text of the v10, v11 and v12 changelogs — 1,070 + 1,444 + 188 = 2,702 bullets — it flags nothing.

Scoping for that check was measured, not assumed: replaying the no-API-key fallback over the 71 real release notes on the v12.0.0 milestone flags 4 that simply end without a full stop, which is why the check is gated on the AI path. The 188 bullets of the generated v12.0 entry — the output the check actually guards — all pass. `polish_with_ai()` returns `False` for the polished flag when `ANTHROPIC_API_KEY` is unset, and it has a single call site.

Release type — `RELEASE_LABELS` resolves `major` → "Major Release" / `#release-v12-0-major-release`, `feature` → "Feature Release" / `#release-v11-9-feature-release`, `esr` → "Extended Support Release" / `#release-v11-7-extended-support-release`, and an unrecognized value falls back to `feature`. `v11.0.0` and `v10.0.0` under `major` reproduce the anchors those entries already use. The fully assembled v12.0 heading was compared byte-for-byte against line 17 of the current `mattermost-v12-changelog.mdx` and matches exactly. The vX.0 warning fires for `v12.0.0`/`feature` and stays silent for `v12.0.0`/`major` and `v11.9.0`/`feature`.

`changelog_path_for_version()` — v11.9.0, v12.0.0 and 12.0.0 resolve to the v11/v12/v12 files; `""`, `"v"`, `"nightly"` and `"v12"` raise.

Bootstrap — inserting into a missing `mattermost-v12-changelog.mdx` under a directory that does not exist writes the frontmatter header above the entry; a second insert lands after that header and above the first entry, with the header written once; `previous_major_changelog_path()` resolves v12 → v11.

Workflow — the YAML parses, `release_type.options` is `['feature', 'major', 'esr']`, the guard is the job's first step with both inputs bound to `env:`, and its shell logic accepts matching majors (including an unprefixed `11.9.0` against `v11.9.0`) while rejecting `v12.0.0` against `v11.9.0`.

Not covered: neither `main()` nor the workflow has been run end-to-end, which needs the GitHub API and a dispatch. The `stop_reason == "max_tokens"` branch is likewise not exercised against the live API.

No behavior change when `ANTHROPIC_API_KEY` is unset — that path returns raw notes, does not reach either formatting function, and is excluded from the truncation check.

#### Screenshots

N/A — no user interface changes.

#### Release Note

```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Nrmq4ezefYWqa9YkxtX3mR
https://claude.ai/code/session_014gJFVcJtw4rdpjWrmpP9T7
https://claude.ai/code/session_01DR6hsSCuRfXqAnyHNY7sKo