### PR TITLE
Show non-template property fields on Manage Attributes

### DIFF
--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_applies_to.test.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_applies_to.test.tsx
@@ -129,4 +129,18 @@ describe('AttributeAppliesTo', () => {
             expect(screen.getByTestId('attributeAppliesToEmptyState')).toHaveTextContent('Add a resource to apply this attribute');
         });
     });
+
+    describe('lockedTooltip on the Channels row', () => {
+        it('wraps the toggle in the lock tooltip when lockedTooltip is given', () => {
+            renderComponent({appliesTo: ['channel'], lockedTooltip: 'Locked'});
+
+            expect(screen.getByTestId('attributeAppliesToRow-channel-toggleLockWrap')).toBeInTheDocument();
+        });
+
+        it('renders no lock wrapper when lockedTooltip is not given', () => {
+            renderComponent({appliesTo: ['channel']});
+
+            expect(screen.queryByTestId('attributeAppliesToRow-channel-toggleLockWrap')).not.toBeInTheDocument();
+        });
+    });
 });

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_applies_to.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_applies_to.tsx
@@ -170,6 +170,7 @@ function AttributeAppliesTo({appliesTo, disabled = false, hideAddResource = fals
                                                 onConfigChange={onChannelResourceChange}
                                                 ordered={ordered}
                                                 disabled={disabled}
+                                                lockedTooltip={lockedTooltip}
                                                 onRemove={() => onRemove(type)}
                                             />
                                         );

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.test.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.test.tsx
@@ -1569,6 +1569,44 @@ describe('AttributeDetails', () => {
             });
         });
 
+        describe('non-template field external source', () => {
+            it('does not render the external-source editor for a non-template channel field', async () => {
+                mockLoadedNonTemplateField(makeNonTemplate('channel'));
+
+                renderEdit();
+                await waitForForm();
+
+                expect(screen.queryByTestId('attributeExternalSource')).not.toBeInTheDocument();
+            });
+
+            it('does not render the external-source editor for a non-template post field', async () => {
+                mockLoadedNonTemplateField(makeNonTemplate('post'));
+
+                renderEdit();
+                await waitForForm();
+
+                expect(screen.queryByTestId('attributeExternalSource')).not.toBeInTheDocument();
+            });
+
+            it('renders the external-source editor for a non-template user field', async () => {
+                mockLoadedNonTemplateField(makeNonTemplate('user'));
+
+                renderEdit();
+                await waitForForm();
+
+                expect(screen.getByTestId('attributeExternalSource')).toBeInTheDocument();
+            });
+
+            it('leaves a loaded template\'s external-source editor rendered with no resources applied', async () => {
+                mockLoadedField(makeTemplate());
+
+                renderEdit();
+                await waitForForm();
+
+                expect(screen.getByTestId('attributeExternalSource')).toBeInTheDocument();
+            });
+        });
+
         it('keeps existing option IDs on PATCH and sends an empty id for newly added options', async () => {
             mockLoadedField(makeTemplate({
                 type: 'select',

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.test.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.test.tsx
@@ -1291,6 +1291,34 @@ describe('AttributeDetails', () => {
             });
         }
 
+        function makeNonTemplate(objectType: 'user' | 'channel' | 'post', overrides: Partial<PropertyField> = {}): PropertyField {
+            return {
+                id: FIELD_ID,
+                name: 'department',
+                type: 'text',
+                group_id: 'accesscontrolgroupuuid001',
+                object_type: objectType,
+                target_id: '',
+                target_type: 'system',
+                create_at: 1,
+                update_at: 1,
+                delete_at: 0,
+                created_by: '',
+                updated_by: '',
+                attrs: {display_name: 'Department'},
+                ...overrides,
+            } as PropertyField;
+        }
+
+        function mockLoadedNonTemplateField(field: PropertyField) {
+            jest.spyOn(Client4, 'getPropertyFields').mockImplementation((_group, objectType) => {
+                if (objectType === field.object_type) {
+                    return Promise.resolve([field]);
+                }
+                return Promise.resolve([]);
+            });
+        }
+
         const renderEdit = (initialState: Record<string, unknown> = {}) => renderWithContext(
             <div>
                 <Route path='/admin_console/system_attributes/manage_attributes/attribute_details/:field_id'>
@@ -1430,6 +1458,58 @@ describe('AttributeDetails', () => {
                 attrs: expect.objectContaining({display_name: 'Department 2'}),
             }));
             expect(patchPropertyField.mock.calls[0][3]).not.toHaveProperty('name');
+        });
+
+        it('loads a non-template field into Definition without redirecting to the list', async () => {
+            mockLoadedNonTemplateField(makeNonTemplate('user', {
+                type: 'select',
+                attrs: {display_name: 'Department', options: [{id: 'opt-1', name: 'Engineering'}]},
+            }));
+
+            renderEdit();
+            await waitForForm();
+
+            expect(screen.getByTestId('attributeDisplayNameInput')).toHaveValue('Department');
+            expect(screen.getByTestId('attributeUniqueNameValue')).toHaveTextContent('department');
+            expect(screen.getByTestId('attributeTypeMenuButton')).toHaveTextContent('Select');
+            expect(mockHistoryPush).not.toHaveBeenCalled();
+        });
+
+        it('saves a non-template field with a PATCH to its own object type, not the template create/link path', async () => {
+            mockLoadedNonTemplateField(makeNonTemplate('user'));
+            const patchPropertyField = jest.spyOn(Client4, 'patchPropertyField').mockResolvedValue(makeNonTemplate('user'));
+            const createPropertyField = jest.spyOn(Client4, 'createPropertyField');
+            const deletePropertyField = jest.spyOn(Client4, 'deletePropertyField');
+
+            renderEdit();
+            await waitForForm();
+
+            await userEvent.type(screen.getByTestId('attributeDisplayNameInput'), ' 2');
+            await userEvent.click(screen.getByTestId('saveSetting'));
+
+            await waitFor(() => expect(mockHistoryPush).toHaveBeenCalledWith('/admin_console/system_attributes/manage_attributes'));
+            expect(patchPropertyField).toHaveBeenCalledWith('access_control', 'user', FIELD_ID, expect.objectContaining({
+                type: 'text',
+                attrs: expect.objectContaining({display_name: 'Department 2'}),
+            }));
+            expect(createPropertyField).not.toHaveBeenCalled();
+            expect(deletePropertyField).not.toHaveBeenCalled();
+        });
+
+        it('surfaces a rejected PATCH for a non-template field and leaves Save usable', async () => {
+            mockLoadedNonTemplateField(makeNonTemplate('user'));
+            const patchPropertyField = jest.spyOn(Client4, 'patchPropertyField').mockRejectedValue(makeClientError('app.property_field.update.name_conflict.app_error'));
+
+            renderEdit();
+            await waitForForm();
+
+            await userEvent.type(screen.getByTestId('attributeDisplayNameInput'), ' 2');
+            await userEvent.click(screen.getByTestId('saveSetting'));
+
+            expect(await screen.findByTestId('attributeSaveError')).toBeInTheDocument();
+            expect(patchPropertyField).toHaveBeenCalledTimes(1);
+            expect(mockHistoryPush).not.toHaveBeenCalled();
+            expect(screen.getByTestId('saveSetting')).not.toBeDisabled();
         });
 
         it('keeps existing option IDs on PATCH and sends an empty id for newly added options', async () => {

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.test.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.test.tsx
@@ -1512,6 +1512,63 @@ describe('AttributeDetails', () => {
             expect(screen.getByTestId('saveSetting')).not.toBeDisabled();
         });
 
+        describe('non-template field applies-to', () => {
+            it('shows only the field\'s own resource row, with neither Add-resource trigger', async () => {
+                mockLoadedNonTemplateField(makeNonTemplate('user'));
+
+                renderEdit();
+                await waitForForm();
+
+                expect(screen.getByTestId('attributeAppliesToRow-user')).toBeInTheDocument();
+                expect(screen.queryByTestId('attributeAppliesToRow-channel')).not.toBeInTheDocument();
+                expect(screen.queryByTestId('attributeAppliesToRow-post')).not.toBeInTheDocument();
+                expect(screen.queryByTestId('attributeAppliesToAddResourceButtonHeader')).not.toBeInTheDocument();
+                expect(screen.queryByTestId('attributeAppliesToAddResourceButtonInline')).not.toBeInTheDocument();
+            });
+
+            it('shows the Channels row for a non-template channel field', async () => {
+                mockLoadedNonTemplateField(makeNonTemplate('channel'));
+
+                renderEdit();
+                await waitForForm();
+
+                expect(screen.getByTestId('attributeAppliesToRow-channel')).toBeInTheDocument();
+                expect(screen.queryByTestId('attributeAppliesToRow-user')).not.toBeInTheDocument();
+                expect(screen.queryByTestId('attributeAppliesToRow-post')).not.toBeInTheDocument();
+            });
+
+            it('disables the row\'s toggle behind an explanatory lock tooltip', async () => {
+                mockLoadedNonTemplateField(makeNonTemplate('user'));
+
+                renderEdit();
+                await waitForForm();
+
+                expect(screen.getByTestId('attributeAppliesToRow-user-toggle')).toBeDisabled();
+                expect(screen.getByTestId('attributeAppliesToRow-user-toggleLockWrap')).toBeInTheDocument();
+            });
+
+            it('leaves Type editable -- the single-resource lock must not regress the earlier applies-to-stays-editable guard', async () => {
+                mockLoadedNonTemplateField(makeNonTemplate('user'));
+
+                renderEdit();
+                await waitForForm();
+
+                expect(screen.getByTestId('attributeTypeMenuButton')).not.toBeDisabled();
+                expect(screen.queryByTestId('attributeTypeLockWrap')).not.toBeInTheDocument();
+            });
+
+            it('leaves a loaded template\'s Applies-to row enabled with its Add-resource trigger present', async () => {
+                mockLoadedField(makeTemplate(), [makeLinked('user', 'user-field')]);
+
+                renderEdit();
+                await waitForForm();
+
+                expect(screen.getByTestId('attributeAppliesToRow-user-toggle')).not.toBeDisabled();
+                expect(screen.queryByTestId('attributeAppliesToRow-user-toggleLockWrap')).not.toBeInTheDocument();
+                expect(screen.getByTestId('attributeAppliesToAddResourceButtonHeader')).toBeInTheDocument();
+            });
+        });
+
         it('keeps existing option IDs on PATCH and sends an empty id for newly added options', async () => {
             mockLoadedField(makeTemplate({
                 type: 'select',

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.test.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.test.tsx
@@ -1475,6 +1475,28 @@ describe('AttributeDetails', () => {
             expect(mockHistoryPush).not.toHaveBeenCalled();
         });
 
+        it('loads a user field with the channel scope skipped when channel attributes are unavailable', async () => {
+            // Below Enterprise Advanced the channel GET 501s; fetchAttributeField
+            // must skip it rather than reject and bounce a user-field edit to the
+            // list. The channel reject below must never be reached.
+            const getPropertyFields = jest.spyOn(Client4, 'getPropertyFields').mockImplementation((_group, objectType) => {
+                if (objectType === 'channel') {
+                    return Promise.reject(new Error('channel 501'));
+                }
+                if (objectType === 'user') {
+                    return Promise.resolve([makeNonTemplate('user')]);
+                }
+                return Promise.resolve([]);
+            });
+
+            renderEdit({entities: {general: {config: {FeatureFlagChannelAttributes: 'false'}, license: {SkuShortName: 'professional'}}}});
+            await waitForForm();
+
+            expect(screen.getByTestId('attributeDisplayNameInput')).toHaveValue('Department');
+            expect(mockHistoryPush).not.toHaveBeenCalled();
+            expect(getPropertyFields.mock.calls.every((call) => call[1] !== 'channel')).toBe(true);
+        });
+
         it('saves a non-template field with a PATCH to its own object type, not the template create/link path', async () => {
             mockLoadedNonTemplateField(makeNonTemplate('user'));
             const patchPropertyField = jest.spyOn(Client4, 'patchPropertyField').mockResolvedValue(makeNonTemplate('user'));
@@ -1535,6 +1557,17 @@ describe('AttributeDetails', () => {
                 expect(screen.getByTestId('attributeAppliesToRow-channel')).toBeInTheDocument();
                 expect(screen.queryByTestId('attributeAppliesToRow-user')).not.toBeInTheDocument();
                 expect(screen.queryByTestId('attributeAppliesToRow-post')).not.toBeInTheDocument();
+            });
+
+            it('seeds the locked Channels row summary from the field, not the default config', async () => {
+                mockLoadedNonTemplateField(makeNonTemplate('channel', {attrs: {display_name: 'Region', required: true}}));
+
+                renderEdit();
+                await waitForForm();
+
+                // required:true parses to "Required"; the default config is "Optional",
+                // so this proves the row reflects the field rather than the default.
+                expect(screen.getByTestId('attributeAppliesToRow-channel-summary')).toHaveTextContent('Required');
             });
 
             it('disables the row\'s toggle behind an explanatory lock tooltip', async () => {

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
@@ -733,6 +733,12 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
     }, [handleDoneClick, handleCancelEdit]);
 
     const hasExternalSource = Boolean(ldapAttr || samlAttr);
+
+    // External source (LDAP/SAML) is a user-identity concept. A template's linked
+    // children can include a user field, so every template keeps the editor
+    // regardless of which resources it currently applies to; among non-template
+    // fields only a user field qualifies.
+    const showsExternalSource = !isNonTemplate || objectType === 'user';
     const typeLockedByAppliesTo = isEditMode && appliesTo.length > 0 && !isNonTemplate;
     const typeLocked = hasExternalSource || typeLockedByAppliesTo || isPluginOwned;
     const typeChanged = isEditMode && fieldType !== originalFieldTypeRef.current;
@@ -1351,14 +1357,16 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
                                             pluginInventoryLoaded={pluginInventoryLoaded}
                                         />
                                     ) : (
-                                        <AttributeExternalSource
-                                            ldapAttr={ldapAttr}
-                                            samlAttr={samlAttr}
-                                            fieldType={fieldType}
-                                            onLink={handleLink}
-                                            disabled={saving || effectiveDisabled}
-                                            disableAdding={typeLockedByAppliesTo}
-                                        />
+                                        showsExternalSource && (
+                                            <AttributeExternalSource
+                                                ldapAttr={ldapAttr}
+                                                samlAttr={samlAttr}
+                                                fieldType={fieldType}
+                                                onLink={handleLink}
+                                                disabled={saving || effectiveDisabled}
+                                                disableAdding={typeLockedByAppliesTo}
+                                            />
+                                        )
                                     )}
                                 </div>
                             </div>

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
@@ -826,7 +826,7 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
             }
 
             try {
-                await updateAttributeField(fieldId, {
+                await updateAttributeField(GLOBAL_ATTRIBUTES_OBJECT_TYPE, fieldId, {
                     ...(nameUnchanged ? {} : {name: currentName}),
                     type: fieldType,
                     displayName,

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
@@ -47,7 +47,7 @@ import {useConfirmRemoveAppliesTo} from './attribute_remove_applies_to_warning_m
 
 import {CHANNEL_VALUE_SETTER, DEFAULT_CHANNEL_RESOURCE_CONFIG, buildChannelFieldAttrs, buildChannelFieldPatch, isOrderedChangePolicy, parseChannelFieldConfig} from '../applies_to/channels';
 import type {ChannelResourceConfig} from '../applies_to/channels';
-import {GLOBAL_ATTRIBUTES_LIST_ROUTE} from '../constants';
+import {GLOBAL_ATTRIBUTES_LIST_ROUTE, GLOBAL_ATTRIBUTES_OBJECT_TYPE} from '../constants';
 import {getSourceKind, getTypeIcon, getTypeLabel, isClassificationMarkingsField, typeLabels} from '../global_attributes_table';
 import type {AttributeFieldType} from '../utils';
 import {
@@ -226,7 +226,7 @@ async function rollbackLinkedFields(
     }
 
     try {
-        await deleteAttributeField(templateFieldId);
+        await deleteAttributeField(GLOBAL_ATTRIBUTES_OBJECT_TYPE, templateFieldId);
     } catch (deleteTemplateError) {
         // Linked fields are gone, but the template is still on the server.
         // A retry under the same Unique name will conflict with it, so this

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
@@ -474,9 +474,8 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
                 setSamlAttr(typeof field.attrs?.saml === 'string' ? field.attrs.saml : '');
 
                 // A non-template field has no linked fields to seed from --
-                // its Applies-to is its own object type, fixed (see
-                // typeLockedByAppliesTo/isNonTemplate below for why it can't
-                // be changed).
+                // its Applies-to is its own object type, fixed (the
+                // AttributeAppliesTo call below disables it via isNonTemplate).
                 setAppliesTo(
                     field.object_type === GLOBAL_ATTRIBUTES_OBJECT_TYPE ?
                         ALL_RESOURCE_TYPES.filter((type) => Boolean(linkedByType[type])) :

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
@@ -434,7 +434,7 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
 
         const load = async () => {
             try {
-                const field = await fetchAttributeField(fieldId);
+                const field = await fetchAttributeField(fieldId, channelAttributesEnabled);
                 if (cancelled) {
                     return;
                 }
@@ -481,8 +481,14 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
                         ALL_RESOURCE_TYPES.filter((type) => Boolean(linkedByType[type])) :
                         ALL_RESOURCE_TYPES.filter((type) => type === field.object_type),
                 );
-                if (linkedByType.channel) {
-                    setChannelResource(parseChannelFieldConfig(linkedByType.channel));
+
+                // A non-template channel field is itself the channel field, so its
+                // row settings parse from it directly; a template seeds them from
+                // its linked channel child instead. Without this the locked Channels
+                // row would show the default config, misrepresenting the field.
+                const channelConfigSource = field.object_type === 'channel' ? field : linkedByType.channel;
+                if (channelConfigSource) {
+                    setChannelResource(parseChannelFieldConfig(channelConfigSource));
                 }
                 setLoading(false);
             } catch {
@@ -497,7 +503,7 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
         return () => {
             cancelled = true;
         };
-    }, [fieldId]);
+    }, [fieldId, channelAttributesEnabled]);
 
     const autoSlugDisplay = useMemo(() => computeAutoSlugDisplay(displayName), [displayName]);
     const currentName = (isEditingName || isNameManuallyEdited) ? manualName : (autoSlugDisplay ?? '');

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
@@ -297,6 +297,12 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
     const [sourcePluginId, setSourcePluginId] = useState<string | undefined>(undefined);
     const isPluginOwned = Boolean(sourcePluginId);
 
+    // Which object type Save PATCHes back to. Set once from the loaded field
+    // (see load() below); create mode never changes it, since creating a
+    // non-template field from this page is out of scope (phase 3 handles the
+    // rest of that constraint).
+    const [objectType, setObjectType] = useState<string>(GLOBAL_ATTRIBUTES_OBJECT_TYPE);
+
     // Substituted for the bare `disabled` prop everywhere else on this page --
     // one boolean, not a second parallel disabled path. Keeps the pre-existing
     // non-sysadmin `disabled` prop (schema-wired via isDisabled: it.not
@@ -434,12 +440,20 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
                     return;
                 }
 
-                const linkedFields = await fetchLinkedFieldsForTemplate(fieldId);
-                if (cancelled) {
-                    return;
-                }
+                setObjectType(field.object_type);
 
-                const linkedByType = linkedFieldsByResourceType(linkedFields);
+                // Only a template has linked fields to fetch -- an unlinked
+                // user/channel/post field has none, so Applies-to stays empty
+                // and there is no Channels config to parse (see §3, phase 3
+                // fixes the Applies-to/external-source display for real).
+                let linkedByType: Partial<Record<ResourceObjectType, PropertyField>> = {};
+                if (field.object_type === GLOBAL_ATTRIBUTES_OBJECT_TYPE) {
+                    const linkedFields = await fetchLinkedFieldsForTemplate(fieldId);
+                    if (cancelled) {
+                        return;
+                    }
+                    linkedByType = linkedFieldsByResourceType(linkedFields);
+                }
                 persistedLinkedFieldsRef.current = linkedByType;
                 originalNameRef.current = field.name;
                 const loadedFieldType = isAttributeFieldType(field.type) ? field.type : 'text';
@@ -771,6 +785,32 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
         setFailedResourceTypes(null);
 
         if (isEditMode && fieldId) {
+            // An unlinked user/channel/post field owns its own row -- one PATCH
+            // to that object type, never the template create-plus-link path
+            // below (which is a template's own edit path from here on).
+            if (objectType !== GLOBAL_ATTRIBUTES_OBJECT_TYPE) {
+                try {
+                    await updateAttributeField(objectType, fieldId, {
+                        ...(nameUnchanged ? {} : {name: currentName}),
+                        type: fieldType,
+                        displayName,
+                        options,
+                        ldapAttr,
+                        samlAttr,
+                    });
+                } catch (error) {
+                    finalizeSave({
+                        success: false,
+                        errorKind: errorKindFromError(error),
+                        serverErrorMessage: (error as ClientError | undefined)?.message ?? null,
+                        failedResourceTypes: null,
+                    });
+                    return;
+                }
+                finalizeSave({success: true});
+                return;
+            }
+
             const persisted = persistedLinkedFieldsRef.current;
             const toDelete = (Object.keys(persisted) as ResourceObjectType[]).filter((type) => !appliesTo.includes(type));
             const toCreate = appliesTo.filter((type) => !persisted[type]);
@@ -937,7 +977,7 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
         }
 
         finalizeSave(outcome);
-    }, [canSave, isEditMode, fieldId, nameUnchanged, displayName, currentName, fieldType, typeChanged, options, ldapAttr, samlAttr, appliesTo, channelResource, finalizeSave, confirmRemoveAppliesTo]);
+    }, [canSave, isEditMode, fieldId, objectType, nameUnchanged, displayName, currentName, fieldType, typeChanged, options, ldapAttr, samlAttr, appliesTo, channelResource, finalizeSave, confirmRemoveAppliesTo]);
 
     const handleChannelResourceChange = useCallback((next: ChannelResourceConfig) => {
         setChannelResource(next);

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
@@ -303,6 +303,12 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
     // user/channel/post field directly.
     const [objectType, setObjectType] = useState<string>(GLOBAL_ATTRIBUTES_OBJECT_TYPE);
 
+    // True for a loaded user/channel/post field that owns no template of its
+    // own -- create mode and templates both leave objectType at
+    // GLOBAL_ATTRIBUTES_OBJECT_TYPE, so this is false for them without an
+    // extra isEditMode clause.
+    const isNonTemplate = objectType !== GLOBAL_ATTRIBUTES_OBJECT_TYPE;
+
     // Substituted for the bare `disabled` prop everywhere else on this page --
     // one boolean, not a second parallel disabled path. Keeps the pre-existing
     // non-sysadmin `disabled` prop (schema-wired via isDisabled: it.not
@@ -466,7 +472,16 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
                 setOptions(optionsFromField(field));
                 setLdapAttr(typeof field.attrs?.ldap === 'string' ? field.attrs.ldap : '');
                 setSamlAttr(typeof field.attrs?.saml === 'string' ? field.attrs.saml : '');
-                setAppliesTo(ALL_RESOURCE_TYPES.filter((type) => Boolean(linkedByType[type])));
+
+                // A non-template field has no linked fields to seed from --
+                // its Applies-to is its own object type, fixed (see
+                // typeLockedByAppliesTo/isNonTemplate below for why it can't
+                // be changed).
+                setAppliesTo(
+                    field.object_type === GLOBAL_ATTRIBUTES_OBJECT_TYPE ?
+                        ALL_RESOURCE_TYPES.filter((type) => Boolean(linkedByType[type])) :
+                        ALL_RESOURCE_TYPES.filter((type) => type === field.object_type),
+                );
                 if (linkedByType.channel) {
                     setChannelResource(parseChannelFieldConfig(linkedByType.channel));
                 }
@@ -516,6 +531,15 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
         nameDescribedBy = 'attribute-unique-name-error';
     } else if (isServerNameError) {
         nameDescribedBy = 'attribute-save-error';
+    }
+
+    // Plugin ownership wins over non-template: it disables the whole page,
+    // so it is the more specific reason to show.
+    let appliesToLockedTooltip: string | undefined;
+    if (isPluginOwned) {
+        appliesToLockedTooltip = formatMessage(isOrphaned ? messages.appliesToLockedPluginOrphanedTooltip : messages.appliesToLockedPluginTooltip);
+    } else if (isNonTemplate) {
+        appliesToLockedTooltip = formatMessage(messages.appliesToLockedSingleResourceTooltip);
     }
 
     const markDirty = useCallback(() => {
@@ -709,7 +733,7 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
     }, [handleDoneClick, handleCancelEdit]);
 
     const hasExternalSource = Boolean(ldapAttr || samlAttr);
-    const typeLockedByAppliesTo = isEditMode && appliesTo.length > 0;
+    const typeLockedByAppliesTo = isEditMode && appliesTo.length > 0 && !isNonTemplate;
     const typeLocked = hasExternalSource || typeLockedByAppliesTo || isPluginOwned;
     const typeChanged = isEditMode && fieldType !== originalFieldTypeRef.current;
     const typeSupportsOptions = supportsOptions({type: fieldType} as PropertyField);
@@ -1343,9 +1367,9 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
                     <AttributeAppliesTo
                         appliesTo={appliesTo}
                         allowedTypes={allowedResourceTypes}
-                        disabled={saving || effectiveDisabled}
-                        hideAddResource={isPluginOwned}
-                        lockedTooltip={isPluginOwned ? formatMessage(isOrphaned ? messages.appliesToLockedPluginOrphanedTooltip : messages.appliesToLockedPluginTooltip) : undefined}
+                        disabled={saving || effectiveDisabled || isNonTemplate}
+                        hideAddResource={isPluginOwned || isNonTemplate}
+                        lockedTooltip={appliesToLockedTooltip}
                         onAdd={handleAdd}
                         onRemove={handleRemove}
                         channelResource={channelResource}
@@ -1471,6 +1495,10 @@ const messages = defineMessages({
     appliesToLockedPluginOrphanedTooltip: {
         id: 'admin.global_attributes.attribute_details.applies_to.locked_plugin_orphaned_tooltip',
         defaultMessage: "This resource cannot be changed — this attribute was managed by a plugin that's no longer installed.",
+    },
+    appliesToLockedSingleResourceTooltip: {
+        id: 'admin.global_attributes.attribute_details.applies_to.locked_single_resource_tooltip',
+        defaultMessage: 'This resource cannot be changed — this attribute applies to only one resource.',
     },
     optionsLabel: {id: 'admin.global_attributes.attribute_details.options.label', defaultMessage: 'Options'},
     optionsHelp: {

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
@@ -298,9 +298,9 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
     const isPluginOwned = Boolean(sourcePluginId);
 
     // Which object type Save PATCHes back to. Set once from the loaded field
-    // (see load() below); create mode never changes it, since creating a
-    // non-template field from this page is out of scope (phase 3 handles the
-    // rest of that constraint).
+    // in load() below; create mode leaves it at the template type, since this
+    // page only edits existing fields and has no way to create a
+    // user/channel/post field directly.
     const [objectType, setObjectType] = useState<string>(GLOBAL_ATTRIBUTES_OBJECT_TYPE);
 
     // Substituted for the bare `disabled` prop everywhere else on this page --
@@ -444,8 +444,7 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
 
                 // Only a template has linked fields to fetch -- an unlinked
                 // user/channel/post field has none, so Applies-to stays empty
-                // and there is no Channels config to parse (see §3, phase 3
-                // fixes the Applies-to/external-source display for real).
+                // and there is no Channels config to parse for it.
                 let linkedByType: Partial<Record<ResourceObjectType, PropertyField>> = {};
                 if (field.object_type === GLOBAL_ATTRIBUTES_OBJECT_TYPE) {
                     const linkedFields = await fetchLinkedFieldsForTemplate(fieldId);
@@ -786,8 +785,8 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
 
         if (isEditMode && fieldId) {
             // An unlinked user/channel/post field owns its own row -- one PATCH
-            // to that object type, never the template create-plus-link path
-            // below (which is a template's own edit path from here on).
+            // to that object type, skipping the template create-plus-link path
+            // below entirely.
             if (objectType !== GLOBAL_ATTRIBUTES_OBJECT_TYPE) {
                 try {
                     await updateAttributeField(objectType, fieldId, {

--- a/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/attribute_details/attribute_details.tsx
@@ -49,7 +49,7 @@ import {CHANNEL_VALUE_SETTER, DEFAULT_CHANNEL_RESOURCE_CONFIG, buildChannelField
 import type {ChannelResourceConfig} from '../applies_to/channels';
 import {GLOBAL_ATTRIBUTES_LIST_ROUTE, GLOBAL_ATTRIBUTES_OBJECT_TYPE} from '../constants';
 import {getSourceKind, getTypeIcon, getTypeLabel, isClassificationMarkingsField, typeLabels} from '../global_attributes_table';
-import type {AttributeFieldType} from '../utils';
+import type {AttributeFieldType, UpdateAttributeFieldPatch} from '../utils';
 import {
     createAttributeField,
     createLinkedAttributeField,
@@ -784,19 +784,21 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
         setFailedResourceTypes(null);
 
         if (isEditMode && fieldId) {
+            const patch: UpdateAttributeFieldPatch = {
+                ...(nameUnchanged ? {} : {name: currentName}),
+                type: fieldType,
+                displayName,
+                options,
+                ldapAttr,
+                samlAttr,
+            };
+
             // An unlinked user/channel/post field owns its own row -- one PATCH
             // to that object type, skipping the template create-plus-link path
             // below entirely.
             if (objectType !== GLOBAL_ATTRIBUTES_OBJECT_TYPE) {
                 try {
-                    await updateAttributeField(objectType, fieldId, {
-                        ...(nameUnchanged ? {} : {name: currentName}),
-                        type: fieldType,
-                        displayName,
-                        options,
-                        ldapAttr,
-                        samlAttr,
-                    });
+                    await updateAttributeField(objectType, fieldId, patch);
                 } catch (error) {
                     finalizeSave({
                         success: false,
@@ -865,14 +867,7 @@ function AttributeDetails({disabled = false}: Props): JSX.Element {
             }
 
             try {
-                await updateAttributeField(GLOBAL_ATTRIBUTES_OBJECT_TYPE, fieldId, {
-                    ...(nameUnchanged ? {} : {name: currentName}),
-                    type: fieldType,
-                    displayName,
-                    options,
-                    ldapAttr,
-                    samlAttr,
-                });
+                await updateAttributeField(GLOBAL_ATTRIBUTES_OBJECT_TYPE, fieldId, patch);
             } catch (error) {
                 finalizeSave({
                     success: false,

--- a/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.test.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.test.tsx
@@ -203,6 +203,99 @@ describe('GlobalAttributesTable', () => {
         expect(names).toEqual(['Aardvark Attribute', 'Zebra Attribute']);
     });
 
+    describe('Non-template fields', () => {
+        // Mirrors the fixed template-user-channel-post fetch order the component
+        // dispatches in. Each fetch pages until it sees an empty page: all four scopes'
+        // first pages resolve together (their calls fire before any of them awaits), then
+        // any scope whose first page was non-empty asks again, in that same scope order —
+        // so the queue is every scope's first page, followed by a terminating [] for each
+        // scope that got real data.
+        function mockScopedFields(scopes: {template?: PropertyField[]; user?: PropertyField[]; channel?: PropertyField[]; post?: PropertyField[]}) {
+            const firstPages = [scopes.template ?? [], scopes.user ?? [], scopes.channel ?? [], scopes.post ?? []];
+            firstPages.forEach((fields) => getPropertyFields.mockResolvedValueOnce(fields));
+            firstPages.forEach((fields) => {
+                if (fields.length > 0) {
+                    getPropertyFields.mockResolvedValueOnce([]);
+                }
+            });
+        }
+
+        it('lists an unlinked field from each resource scope alongside templates', async () => {
+            mockScopedFields({
+                user: [makeField({id: 'u1', name: 'user_field', object_type: 'user'})],
+                channel: [makeField({id: 'c1', name: 'channel_field', object_type: 'channel'})],
+                post: [makeField({id: 'p1', name: 'post_field', object_type: 'post'})],
+            });
+
+            renderWithContext(<GlobalAttributesTable/>, getBaseState());
+
+            expect(await screen.findByText('user_field')).toBeInTheDocument();
+            expect(screen.getByText('channel_field')).toBeInTheDocument();
+            expect(screen.getByText('post_field')).toBeInTheDocument();
+        });
+
+        it('excludes a non-template field that is linked to a template', async () => {
+            mockScopedFields({
+                user: [makeField({id: 'u1', name: 'linked_field', object_type: 'user', linked_field_id: 'template-1'})],
+            });
+
+            renderWithContext(<GlobalAttributesTable/>, getBaseState());
+
+            expect(await screen.findByTestId('global-attributes-empty')).toBeInTheDocument();
+            expect(screen.queryByText('linked_field')).not.toBeInTheDocument();
+        });
+
+        it('sorts templates and non-template fields together by display name, not templates-then-non-templates', async () => {
+            mockScopedFields({
+                template: [
+                    makeField({id: 't1', name: 'charlie_template', attrs: {display_name: 'Charlie'}}),
+                    makeField({id: 't2', name: 'echo_template', attrs: {display_name: 'Echo'}}),
+                ],
+                user: [makeField({id: 'u1', name: 'bravo_user', object_type: 'user', attrs: {display_name: 'Bravo'}})],
+                channel: [makeField({id: 'c1', name: 'delta_channel', object_type: 'channel', attrs: {display_name: 'Delta'}})],
+            });
+
+            renderWithContext(<GlobalAttributesTable/>, getBaseState());
+
+            await screen.findByText('Charlie');
+            const names = screen.getAllByTestId('global-attribute-name').map((cell) => cell.textContent);
+            expect(names).toEqual(['Bravo', 'Charlie', 'Delta', 'Echo']);
+        });
+
+        it('does not show the empty state when only non-template fields exist', async () => {
+            mockScopedFields({user: [makeField({id: 'u1', name: 'user_field', object_type: 'user'})]});
+
+            renderWithContext(<GlobalAttributesTable/>, getBaseState());
+
+            expect(await screen.findByText('user_field')).toBeInTheDocument();
+            expect(screen.queryByTestId('global-attributes-empty')).not.toBeInTheDocument();
+        });
+
+        it('shows the error state, not a partial list, when a resource-scope fetch fails', async () => {
+            // Suppress the expected console.error from the load failure this test triggers.
+            const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+            // Calls land in scope order (template, user, channel, post) for each page, then
+            // any scope whose page came back non-empty pages again in that same order — so
+            // the template and user pages each need a trailing [] to end their own paging
+            // before the channel scope's rejection.
+            getPropertyFields.mockResolvedValueOnce([makeField({id: 't1', name: 'template_field'})]). // template page 1
+                mockResolvedValueOnce([makeField({id: 'u1', name: 'user_field', object_type: 'user'})]). // user page 1
+                mockRejectedValueOnce(new Error('boom')). // channel page 1
+                mockResolvedValueOnce([]). // post page 1
+                mockResolvedValueOnce([]). // template page 2 (terminates)
+                mockResolvedValueOnce([]); // user page 2 (terminates)
+
+            renderWithContext(<GlobalAttributesTable/>, getBaseState());
+
+            expect(await screen.findByTestId('global-attributes-error')).toBeInTheDocument();
+            expect(screen.queryByText('template_field')).not.toBeInTheDocument();
+            expect(screen.queryByText('user_field')).not.toBeInTheDocument();
+
+            consoleSpy.mockRestore();
+        });
+    });
+
     it('renders the Applies-to column as an explicit placeholder, not a blank cell', async () => {
         getPropertyFields.mockResolvedValueOnce([makeField()]).mockResolvedValue([]);
 
@@ -628,6 +721,35 @@ describe('GlobalAttributesTable', () => {
 
             expect(deletePropertyField).not.toHaveBeenCalled();
             expect(screen.getByTestId('global-attribute-name')).toHaveTextContent('Department');
+        });
+
+        it('deletes a non-template field via its own object type scope', async () => {
+            deletePropertyField.mockResolvedValue({status: 'OK'});
+
+            const channelField = makeField({id: 'c1', name: 'channel_field', object_type: 'channel', attrs: {display_name: 'Channel Field'}});
+
+            // Calls land in scope order (template, user, channel, post) for the first page
+            // of each; only the channel scope got real data, so only it pages again.
+            getPropertyFields.mockResolvedValueOnce([]). // template
+                mockResolvedValueOnce([]). // user
+                mockResolvedValueOnce([channelField]). // channel
+                mockResolvedValueOnce([]). // post
+                mockResolvedValueOnce([]); // channel page 2 (terminates)
+
+            renderWithContext(
+                <div className='admin-console__wrapper'>
+                    <GlobalAttributesTable/>
+                    <ModalController/>
+                </div>,
+                getBaseState(),
+            );
+
+            await openDeleteModal('c1');
+            await userEvent.click(await screen.findByRole('button', {name: /^delete$/i}));
+
+            await waitFor(() => {
+                expect(deletePropertyField).toHaveBeenCalledWith('access_control', 'channel', 'c1');
+            });
         });
 
         it('deletes via the access_control/template scope and drops the row on success', async () => {

--- a/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.test.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.test.tsx
@@ -323,6 +323,39 @@ describe('GlobalAttributesTable', () => {
             expect(screen.queryByTestId('global-attributes-error')).not.toBeInTheDocument();
             expect(getPropertyFields.mock.calls.every((call) => call[1] !== 'channel')).toBe(true);
         });
+
+        it('hides a cached channel field when channel attributes are disabled', async () => {
+            // Channel-header labels (and a prior visit while licensed) can leave a
+            // channel field in the store after this page has stopped fetching that
+            // scope. First pages fire together as template/user/post; the user page
+            // then terminates with [].
+            const cachedChannel = makeField({id: 'c1', name: 'cached_channel_field', object_type: 'channel'});
+            const userField = makeField({id: 'u1', name: 'user_field', object_type: 'user'});
+            getPropertyFields.
+                mockResolvedValueOnce([]).
+                mockResolvedValueOnce([userField]).
+                mockResolvedValueOnce([]).
+                mockResolvedValueOnce([]);
+
+            const state = getBaseState();
+            state.entities!.properties = {
+                groups: {
+                    byId: {[ACCESS_CONTROL_GROUP_UUID]: {id: ACCESS_CONTROL_GROUP_UUID, name: 'access_control'}},
+                    byName: {access_control: {id: ACCESS_CONTROL_GROUP_UUID, name: 'access_control'}},
+                },
+                fields: {
+                    byId: {c1: cachedChannel},
+                    byObjectType: {
+                        channel: {[ACCESS_CONTROL_GROUP_UUID]: {c1: cachedChannel}},
+                    },
+                },
+            };
+
+            renderWithContext(<GlobalAttributesTable/>, state);
+
+            expect(await screen.findByText('user_field')).toBeInTheDocument();
+            expect(screen.queryByText('cached_channel_field')).not.toBeInTheDocument();
+        });
     });
 
     it('renders the Applies-to column as an explicit placeholder, not a blank cell', async () => {

--- a/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.test.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.test.tsx
@@ -98,6 +98,19 @@ function getReachableState(overrides: {licenseSku?: string; classificationMarkin
     return state;
 }
 
+// State where the table fetches the channel scope: Enterprise Advanced license
+// plus the ChannelAttributes flag in client config (where getFeatureFlagValue
+// reads it), matching the gate the table applies before fetching channel. Without
+// this the channel scope is skipped and the *-channel-* mocks below go unconsumed.
+function getChannelScopeState(): DeepPartial<GlobalState> {
+    const state = getBaseState();
+    state.entities!.general = {
+        config: {FeatureFlagChannelAttributes: 'true'},
+        license: {IsLicensed: 'true', SkuShortName: 'advanced'},
+    } as EntitiesPartial['general'];
+    return state;
+}
+
 function getMobileState(): DeepPartial<GlobalState> {
     const state = getReachableState();
     state.views = {browser: {windowSize: WindowSizes.MOBILE_VIEW}} as DeepPartial<GlobalState>['views'];
@@ -227,7 +240,7 @@ describe('GlobalAttributesTable', () => {
                 post: [makeField({id: 'p1', name: 'post_field', object_type: 'post'})],
             });
 
-            renderWithContext(<GlobalAttributesTable/>, getBaseState());
+            renderWithContext(<GlobalAttributesTable/>, getChannelScopeState());
 
             expect(await screen.findByText('user_field')).toBeInTheDocument();
             expect(screen.getByText('channel_field')).toBeInTheDocument();
@@ -239,7 +252,7 @@ describe('GlobalAttributesTable', () => {
                 user: [makeField({id: 'u1', name: 'linked_field', object_type: 'user', linked_field_id: 'template-1'})],
             });
 
-            renderWithContext(<GlobalAttributesTable/>, getBaseState());
+            renderWithContext(<GlobalAttributesTable/>, getChannelScopeState());
 
             expect(await screen.findByTestId('global-attributes-empty')).toBeInTheDocument();
             expect(screen.queryByText('linked_field')).not.toBeInTheDocument();
@@ -255,7 +268,7 @@ describe('GlobalAttributesTable', () => {
                 channel: [makeField({id: 'c1', name: 'delta_channel', object_type: 'channel', attrs: {display_name: 'Delta'}})],
             });
 
-            renderWithContext(<GlobalAttributesTable/>, getBaseState());
+            renderWithContext(<GlobalAttributesTable/>, getChannelScopeState());
 
             await screen.findByText('Charlie');
             const names = screen.getAllByTestId('global-attribute-name').map((cell) => cell.textContent);
@@ -265,7 +278,7 @@ describe('GlobalAttributesTable', () => {
         it('does not show the empty state when only non-template fields exist', async () => {
             mockScopedFields({user: [makeField({id: 'u1', name: 'user_field', object_type: 'user'})]});
 
-            renderWithContext(<GlobalAttributesTable/>, getBaseState());
+            renderWithContext(<GlobalAttributesTable/>, getChannelScopeState());
 
             expect(await screen.findByText('user_field')).toBeInTheDocument();
             expect(screen.queryByTestId('global-attributes-empty')).not.toBeInTheDocument();
@@ -286,13 +299,29 @@ describe('GlobalAttributesTable', () => {
                 mockResolvedValueOnce([]). // template page 2 (terminates)
                 mockResolvedValueOnce([]); // user page 2 (terminates)
 
-            renderWithContext(<GlobalAttributesTable/>, getBaseState());
+            renderWithContext(<GlobalAttributesTable/>, getChannelScopeState());
 
             expect(await screen.findByTestId('global-attributes-error')).toBeInTheDocument();
             expect(screen.queryByText('template_field')).not.toBeInTheDocument();
             expect(screen.queryByText('user_field')).not.toBeInTheDocument();
 
             consoleSpy.mockRestore();
+        });
+
+        it('skips the channel scope below Enterprise Advanced, so a channel 501 cannot fail the page', async () => {
+            // The server 501s a channel-scoped access_control GET below Enterprise
+            // Advanced; fetching it here would reject the load and show the error
+            // state. getBaseState() has no Advanced license, so the channel scope
+            // must be skipped entirely -- the reject below must never be reached.
+            getPropertyFields.mockImplementation((_group, objectType) =>
+                (objectType === 'channel' ? Promise.reject(new Error('channel 501')) : Promise.resolve([])),
+            );
+
+            renderWithContext(<GlobalAttributesTable/>, getBaseState());
+
+            expect(await screen.findByTestId('global-attributes-empty')).toBeInTheDocument();
+            expect(screen.queryByTestId('global-attributes-error')).not.toBeInTheDocument();
+            expect(getPropertyFields.mock.calls.every((call) => call[1] !== 'channel')).toBe(true);
         });
     });
 
@@ -741,7 +770,7 @@ describe('GlobalAttributesTable', () => {
                     <GlobalAttributesTable/>
                     <ModalController/>
                 </div>,
-                getBaseState(),
+                getChannelScopeState(),
             );
 
             await openDeleteModal('c1');

--- a/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.tsx
@@ -252,7 +252,7 @@ function ActionsCell({field, isClassificationRow, canEditClassification, isMobil
         onDeleteError(null);
 
         try {
-            await deleteAttributeField(field.id);
+            await deleteAttributeField(field.object_type, field.id);
             dispatch({type: PropertyTypes.PROPERTY_FIELD_DELETED, data: {fieldId: field.id}});
         } catch (error) {
             onDeleteError(formatMessage(

--- a/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.tsx
@@ -21,7 +21,7 @@ import PropertyTypes from 'mattermost-redux/action_types/properties';
 import {fetchPropertyFields} from 'mattermost-redux/actions/properties';
 import {getConfig as getAdminConfig} from 'mattermost-redux/selectors/entities/admin';
 import {getLicense} from 'mattermost-redux/selectors/entities/general';
-import {getPropertyFieldsForObjectTypeAndGroup, getPropertyGroupByName} from 'mattermost-redux/selectors/entities/properties';
+import {getPropertyFieldsForObjectTypeAndGroup, getPropertyGroupByName, getUnlinkedSystemFieldsForGroup} from 'mattermost-redux/selectors/entities/properties';
 
 import {getPluginDisplayName} from 'selectors/plugins';
 import {getIsMobileView} from 'selectors/views/browser';
@@ -41,6 +41,7 @@ import {LicenseSkus} from 'utils/constants';
 
 import type {GlobalState} from 'types/store';
 
+import {ALL_RESOURCE_TYPES} from './attribute_details/attribute_applies_to_constants';
 import {CLASSIFICATION_ATTRIBUTE_ROUTE} from './classification_attribute';
 import {attributeDetailsRoute, GLOBAL_ATTRIBUTES_GROUP_NAME, GLOBAL_ATTRIBUTES_OBJECT_TYPE, GLOBAL_ATTRIBUTES_TARGET_TYPE} from './constants';
 import {useGlobalAttributeFieldDelete} from './global_attribute_delete_modal';
@@ -52,6 +53,11 @@ import {AdminConsoleListTable} from '../list_table';
 import './global_attributes_table.scss';
 
 const columnHelper = createColumnHelper<PropertyField>();
+
+// Every scope the table lists rows from: templates, then each resource type's
+// unlinked non-template fields. Module-level so the load effect's [dispatch]
+// dependency list doesn't need to change.
+const OBJECT_TYPES_TO_FETCH: string[] = [GLOBAL_ATTRIBUTES_OBJECT_TYPE, ...ALL_RESOURCE_TYPES];
 
 // Same set as the User Attributes page's type selector (user_properties_type_menu.tsx).
 const TYPE_ICONS: Partial<Record<FieldType, ComponentType<IconProps>>> = {
@@ -401,13 +407,18 @@ export default function GlobalAttributesTable() {
     const fields = useSelector((state: GlobalState) =>
         getPropertyFieldsForObjectTypeAndGroup(state, GLOBAL_ATTRIBUTES_OBJECT_TYPE, groupId),
     );
+    const unlinkedFields = useSelector((state: GlobalState) =>
+        getUnlinkedSystemFieldsForGroup(state, groupId),
+    );
 
     useEffect(() => {
         let active = true;
 
         const load = async () => {
             try {
-                await dispatch(fetchPropertyFields(GLOBAL_ATTRIBUTES_GROUP_NAME, GLOBAL_ATTRIBUTES_OBJECT_TYPE, GLOBAL_ATTRIBUTES_TARGET_TYPE));
+                await Promise.all(OBJECT_TYPES_TO_FETCH.map(
+                    (objectType) => dispatch(fetchPropertyFields(GLOBAL_ATTRIBUTES_GROUP_NAME, objectType, GLOBAL_ATTRIBUTES_TARGET_TYPE)),
+                ));
                 if (active) {
                     setLoadError(false);
                 }
@@ -431,11 +442,16 @@ export default function GlobalAttributesTable() {
         };
     }, [dispatch]);
 
+    const rows = useMemo(
+        () => [...fields, ...unlinkedFields].sort((a, b) => getDisplayName(a).localeCompare(getDisplayName(b))),
+        [fields, unlinkedFields],
+    );
+
     // The Source column resolves plugin-owned rows to a plugin display name, but
     // server-only plugins are absent from the webapp manifest registry — their names
     // live in the admin plugin statuses, which nothing else on this page loads.
     // Fetched once, and only when a plugin-owned row is actually present.
-    const hasPluginOwnedFields = useMemo(() => fields.some((field) => Boolean(field.attrs?.source_plugin_id)), [fields]);
+    const hasPluginOwnedFields = useMemo(() => rows.some((field) => Boolean(field.attrs?.source_plugin_id)), [rows]);
 
     // Whether the plugin inventory is known yet. This gates the orphan check
     // rather than the Source column, which degrades harmlessly to the plugin ID:
@@ -478,11 +494,6 @@ export default function GlobalAttributesTable() {
         bannerRef.current?.focus?.({preventScroll: true});
         bannerRef.current?.closest('.admin-console__wrapper')?.scrollTo?.({top: 0});
     }, [deleteError, deleteModalExited]);
-
-    const rows = useMemo(
-        () => [...fields].sort((a, b) => getDisplayName(a).localeCompare(getDisplayName(b))),
-        [fields],
-    );
 
     const columns = useMemo<Array<ColumnDef<PropertyField, any>>>(() => {
         const isClassificationRow = (field: PropertyField) =>

--- a/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.tsx
@@ -20,7 +20,7 @@ import {supportsOptions} from '@mattermost/types/properties';
 import PropertyTypes from 'mattermost-redux/action_types/properties';
 import {fetchPropertyFields} from 'mattermost-redux/actions/properties';
 import {getConfig as getAdminConfig} from 'mattermost-redux/selectors/entities/admin';
-import {getLicense} from 'mattermost-redux/selectors/entities/general';
+import {getFeatureFlagValue, getLicense} from 'mattermost-redux/selectors/entities/general';
 import {getPropertyFieldsForObjectTypeAndGroup, getPropertyGroupByName, getUnlinkedSystemFieldsForGroup} from 'mattermost-redux/selectors/entities/properties';
 
 import {getPluginDisplayName} from 'selectors/plugins';
@@ -38,6 +38,7 @@ import * as Menu from 'components/menu';
 
 import {getHistory} from 'utils/browser_history';
 import {LicenseSkus} from 'utils/constants';
+import {isMinimumEnterpriseAdvancedLicense} from 'utils/license_utils';
 
 import type {GlobalState} from 'types/store';
 
@@ -53,11 +54,6 @@ import {AdminConsoleListTable} from '../list_table';
 import './global_attributes_table.scss';
 
 const columnHelper = createColumnHelper<PropertyField>();
-
-// Every scope the table lists rows from: templates, then each resource type's
-// unlinked non-template fields. Module-level so the load effect's [dispatch]
-// dependency list doesn't need to change.
-const OBJECT_TYPES_TO_FETCH: string[] = [GLOBAL_ATTRIBUTES_OBJECT_TYPE, ...ALL_RESOURCE_TYPES];
 
 // Same set as the User Attributes page's type selector (user_properties_type_menu.tsx).
 const TYPE_ICONS: Partial<Record<FieldType, ComponentType<IconProps>>> = {
@@ -411,12 +407,27 @@ export default function GlobalAttributesTable() {
         getUnlinkedSystemFieldsForGroup(state, groupId),
     );
 
+    // Same gate the details page applies. Channel is fetched only when channel
+    // attributes are licensed and enabled: the server 501s a channel-scoped
+    // access_control GET below Enterprise Advanced, and this page is reachable at
+    // plain Enterprise, so an unconditional channel fetch would reject the load's
+    // Promise.all and fail the whole page there.
+    const channelAttributesEnabled = useSelector((state: GlobalState) =>
+        getFeatureFlagValue(state, 'ChannelAttributes') === 'true' && isMinimumEnterpriseAdvancedLicense(getLicense(state)));
+
+    // Every scope the table lists rows from: templates, then each resource type's
+    // unlinked non-template fields (channel only when the gate above allows it).
+    const objectTypesToFetch = useMemo(
+        () => [GLOBAL_ATTRIBUTES_OBJECT_TYPE, ...ALL_RESOURCE_TYPES.filter((type) => channelAttributesEnabled || type !== 'channel')],
+        [channelAttributesEnabled],
+    );
+
     useEffect(() => {
         let active = true;
 
         const load = async () => {
             try {
-                await Promise.all(OBJECT_TYPES_TO_FETCH.map(
+                await Promise.all(objectTypesToFetch.map(
                     (objectType) => dispatch(fetchPropertyFields(GLOBAL_ATTRIBUTES_GROUP_NAME, objectType, GLOBAL_ATTRIBUTES_TARGET_TYPE)),
                 ));
                 if (active) {
@@ -440,7 +451,7 @@ export default function GlobalAttributesTable() {
         return () => {
             active = false;
         };
-    }, [dispatch]);
+    }, [dispatch, objectTypesToFetch]);
 
     const rows = useMemo(
         () => [...fields, ...unlinkedFields].sort((a, b) => getDisplayName(a).localeCompare(getDisplayName(b))),

--- a/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.tsx
@@ -415,8 +415,6 @@ export default function GlobalAttributesTable() {
     const channelAttributesEnabled = useSelector((state: GlobalState) =>
         getFeatureFlagValue(state, 'ChannelAttributes') === 'true' && isMinimumEnterpriseAdvancedLicense(getLicense(state)));
 
-    // Every scope the table lists rows from: templates, then each resource type's
-    // unlinked non-template fields (channel only when the gate above allows it).
     const objectTypesToFetch = useMemo(
         () => [GLOBAL_ATTRIBUTES_OBJECT_TYPE, ...ALL_RESOURCE_TYPES.filter((type) => channelAttributesEnabled || type !== 'channel')],
         [channelAttributesEnabled],

--- a/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.tsx
+++ b/webapp/channels/src/components/admin_console/global_attributes/global_attributes_table.tsx
@@ -416,7 +416,7 @@ export default function GlobalAttributesTable() {
         getFeatureFlagValue(state, 'ChannelAttributes') === 'true' && isMinimumEnterpriseAdvancedLicense(getLicense(state)));
 
     const objectTypesToFetch = useMemo(
-        () => [GLOBAL_ATTRIBUTES_OBJECT_TYPE, ...ALL_RESOURCE_TYPES.filter((type) => channelAttributesEnabled || type !== 'channel')],
+        (): string[] => [GLOBAL_ATTRIBUTES_OBJECT_TYPE, ...ALL_RESOURCE_TYPES.filter((type) => channelAttributesEnabled || type !== 'channel')],
         [channelAttributesEnabled],
     );
 
@@ -451,9 +451,15 @@ export default function GlobalAttributesTable() {
         };
     }, [dispatch, objectTypesToFetch]);
 
+    // getUnlinkedSystemFieldsForGroup reads every cached user/channel/post field.
+    // Channel fields can already be in the store (channel-header labels, a prior
+    // visit while licensed) after objectTypesToFetch has dropped that scope, so
+    // keep the table in lockstep with what this page is allowed to fetch.
     const rows = useMemo(
-        () => [...fields, ...unlinkedFields].sort((a, b) => getDisplayName(a).localeCompare(getDisplayName(b))),
-        [fields, unlinkedFields],
+        () => [...fields, ...unlinkedFields.filter((field) => objectTypesToFetch.includes(field.object_type))].sort(
+            (a, b) => getDisplayName(a).localeCompare(getDisplayName(b)),
+        ),
+        [fields, unlinkedFields, objectTypesToFetch],
     );
 
     // The Source column resolves plugin-owned rows to a plugin display name, but

--- a/webapp/channels/src/components/admin_console/global_attributes/utils.test.ts
+++ b/webapp/channels/src/components/admin_console/global_attributes/utils.test.ts
@@ -344,7 +344,7 @@ describe('global_attributes/utils', () => {
                 return Promise.resolve([]);
             });
 
-            await expect(fetchAttributeField('field-1')).resolves.toBe(live);
+            await expect(fetchAttributeField('field-1', true)).resolves.toBe(live);
         });
 
         it('returns a matching live user/channel/post field', async () => {
@@ -356,7 +356,7 @@ describe('global_attributes/utils', () => {
                 return Promise.resolve([]);
             });
 
-            await expect(fetchAttributeField('field-1')).resolves.toBe(live);
+            await expect(fetchAttributeField('field-1', true)).resolves.toBe(live);
         });
 
         it('ignores a user/channel/post field that is a linked child of a template', async () => {
@@ -367,13 +367,23 @@ describe('global_attributes/utils', () => {
                 return Promise.resolve([]);
             });
 
-            await expect(fetchAttributeField('field-1')).resolves.toBeUndefined();
+            await expect(fetchAttributeField('field-1', true)).resolves.toBeUndefined();
         });
 
         it('returns undefined when the id is not in any object type', async () => {
             jest.spyOn(Client4, 'getPropertyFields').mockResolvedValue([{id: 'other', delete_at: 0} as PropertyField]);
 
-            await expect(fetchAttributeField('field-1')).resolves.toBeUndefined();
+            await expect(fetchAttributeField('field-1', true)).resolves.toBeUndefined();
+        });
+
+        it('does not query the channel scope when includeChannel is false', async () => {
+            const getPropertyFields = jest.spyOn(Client4, 'getPropertyFields').mockResolvedValue([]);
+
+            await fetchAttributeField('field-1', false);
+
+            const queriedObjectTypes = getPropertyFields.mock.calls.map((call) => call[1]);
+            expect(queriedObjectTypes).toEqual(expect.arrayContaining(['template', 'user', 'post']));
+            expect(queriedObjectTypes).not.toContain('channel');
         });
     });
 

--- a/webapp/channels/src/components/admin_console/global_attributes/utils.test.ts
+++ b/webapp/channels/src/components/admin_console/global_attributes/utils.test.ts
@@ -269,7 +269,7 @@ describe('global_attributes/utils', () => {
         it('PATCHes the template and keeps option ids, sending null ldap/saml to unlink', async () => {
             const patchPropertyField = jest.spyOn(Client4, 'patchPropertyField').mockResolvedValue({} as PropertyField);
 
-            await updateAttributeField('field-id', {
+            await updateAttributeField('template', 'field-id', {
                 name: 'renamed',
                 type: 'select',
                 displayName: 'Renamed',
@@ -293,7 +293,7 @@ describe('global_attributes/utils', () => {
         it('omits name when it is not in the patch, and sends options: null for text', async () => {
             const patchPropertyField = jest.spyOn(Client4, 'patchPropertyField').mockResolvedValue({} as PropertyField);
 
-            await updateAttributeField('field-id', {
+            await updateAttributeField('template', 'field-id', {
                 type: 'text',
                 displayName: 'Cost center',
                 options: [{id: 'opt-1', name: ' leftover '}],
@@ -311,6 +311,20 @@ describe('global_attributes/utils', () => {
                 },
             });
         });
+
+        it('passes a non-template object type through as the PATCH path segment', async () => {
+            const patchPropertyField = jest.spyOn(Client4, 'patchPropertyField').mockResolvedValue({} as PropertyField);
+
+            await updateAttributeField('user', 'field-id', {
+                type: 'text',
+                displayName: 'Cost center',
+                options: [],
+                ldapAttr: '',
+                samlAttr: '',
+            });
+
+            expect(patchPropertyField).toHaveBeenCalledWith('access_control', 'user', 'field-id', expect.anything());
+        });
     });
 
     describe('fetchAttributeField', () => {
@@ -319,16 +333,44 @@ describe('global_attributes/utils', () => {
         });
 
         it('returns the matching live template field and ignores deleted ones', async () => {
-            const live = {id: 'field-1', delete_at: 0} as PropertyField;
-            jest.spyOn(Client4, 'getPropertyFields').mockResolvedValue([
-                {id: 'field-1', delete_at: 1} as PropertyField,
-                live,
-            ]);
+            const live = {id: 'field-1', object_type: 'template', delete_at: 0} as PropertyField;
+            jest.spyOn(Client4, 'getPropertyFields').mockImplementation((_group, objectType) => {
+                if (objectType === 'template') {
+                    return Promise.resolve([
+                        {id: 'field-1', object_type: 'template', delete_at: 1} as PropertyField,
+                        live,
+                    ]);
+                }
+                return Promise.resolve([]);
+            });
 
             await expect(fetchAttributeField('field-1')).resolves.toBe(live);
         });
 
-        it('returns undefined when the id is not in the page', async () => {
+        it('returns a matching live user/channel/post field', async () => {
+            const live = {id: 'field-1', object_type: 'channel', delete_at: 0} as PropertyField;
+            jest.spyOn(Client4, 'getPropertyFields').mockImplementation((_group, objectType) => {
+                if (objectType === 'channel') {
+                    return Promise.resolve([live]);
+                }
+                return Promise.resolve([]);
+            });
+
+            await expect(fetchAttributeField('field-1')).resolves.toBe(live);
+        });
+
+        it('ignores a user/channel/post field that is a linked child of a template', async () => {
+            jest.spyOn(Client4, 'getPropertyFields').mockImplementation((_group, objectType) => {
+                if (objectType === 'channel') {
+                    return Promise.resolve([{id: 'field-1', object_type: 'channel', linked_field_id: 'template-id', delete_at: 0} as PropertyField]);
+                }
+                return Promise.resolve([]);
+            });
+
+            await expect(fetchAttributeField('field-1')).resolves.toBeUndefined();
+        });
+
+        it('returns undefined when the id is not in any object type', async () => {
             jest.spyOn(Client4, 'getPropertyFields').mockResolvedValue([{id: 'other', delete_at: 0} as PropertyField]);
 
             await expect(fetchAttributeField('field-1')).resolves.toBeUndefined();

--- a/webapp/channels/src/components/admin_console/global_attributes/utils.test.ts
+++ b/webapp/channels/src/components/admin_console/global_attributes/utils.test.ts
@@ -198,9 +198,17 @@ describe('global_attributes/utils', () => {
         it('calls Client4.deletePropertyField against the template object type', async () => {
             const deletePropertyField = jest.spyOn(Client4, 'deletePropertyField').mockResolvedValue({status: 'OK'});
 
-            await deleteAttributeField('field-id');
+            await deleteAttributeField('template', 'field-id');
 
             expect(deletePropertyField).toHaveBeenCalledWith('access_control', 'template', 'field-id');
+        });
+
+        it.each((['user', 'channel', 'post'] as const))('passes %s through unchanged as the object_type path segment', async (objectType) => {
+            const deletePropertyField = jest.spyOn(Client4, 'deletePropertyField').mockResolvedValue({status: 'OK'});
+
+            await deleteAttributeField(objectType, 'field-id');
+
+            expect(deletePropertyField).toHaveBeenCalledWith('access_control', objectType, 'field-id');
         });
     });
 

--- a/webapp/channels/src/components/admin_console/global_attributes/utils.ts
+++ b/webapp/channels/src/components/admin_console/global_attributes/utils.ts
@@ -172,12 +172,13 @@ export function updateAttributeField(
     });
 }
 
-// Deletes a template field from the access_control group. The server returns
-// 409 when the field still has active linked dependents (CountLinkedFields > 0);
-// callers are expected to surface that case distinctly (or, for a save-time
-// rollback, to only delete linked fields first -- see createLinkedAttributeField).
-export function deleteAttributeField(fieldId: string): Promise<unknown> {
-    return Client4.deletePropertyField(GLOBAL_ATTRIBUTES_GROUP_NAME, GLOBAL_ATTRIBUTES_OBJECT_TYPE, fieldId);
+// Deletes a field from the access_control group in its own object type. The
+// server returns 409 when the field still has active linked dependents
+// (CountLinkedFields > 0); callers are expected to surface that case distinctly
+// (or, for a save-time rollback, to only delete linked fields first -- see
+// createLinkedAttributeField).
+export function deleteAttributeField(objectType: string, fieldId: string): Promise<unknown> {
+    return Client4.deletePropertyField(GLOBAL_ATTRIBUTES_GROUP_NAME, objectType, fieldId);
 }
 
 // Creates a linked field for one Applies-to resource. The server validates

--- a/webapp/channels/src/components/admin_console/global_attributes/utils.ts
+++ b/webapp/channels/src/components/admin_console/global_attributes/utils.ts
@@ -79,16 +79,20 @@ async function listPropertyFields(objectType: string): Promise<PropertyField[]> 
     return fields;
 }
 
-const ALL_ATTRIBUTE_FIELD_OBJECT_TYPES = [GLOBAL_ATTRIBUTES_OBJECT_TYPE, ...ALL_RESOURCE_TYPES];
-
 // There is no GET-by-id property-fields HTTP handler. List every object type a
 // field can live in and find the one whose id matches. A user/channel/post
 // field only counts when it isn't a template's linked child (linked_field_id
 // set) -- those aren't listed or edited on their own, so an id that only
 // resolves to one returns undefined and the details page redirects to the list.
-export async function fetchAttributeField(fieldId: string): Promise<PropertyField | undefined> {
+//
+// includeChannel is false below Enterprise Advanced (or with the ChannelAttributes
+// flag off): the server 501s a channel-scoped access_control GET there, and
+// fetching it unconditionally would reject the whole Promise.all and bounce every
+// details page to the list -- even one editing a user or template field.
+export async function fetchAttributeField(fieldId: string, includeChannel: boolean): Promise<PropertyField | undefined> {
+    const objectTypes = [GLOBAL_ATTRIBUTES_OBJECT_TYPE, ...ALL_RESOURCE_TYPES.filter((type) => includeChannel || type !== 'channel')];
     const pages = await Promise.all(
-        ALL_ATTRIBUTE_FIELD_OBJECT_TYPES.map((objectType) => listPropertyFields(objectType)),
+        objectTypes.map((objectType) => listPropertyFields(objectType)),
     );
     return pages.flat().find((field) => (
         field.id === fieldId &&

--- a/webapp/channels/src/components/admin_console/global_attributes/utils.ts
+++ b/webapp/channels/src/components/admin_console/global_attributes/utils.ts
@@ -79,11 +79,22 @@ async function listPropertyFields(objectType: string): Promise<PropertyField[]> 
     return fields;
 }
 
-// There is no GET-by-id property-fields HTTP handler. List template fields and
-// find the one whose id matches. Returns undefined when it isn't in the group.
+const ALL_ATTRIBUTE_FIELD_OBJECT_TYPES = [GLOBAL_ATTRIBUTES_OBJECT_TYPE, ...ALL_RESOURCE_TYPES];
+
+// There is no GET-by-id property-fields HTTP handler. List every object type a
+// field can live in and find the one whose id matches. A user/channel/post
+// field only counts when it isn't a template's linked child (linked_field_id
+// set) -- those aren't listed or edited on their own, so an id that only
+// resolves to one returns undefined and the details page redirects to the list.
 export async function fetchAttributeField(fieldId: string): Promise<PropertyField | undefined> {
-    const fields = await listPropertyFields(GLOBAL_ATTRIBUTES_OBJECT_TYPE);
-    return fields.find((field) => field.id === fieldId && field.delete_at === 0);
+    const pages = await Promise.all(
+        ALL_ATTRIBUTE_FIELD_OBJECT_TYPES.map((objectType) => listPropertyFields(objectType)),
+    );
+    return pages.flat().find((field) => (
+        field.id === fieldId &&
+        field.delete_at === 0 &&
+        (field.object_type === GLOBAL_ATTRIBUTES_OBJECT_TYPE || !field.linked_field_id)
+    ));
 }
 
 function isResourceObjectType(value: string): value is ResourceObjectType {
@@ -152,15 +163,16 @@ export type UpdateAttributeFieldPatch = {
     samlAttr: string;
 };
 
-// PATCHes a template field. Attrs are merge-patched (mergeAttrs=true on the
-// server): ldap/saml send null to unlink, and Text sends options: null so a
-// leftover options array is dropped. name is omitted when unchanged so the
-// server skips uniqueness re-validation.
+// PATCHes a field in the given object type. Attrs are merge-patched
+// (mergeAttrs=true on the server): ldap/saml send null to unlink, and Text
+// sends options: null so a leftover options array is dropped. name is omitted
+// when unchanged so the server skips uniqueness re-validation.
 export function updateAttributeField(
+    objectType: string,
     fieldId: string,
     patch: UpdateAttributeFieldPatch,
 ): Promise<PropertyField> {
-    return Client4.patchPropertyField(GLOBAL_ATTRIBUTES_GROUP_NAME, GLOBAL_ATTRIBUTES_OBJECT_TYPE, fieldId, {
+    return Client4.patchPropertyField(GLOBAL_ATTRIBUTES_GROUP_NAME, objectType, fieldId, {
         ...(patch.name === undefined ? {} : {name: patch.name}),
         type: patch.type as PropertyField['type'],
         attrs: {

--- a/webapp/channels/src/i18n/en.json
+++ b/webapp/channels/src/i18n/en.json
@@ -1495,6 +1495,7 @@
   "admin.global_attributes.attribute_details.applies_to.item.remove": "Remove resource",
   "admin.global_attributes.attribute_details.applies_to.locked_plugin_orphaned_tooltip": "This resource cannot be changed — this attribute was managed by a plugin that's no longer installed.",
   "admin.global_attributes.attribute_details.applies_to.locked_plugin_tooltip": "This resource cannot be changed — this attribute is managed by a plugin.",
+  "admin.global_attributes.attribute_details.applies_to.locked_single_resource_tooltip": "This resource cannot be changed — this attribute applies to only one resource.",
   "admin.global_attributes.attribute_details.applies_to.resource_type.channel": "Channels",
   "admin.global_attributes.attribute_details.applies_to.resource_type.post": "Posts",
   "admin.global_attributes.attribute_details.applies_to.resource_type.user": "Users",

--- a/webapp/channels/src/packages/mattermost-redux/src/constants/properties.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/constants/properties.ts
@@ -5,6 +5,8 @@
 export const ACCESS_CONTROL_PROPERTY_GROUP = 'access_control';
 
 export const CHANNEL_OBJECT_TYPE = 'channel';
+export const USER_OBJECT_TYPE = 'user';
+export const POST_OBJECT_TYPE = 'post';
 export const SYSTEM_TARGET_TYPE = 'system';
 export const SYSTEM_TARGET_ID = '';
 

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/properties.test.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/properties.test.ts
@@ -19,6 +19,7 @@ import {
     getPropertyValuesForField,
     getChannelAttributeFields,
     getChannelLabelFields,
+    getUnlinkedSystemFieldsForGroup,
     makeGetResolvedChannelAttributes,
 } from './properties';
 
@@ -538,6 +539,86 @@ describe('getChannelAttributeFields', () => {
         ]);
 
         expect(getChannelAttributeFields(state).map((f) => f.id)).toEqual(['live']);
+    });
+});
+
+function makeUnlinkedFieldsState(fields: PropertyField[]): GlobalState {
+    const byObjectType: Record<string, Record<string, Record<string, PropertyField>>> = {};
+    for (const field of fields) {
+        byObjectType[field.object_type] = {
+            ...byObjectType[field.object_type],
+            [GROUP_ID]: {
+                ...byObjectType[field.object_type]?.[GROUP_ID],
+                [field.id]: field,
+            },
+        };
+    }
+
+    return deepFreeze({
+        entities: {
+            properties: {
+                groups: {byId: {}, byName: {}},
+                fields: {
+                    byId: Object.fromEntries(fields.map((f) => [f.id, f])),
+                    byObjectType,
+                },
+                values: {byTargetId: {}, byFieldId: {}},
+            },
+        },
+    }) as unknown as GlobalState;
+}
+
+describe('getUnlinkedSystemFieldsForGroup', () => {
+    test('returns fields from all three object types in one list', () => {
+        const state = makeUnlinkedFieldsState([
+            attrField({id: 'u1', object_type: 'user'}),
+            attrField({id: 'c1', object_type: 'channel'}),
+            attrField({id: 'p1', object_type: 'post'}),
+        ]);
+
+        expect(getUnlinkedSystemFieldsForGroup(state, GROUP_ID).map((f) => f.id).sort()).toEqual(['c1', 'p1', 'u1']);
+    });
+
+    test('excludes a field with linked_field_id set', () => {
+        const state = makeUnlinkedFieldsState([
+            attrField({id: 'linked', object_type: 'user', linked_field_id: 'template1'}),
+            attrField({id: 'standalone', object_type: 'user'}),
+        ]);
+
+        expect(getUnlinkedSystemFieldsForGroup(state, GROUP_ID).map((f) => f.id)).toEqual(['standalone']);
+    });
+
+    test('excludes a deleted field', () => {
+        const state = makeUnlinkedFieldsState([
+            attrField({id: 'live', object_type: 'user'}),
+            attrField({id: 'gone', object_type: 'user', delete_at: 12345}),
+        ]);
+
+        expect(getUnlinkedSystemFieldsForGroup(state, GROUP_ID).map((f) => f.id)).toEqual(['live']);
+    });
+
+    test('excludes a field whose target_type is not system', () => {
+        const state = makeUnlinkedFieldsState([
+            attrField({id: 'system_field', object_type: 'user'}),
+            attrField({id: 'other_target', object_type: 'user', target_type: 'other'}),
+        ]);
+
+        expect(getUnlinkedSystemFieldsForGroup(state, GROUP_ID).map((f) => f.id)).toEqual(['system_field']);
+    });
+
+    test('excludes a template-object-type field in the same group', () => {
+        const state = makeUnlinkedFieldsState([
+            attrField({id: 'template1', object_type: 'template'}),
+            attrField({id: 'user1', object_type: 'user'}),
+        ]);
+
+        expect(getUnlinkedSystemFieldsForGroup(state, GROUP_ID).map((f) => f.id)).toEqual(['user1']);
+    });
+
+    test('returns the identical array reference across calls against an unchanged state', () => {
+        const state = makeUnlinkedFieldsState([attrField({id: 'u1', object_type: 'user'})]);
+
+        expect(getUnlinkedSystemFieldsForGroup(state, GROUP_ID)).toBe(getUnlinkedSystemFieldsForGroup(state, GROUP_ID));
     });
 });
 

--- a/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/properties.ts
+++ b/webapp/channels/src/packages/mattermost-redux/src/selectors/entities/properties.ts
@@ -12,6 +12,9 @@ import {
     DISPLAY_BANNER_TOP,
     DISPLAY_LABEL_HEADER,
     DISPLAY_LABEL_INFO,
+    POST_OBJECT_TYPE,
+    SYSTEM_TARGET_TYPE,
+    USER_OBJECT_TYPE,
 } from 'mattermost-redux/constants/properties';
 import {createSelector} from 'mattermost-redux/selectors/create_selector';
 import {isPropertyValueSet} from 'mattermost-redux/utils/property_utils';
@@ -153,6 +156,35 @@ export const getChannelAttributeFields: (state: GlobalState) => PropertyField[] 
         }
         const live = Object.values(fields).filter((field) => field.delete_at === 0);
         return live.length === 0 ? EMPTY_FIELDS : sortByFieldOrder(live);
+    },
+);
+
+/**
+ * System-scoped fields from all three object types (user, channel, post) that are
+ * not a template's linked child, for the Manage Attributes page. A field with
+ * linked_field_id set is already represented by that template's own row, so it is
+ * excluded here to avoid listing the same attribute twice.
+ *
+ * groupId is the group's real UUID; fields are stored under that id, never under
+ * the group name, so the caller resolves the id first.
+ */
+export const getUnlinkedSystemFieldsForGroup: (state: GlobalState, groupId: string) => PropertyField[] = createSelector(
+    'getUnlinkedSystemFieldsForGroup',
+    (state: GlobalState, groupId: string) => state.entities.properties.fields.byObjectType[USER_OBJECT_TYPE]?.[groupId],
+    (state: GlobalState, groupId: string) => state.entities.properties.fields.byObjectType[CHANNEL_OBJECT_TYPE]?.[groupId],
+    (state: GlobalState, groupId: string) => state.entities.properties.fields.byObjectType[POST_OBJECT_TYPE]?.[groupId],
+    (userFields, channelFields, postFields) => {
+        const all = [
+            ...Object.values(userFields ?? {}),
+            ...Object.values(channelFields ?? {}),
+            ...Object.values(postFields ?? {}),
+        ];
+        const unlinked = all.filter((field) => (
+            field.target_type === SYSTEM_TARGET_TYPE &&
+            field.delete_at === 0 &&
+            !field.linked_field_id
+        ));
+        return unlinked.length === 0 ? EMPTY_FIELDS : unlinked;
     },
 );
 


### PR DESCRIPTION
#### Summary
System Console → System Attributes → Manage Attributes is a page where admins manage the custom fields ("attributes") that can be attached to users, channels, and posts. Today it only shows one kind of field: "templates," which are reusable definitions that can be linked to several resource types at once. But an admin can also create a field that isn't a template — one that's tied directly to a single resource type (for example, every field made from the older User Attributes page is like this). Those fields were invisible on the Manage Attributes page even though they're real, working attributes, so an admin had no single place to see everything.

This PR makes those non-template fields show up in the table alongside templates, looking and behaving the same way — same columns, same edit/delete actions. Opening one from the details page loads and saves it correctly, and deleting it removes the right field. The one place it differs from a template is the "Applies to" section, which is locked to that field's single resource type, since turning a plain field into a multi-resource template is a separate change this PR doesn't attempt.

It also fixes a bug found while building this: fetching channel-type fields unconditionally caused the whole page (and every attribute edit) to fail on Enterprise licenses below Enterprise Advanced, because the server rejects that request at lower tiers. The fetch is now skipped unless channel attributes are actually available.

#### Ticket Link

https://mattermost.atlassian.net/browse/MM-70685

#### Demo

[Screencast from 2026-09-11 09-59-05.webm](https://github.com/user-attachments/assets/36c37a5d-16a3-4af8-afe6-4b7065dda57f)

#### Release Note
```release-note
NONE
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Change Impact: 🟡 Medium

**Regression Risk:** The change spans shared selectors, attribute utilities, API routing, and the Manage Attributes UI. Automated coverage is broad, but user-facing field loading, editing, and deletion remain persistence flows.

**QA Recommendation:** Perform targeted manual QA for template and non-template fields across user, channel, and post types, including license-based channel behavior.

*Generated by CodeRabbitAI*
<!-- end of auto-generated comment: release notes by coderabbit.ai -->