### PR TITLE
Render English from each message's defaultMessage, not en.json

### DIFF
--- a/webapp/channels/eslint.config.mjs
+++ b/webapp/channels/eslint.config.mjs
@@ -68,6 +68,9 @@ export default defineConfig([
                         name: 'mattermost-redux/types/actions',
                         importNames: ['DispatchFunc', 'GetStateFunc', 'ActionFunc', 'ActionFuncAsync', 'ThunkActionFunc'],
                         message: 'Use the web app version of it from types/store',
+                    }, {
+                        name: 'i18n/en.json',
+                        message: 'en.json is not shipped. English renders from the defaultMessage at each call site, so importing it only duplicates every English string in the bundle.',
                     }],
                     patterns: [{
                         group: ['@mattermost/client/src/*', '@mattermost/components/src/*', '@mattermost/types/src/*'],

--- a/webapp/channels/src/actions/views/root.ts
+++ b/webapp/channels/src/actions/views/root.ts
@@ -5,7 +5,6 @@ import {Client4} from 'mattermost-redux/client';
 
 import {getCurrentLocale, getTranslations} from 'selectors/i18n';
 
-import en from 'i18n/en.json';
 import {ActionTypes} from 'utils/constants';
 
 import type {ActionFuncAsync, ThunkActionFunc} from 'types/store';
@@ -42,7 +41,7 @@ export function unregisterPluginTranslationsSource(pluginId: string) {
 
 export function loadTranslations(locale: string, url: string): ActionFuncAsync {
     return async (dispatch) => {
-        const translations = {...en};
+        const translations: Translations = {};
         Object.values(pluginTranslationSources).forEach((pluginFunc) => {
             Object.assign(translations, pluginFunc(locale));
         });

--- a/webapp/channels/src/components/intl_provider/intl_provider.tsx
+++ b/webapp/channels/src/components/intl_provider/intl_provider.tsx
@@ -79,6 +79,7 @@ export default class IntlProvider extends React.PureComponent<Props> {
             <BaseIntlProvider
                 key={this.props.locale}
                 locale={this.props.locale}
+                defaultLocale={this.props.locale}
                 messages={this.props.translations}
                 textComponent='span'
                 wrapRichTextChunksInFragment={false}

--- a/webapp/channels/src/components/post_view/post_aria_label_div.test.tsx
+++ b/webapp/channels/src/components/post_view/post_aria_label_div.test.tsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import * as reactIntl from 'react-intl';
 
-import enMessages from 'i18n/en.json';
 import esMessages from 'i18n/es.json';
 import {renderWithContext, screen} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';
@@ -54,11 +53,11 @@ describe('PostAriaLabelDiv', () => {
     };
 
     test('should render aria-label in the given locale', () => {
-        (reactIntl.useIntl as jest.Mock).mockImplementation(() => reactIntl.createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'}));
+        (reactIntl.useIntl as jest.Mock).mockImplementation(() => reactIntl.createIntl({locale: 'en', messages: {}, defaultLocale: 'en'}));
 
         let renderResult = renderWithContext(<PostAriaLabelDiv {...baseProps}/>, baseState, {
             locale: 'en',
-            intlMessages: enMessages,
+            intlMessages: {},
         });
 
         let div = renderResult.container.firstChild as HTMLElement;
@@ -78,13 +77,13 @@ describe('PostAriaLabelDiv', () => {
     });
 
     test('should pass other props through to the rendered div', () => {
-        (reactIntl.useIntl as jest.Mock).mockImplementation(() => reactIntl.createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'}));
+        (reactIntl.useIntl as jest.Mock).mockImplementation(() => reactIntl.createIntl({locale: 'en', messages: {}, defaultLocale: 'en'}));
 
         let props = baseProps;
 
         let renderResult = renderWithContext(<PostAriaLabelDiv {...props}/>, baseState, {
             locale: 'en',
-            intlMessages: enMessages,
+            intlMessages: {},
         });
         let div = renderResult.container.firstChild as HTMLElement;
 
@@ -105,7 +104,7 @@ describe('PostAriaLabelDiv', () => {
             baseState,
             {
                 locale: 'en',
-                intlMessages: enMessages,
+                intlMessages: {},
             },
         );
         div = renderResult.container.firstChild as HTMLElement;

--- a/webapp/channels/src/components/post_view/post_list_virtualized/latest_post_reader.test.tsx
+++ b/webapp/channels/src/components/post_view/post_list_virtualized/latest_post_reader.test.tsx
@@ -4,7 +4,6 @@
 import React from 'react';
 import {createIntl, useIntl} from 'react-intl';
 
-import enMessages from 'i18n/en.json';
 import esMessages from 'i18n/es.json';
 import {renderWithContext, screen} from 'tests/react_testing_utils';
 import {TestHelper} from 'utils/test_helper';
@@ -57,7 +56,7 @@ describe('LatestPostReader', () => {
     };
 
     test('should render aria-label as a child in the given locale', () => {
-        (useIntl as jest.Mock).mockImplementation(() => createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'}));
+        (useIntl as jest.Mock).mockImplementation(() => createIntl({locale: 'en', messages: {}, defaultLocale: 'en'}));
 
         const {rerender} = renderWithContext(
             <LatestPostReader {...baseProps}/>,

--- a/webapp/channels/src/tests/helpers/intl-test-helper.tsx
+++ b/webapp/channels/src/tests/helpers/intl-test-helper.tsx
@@ -9,13 +9,11 @@ import {
 } from 'react-intl';
 import type {IntlShape} from 'react-intl';
 
-import defaultMessages from 'i18n/en.json';
-
 export const defaultIntl = createIntl({
     locale: 'en',
     defaultLocale: 'en',
     timeZone: 'Etc/UTC',
-    messages: defaultMessages,
+    messages: {},
     textComponent: 'span',
 });
 

--- a/webapp/channels/src/tests/react-intl_mock.ts
+++ b/webapp/channels/src/tests/react-intl_mock.ts
@@ -3,11 +3,10 @@
 
 jest.mock('react-intl', function() {
     const reactIntl = jest.requireActual('react-intl');
-    const enMessages = require('i18n/en.json');
 
     const intl = reactIntl.createIntl({
         locale: 'en',
-        messages: enMessages,
+        messages: {},
         defaultLocale: 'en',
         timeZone: 'Etc/UTC',
         textComponent: 'span',

--- a/webapp/channels/src/utils/i18n.tsx
+++ b/webapp/channels/src/utils/i18n.tsx
@@ -45,6 +45,7 @@ export function getIntl(): IntlShape {
 
     return createIntl({
         locale,
+        defaultLocale: locale,
         messages: getTranslations(state, locale),
     }, cache);
 }

--- a/webapp/channels/src/utils/post_utils.test.tsx
+++ b/webapp/channels/src/utils/post_utils.test.tsx
@@ -7,7 +7,6 @@ import type {Post} from '@mattermost/types/posts';
 
 import {Preferences} from 'mattermost-redux/constants';
 
-import enMessages from 'i18n/en.json';
 import {makeInitialState} from 'packages/mattermost-redux/test/test_store';
 import {PostListRowListIds, Constants} from 'utils/constants';
 import EmojiMap from 'utils/emoji_map';
@@ -896,7 +895,7 @@ describe('PostUtils.createAriaLabelForPost', () => {
     const teammateNameDisplaySetting = 'username';
 
     test('Should show username, timestamp, message, attachments, reactions, flagged and pinned', () => {
-        const intl = createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'});
+        const intl = createIntl({locale: 'en', messages: {}, defaultLocale: 'en'});
 
         const testPost = TestHelper.getPostMock({
             message: 'test_message',
@@ -926,7 +925,7 @@ describe('PostUtils.createAriaLabelForPost', () => {
     });
 
     test('Should show that message is a reply', () => {
-        const intl = createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'});
+        const intl = createIntl({locale: 'en', messages: {}, defaultLocale: 'en'});
 
         const testPost = TestHelper.getPostMock({
             message: 'test_message',
@@ -942,7 +941,7 @@ describe('PostUtils.createAriaLabelForPost', () => {
     });
 
     test('Should translate emoji into {emoji-name} emoji', () => {
-        const intl = createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'});
+        const intl = createIntl({locale: 'en', messages: {}, defaultLocale: 'en'});
 
         const testPost = TestHelper.getPostMock({
             message: 'emoji_test :smile: :+1: :non-potable_water: :space emoji: :not_an_emoji:',
@@ -961,7 +960,7 @@ describe('PostUtils.createAriaLabelForPost', () => {
     });
 
     test('Generating aria label should not break if message is undefined', () => {
-        const intl = createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'});
+        const intl = createIntl({locale: 'en', messages: {}, defaultLocale: 'en'});
 
         const testPost = TestHelper.getPostMock({
             id: '32',
@@ -976,7 +975,7 @@ describe('PostUtils.createAriaLabelForPost', () => {
     });
 
     test('Should not mention reactions if passed an empty object', () => {
-        const intl = createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'});
+        const intl = createIntl({locale: 'en', messages: {}, defaultLocale: 'en'});
 
         const testPost = TestHelper.getPostMock({
             message: 'test_message',
@@ -992,7 +991,7 @@ describe('PostUtils.createAriaLabelForPost', () => {
     });
 
     test('Should show the username as mention name in the message', () => {
-        const intl = createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'});
+        const intl = createIntl({locale: 'en', messages: {}, defaultLocale: 'en'});
 
         const testPost = TestHelper.getPostMock({
             message: 'test_message @benjamin.cooke',
@@ -1008,7 +1007,7 @@ describe('PostUtils.createAriaLabelForPost', () => {
     });
 
     test('Should show the nickname as mention name in the message', () => {
-        const intl = createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'});
+        const intl = createIntl({locale: 'en', messages: {}, defaultLocale: 'en'});
 
         const testPost = TestHelper.getPostMock({
             message: 'test_message @benjamin.cooke',
@@ -1024,7 +1023,7 @@ describe('PostUtils.createAriaLabelForPost', () => {
     });
 
     test('Should show translated message', () => {
-        const intl = createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'});
+        const intl = createIntl({locale: 'en', messages: {}, defaultLocale: 'en'});
 
         const testPost = TestHelper.getPostMock({
             message: 'test_message in Spanish',
@@ -1051,7 +1050,7 @@ describe('PostUtils.createAriaLabelForPost', () => {
     });
 
     test('Should show original message if translation is not ready', () => {
-        const intl = createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'});
+        const intl = createIntl({locale: 'en', messages: {}, defaultLocale: 'en'});
 
         const testPost = TestHelper.getPostMock({
             message: 'test_message in Spanish',
@@ -1078,7 +1077,7 @@ describe('PostUtils.createAriaLabelForPost', () => {
     });
 
     test('Should show original message if there is no translation for the current language', () => {
-        const intl = createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'});
+        const intl = createIntl({locale: 'en', messages: {}, defaultLocale: 'en'});
 
         const testPost = TestHelper.getPostMock({
             message: 'test_message in Spanish',
@@ -1105,7 +1104,7 @@ describe('PostUtils.createAriaLabelForPost', () => {
     });
 
     test('Should show original message if we pass autotranslated as false', () => {
-        const intl = createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'});
+        const intl = createIntl({locale: 'en', messages: {}, defaultLocale: 'en'});
 
         const testPost = TestHelper.getPostMock({
             message: 'test_message in Spanish',
@@ -1132,7 +1131,7 @@ describe('PostUtils.createAriaLabelForPost', () => {
     });
 
     test('Should show original message if the post type is not empty', () => {
-        const intl = createIntl({locale: 'en', messages: enMessages, defaultLocale: 'en'});
+        const intl = createIntl({locale: 'en', messages: {}, defaultLocale: 'en'});
 
         const testPost = TestHelper.getPostMock({
             message: 'test_message in Spanish',


### PR DESCRIPTION
### Summary
Stop bundling `webapp/channels/src/i18n/en.json`: the `defaultMessage` is already compiled in, and there's no reason to ship another 167KB duplicating all these screens. Nothing changes for endusers.

Note that an id only reaches `en.json` because `formatjs extract` found a *literal* `defaultMessage` at its call site, nothing strips that literal from the bundle, react-intl's documented fallback picks it up, and `formatjs/enforce-default-message` is an extra safe guard.

What about non-English languages? Previously, `loadTranslations` would start with `en.json`, then merge in the non-English locale, guaranteeing /some/ string for each id, even if not yet translated. This isn't possible without `en.json`, so to avoid the overhead of having `react-intl` reporting and catching a `MissingTranslationError` before automatically falling back to the `defaultMessage`, we also explicitly pass the current locale as the `defaultLocale` to sidestep any processing overhead.

#### QA Steps
Switch the UI to a thinly translated locale (Italian is the sparsest at 39%) and confirm untranslated strings still render in English, with plurals and interpolated values intact; switch back to English and confirm nothing changed. Confirm plugin-provided translations still apply.

#### Release Note
```release-note
NONE
```
