### PR TITLE
Replace unlisted minio/minio image with Chainguard minio

### DIFF
--- a/e2e-tests/.ci/server.generate.sh
+++ b/e2e-tests/.ci/server.generate.sh
@@ -128,7 +128,7 @@ $(if mme2e_is_token_in_list "minio" "$ENABLED_DOCKER_SERVICES"; then
       file: ../../server/build/docker-compose.common.yml
       service: minio
     healthcheck:
-      test: [ "CMD", "curl", "-f", "127.0.0.1:9000/minio/health/live" ]
+      test: [ "CMD", "mc", "ready", "local" ]
       interval: 10s
       timeout: 15s
       retries: 12'

--- a/e2e-tests/playwright/lib/src/containers/default_images.ts
+++ b/e2e-tests/playwright/lib/src/containers/default_images.ts
@@ -8,7 +8,7 @@ export const POSTGRES_IMAGE = 'postgres:15';
 export const INBUCKET_IMAGE = 'inbucket/inbucket:3.1.1';
 export const OPENLDAP_IMAGE = 'osixia/openldap:1.4.0';
 export const KEYCLOAK_IMAGE = 'quay.io/keycloak/keycloak:23.0.7';
-export const MINIO_IMAGE = 'minio/minio:RELEASE.2024-06-22T05-26-45Z';
+export const MINIO_IMAGE = 'cgr.dev/chainguard/minio:latest';
 export const AZURITE_IMAGE = 'mcr.microsoft.com/azure-storage/azurite:3.34.0';
 // Built from a Dockerfile on top of docker.elastic.co/elasticsearch/elasticsearch, rather than
 // pulled as a fixed image — so only the version is fixed here.

--- a/server/build/docker-compose.common.yml
+++ b/server/build/docker-compose.common.yml
@@ -25,7 +25,7 @@ services:
       timeout: 10s
       retries: 3
   minio:
-    image: "minio/minio:RELEASE.2024-06-22T05-26-45Z"
+    image: "cgr.dev/chainguard/minio:latest"
     logging: *default-logging
     command: "server /data --console-address :9002"
     networks:

--- a/server/scripts/mirror-docker-images.json
+++ b/server/scripts/mirror-docker-images.json
@@ -9,8 +9,7 @@
     "17": "postgres:17@sha256:4f6c1ec9743885ba6438a91f7c08c4ef4d645a41eae31fc8521c2d831c622107"
   },
   "minio": {
-    "RELEASE.2019-10-11T00-38-09Z-1": "minio/minio:RELEASE.2019-10-11T00-38-09Z@sha256:0d02f16a1662653f9b961211b21ed7de04bf04492f44c2b7594bacbfcc519eb5",
-    "RELEASE.2024-06-22T05-26-45Z": "minio/minio:RELEASE.2024-06-22T05-26-45Z@sha256:dda5e13d3df07fae2c1877701998742bcbe3bbb2b9c24c18ed5b9469cc777761"
+    "RELEASE.2026-07-17T12-07-51Z": "cgr.dev/chainguard/minio@sha256:039800e64ec7247d2fde7cff3697e964f6fe20b6d7d2c46aa7d82cc63355d512"
   },
   "redis": {
     "7.4.0": "redis:7.4.0@sha256:6725a7dc7a44a6486b9d0a5172b10ccaf0c2ea600df87c0b93450d0e7769297f"


### PR DESCRIPTION
#### Summary

`minio/minio` was unlisted from Docker Hub, so every build and test run that pulls it now fails. This swaps it for the [Chainguard minio image](https://images.chainguard.dev/directory/image/minio/overview) (`cgr.dev/chainguard/minio`), which is a maintained fork published as a multi-arch (amd64 + arm64) image.

Note that Chainguard's public tier only publishes `latest`/`latest-dev` — there are no version tags to pin, and hard-pinning a digest in the compose files would eventually break when Chainguard garbage-collects it. The mirror spec is digest-pinned (it is only read by the mirroring job, which can be bumped deliberately), but the dev/test stacks float. 

#### Release Note
```release-note
NONE
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Change Impact: 🟢 Low

**Regression Risk:** The changes affect MinIO container images and health checks in development and test environments. The main risk is image availability or compatibility with the new Chainguard image.

**QA Recommendation:** Automated testing is sufficient. Manual QA is not required.

*Generated by CodeRabbitAI*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->