### PR TITLE
MM-70601: Bound input size in the plain-text content extractor

### DIFF
--- a/server/platform/services/docextractor/plain.go
+++ b/server/platform/services/docextractor/plain.go
@@ -5,13 +5,10 @@ package docextractor
 
 import (
 	"context"
-	"errors"
 	"io"
 	"strings"
 	"unicode"
 	"unicode/utf8"
-
-	"github.com/mattermost/mattermost/server/v8/channels/utils"
 )
 
 // maxPlainTextExtractionSize bounds how much of a file this extractor reads
@@ -30,10 +27,19 @@ func (pe *plainExtractor) Match(filename string) bool {
 }
 
 func (pe *plainExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, maxFileSize int64) (string, error) {
+	limit := int64(maxPlainTextExtractionSize)
+	if maxFileSize > 0 && maxFileSize < limit {
+		limit = maxFileSize
+	}
+
+	// The initial probe never reads more than the limit, so a small
+	// maxFileSize also bounds how much is pulled from the underlying reader.
+	probeSize := min(limit, 1024)
+
 	// This detects any visible character plus any whitespace
 	validRanges := append(unicode.GraphicRanges, unicode.White_Space)
 
-	runes := make([]byte, 1024)
+	runes := make([]byte, probeSize)
 	total, err := r.Read(runes)
 	if err != nil && err != io.EOF {
 		return "", err
@@ -54,34 +60,35 @@ func (pe *plainExtractor) Extract(_ context.Context, filename string, r io.ReadS
 		}
 		count += size
 
-		// subtract the max rune size to prevent accidentally splitted runes at the end of first 1024 bytes
+		// subtract the max rune size to prevent accidentally splitted runes at the end of the probe
 		if count > total-utf8.UTFMax {
 			break
 		}
 	}
 
-	limit := int64(maxPlainTextExtractionSize)
-	if maxFileSize > 0 && maxFileSize < limit {
-		limit = maxFileSize
-	}
-
 	var sb strings.Builder
 	sb.Grow(int(limit))
-	if int64(total) > limit {
-		total = int(limit)
-	}
 	sb.Write(runes[0:total])
 	if remaining := limit - int64(total); remaining > 0 {
-		if _, err := io.Copy(&sb, utils.NewLimitedReaderWithError(r, remaining)); err != nil && !errors.Is(err, utils.ErrSizeLimitExceeded) {
+		// io.LimitReader never reads past remaining, so the underlying
+		// reader is never consumed beyond the configured limit.
+		if _, err := io.Copy(&sb, io.LimitReader(r, remaining)); err != nil {
 			return "", err
 		}
 	}
 
-	// LimitedReaderWithError may return one byte past the limit; clamp to enforce it.
-	out := sb.String()
-	if int64(len(out)) > limit {
-		out = out[:limit]
-	}
+	// The limit can land in the middle of a multi-byte rune; trim back to
+	// the last complete one so the result is always valid UTF-8.
+	return truncateUTF8(sb.String()), nil
+}
 
-	return out, nil
+func truncateUTF8(s string) string {
+	for s != "" {
+		r, size := utf8.DecodeLastRuneInString(s)
+		if r != utf8.RuneError || size != 1 {
+			break
+		}
+		s = s[:len(s)-1]
+	}
+	return s
 }

--- a/server/platform/services/docextractor/plain.go
+++ b/server/platform/services/docextractor/plain.go
@@ -5,10 +5,19 @@ package docextractor
 
 import (
 	"context"
+	"errors"
 	"io"
+	"strings"
 	"unicode"
 	"unicode/utf8"
+
+	"github.com/mattermost/mattermost/server/v8/channels/utils"
 )
+
+// maxPlainTextExtractionSize bounds how much of a file this extractor reads
+// into memory (1MB). Aligned with the caller's extraction cap so reading
+// further never yields usable extra content.
+const maxPlainTextExtractionSize = 1024 * 1024 // 1MB
 
 type plainExtractor struct{}
 
@@ -20,7 +29,7 @@ func (pe *plainExtractor) Match(filename string) bool {
 	return true
 }
 
-func (pe *plainExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, _ int64) (string, error) {
+func (pe *plainExtractor) Extract(_ context.Context, filename string, r io.ReadSeeker, maxFileSize int64) (string, error) {
 	// This detects any visible character plus any whitespace
 	validRanges := append(unicode.GraphicRanges, unicode.White_Space)
 
@@ -51,6 +60,28 @@ func (pe *plainExtractor) Extract(_ context.Context, filename string, r io.ReadS
 		}
 	}
 
-	text, _ := io.ReadAll(r)
-	return string(runes[0:total]) + string(text), nil
+	limit := int64(maxPlainTextExtractionSize)
+	if maxFileSize > 0 && maxFileSize < limit {
+		limit = maxFileSize
+	}
+
+	var sb strings.Builder
+	sb.Grow(int(limit))
+	if int64(total) > limit {
+		total = int(limit)
+	}
+	sb.Write(runes[0:total])
+	if remaining := limit - int64(total); remaining > 0 {
+		if _, err := io.Copy(&sb, utils.NewLimitedReaderWithError(r, remaining)); err != nil && !errors.Is(err, utils.ErrSizeLimitExceeded) {
+			return "", err
+		}
+	}
+
+	// LimitedReaderWithError may return one byte past the limit; clamp to enforce it.
+	out := sb.String()
+	if int64(len(out)) > limit {
+		out = out[:limit]
+	}
+
+	return out, nil
 }

--- a/server/platform/services/docextractor/plain_test.go
+++ b/server/platform/services/docextractor/plain_test.go
@@ -52,3 +52,37 @@ func TestBigBinaryFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, "", extractedText)
 }
+
+// MM-70601: the extractor must never read more than maxPlainTextExtractionSize
+// into memory, regardless of the input size.
+func TestPlainFileIsBoundedRegardlessOfInputSize(t *testing.T) {
+	extractor := plainExtractor{}
+	content := bytes.Repeat([]byte("a"), maxPlainTextExtractionSize+1024)
+	out, err := extractor.Extract(context.Background(), "test.txt", bytes.NewReader(content), 0)
+	require.NoError(t, err)
+	require.Equal(t, maxPlainTextExtractionSize, len(out))
+	require.Equal(t, string(content[:maxPlainTextExtractionSize]), out)
+}
+
+// MM-70601: when the caller passes a smaller maxFileSize, that bound wins
+// over the extractor's own default cap.
+func TestPlainFileRespectsSmallerMaxFileSize(t *testing.T) {
+	extractor := plainExtractor{}
+	content := bytes.Repeat([]byte("x"), 4096)
+	const max = int64(100)
+	out, err := extractor.Extract(context.Background(), "test.txt", bytes.NewReader(content), max)
+	require.NoError(t, err)
+	require.Equal(t, int(max), len(out))
+	require.Equal(t, string(content[:max]), out)
+}
+
+// MM-70601: a caller-supplied maxFileSize larger than the extractor's own
+// cap does not widen it.
+func TestPlainFileIgnoresLargerMaxFileSize(t *testing.T) {
+	extractor := plainExtractor{}
+	content := bytes.Repeat([]byte("b"), maxPlainTextExtractionSize+10)
+	out, err := extractor.Extract(context.Background(), "test.txt",
+		bytes.NewReader(content), int64(maxPlainTextExtractionSize)*2)
+	require.NoError(t, err)
+	require.Equal(t, maxPlainTextExtractionSize, len(out))
+}

--- a/server/platform/services/docextractor/plain_test.go
+++ b/server/platform/services/docextractor/plain_test.go
@@ -6,8 +6,10 @@ package docextractor
 import (
 	"bytes"
 	"context"
+	"io"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/stretchr/testify/require"
 )
@@ -85,4 +87,58 @@ func TestPlainFileIgnoresLargerMaxFileSize(t *testing.T) {
 		bytes.NewReader(content), int64(maxPlainTextExtractionSize)*2)
 	require.NoError(t, err)
 	require.Equal(t, maxPlainTextExtractionSize, len(out))
+}
+
+// MM-70601: truncating at maxFileSize must not split a multi-byte UTF-8
+// rune straddling the boundary.
+func TestPlainFileTruncationDoesNotSplitRune(t *testing.T) {
+	extractor := plainExtractor{}
+	// "€" is a 3-byte rune (U+20AC); placing it right at the cut point
+	// leaves only its first byte inside the limit.
+	content := []byte(strings.Repeat("a", 9) + "€" + "trailing data past the limit")
+	const maxSize = int64(10)
+	out, err := extractor.Extract(context.Background(), "test.txt", bytes.NewReader(content), maxSize)
+	require.NoError(t, err)
+	require.True(t, utf8.ValidString(out))
+	require.Equal(t, strings.Repeat("a", 9), out)
+}
+
+// countingReadSeeker records how many bytes the extractor actually pulls
+// from the underlying source.
+type countingReadSeeker struct {
+	r         io.ReadSeeker
+	bytesRead int
+}
+
+func (c *countingReadSeeker) Read(p []byte) (int, error) {
+	n, err := c.r.Read(p)
+	c.bytesRead += n
+	return n, err
+}
+
+func (c *countingReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	return c.r.Seek(offset, whence)
+}
+
+// MM-70601: the extractor must not read more than maxPlainTextExtractionSize
+// from the source when no (or a larger) maxFileSize is given.
+func TestPlainFileDoesNotOverreadPastDefaultCap(t *testing.T) {
+	extractor := plainExtractor{}
+	content := bytes.Repeat([]byte("a"), maxPlainTextExtractionSize*2)
+	counter := &countingReadSeeker{r: bytes.NewReader(content)}
+	_, err := extractor.Extract(context.Background(), "test.txt", counter, 0)
+	require.NoError(t, err)
+	require.LessOrEqual(t, counter.bytesRead, maxPlainTextExtractionSize)
+}
+
+// MM-70601: a smaller maxFileSize must bound reads from the source from the
+// very first probe, not just the returned content.
+func TestPlainFileDoesNotOverreadPastMaxFileSize(t *testing.T) {
+	extractor := plainExtractor{}
+	content := bytes.Repeat([]byte("a"), 4096)
+	const maxSize = int64(10)
+	counter := &countingReadSeeker{r: bytes.NewReader(content)}
+	_, err := extractor.Extract(context.Background(), "test.txt", counter, maxSize)
+	require.NoError(t, err)
+	require.LessOrEqual(t, int64(counter.bytesRead), maxSize)
 }

--- a/server/platform/services/docextractor/plain_test.go
+++ b/server/platform/services/docextractor/plain_test.go
@@ -69,11 +69,11 @@ func TestPlainFileIsBoundedRegardlessOfInputSize(t *testing.T) {
 func TestPlainFileRespectsSmallerMaxFileSize(t *testing.T) {
 	extractor := plainExtractor{}
 	content := bytes.Repeat([]byte("x"), 4096)
-	const max = int64(100)
-	out, err := extractor.Extract(context.Background(), "test.txt", bytes.NewReader(content), max)
+	const maxSize = int64(100)
+	out, err := extractor.Extract(context.Background(), "test.txt", bytes.NewReader(content), maxSize)
 	require.NoError(t, err)
-	require.Equal(t, int(max), len(out))
-	require.Equal(t, string(content[:max]), out)
+	require.Equal(t, int(maxSize), len(out))
+	require.Equal(t, string(content[:maxSize]), out)
 }
 
 // MM-70601: a caller-supplied maxFileSize larger than the extractor's own


### PR DESCRIPTION
#### Summary
`plainExtractor.Extract` read the entire input into memory via `io.ReadAll`, ignoring the `maxFileSize` argument that every other extractor in this package respects (`documentExtractor`, `pdfExtractor`, `archiveExtractor`). Since `plainExtractor` matches any filename not claimed by a more specific extractor, this meant extracting content from a large plain-text-like file (`.csv`, `.txt`, `.log`, etc.) could allocate several times the file's size in a single pass, with no bound.

This PR bounds the read to the smaller of the caller-supplied `maxFileSize` and the extractor's own cap (1MB, matching the truncation the caller already applies to extracted content), using the same `utils.LimitedReaderWithError` pattern used by the other extractors. Since the caller already discards everything past 1MB, behavior for existing files and search results is unchanged.

QA steps:
1. Upload a plain-text-like file (e.g. `.csv`) larger than a few MB with content search/extraction enabled.
2. Confirm the file uploads successfully and its searchable content still reflects the beginning of the file, same as before.

#### Ticket Link
Fixes: https://mattermost.atlassian.net/browse/MM-70601

#### Release Note
```release-note
NONE
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟢 Low

**Regression Risk:** The change is isolated to plain-text extraction. Focused tests cover read limits, over-read prevention, and UTF-8 boundaries.

**QA Recommendation:** Manual QA is not required.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->